### PR TITLE
Address wrong number of arguments 5 for 3

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -716,7 +716,7 @@ module ActiveRecord
       EXEC_INSERT_RESULT_COLUMNS = %w(returning_id) #:nodoc:
 
       # New method in ActiveRecord 3.1
-      def exec_insert(sql, name, binds)
+      def exec_insert(sql, name, binds, pk = nil, sequence_name = nil)
         log(sql, name, binds) do
           returning_id_index = nil
           cursor = if @statements.key?(sql)


### PR DESCRIPTION
Since [this commit](https://github.com/dougcole/rails/commit/f09bb33bb534fe2e729e292c8ac6b0e2ffdcea2a) has been merged to the rails-master branch, $ rake test_oracle got "ArgumentError: wrong number of arguments (5 for 3)" error 928 times.
