### PR TITLE
Fixed schema dump with multiple adapters

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_dumper.rb
@@ -105,6 +105,9 @@ module ActiveRecord #:nodoc:
       end
 
       def indexes_with_oracle_enhanced(table, stream)
+        abcs = ActiveRecord::Base.configurations
+        rails_env = defined?(Rails.env) ? Rails.env : RAILS_ENV
+        return indexes_without_oracle_enhanced(table, stream) unless abcs[rails_env]['adapter'] == 'oracle_enhanced'
         if (indexes = @connection.indexes(table)).any?
           add_index_statements = indexes.map do |index|
             case index.type


### PR DESCRIPTION
Hi,

I've run into a bug where I'm connecting to multiple databases, one of which is mysql (`mysql2` gem). The mysql connection is primary but when I also use the oracle enhanced adapter, `rake db:schema:dump` fails silently with an error message in `db/schema.rb`:

```
# Could not dump table "report_templates" because of following NoMethodError
#   undefined method `type' for #<ActiveRecord::ConnectionAdapters::IndexDefinition:0x000001032814b0>
```

The corresponding migration is:

```
class CreateReportTemplates < ActiveRecord::Migration
  def self.up
    create_table :report_templates do |t|
      t.string :name, :null => false

      t.timestamps
    end

    add_index :report_templates, :name, :unique => true
  end

  def self.down
    drop_table :report_templates
  end
end
```

You can reproduce this issue by doing the following:
1. create a new app using the `mysql2` adapter (or another non-oracle one)
2. generate a model and add an index to the migration file with `add_index`
3. add `ruby-oci8` and `activerecord-oracle_enhanced-adapter` gems to your Gemfile
4. migrate

and you will see a similar error in `db/schema.rb`

I've patched `oracle_enhanced_schema_dumper.rb` to resolve this issue.

_Luca Bernardo Ciddio_
