### PR TITLE
Bugfix: Enable connection to ASM instances

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_jdbc_connection.rb
@@ -124,8 +124,11 @@ module ActiveRecord
           # @raw_connection.setDefaultRowPrefetch(prefetch_rows) if prefetch_rows
         end
 
-        cursor_sharing = config[:cursor_sharing] || 'force'
-        exec "alter session set cursor_sharing = #{cursor_sharing}"
+        # Check if it's an ASM instance as cursor sharing can't be set on ASM
+      	if select("select value from v$parameter where name='instance_type'")[0]['value'] != 'asm'
+          cursor_sharing = config[:cursor_sharing] || 'force'
+          exec "alter session set cursor_sharing = #{cursor_sharing}"
+        end
 
         # Initialize NLS parameters
         OracleEnhancedAdapter::DEFAULT_NLS_PARAMETERS.each do |key, default_value|


### PR DESCRIPTION
If this check is not done it is not possible to connect to an ASM instance using the adapter, as you cannot do alter session cursor_sharing in an ASM. Trying to do causes an 'ORA-15000: command disallowed by current instance type (NativeException)' exception.