### PR TITLE
Fixed a failure for "structure dump should dump virtual columns"

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
@@ -147,7 +147,7 @@ describe "OracleEnhancedAdapter structure dump" do
         )
       SQL
       dump = ActiveRecord::Base.connection.structure_dump
-      dump.should =~ /ID_PLUS NUMBER GENERATED ALWAYS AS \(ID\+2\) VIRTUAL/
+      dump.should =~ /"ID_PLUS\" NUMBER GENERATED ALWAYS AS \(ID\+2\) VIRTUAL/
     end
   
     it "should dump unique keys" do


### PR DESCRIPTION
Hi,

When I execute rake spec for Oracle enhanced adapter, always got a following failure.
This pull request fix this failure and work in my environment ( Oracle Database 11gR2, ruby 1.9.2 and Rails 3.1.0 RC4).

Although I'm not sure if this reproduces at other environments, I made a pull request for this failure.

  1) OracleEnhancedAdapter structure dump structure dump should dump virtual columns
     Failure/Error: dump.should =~ /ID_PLUS NUMBER GENERATED ALWAYS AS (ID+2) VIRTUAL/
       expected: /ID_PLUS NUMBER GENERATED ALWAYS AS (ID+2) VIRTUAL/
            got: "CREATE SEQUENCE \"FOOS_SEQ\"\n\n/\n\nCREATE SEQUENCE 

