### PR TITLE
Fix for issue #98

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -666,8 +666,9 @@ module ActiveRecord
 
       # New method in ActiveRecord 3.1
       # Will add RETURNING clause in case of trigger generated primary keys
+      # Don't do RETURNING when there is a composite primary key (makes little sense).
       def sql_for_insert(sql, pk, id_value, sequence_name, binds)
-        unless id_value || pk.nil?
+        unless id_value || pk.nil? || pk.is_a?(Array)
           sql = "#{sql} RETURNING #{quote_column_name(pk)} INTO :returning_id"
           (binds = binds.dup) << [:returning_id, nil]
         end


### PR DESCRIPTION
Skip clause for RETURNING when doing inserts of records using composite primary keys. RETURNING is used for getting last inserted id which doesn't make a lot of sense to do when having CPKs.
