### PR TITLE
Support Refactored remove_column with Oracle

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
@@ -257,8 +257,9 @@ module ActiveRecord
         clear_table_columns_cache(table_name)
       end
 
-      def remove_column(table_name, column_name) #:nodoc:
-        execute "ALTER TABLE #{quote_table_name(table_name)} DROP COLUMN #{quote_column_name(column_name)}"
+      def remove_column(table_name, *column_names) #:nodoc:
+        raise ArgumentError.new("You must specify at least one column name. Example: remove_column(:people, :first_name)") if column_names.empty?
+        column_names.each {|column_name| execute "ALTER TABLE #{quote_table_name(table_name)} DROP COLUMN #{quote_column_name(column_name)}"}
       ensure
         clear_table_columns_cache(table_name)
       end


### PR DESCRIPTION
This pull request supports refactored remove_column with *column_names.

These two tests have passed with rails master branch.

``` ruby

$ ARCONN=oracle ruby -Itest test/cases/migration/change_table_test.rb -n test_remove_drops_single_column
Using oracle
Run options: -n test_remove_drops_single_column --seed 28113

# Running tests:

.

Finished tests in 0.005634s, 177.4953 tests/s, 177.4953 assertions/s.

1 tests, 1 assertions, 0 failures, 0 errors, 0 skips


$ ARCONN=oracle ruby -Itest test/cases/migration/change_table_test.rb -n test_remove_drops_multiple_columns
Using oracle
Run options: -n test_remove_drops_multiple_columns --seed 28153

# Running tests:

.

Finished tests in 0.005418s, 184.5673 tests/s, 184.5673 assertions/s.

1 tests, 1 assertions, 0 failures, 0 errors, 0 skips
$
```
