### PR TITLE
Only run class_eval on ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter if is defined.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,16 +114,18 @@ If you want to change Oracle enhanced adapter default settings then create initi
     ENV['TZ'] = 'UTC'
 
     ActiveSupport.on_load(:active_record) do
-      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.class_eval do
-        # id columns and columns which end with _id will always be converted to integers
-        self.emulate_integers_by_column_name = true
-        # DATE columns which include "date" in name will be converted to Date, otherwise to Time
-        self.emulate_dates_by_column_name = true
-        # true and false will be stored as 'Y' and 'N'
-        self.emulate_booleans_from_strings = true
-        # start primary key sequences from 1 (and not 10000) and take just one next value in each session
-        self.default_sequence_start_value = "1 NOCACHE INCREMENT BY 1"
-        # other settings ...
+      if ActiveRecord::ConnectionAdapters.const_defined?('OracleEnhancedAdapter')
+        ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.class_eval do
+          # id columns and columns which end with _id will always be converted to integers
+          self.emulate_integers_by_column_name = true
+          # DATE columns which include "date" in name will be converted to Date, otherwise to Time
+          self.emulate_dates_by_column_name = true
+          # true and false will be stored as 'Y' and 'N'
+          self.emulate_booleans_from_strings = true
+          # start primary key sequences from 1 (and not 10000) and take just one next value in each session
+          self.default_sequence_start_value = "1 NOCACHE INCREMENT BY 1"
+          # other settings ...
+        end
       end
     end
 


### PR DESCRIPTION
If you only use oracle-enhances in production, trying to run `class_eval` on ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter will fail in development mode. So: check for presence before calling.
