### PR TITLE
Add rename_constraint, rename_default_primary_key_constraint and rename_default_foreign_key_constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,12 +267,12 @@ There are several additional schema statements and data types available that you
 
         rename_constraint("TEST_POSTS", "TEST_POSTS_PK", "NEW_TEST_POSTS_PK")
 
-  * `rename_default_primary_key` and `rename_default_foreign_key` to rename them from 'SYS_C%' to '%_PK' and '%_FK'
+  * `rename_default_primary_key_constraint` and `rename_default_foreign_key_constraint` to rename them from 'SYS_C%' to '%_PK' and '%_FK'
 
-        # rename a primary key name from 'SYS_C%' to "PRODUCTS_PK"
-        rename_default_primary_key("PRODUCTS")
-        # rename a foreign key name from 'SYS_C%' to "ORDER_ITEMS_PRODUCTS_FK"
-        rename_default_foreign_key("ORDER_ITEMS")
+        # rename a primary key constraint name from 'SYS_C%' to "PRODUCTS_PK"
+        rename_default_primary_key_constraint("PRODUCTS")
+        # rename a foreign key constraint name from 'SYS_C%' to "ORDER_ITEMS_PRODUCTS_FK"
+        rename_default_foreign_key_constraint("ORDER_ITEMS")
 
 
 

--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
@@ -225,7 +225,7 @@ module ActiveRecord
         execute "ALTER TABLE #{quote_table_name(table_name)} RENAME CONSTRAINT #{quote_column_name(constraint_name)} TO #{quote_column_name(new_constraint_name)}"
       end
 
-      def rename_default_primary_key(table_name)
+      def rename_default_primary_key_constraint(table_name)
         table_name.upcase!
         unless table_exists?(table_name)
           raise ArgumentError, "Table name '#{table_name} does not exist"
@@ -246,7 +246,7 @@ module ActiveRecord
         rename_index(table_name, index_name, new_index_name)
       end
 
-      def rename_default_foreign_key(table_name)
+      def rename_default_foreign_key_constraint(table_name)
         table_name.upcase!
         unless table_exists?(table_name)
           raise ArgumentError, "Table name '#{table_name} does not exist"

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -558,7 +558,7 @@ end
 
   end
 
-  describe "rename default primary key and foreign key name" do
+  describe "rename default primary key constraint name and foreign key constraint name" do
     before(:each) do
       @conn = ActiveRecord::Base.connection
       schema_define do
@@ -589,68 +589,68 @@ end
       ActiveRecord::Base.clear_cache! if ActiveRecord::Base.respond_to?(:"clear_cache!")
      end
 
-    it "should rename primary key name of referenced table in UPPERCASE" do
+    it "should rename primary key constraint name of referenced table in UPPERCASE" do
       lambda do
-        @conn.rename_default_primary_key("TEST_POSTS")
+        @conn.rename_default_primary_key_constraint("TEST_POSTS")
       end.should_not raise_error
     end
 
-    it "should rename primary key name of referenced table in lowercase" do
+    it "should rename primary key constraint name of referenced table in lowercase" do
       lambda do
-        @conn.rename_default_primary_key("test_posts")
+        @conn.rename_default_primary_key_constraint("test_posts")
       end.should_not raise_error
     end
 
-    it "should rename primary key name of referencing table in UPPERCASE" do
+    it "should rename primary key constraint name of referencing table in UPPERCASE" do
       lambda do
-        @conn.rename_default_primary_key("TEST_COMMENTS")
+        @conn.rename_default_primary_key_constraint("TEST_COMMENTS")
       end.should_not raise_error
     end
 
-    it "should rename primary key name of referencing table in lowercase" do
+    it "should rename primary key constraint name of referencing table in lowercase" do
       lambda do
-        @conn.rename_default_primary_key("test_comments")
+        @conn.rename_default_primary_key_constraint("test_comments")
       end.should_not raise_error
     end
 
-    it "should raise error rename primary key name of nonexist table in UPPERCASE" do
+    it "should raise error rename primary key constraint name of nonexist table in UPPERCASE" do
       lambda do
-        @conn.rename_default_primary_key("NONEXIST_TABLE_NAME")
+        @conn.rename_default_primary_key_constraint("NONEXIST_TABLE_NAME")
       end.should raise_error
     end
 
