### PR TITLE
Add visitor to Oracle enhanced adapter

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -271,6 +271,7 @@ module ActiveRecord
         @config = config
         @statements = StatementPool.new(connection, config.fetch(:statement_limit) { 300 })
         @enable_dbms_output = false
+        @visitor = Arel::Visitors::Oracle.new self
       end
 
       def self.visitor_for(pool) # :nodoc:


### PR DESCRIPTION
Since the following commit, 

https://github.com/rails/rails/commit/bd2f5c062da011e092c1f122567f24bd5fc6d9b5 

ActiveRecord unit tests for Oracle got bunch of errors and failures.
This commit add a visitor to oracle-enhanced. 

``` ruby
  1) Error:
test_find_one_uses_binds(ActiveRecord::BindParameterTest):
NoMethodError: undefined method `accept' for nil:NilClass
    /home/yahonda/Dropbox/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:7:in `to_sql'
    /home/yahonda/Dropbox/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:16:in `select_all'
    /home/yahonda/Dropbox/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:63:in `select_all'
    /home/yahonda/Dropbox/git/rails/activerecord/lib/active_record/base.rb:476:in `find_by_sql'
    /home/yahonda/Dropbox/git/rails/activerecord/lib/active_record/relation.rb:169:in `to_a'
    /home/yahonda/Dropbox/git/rails/activerecord/lib/active_record/relation/finder_methods.rb:377:in `find_first'
    /home/yahonda/Dropbox/git/rails/activerecord/lib/active_record/relation/finder_methods.rb:122:in `first'
    /home/yahonda/Dropbox/git/rails/activerecord/lib/active_record/relation/finder_methods.rb:335:in `find_one'
    /home/yahonda/Dropbox/git/rails/activerecord/lib/active_record/relation/finder_methods.rb:311:in `find_with_ids'
    /home/yahonda/Dropbox/git/rails/activerecord/lib/active_record/relation/finder_methods.rb:107:in `find'
    /home/yahonda/Dropbox/git/rails/activerecord/lib/active_record/base.rb:444:in `find'
    /home/yahonda/Dropbox/git/rails/activerecord/test/cases/bind_parameter_test.rb:50:in `test_find_one_uses_binds'
    /home/yahonda/.rvm/gems/ruby-1.9.3-p0@rails_master/gems/mocha-0.10.0/lib/mocha/integration/mini_test/version_230_to_251.rb:28:in `run'
... snip ...
3102 tests, 2561 assertions, 144 failures, 2248 errors, 0 skips
rake aborted!
Command failed with status (88): [/home/yahonda/.rvm/rubies/ruby-1.9.3-p0/bi...]

Tasks: TOP => test_oracle
(See full trace by running task with --trace)
```