``` ruby
$ rake spec


(in /home/yahonda/Dropbox/git/oracle-enhanced)
rake/rdoctask is deprecated.  Use rdoc/task instead (in RDoc 2.4.2+)
/usr/local/bin/ruby -S bundle exec rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_emulate_oracle_adapter_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_dbms_output_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_core_ext_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_cpk_spec.rb
==> Running specs with MRI version 1.9.2
==> Running specs with Rails version 3.1.0.rc4
/home/yahonda/Dropbox/git/oracle-enhanced/spec/spec_helper.rb:188: warning: variable $KCODE is no longer effective; ignored
................................................................................................................................................................F......................................................................................................*.............................................

Pending:
  OracleEnhancedAdapter database session store should have one enhanced_write_lobs callback
    # Not in this ActiveRecord version
    # ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:100

Failures:

  1) OracleEnhancedAdapter structure dump structure dump should dump virtual columns
     Failure/Error: dump.should =~ /ID_PLUS NUMBER GENERATED ALWAYS AS \(ID\+2\) VIRTUAL/
       expected: /ID_PLUS NUMBER GENERATED ALWAYS AS \(ID\+2\) VIRTUAL/
            got: "CREATE SEQUENCE \"FOOS_SEQ\"\n\n/\n\nCREATE SEQUENCE \"TEST_POSTS_SEQ\"\n\n/\n\nCREATE TABLE \"BARS\" (\n\"ID\" NUMBER(38,0) NOT NULL,\n \"ID_PLUS\" NUMBER GENERATED ALWAYS AS (ID+2) VIRTUAL,\n CONSTRAINT SYS_C0083526 PRIMARY KEY (ID)\n)\n\n/\n\n\n\n/\n\n\n\n/\n\nCREATE TABLE \"FOOS\" (\n\"ID\" NUMBER(38,0) NOT NULL,\n CONSTRAINT SYS_C0083524 PRIMARY KEY (ID)\n)\n\n/\n\n\n\n/\n\n\n\n/\n\nCREATE TABLE \"TEST_POSTS\" (\n\"ID\" NUMBER(38,0) NOT NULL,\n \"TITLE\" VARCHAR2(255),\n \"FOO\" VARCHAR2(255),\n \"FOO_ID\" NUMBER(38,0),\n CONSTRAINT SYS_C0083522 PRIMARY KEY (ID)\n)\n\n/\n\n\n\n/\n\n\n\n/\n\n" (using =~)
       Diff:
       @@ -1,2 +1,57 @@
       -/ID_PLUS NUMBER GENERATED ALWAYS AS \(ID\+2\) VIRTUAL/
       +CREATE SEQUENCE "FOOS_SEQ"
       +
       +/
       +
       +CREATE SEQUENCE "TEST_POSTS_SEQ"
       +
       +/
       +
       +CREATE TABLE "BARS" (
       +"ID" NUMBER(38,0) NOT NULL,
       + "ID_PLUS" NUMBER GENERATED ALWAYS AS (ID+2) VIRTUAL,
       + CONSTRAINT SYS_C0083526 PRIMARY KEY (ID)
       +)
       +
       +/
       +
       +
       +
       +/
       +
       +
       +
       +/
       +
       +CREATE TABLE "FOOS" (
       +"ID" NUMBER(38,0) NOT NULL,
       + CONSTRAINT SYS_C0083524 PRIMARY KEY (ID)
       +)
       +
       +/
       +
       +
       +
       +/
       +
       +
       +
       +/
       +
       +CREATE TABLE "TEST_POSTS" (
       +"ID" NUMBER(38,0) NOT NULL,
       + "TITLE" VARCHAR2(255),
       + "FOO" VARCHAR2(255),
       + "FOO_ID" NUMBER(38,0),
       + CONSTRAINT SYS_C0083522 PRIMARY KEY (ID)
       +)
       +
       +/
       +
       +
       +
       +/
       +
       +
       +
       +/
     # /usr/local/lib/ruby/gems/1.9.1/gems/rspec-expectations-2.6.0/lib/rspec/expectations/fail_with.rb:29:in `fail_with'
     # /usr/local/lib/ruby/gems/1.9.1/gems/rspec-expectations-2.6.0/lib/rspec/matchers/operator_matcher.rb:48:in `fail_with_message'
     # /usr/local/lib/ruby/gems/1.9.1/gems/rspec-expectations-2.6.0/lib/rspec/matchers/operator_matcher.rb:70:in `__delegate_operator'
     # /usr/local/lib/ruby/gems/1.9.1/gems/rspec-expectations-2.6.0/lib/rspec/matchers/operator_matcher.rb:60:in `eval_match'
     # /usr/local/lib/ruby/gems/1.9.1/gems/rspec-expectations-2.6.0/lib/rspec/matchers/operator_matcher.rb:29:in `block in use_custom_matcher_or_delegate'
     # ./spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb:150:in `block (3 levels) in <top (required)>'
     # /usr/local/lib/ruby/gems/1.9.1/gems/rspec-core-2.6.4/lib/rspec/core/example.rb:48:in `instance_eval'
     # /usr/local/lib/ruby/gems/1.9.1/gems/rspec-core-2.6.4/lib/rspec/core/example.rb:48:in `block in run'
     # /usr/local/lib/ruby/gems/1.9.1/gems/rspec-core-2.6.4/lib/rspec/core/example.rb:107:in `with_around_hooks'
     # /usr/local/lib/ruby/gems/1.9.1/gems/rspec-core-2.6.4/lib/rspec/core/example.rb:45:in `run'
     # /usr/local/lib/ruby/gems/1.9.1/gems/rspec-core-2.6.4/lib/rspec/core/example_group.rb:294:in `block in run_examples'
     # /usr/local/lib/ruby/gems/1.9.1/gems/rspec-core-2.6.4/lib/rspec/core/example_group.rb:290:in `map'
     # /usr/local/lib/ruby/gems/1.9.1/gems/rspec-core-2.6.4/lib/rspec/core/example_group.rb:290:in `run_examples'
     # /usr/local/lib/ruby/gems/1.9.1/gems/rspec-core-2.6.4/lib/rspec/core/example_group.rb:262:in `run'
     # /usr/local/lib/ruby/gems/1.9.1/gems/rspec-core-2.6.4/lib/rspec/core/example_group.rb:263:in `block in run'
     # /usr/local/lib/ruby/gems/1.9.1/gems/rspec-core-2.6.4/lib/rspec/core/example_group.rb:263:in `map'
     # /usr/local/lib/ruby/gems/1.9.1/gems/rspec-core-2.6.4/lib/rspec/core/example_group.rb:263:in `run'
     # /usr/local/lib/ruby/gems/1.9.1/gems/rspec-core-2.6.4/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /usr/local/lib/ruby/gems/1.9.1/gems/rspec-core-2.6.4/lib/rspec/core/command_line.rb:24:in `map'
     # /usr/local/lib/ruby/gems/1.9.1/gems/rspec-core-2.6.4/lib/rspec/core/command_line.rb:24:in `block in run'
     # /usr/local/lib/ruby/gems/1.9.1/gems/rspec-core-2.6.4/lib/rspec/core/reporter.rb:12:in `report'
     # /usr/local/lib/ruby/gems/1.9.1/gems/rspec-core-2.6.4/lib/rspec/core/command_line.rb:21:in `run'
     # /usr/local/lib/ruby/gems/1.9.1/gems/rspec-core-2.6.4/lib/rspec/core/runner.rb:80:in `run_in_process'
     # /usr/local/lib/ruby/gems/1.9.1/gems/rspec-core-2.6.4/lib/rspec/core/runner.rb:69:in `run'
     # /usr/local/lib/ruby/gems/1.9.1/gems/rspec-core-2.6.4/lib/rspec/core/runner.rb:11:in `block in autorun'

Finished in 76.04 seconds
309 examples, 1 failure, 1 pending

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb:140 # OracleEnhancedAdapter structure dump structure dump should dump virtual columns
rake aborted!
ruby -S bundle exec rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_emulate_oracle_adapter_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_dbms_output_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_core_ext_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_cpk_spec.rb failed

Tasks: TOP => spec
(See full trace by running task with --trace)
```
