### PR TITLE
Address the ORA-00904 error with Rails 3.2.4.rc1

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
@@ -257,8 +257,15 @@ module ActiveRecord
         clear_table_columns_cache(table_name)
       end
 
-      def remove_column(table_name, column_name) #:nodoc:
-        execute "ALTER TABLE #{quote_table_name(table_name)} DROP COLUMN #{quote_column_name(column_name)}"
+      def remove_column(table_name, *column_names) #:nodoc:
+        raise ArgumentError.new("You must specify at least one column name. Example: remove_column(:people, :first_name)") if column_names.empty?
+
+        if column_names.first.kind_of?(Enumerable)
+          message = 'Passing array to remove_columns is deprecated, please use ' +
+                    'multiple arguments, like: `remove_columns(:posts, :foo, :bar)`'
+          ActiveSupport::Deprecation.warn message, caller
+        end
+        column_names.flatten.each {|column_name| execute "ALTER TABLE #{quote_table_name(table_name)} DROP COLUMN #{quote_column_name(column_name)}"}
       ensure
         clear_table_columns_cache(table_name)
       end


### PR DESCRIPTION
Tested with the Rails 3.2.4.rc1, test_remove_column_with_array_as_an_argument_is_deprecated got 
an error with ORA-00904 error.

``` ruby
  1) Error:
test_remove_column_with_array_as_an_argument_is_deprecated(MigrationTest):
ActiveRecord::StatementInvalid: OCIError: ORA-00904: "[hat_name, hat_size]": invalid identifier: ALTER TABLE "HATS" DROP COLUMN "[hat_name, hat_size]"
```

All log file is available from [here](https://gist.github.com/2840310) .

It looks this commit is related with thie error (https://github.com/rails/rails/commit/02ca9151a043a4fefbb3f22edd05f0cd392fffaa) . I do not fully understand how new refactored remove_column method should be handled yet.
