### PR TITLE
Update db:create and db:drop to allow non-SYSTEM user to be specified and for setup SQL scripts to be run

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,21 @@ There are several additional schema statements and data types available that you
         ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces =
           {:clob => 'TS_LOB', :blob => 'TS_LOB', :index => 'TS_INDEX', :table => 'TS_DATA'}
 
+### db:create and db:drop Rake Tasks
+
+You can use the `db:create` and `db:drop` rake tasks to prepare and destroy your schemas, respectively. If you have access to the SYSTEM account, these tasks will prompt you for its password. If not, add a `dbauser` entry to your database config file to specify the account to use for creating the new user and granting its initial permissions. For example:
+
+    development:
+      adapter: oracle_enhanced
+      database: xe
+      username: user
+      password: secret
+      dbauser: anotheruser
+
+Note that `db:create` first attempts to drop an existing user, so this is a convenient way to start your schema fresh.
+
+In many cases, in addition to creating your application user you will need to perform additional schema setup with elevated permissions as part of `db:create`. For example, you might need to create a DB Link or a set of public synonyms, but you don't want your app id to have access to create these objects. To accomodate this as part of the `db:create` process, any `*.sql` file found in the `db/` folder will be executed. These files expect one SQL command per line and will be run under the SYSTEM/dbauser account. Files will be processed in alphanumeric order.
+
 TROUBLESHOOTING
 ---------------
 

