### PR TITLE
Add a :schema option to allow switching the active schema using 'alter session'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'http://rubygems.org'
 
 group :development do
-  gem 'jeweler', '~> 1.5.1'
+  gem 'jeweler'
   gem 'rspec', '~> 2.4'
   gem 'rdoc'
 

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -901,12 +901,12 @@ module ActiveRecord
 
       # Default tablespace name of current user
       def default_tablespace
-        select_value("SELECT LOWER(default_tablespace) FROM user_users WHERE username = SYS_CONTEXT('userenv', 'session_user')")
+        select_value("SELECT LOWER(default_tablespace) FROM user_users WHERE username = SYS_CONTEXT('userenv', 'current_schema')")
       end
 
       def tables(name = nil) #:nodoc:
         select_values(
-        "SELECT DECODE(table_name, UPPER(table_name), LOWER(table_name), table_name) FROM all_tables WHERE owner = SYS_CONTEXT('userenv', 'session_user') AND secondary = 'N'",
+        "SELECT DECODE(table_name, UPPER(table_name), LOWER(table_name), table_name) FROM all_tables WHERE owner = SYS_CONTEXT('userenv', 'current_schema') AND secondary = 'N'",
         name)
       end
 
@@ -919,7 +919,7 @@ module ActiveRecord
       end
 
       def materialized_views #:nodoc:
-        select_values("SELECT LOWER(mview_name) FROM all_mviews WHERE owner = SYS_CONTEXT('userenv', 'session_user')")
+        select_values("SELECT LOWER(mview_name) FROM all_mviews WHERE owner = SYS_CONTEXT('userenv', 'current_schema')")
       end
 
       cattr_accessor :all_schema_indexes #:nodoc:

--- a/lib/active_record/connection_adapters/oracle_enhanced_jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_jdbc_connection.rb
@@ -146,7 +146,7 @@ module ActiveRecord
         self.autocommit = true
 
         # default schema owner
-        @owner = username.upcase unless username.nil?
+        @username = username.upcase unless username.nil?
 
         @raw_connection
       end

--- a/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb
@@ -23,7 +23,7 @@ module ActiveRecord
       def initialize(config)
         @raw_connection = OCI8EnhancedAutoRecover.new(config, OracleEnhancedOCIFactory)
         # default schema owner
-        @owner = config[:username].to_s.upcase
+        @username = config[:username].to_s.upcase
       end
 
       def raw_oci_connection

--- a/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
@@ -32,7 +32,6 @@ describe "OracleEnhancedConnection" do
     it "should be in autocommit mode after connection" do
       @conn.should be_autocommit
     end
-
   end
 
   describe "create connection with NLS parameters" do
@@ -57,6 +56,22 @@ describe "OracleEnhancedConnection" do
       @conn = ActiveRecord::ConnectionAdapters::OracleEnhancedConnection.create(CONNECTION_PARAMS)
       default = ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter::DEFAULT_NLS_PARAMETERS[:nls_date_format]
       @conn.select("SELECT value FROM v$nls_parameters WHERE parameter = 'NLS_DATE_FORMAT'").should == [{'value' => default}]
+    end
+  end
+
+  describe "switch the active schema" do
+    it "should default the current schema to the :username" do
+      @conn = ActiveRecord::ConnectionAdapters::OracleEnhancedConnection.create(CONNECTION_PARAMS)
+      @conn.select("select sys_context( 'userenv', 'current_schema' ) as current_schema from dual")[0]['current_schema'].should == CONNECTION_PARAMS[:username].upcase
+      @conn.owner.should == CONNECTION_PARAMS[:username].upcase
+    end
+
+    it "should allow switching to another schema by setting the :schema option" do
+      params = CONNECTION_PARAMS.dup
+      params[:schema] = 'system'
+      @conn = ActiveRecord::ConnectionAdapters::OracleEnhancedConnection.create(params)
+      @conn.select("select sys_context( 'userenv', 'current_schema' ) as current_schema from dual")[0]['current_schema'].should == params[:schema].upcase
+      @conn.owner.should == params[:schema].upcase
     end
   end
 


### PR DESCRIPTION
Makes a schema option available in database.yml like so:

    development:
      database: xe
      username: database_user
      password: 1234
      adapter: oracle_enhanced
      host: localhost
      schema: schema_to_use

Use case:

I work in a corporate environment that insists on running the application under a different user/schema than the schema where the application lives (ie; blah_update_user is what we connect with, but the app lives in the blah schema). We could hack around this in Rails by hard-coding schema prefixes in a `set_table_name` declaration, but this had many implications including making setup of testing databases extremely annoying.

This patch basically just runs `alter session set current_schema = schema_name` immediately after initializing a connection. We've been using a variation of this patch in several production jruby/rails3/oracle 10/11 applications for the past year without issue. 