### PR TITLE
Limit length of IDs in rails 3.0.4

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -324,6 +324,7 @@ module ActiveRecord
       def in_clause_length
         1000
       end
+      alias ids_in_list_limit in_clause_length
 
       # QUOTING ==================================================
       #


### PR DESCRIPTION
The commit that changes ids_in_list_limit to in_clause_length was not on the 3-0-stable branch of rails, which means that the error fixed by this method still occurs
