### PR TITLE
Remove schema prefix before truncating.

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -842,9 +842,7 @@ module ActiveRecord
       # Returns default sequence name for table.
       # Will take all or first 26 characters of table name and append _seq suffix
       def default_sequence_name(table_name, primary_key = nil)
-        # TODO: remove schema prefix if present before truncating
-        # truncate table name if necessary to fit in max length of identifier
-        "#{table_name.to_s[0,IDENTIFIER_MAX_LENGTH-4]}_seq"
+        table_name.to_s.gsub /(^|\.)([\w$-]{1,#{sequence_name_length-4}})([\w$-]*)$/, '\1\2_seq'
       end
 
       # Inserts the given fixture into the table. Overridden to properly handle lobs.

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -51,6 +51,15 @@ describe "OracleEnhancedAdapter schema definition" do
     end
   end
 
+  describe "default sequence name" do
+
+    it "should return sequence name without truncating too much" do
+      seq_name_length = ActiveRecord::Base.connection.sequence_name_length
+      tname = "#{DATABASE_USER}" + "." +"a"*(seq_name_length - DATABASE_USER.length) + "z"*(DATABASE_USER).length
+      ActiveRecord::Base.connection.default_sequence_name(tname).should match (/z_seq$/)
+    end
+  end
+
   describe "sequence creation parameters" do
 
     def create_test_employees_table(sequence_start_value = nil)


### PR DESCRIPTION
Originally, this is reported #145.
It works with Rails 3.2.2, 3.1.4, 3.0.12 and  2.3.14.

I'd like to hear from users for this pull request because it implements some incompatibility with older version of oracle-enhanced, default_sequence_name return value changes.
