### PR TITLE
Modified to use the rdoc gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'http://rubygems.org'
 group :development do
   gem 'jeweler', '~> 1.5.1'
   gem 'rspec', '~> 2.4'
+  gem 'rdoc'
 
   if ENV['RAILS_GEM_VERSION']
     gem 'activerecord', "=#{ENV['RAILS_GEM_VERSION']}"

--- a/Rakefile
+++ b/Rakefile
@@ -35,7 +35,7 @@ end
 
 task :default => :spec
 
-require 'rake/rdoctask'
+require 'rdoc/task'
 Rake::RDocTask.new do |rdoc|
   version = File.exist?('VERSION') ? File.read('VERSION') : ""
 


### PR DESCRIPTION
To address the WARNING, Modified to use the rdoc gem for unit tests.

``` ruby
$ rake spec
WARNING: 'require 'rake/rdoctask'' is deprecated.  Please use 'require 'rdoc/task' (in RDoc 2.4.2+)' instead.
    at /home/yahonda/.rvm/gems/ruby-1.9.3-p125@rails322rc1/gems/rake-0.9.2.2/lib/rake/rdoctask.rb
```
