### PR TITLE
Fixed "comparison of String with :employee_id failed" errors.

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -90,9 +90,9 @@ describe "OracleEnhancedAdapter date type detection based on column names" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates = false
       class ::TestEmployee < ActiveRecord::Base
         if self.respond_to?(:primary_key=)
-          self.primary_key = :employee_id
+          self.primary_key = "employee_id"
         else
-          set_primary_key :employee_id
+          set_primary_key "employee_id"
         end
       end
     end
@@ -570,9 +570,9 @@ describe "OracleEnhancedAdapter timestamp with timezone support" do
     before(:all) do
       class ::TestEmployee < ActiveRecord::Base
         if self.respond_to?(:primary_key=)
-          self.primary_key = :employee_id
+          self.primary_key = "employee_id"
         else
-          set_primary_key :employee_id
+          set_primary_key "employee_id"
         end
       end
     end
@@ -656,9 +656,9 @@ describe "OracleEnhancedAdapter date and timestamp with different NLS date forma
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = false
     class ::TestEmployee < ActiveRecord::Base
       if self.respond_to?(:primary_key=)
-        self.primary_key = :employee_id
+        self.primary_key = "employee_id"
       else
-        set_primary_key :employee_id
+        set_primary_key "employee_id"
       end
     end
     @today = Date.new(2008,6,28)
@@ -745,9 +745,9 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
     SQL
     class ::TestEmployee < ActiveRecord::Base
       if self.respond_to?(:primary_key=)
-        self.primary_key = :employee_id
+        self.primary_key = "employee_id"
       else
-        set_primary_key :employee_id
+        set_primary_key "employee_id"
       end
     end
     @today = Date.new(2008,6,28)
@@ -1062,9 +1062,9 @@ describe "OracleEnhancedAdapter handling of BLOB columns" do
   before(:each) do
     class ::TestEmployee < ActiveRecord::Base
       if self.respond_to?(:primary_key=)
-        self.primary_key = :employee_id
+        self.primary_key = "employee_id"
       else
-        set_primary_key :employee_id
+        set_primary_key "employee_id"
       end
     end
   end
@@ -1192,9 +1192,9 @@ describe "OracleEnhancedAdapter handling of RAW columns" do
   before(:each) do
     class ::TestEmployee < ActiveRecord::Base
       if self.respond_to?(:primary_key=)
-        self.primary_key = :employee_id
+        self.primary_key = "employee_id"
       else
-        set_primary_key :employee_id
+        set_primary_key "employee_id"
       end
     end
   end


### PR DESCRIPTION
This pull request addresses issue#151. Tested with Rails 2.3.8, 3.2.2.rc1, 3.1.4.rc1, and 3.0.12.rc1.
