### PR TITLE
Cpk write lob and 3.1 fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :development do
       gem 'composite_primary_keys', '=2.3.2'
     when /^3/
       gem 'railties', "=#{ENV['RAILS_GEM_VERSION']}"
+      gem 'composite_primary_keys', '=4.0.0'
     end
   else
     # uses local copy of Rails 3 and Arel gems

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -380,6 +380,14 @@ module ActiveRecord
       # see: abstract/quoting.rb
 
       def quote_column_name(name) #:nodoc:
+	if name.class == Array #cpk -- resursively process all of the elements
+	 result = ""
+	 name.each do |component_key|
+		result += quote_column_name(component_key)
+		result += ", " if component_key != name.last
+	 end
+	 return result
+	end
         name = name.to_s
         @quoted_column_names[name] ||= begin
           # if only valid lowercase column characters in name
@@ -667,7 +675,7 @@ module ActiveRecord
       # New method in ActiveRecord 3.1
       # Will add RETURNING clause in case of trigger generated primary keys
       def sql_for_insert(sql, pk, id_value, sequence_name, binds)
-        unless id_value || pk.nil?
+        unless id_value || pk.nil? || pk.is_a?(Array) #don't do this for cpk
           sql = "#{sql} RETURNING #{quote_column_name(pk)} INTO :returning_id"
           (binds = binds.dup) << [:returning_id, nil]
         end

--- a/spec/active_record/connection_adapters/oracle_enhanced_cpk_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_cpk_spec.rb
@@ -33,10 +33,12 @@ describe "OracleEnhancedAdapter composite_primary_keys support" do
   describe "do not use count distinct" do
     before(:all) do
       schema_define do
-        create_table :job_history, :primary_key => [:employee_id, :start_date], :force => true do |t|
+        create_table :job_history, :id => false, :force => true do |t|
           t.integer :employee_id
           t.date    :start_date
         end
+	execute "ALTER TABLE job_history ADD CONSTRAINT job_history_ID_PK PRIMARY KEY (employee_id, start_date)"
+
       end
       class ::JobHistory < ActiveRecord::Base
         set_table_name "job_history"
@@ -63,12 +65,14 @@ describe "OracleEnhancedAdapter composite_primary_keys support" do
   describe "table with LOB" do
     before(:all) do
       schema_define do
-        create_table  :cpk_write_lobs_test, :primary_key => [:type_category, :date_value], :force => true do |t|
+        create_table  :cpk_write_lobs_test, :id => false, :force => true do |t|
           t.string  :type_category, :limit => 15, :null => false  
           t.date    :date_value, :null => false
           t.text    :results, :null => false
           t.timestamps
         end
+	execute "ALTER TABLE cpk_write_lobs_test ADD CONSTRAINT cpk_write_lobs_test_ID_PK PRIMARY KEY (type_category, date_value)"
+
         create_table :non_cpk_write_lobs_test, :force => true do |t|
           t.date    :date_value, :null => false
           t.text    :results, :null => false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ elsif RUBY_ENGINE == 'jruby'
 end
 
 ENV['RAILS_GEM_VERSION'] ||= '3.1-master'
-NO_COMPOSITE_PRIMARY_KEYS = true if ENV['RAILS_GEM_VERSION'] >= '2.3.5' || ENV['RAILS_GEM_VERSION'] =~ /^2\.3\.1\d$/
+#NO_COMPOSITE_PRIMARY_KEYS = true #if ENV['RAILS_GEM_VERSION'] >= '2.3.5' || ENV['RAILS_GEM_VERSION'] =~ /^2\.3\.1\d$/
 
 puts "==> Running specs with Rails version #{ENV['RAILS_GEM_VERSION']}"
 


### PR DESCRIPTION
enabled cpk for rails 3.0/3.1 with cpk 4.0.  some fixes for tests not generating primary keys correctly and also deal with quoting the pk.     Please review.
