### PR TITLE
Too many ids in in list

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_activerecord_patches.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_activerecord_patches.rb
@@ -35,3 +35,101 @@ if ActiveRecord::VERSION::MAJOR == 2 && ActiveRecord::VERSION::MINOR == 3
   end
 
 end
+
+
+# Rails 2.3 and 3.0 patch to avoid "ORA-01795: maximum number of expressions in a list is 1000" errors
+# when including more than 1000 associated records in a preloaded query
+# i.e. Post.all(:include=>:comments) when a Post has_many :comments
+#      or Post.all(:include=>:tags) when a Post has_and_belongs_to_many :tags
+# The has_many case is fairly clean and works through inheritance and super
+# but the habtm case requires pasting the active record implementation here and overriding it
+# so will need to be checked and updated if/when active record's implementation of
+# preload_has_and_belongs_to_many_association changes in assocation_preload.rb
+if [[2,3], [3,0]].include? [ActiveRecord::VERSION::MAJOR, ActiveRecord::VERSION::MINOR]
+  require "active_record/association_preload"
+
+  module ActiveRecord
+    module AssociationPreload
+      MAX_IDS_PER_ORACLE_QUERY = 1000
+
+      # has_many patch for both Rails 2.3 and 3.0
+      module OracleEnhancedAdapterPatch
+        private
+
+        # Make multiple requests of up to 1000 ids at a time to avoid ORA-01795: maximum number of expressions in a list is 1000
+        def find_associated_records(ids, reflection, preload_options)
+          associated_records = []
+          ids.each_slice(MAX_IDS_PER_ORACLE_QUERY) do |safe_for_oracle_ids|
+            associated_records += super(safe_for_oracle_ids, reflection, preload_options)
+          end
+          associated_records
+        end
+      end
+
+      ActiveRecord::Base.class_eval do
+        extend ActiveRecord::AssociationPreload::OracleEnhancedAdapterPatch
+      end
+
+
+      # habtm patch for Rails 2.3 and 3.0 (separate patches below)
+      ClassMethods.module_eval do
+        private
+        # WARNING we are pasting the ActiveRecord implementations directly in here so this will likely break in a future version.
+        # Sorry, I could not think of another way to extend preload_has_and_belongs_to_many_association more cleanly as it does not take
+        # ids as a parameter.
+        # There may need to be more if cases for 3.1 or even 3.0.2!
+        # Keep a close eye on https://github.com/rails/rails/blob/master/activerecord/lib/active_record/association_preload.rb
+
+        if [2,3] == [ActiveRecord::VERSION::MAJOR, ActiveRecord::VERSION::MINOR]
+          # The Rails 2.3 method from association_preload.rb
+          def preload_has_and_belongs_to_many_association(records, reflection, preload_options={})
+            table_name = reflection.klass.quoted_table_name
+            id_to_record_map, ids = construct_id_map(records)
+            records.each {|record| record.send(reflection.name).loaded}
+            options = reflection.options
+
+            conditions = "t0.#{reflection.primary_key_name} #{in_or_equals_for_ids(ids)}"
+            conditions << append_conditions(reflection, preload_options)
+
+            # Make several queries with no more than 1000 ids in each one, combining the results into a single array
+            associated_records = []
+            ids.each_slice(MAX_IDS_PER_ORACLE_QUERY) do |safe_for_oracle_ids|
+              associated_records += reflection.klass.with_exclusive_scope do
+                reflection.klass.find(:all, :conditions => [conditions, safe_for_oracle_ids],
+                  :include => options[:include],
+                  :joins => "INNER JOIN #{connection.quote_table_name options[:join_table]} t0 ON #{reflection.klass.quoted_table_name}.#{reflection.klass.primary_key} = t0.#{reflection.association_foreign_key}",
+                  :select => "#{options[:select] || table_name+'.*'}, t0.#{reflection.primary_key_name} as the_parent_record_id",
+                  :order => options[:order])
+              end
+            end
+            set_association_collection_records(id_to_record_map, reflection.name, associated_records, 'the_parent_record_id')
+          end
+
+        elsif [3,0] == [ActiveRecord::VERSION::MAJOR, ActiveRecord::VERSION::MINOR]
+          # The Rails 3.0 method from association_preload.rb
+          def preload_has_and_belongs_to_many_association(records, reflection, preload_options={})
+            table_name = reflection.klass.quoted_table_name
+            id_to_record_map, ids = construct_id_map(records)
+            records.each {|record| record.send(reflection.name).loaded}
+            options = reflection.options
+
+            conditions = "t0.#{reflection.primary_key_name} #{in_or_equals_for_ids(ids)}"
+            conditions << append_conditions(reflection, preload_options)
+
+            # Make several queries with no more than 1000 ids in each one, combining the results into a single array
+            associated_records = []
+            ids.each_slice(MAX_IDS_PER_ORACLE_QUERY) do |safe_for_oracle_ids|
+              associated_records += reflection.klass.unscoped.where([conditions, safe_for_oracle_ids]).
+                  includes(options[:include]).
+                  joins("INNER JOIN #{connection.quote_table_name options[:join_table]} t0 ON #{reflection.klass.quoted_table_name}.#{reflection.klass.primary_key} = t0.#{reflection.association_foreign_key}").
+                  select("#{options[:select] || table_name+'.*'}, t0.#{reflection.primary_key_name} as the_parent_record_id").
+                  order(options[:order]).to_a
+            end
+
+            set_association_collection_records(id_to_record_map, reflection.name, associated_records, 'the_parent_record_id')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/active_record/connection_adapters/oracle_enhanced_activerecord_patches_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_activerecord_patches_spec.rb
@@ -1,0 +1,65 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+
+# This is a scenario you may hit if you are generating a report to download with many, many rows
+describe 'avoiding ORA-01795: maximum number of expressions in a list is 1000' do
+  include SchemaSpecHelper
+
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @conn = ActiveRecord::Base.connection
+  end
+
+  before(:all) do
+    schema_define do
+      create_table :posts do |t|
+        t.string      :body
+      end
+      create_table :comments do |t|
+        t.string      :comment
+        t.integer     :post_id
+      end
+      create_table :tags do |t|
+        t.string      :name
+      end
+      create_table :posts_tags, :id=>false do |t|
+        t.integer     :post_id
+        t.integer     :tag_id
+      end
+    end
+    class ::Comment < ActiveRecord::Base; end
+    class ::Tag < ActiveRecord::Base; end
+    class ::Post < ActiveRecord::Base
+      has_many :comments
+      has_and_belongs_to_many :tags
+    end
+  end
+
+  after(:all) do
+    schema_define do
+      drop_table :comments
+      drop_table :posts
+      drop_table :tags
+      drop_table :posts_tags
+    end
+    Object.send(:remove_const, "Post")
+    Object.send(:remove_const, "Comment")
+    Object.send(:remove_const, "Tag")
+  end
+
+
+  it 'should split a has_many :include into multiple requests to avoid 1000 limit' do
+    1001.times { Post.create(:comments=>[Comment.new]) }
+
+    lambda {
+      Post.all(:include=>:comments)
+    }.should_not raise_error ActiveRecord::StatementInvalid, /ORA-01795/
+  end
+
+  it 'should split HABTM :include into multiple requests to avoid 1000 limit' do
+    1001.times { Post.create(:tags=>[Tag.new])}
+
+    lambda {
+      Post.all(:include=>:tags)
+    }.should_not raise_error ActiveRecord::StatementInvalid, /ORA-01795/
+  end
+end


### PR DESCRIPTION
 Patch to ActiveRecord to avoid "ORA-01795: maximum number of expressions in a list is 1000" errors

This can happen when including more than 1000 associated records in a preloaded query such as 
Post.all(:include=>:comments) when a Post has_many :comments
or Post.all(:include=>:tags) when a Post has_and_belongs_to_many :tags

The has_many case is fairly clean and works through inheritance and super but the habtm case requires pasting the active record implementation here and overriding itso will need to be checked and updated if/when active record's implementation of preload_has_and_belongs_to_many_association changes in assocation_preload.rb

I tested with MRI 1.8.7 against ActiveRecord 2.3.5 and 3.0.1.