-    it "should raise error rename primary key name of nonexist table in lowercase" do
+    it "should raise error rename primary key constraint name of nonexist table in lowercase" do
       lambda do
-        @conn.rename_default_primary_key("nonexist_table_name")
+        @conn.rename_default_primary_key_constraint("nonexist_table_name")
       end.should raise_error
     end
 
-    it "should rename foreign key name of referencing table in UPPERCASE" do
+    it "should rename foreign key constraint name of referencing table in UPPERCASE" do
       lambda do
-        @conn.rename_default_foreign_key("TEST_COMMENTS")
+        @conn.rename_default_foreign_key_constraint("TEST_COMMENTS")
       end.should_not raise_error
     end
 
-    it "should rename foreign key name of referencing table in lowercase" do
+    it "should rename foreign key constraint name of referencing table in lowercase" do
       lambda do
-        @conn.rename_default_foreign_key("test_comments")
+        @conn.rename_default_foreign_key_constraint("test_comments")
       end.should_not raise_error
     end
 
-    it "should raise error rename foreign key name of nonexist table in UPPERCASE" do
+    it "should raise error rename foreign key constraint name of nonexist table in UPPERCASE" do
       lambda do
-        @conn.rename_default_foreign_key("NONEXIST_TABLE_NAME")
+        @conn.rename_default_foreign_key_constraint("NONEXIST_TABLE_NAME")
       end.should raise_error
     end
 
-    it "should raise error rename foreign key name of nonexist table in lowercase" do
+    it "should raise error rename foreign key constraint name of nonexist table in lowercase" do
       lambda do
-        @conn.rename_default_foreign_key("nonexist_table_name")
+        @conn.rename_default_foreign_key_constraint("nonexist_table_name")
       end.should raise_error
     end
   end
 
-  describe "rename default primary key and multiple foreign keys name" do
+  describe "rename default primary key constraint names and multiple foreign constraint key names" do
     before(:each) do
       @conn = ActiveRecord::Base.connection
       schema_define do
@@ -695,15 +695,15 @@ end
       ActiveRecord::Base.clear_cache! if ActiveRecord::Base.respond_to?(:"clear_cache!")
     end
 
-    it "should rename multiple foreign keys name of referencing table in UPPERCASE" do
+    it "should rename multiple foreign key constraint names of referencing table in UPPERCASE" do
       lambda do
-        @conn.rename_default_foreign_key("ORDER_ITEMS")
+        @conn.rename_default_foreign_key_constraint("ORDER_ITEMS")
       end.should_not raise_error
     end
 
-    it "should rename multiple foreign keys name of referencing table in lowercase" do
+    it "should rename multiple foreign key constraint names of referencing table in lowercase" do
       lambda do
-        @conn.rename_default_foreign_key("order_items")
+        @conn.rename_default_foreign_key_constraint("order_items")
       end.should_not raise_error
     end
   end


### PR DESCRIPTION
Tried to add a commit for the pull request #121, got following messages and --force option does not make any change for the issue #121. I've just created a new pull request which includes method name change as discussed.

```
$ git push origin squashed_rename_constraint
To git@github.com:yahonda/oracle-enhanced.git
 ! [rejected]        squashed_rename_constraint -> squashed_rename_constraint (non-fast-forward)
error: failed to push some refs to 'git@github.com:yahonda/oracle-enhanced.git'
To prevent you from losing history, non-fast-forward updates were rejected
Merge the remote changes before pushing again.  See the 'Note about
fast-forwards' section of 'git push --help' for details.
[1.9.3@rails_master] yahonda@myoel6 ~/Dropbox/git/oracle-enhanced (squashed_rename_constraint) 
$ git push origin squashed_rename_constraint --force
Counting objects: 20, done.
Delta compression using up to 2 threads.
Compressing objects: 100% (9/9), done.
Writing objects: 100% (11/11), 1.63 KiB, done.
Total 11 (delta 5), reused 0 (delta 0)
To git@github.com:yahonda/oracle-enhanced.git
 + eddd8e7...86fd851 squashed_rename_constraint -> squashed_rename_constraint (forced update)
[1.9.3@rails_master] yahonda@myoel6 ~/Dropbox/git/oracle-enhanced (squashed_rename_constraint) 
```
