### PR TITLE
Cache nil primary keys on tables that don't have a simple primary key.

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1078,7 +1078,12 @@ module ActiveRecord
       def pk_and_sequence_for(table_name, owner=nil, desc_table_name=nil, db_link=nil) #:nodoc:
         if @@cache_columns
           @@pk_and_sequence_for_cache ||= {}
-          @@pk_and_sequence_for_cache[table_name] ||= pk_and_sequence_for_without_cache(table_name, owner, desc_table_name, db_link)
+          pk_and_sequence = @@pk_and_sequence_for_cache[table_name]
+          unless @@pk_and_sequence_for_cache.include?(table_name)
+            pk_and_sequence = pk_and_sequence_for_without_cache(table_name, owner, desc_table_name, db_link)
+            @@pk_and_sequence_for_cache[table_name] = pk_and_sequence
+          end
+          pk_and_sequence
         else
           pk_and_sequence_for_without_cache(table_name, owner, desc_table_name, db_link)
         end

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -300,6 +300,14 @@ describe "OracleEnhancedAdapter" do
         @logger.logged(:debug).last.should be_blank
       end
 
+      it "should cache that a table does not have a primary key" do
+        TestEmployee.connection.pk_and_sequence_for('no_such_table').should == nil
+        @logger.logged(:debug).last.should =~ /select .* from all_constraints/im
+        @logger.clear(:debug)
+        TestEmployee.connection.pk_and_sequence_for('no_such_table').should == nil
+        @logger.logged(:debug).last.should be_blank
+      end
+
     end
 
   end


### PR DESCRIPTION
This change updates the pk_and_sequence_for method to cache a nil primary key for tables that don't have a single column primary key. The current behavior simply runs the query to find the primary key over and over if the table does not have a primary key.

In the application I'm working on, the primary key query is the highest consuming CPU query by a factor of four.

I tested the code in my application and added a spec. However, I am unable to actually run the spec since I do not have access to an Oracle development server.
