### PR TITLE
Schema dump with cpk

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -838,8 +838,12 @@ module ActiveRecord
              and cc.constraint_name = c.constraint_name
         SQL
 
-        # only support single column keys
-        pks.size == 1 ? [oracle_downcase(pks.first), nil] : nil
+        # only support single column keys unless cpk gem is available
+        unless defined?(CompositePrimaryKeys)
+          pks.size == 1 ? [oracle_downcase(pks.first), nil] : nil
+        else
+          pks.collect {|i| oracle_downcase(i) }
+        end
       end
 
       # Returns just a table's primary key

--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_dumper.rb
@@ -143,7 +143,13 @@ module ActiveRecord #:nodoc:
 
           # first dump primary key column
           if @connection.respond_to?(:pk_and_sequence_for)
-            pk, pk_seq = @connection.pk_and_sequence_for(table)
+            #if cpk is available, then generate it in the schema dump if a cpk exists in this table
+            unless defined?(CompositePrimaryKeys) 
+              pk, pk_seq = @connection.pk_and_sequence_for(table)
+            else
+              pk = @connection.pk_and_sequence_for(table)
+              pk = pk[0] if pk.size == 1 
+            end
           elsif @connection.respond_to?(:primary_key)
             pk = @connection.primary_key(table)
           end
@@ -207,6 +213,17 @@ module ActiveRecord #:nodoc:
           tbl.puts
           
           indexes(table, tbl)
+
+          #generate statements for a composite primary key
+          if pk.class == Array
+            tbl.print 		"  execute 'ALTER TABLE   #{table} ADD CONSTRAINT #{table.upcase}_ID_PK PRIMARY KEY ("
+            pk.each do |pk_name|
+	      tbl.print  pk_name
+	      tbl.print ', ' unless pk_name == pk.last
+	    end
+            tbl.puts ")'"
+            tbl.puts
+          end
 
           tbl.rewind
           stream.print tbl.read


### PR DESCRIPTION
Hi, I made a minor change to allow the schema dumper to write constraint ddl for the declaration of cpks if the project has the cpk gem installed.  This has proven useful to me.  I thought I'd see if you'd take a look.  I've not yet set up an environment for running your tests, but it is a minor enough change that I thought if you had test failures you could just notify me and I can take a look.  Ultimately, I'd love to be able to put cpk syntax straight into the create_table declaration, but I don't know how to pull that off.
I also do not explicitly drop the constraint on the down migration call.  That's something I could add, but I wanted you to take a look first.

Thanks
-Todd Flyr
