### PR TITLE
change to foreign key order

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_dumper.rb
@@ -35,9 +35,14 @@ module ActiveRecord #:nodoc:
           oracle_enhanced_table(tbl, stream)
           # add primary key trigger if table has it
           primary_key_trigger(tbl, stream)
-          # add foreign keys if table has them
-          foreign_keys(tbl, stream)
         end
+        # following table definitions
+        # add foreign keys if table has them
+        sorted_tables.each do |tbl|
+	  next if ignore_table? tbl
+	  foreign_keys(tbl, stream)
+	end
+        
         # add synonyms in local schema
         synonyms(stream)
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
@@ -228,6 +228,15 @@ describe "OracleEnhancedAdapter schema dump" do
       end
       standard_dump.should =~ /add_foreign_key "test_comments", "test_posts", :columns => \["baz_id", "fooz_id"\], :name => "comments_posts_baz_fooz_fk"/
     end
+    it "should include foreign keys following all tables" do
+    	# if foreign keys preceed declaration of all tables
+			# it can cause problems when using db:test rake tasks
+			schema_define do 
+				add_foreign_key :test_comments, :test_posts
+			end
+			dump = standard_dump
+			dump.rindex("create_table").should < dump.rindex("add_foreign_key")
+    end
   end
 
   describe "synonyms" do


### PR DESCRIPTION
As the adapter currently works, foreign keys are outputted to the schema file following the the table they are defined on.  This makes sense, however it causes problems when trying to clone from the schema.  It can attempt to add foreign keys referencing tables which do not exist yet. 
