### PR TITLE
Bug when NUMERIC type has a SCALE of nil

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -870,7 +870,7 @@ module ActiveRecord
         if is_with_cpk
           id = klass.primary_key.map {|pk| attributes[pk.to_s] }
         else
-          id = quote(attributes[klass.primary_key])
+          id = quote(attributes[klass.primary_key.to_s]) #fix or else it can't find it if attributes are quoted and this is a symbol
         end
         klass.columns.select { |col| col.sql_type =~ /LOB$/i }.each do |col|
           value = attributes[col.name]

--- a/lib/active_record/connection_adapters/oracle_enhanced_column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_column.rb
@@ -62,13 +62,18 @@ module ActiveRecord
       
       private
 
+      def scale_present?(field_type)
+        scale = extract_scale(field_type)
+        return scale.nil? || scale == 0
+      end
+
       def simplified_type(field_type)
         forced_column_type ||
         case field_type
         when /decimal|numeric|number/i
           if OracleEnhancedAdapter.emulate_booleans && field_type == 'NUMBER(1)'
             :boolean
-          elsif extract_scale(field_type) == 0 ||
+          elsif scale_present?(field_type) ||
                 # if column name is ID or ends with _ID
                 OracleEnhancedAdapter.emulate_integers_by_column_name && OracleEnhancedAdapter.is_integer_column?(name, table_name)
             :integer


### PR DESCRIPTION
This commit fixes an issue where we have a NUMERIC column with a SCALE of nil that was being considered a BigDecimal instead of an integer