### PR TITLE
An exception "ORA-01722: invalid number" is raised on creating a record in the table with a column of decimal type.

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb
@@ -127,6 +127,8 @@ module ActiveRecord
               @raw_cursor.bind_param(position, ora_value)
             when :raw
               @raw_cursor.bind_param(position, OracleEnhancedAdapter.encode_raw(value))
+            when :decimal
+              @raw_cursor.bind_param(position, BigDecimal.new(value.to_s))
             else
               @raw_cursor.bind_param(position, value)
             end


### PR DESCRIPTION
example of sql query from console log:
INSERT INTO "T_PAYMENT_TYPE" ("DELETED", "ID", "NAME", "NOTE", "PRICE") VALUES (: a1,: a2,: a3,: a4,: a5) [["deleted", false ], ["id", 121], ["name", "test"], ["note", "test"], ["price", #<BigDecimal: 7acbd70, '0 .123 E3 ', 9 (18) >]]

I fixed it by adding handling of decimal columns in method
ActiveRecord::ConnectionAdapters::OracleEnhancedOCIConnection::Cursor#bind_param