--- a/RUNNING_TESTS.md
+++ b/RUNNING_TESTS.md
@@ -7,6 +7,10 @@ If you are on a Mac OS X 10.6 then use [these instructions](http://blog.rayapps.
 
 If you are on Linux (or will use Linux virtual machine) and need Oracle DB just for running tests then Oracle DB XE edition is enough. See [Oracle XE downloads page](http://www.oracle.com/technetwork/database/express-edition/downloads/index.html) for download links and instructions.
 
+Create your database using the Unicode (AL32UTF8) database character set.
+
+If your database exists on a remote server, ensure that the server can resolve the database name otherwise the DB Link tests will fail. You may need to edit the server's TNSNAMES.ORA file.
+
 If you are getting ORA-12520 errors when running tests then it means that Oracle cannot create enough processes to handle many connections (as during tests many connections are created and destroyed). In this case you need to log in as SYSTEM user and execute e.g.
 
     alter system set processes=200 scope=spfile;
@@ -35,6 +39,10 @@ Running tests
 * Set RAILS_GEM_VERSION to Rails version that you would like to use in oracle_enhanced tests, e.g.
 
         export RAILS_GEM_VERSION=3.0.3
+
+* Set NLS_LANG to handle Unicode tests, for example:
+
+		export NLS_LANG=AMERICAN_AMERICA.UTF8
 
 * Install necessary gems with
 

--- a/Rakefile
+++ b/Rakefile
@@ -22,6 +22,7 @@ EOS
   gem.homepage = "http://github.com/rsim/oracle-enhanced"
   gem.authors = ["Raimonds Simanovskis"]
   gem.extra_rdoc_files = ['README.md']
+  gem.add_runtime_dependency "highline"
 end
 Jeweler::RubygemsDotOrgTasks.new
 

--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Raimonds Simanovskis"]
-  s.date = %q{2011-08-09}
+  s.date = %q{2011-09-12}
   s.description = %q{Oracle "enhanced" ActiveRecord adapter contains useful additional methods for working with new and legacy Oracle databases.
 This adapter is superset of original ActiveRecord Oracle adapter.
 }
@@ -66,7 +66,7 @@ This adapter is superset of original ActiveRecord Oracle adapter.
   ]
   s.homepage = %q{http://github.com/rsim/oracle-enhanced}
   s.require_paths = ["lib"]
-  s.rubygems_version = %q{1.6.2}
+  s.rubygems_version = %q{1.3.7}
   s.summary = %q{Oracle enhanced adapter for ActiveRecord}
   s.test_files = [
     "spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb",
@@ -86,42 +86,40 @@ This adapter is superset of original ActiveRecord Oracle adapter.
   ]
 
   if s.respond_to? :specification_version then
+    current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_development_dependency(%q<jeweler>, ["~> 1.5.1"])
       s.add_development_dependency(%q<rspec>, ["~> 2.4"])
-      s.add_development_dependency(%q<activerecord>, [">= 0"])
-      s.add_development_dependency(%q<activemodel>, [">= 0"])
-      s.add_development_dependency(%q<activesupport>, [">= 0"])
-      s.add_development_dependency(%q<actionpack>, [">= 0"])
-      s.add_development_dependency(%q<railties>, [">= 0"])
-      s.add_development_dependency(%q<arel>, [">= 0"])
+      s.add_development_dependency(%q<activerecord>, ["= 3.1.0"])
+      s.add_development_dependency(%q<actionpack>, ["= 3.1.0"])
+      s.add_development_dependency(%q<activesupport>, ["= 3.1.0"])
+      s.add_development_dependency(%q<railties>, ["= 3.1.0"])
       s.add_development_dependency(%q<ruby-plsql>, [">= 0.4.4"])
       s.add_development_dependency(%q<ruby-oci8>, ["~> 2.0.4"])
+      s.add_runtime_dependency(%q<highline>, [">= 0"])
     else
       s.add_dependency(%q<jeweler>, ["~> 1.5.1"])
       s.add_dependency(%q<rspec>, ["~> 2.4"])
-      s.add_dependency(%q<activerecord>, [">= 0"])
-      s.add_dependency(%q<activemodel>, [">= 0"])
-      s.add_dependency(%q<activesupport>, [">= 0"])
-      s.add_dependency(%q<actionpack>, [">= 0"])
-      s.add_dependency(%q<railties>, [">= 0"])
-      s.add_dependency(%q<arel>, [">= 0"])
+      s.add_dependency(%q<activerecord>, ["= 3.1.0"])
+      s.add_dependency(%q<actionpack>, ["= 3.1.0"])
+      s.add_dependency(%q<activesupport>, ["= 3.1.0"])
+      s.add_dependency(%q<railties>, ["= 3.1.0"])
       s.add_dependency(%q<ruby-plsql>, [">= 0.4.4"])
       s.add_dependency(%q<ruby-oci8>, ["~> 2.0.4"])
+      s.add_dependency(%q<highline>, [">= 0"])
     end
   else
     s.add_dependency(%q<jeweler>, ["~> 1.5.1"])
     s.add_dependency(%q<rspec>, ["~> 2.4"])
-    s.add_dependency(%q<activerecord>, [">= 0"])
-    s.add_dependency(%q<activemodel>, [">= 0"])
-    s.add_dependency(%q<activesupport>, [">= 0"])
-    s.add_dependency(%q<actionpack>, [">= 0"])
-    s.add_dependency(%q<railties>, [">= 0"])
-    s.add_dependency(%q<arel>, [">= 0"])
+    s.add_dependency(%q<activerecord>, ["= 3.1.0"])
+    s.add_dependency(%q<actionpack>, ["= 3.1.0"])
+    s.add_dependency(%q<activesupport>, ["= 3.1.0"])
+    s.add_dependency(%q<railties>, ["= 3.1.0"])
     s.add_dependency(%q<ruby-plsql>, [">= 0.4.4"])
     s.add_dependency(%q<ruby-oci8>, ["~> 2.0.4"])
+    s.add_dependency(%q<highline>, [">= 0"])
   end
 end
 


### PR DESCRIPTION
I think the recent changes to include db:commit and db:drop are a welcome addition, but in our shop, we don't have access to the SYSTEM account. As such, please consider adding these changes which allow you to specify a "dbauser" entry in your database config so you can run db:create as a different user with elevated privileges. Note that it will default to SYSTEM if this entry is not included.

As part of our database schema setup, we frequently assign special roles or create special objects, and we don't want (i.e. aren't allowed) our application userid to have the elevated privileges necessary to do some of these things. As such, I updated the db:create task to look for "db/*.sql" files and execute the commands that they contain as the SYSTEM/dbauser user, sort of like migrations but as raw SQL. This works well in our shop and I thought I'd include it for consideration.

I also updated RUNNING_TESTS to describe how to set up your test database to handle Unicode (thanks for your prior advice on this btw) and the README to describe the above behaviour.

Steve
