### PR TITLE
Make it easier to run specs with rails master

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,14 +21,25 @@ group :development do
       gem 'railties', "=#{ENV['RAILS_GEM_VERSION']}"
     end
   else
-    # uses local copy of Rails 3 and Arel gems
-    ENV['RAILS_GEM_PATH'] ||= File.expand_path('../../rails', __FILE__)
     %w(activerecord activemodel activesupport actionpack railties).each do |gem_name|
-      gem gem_name, :path => File.join(ENV['RAILS_GEM_PATH'], gem_name)
+      if ENV['RAILS_GEM_PATH']
+        gem gem_name, :path => File.join(ENV['RAILS_GEM_PATH'], gem_name)
+      else
+        gem gem_name, :git => "git://github.com/rails/rails"
+      end
     end
 
-    ENV['AREL_GEM_PATH'] ||= File.expand_path('../../arel', __FILE__)
-    gem 'arel', :path => ENV['AREL_GEM_PATH']
+    if ENV['AREL_GEM_PATH']
+      gem 'arel', :path => ENV['AREL_GEM_PATH']
+    else
+      gem 'arel', :git => "git://github.com/rails/arel"
+    end
+
+    if ENV['JOURNEY_GEM_PATH']
+      gem 'journey', :path => ENV['JOURNEY_GEM_PATH']
+    else
+      gem "journey", :git => "git://github.com/rails/journey"
+    end
   end
 
   gem 'ruby-plsql', '>=0.4.4'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,7 @@ elsif RUBY_ENGINE == 'jruby'
   puts "==> Running specs with JRuby version #{JRUBY_VERSION}"
 end
 
-ENV['RAILS_GEM_VERSION'] ||= '3.1-master'
+ENV['RAILS_GEM_VERSION'] ||= '3.2-master'
 NO_COMPOSITE_PRIMARY_KEYS = true if ENV['RAILS_GEM_VERSION'] >= '2.3.5' || ENV['RAILS_GEM_VERSION'] =~ /^2\.3\.1\d$/
 
 puts "==> Running specs with Rails version #{ENV['RAILS_GEM_VERSION']}"
@@ -23,6 +23,7 @@ require 'active_record'
 if ENV['RAILS_GEM_VERSION'] >= '3.0'
   require 'action_dispatch'
   require 'active_support/core_ext/module/attribute_accessors'
+  require 'active_support/core_ext/class/attribute_accessors'
 
   if ENV['RAILS_GEM_VERSION'] =~ /^3.0.0.beta/
     require "rails/log_subscriber"


### PR DESCRIPTION
Not everyone has rails, arel checkout out in `../../`.
So now if RAILS_GEM_PATH, AREL_GEM_PATH is not set, gems will be taken from github.
