### PR TITLE
Add @oracle11g instance variable within schema_define to handle Oracle

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
@@ -348,6 +348,7 @@ describe "OracleEnhancedAdapter schema dump" do
   describe 'virtual columns' do
     before(:all) do
       schema_define do
+        @oracle11g = !! ActiveRecord::Base.connection.select_value("SELECT * FROM v$version WHERE banner LIKE 'Oracle%11g%'")
         create_table :test_names, :force => true do |t|
           t.string :first_name
           t.string :last_name

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -943,6 +943,7 @@ end
     before(:all) do
       schema_define do
         @expr = "( numerator/NULLIF(denominator,0) )*100"
+        @oracle11g = !! ActiveRecord::Base.connection.select_value("SELECT * FROM v$version WHERE banner LIKE 'Oracle%11g%'")
         create_table :test_fractions, :force => true do |t|
           t.integer :numerator, :default=>0
           t.integer :denominator, :default=>0


### PR DESCRIPTION
Add @oracle11g instance variable within schema_define to handle Oracle version correctly.
It fixes the issue #87. It also works with Oracle 10g(R2), marking these tests pending.
