### PR TITLE
Address NoMethodError: undefined method `column_types' 

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1097,7 +1097,7 @@ module ActiveRecord
         SQL
 
         # added deletion of ignored columns
-        select_all(table_cols, name).delete_if do |row|
+        select_all(table_cols, name).to_a.delete_if do |row|
           ignored_columns && ignored_columns.include?(row['name'].downcase)
         end.map do |row|
           limit, scale = row['limit'], row['scale']
@@ -1273,7 +1273,7 @@ module ActiveRecord
 
       def select(sql, name = nil, binds = [])
         if ActiveRecord.const_defined?(:Result)
-          exec_query(sql, name, binds).to_a
+          exec_query(sql, name, binds)
         else
           log(sql, name) do
             @connection.select(sql, name, false)


### PR DESCRIPTION
This pull request address the NoMethodError: undefined method `column_types'  errors reported in #167
