### PR TITLE
Add error handlings for the rename_table method.

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -369,6 +369,11 @@ module ActiveRecord
         IDENTIFIER_MAX_LENGTH
       end
 
+      # the maximum length of a sequence name
+      def sequence_name_length
+        IDENTIFIER_MAX_LENGTH
+      end
+
       # To avoid ORA-01795: maximum number of expressions in a list is 1000
       # tell ActiveRecord to limit us to 1000 ids at a time
       def in_clause_length

--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
@@ -98,8 +98,14 @@ module ActiveRecord
       end
 
       def rename_table(name, new_name) #:nodoc:
+        if new_name.to_s.length > table_name_length
+          raise ArgumentError, "New table name '#{new_name}' is too long; the limit is #{table_name_length} characters"
+        end
+        if "#{new_name}_seq".to_s.length > sequence_name_length
+          raise ArgumentError, "New sequence name '#{new_name}_seq' is too long; the limit is #{sequence_name_length} characters"
+        end
         execute "RENAME #{quote_table_name(name)} TO #{quote_table_name(new_name)}"
-        execute "RENAME #{quote_table_name("#{name}_seq")} TO #{quote_table_name("#{new_name}_seq")}" rescue nil
+        execute "RENAME #{quote_table_name("#{name}_seq")} TO #{quote_table_name("#{new_name}_seq")}"
       end
 
       def drop_table(name, options = {}) #:nodoc:

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -346,6 +346,49 @@ describe "OracleEnhancedAdapter schema definition" do
 
   end
 
+  describe "rename tables and sequences" do
+    before(:each) do
+      @conn = ActiveRecord::Base.connection
+        schema_define do
+          drop_table :test_employees rescue nil
+          drop_table :new_test_employees rescue nil
+          create_table  :test_employees do |t|
+            t.string    :first_name
+            t.string    :last_name
+          end
+      end
+#      class ::TestEmployee < ActiveRecord::Base; end
+    end
+
+    after(:each) do
+      schema_define do
+        drop_table :test_employees rescue nil
+        drop_table :new_test_employees rescue nil
+      end
+#      Object.send(:remove_const, "TestEmployee")
+#      ActiveRecord::Base.clear_cache! if ActiveRecord::Base.respond_to?(:"clear_cache!")
+    end
+
+    it "should rename table name with new one" do
+      lambda do
+        @conn.rename_table("test_employees","new_test_employees")
+      end.should_not raise_error
+    end
+
+    it "should raise error when new table name length is too long" do
+      lambda do
+        @conn.rename_table("test_employees","a"*31)
+      end.should raise_error
+    end
+
+    it "should raise error when new sequence name length is too long" do
+      lambda do
+        @conn.rename_table("test_employees","a"*27)
+      end.should raise_error
+    end
+
+  end
+
   describe "create triggers" do
 
     before(:all) do


### PR DESCRIPTION
While investigation with https://github.com/rails/rails/issues/3902 ,
I've found that Oracle-enhanced adapter's rename_table method ignores the error when rename sequence fails.

Error handling and these tests are added.
