### PR TITLE
Don't add the RETURNING clause if using composite_primary_keys gem

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -675,7 +675,7 @@ module ActiveRecord
       # New method in ActiveRecord 3.1
       # Will add RETURNING clause in case of trigger generated primary keys
       def sql_for_insert(sql, pk, id_value, sequence_name, binds)
-        unless id_value || pk.nil?
+        unless id_value || pk.nil? || (defined?(CompositePrimaryKeys) && pk.kind_of?(CompositePrimaryKeys::CompositeKeys))
           sql = "#{sql} RETURNING #{quote_column_name(pk)} INTO :returning_id"
           (binds = binds.dup) << [:returning_id, nil]
         end


### PR DESCRIPTION
The RETURNING clause, added for AR 3.1, returns into a single parameter. There are a few potential fixes for this. The composite_primary_keys gem should be updated to override the insert method, such that the primary_keys_value parameter to connection.insert is properly populated (as an array of values, or a hash). Barring this fix, oracle_enhanced should guard against adding the RETURNING clause. Either that, or the RETURNING clause should be updated to support returning into multiple parameters.
