### PR TITLE
rails4: Bump jeweler, ruby-plsql and ruby-oci8 gems to the latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'http://rubygems.org'
 
 group :development do
-  # gem 'jeweler', '~> 1.5.1'
+  gem 'jeweler', '~> 1.8.3'
   gem 'rspec', '~> 2.4'
   gem 'rdoc'
 
@@ -45,10 +45,10 @@ group :development do
     gem "active_record_deprecated_finders", :git => "git://github.com/rails/active_record_deprecated_finders"
   end
 
-  gem 'ruby-plsql', '>=0.4.4'
+  gem 'ruby-plsql', '>=0.5.0'
 
   platforms :ruby do
-    gem 'ruby-oci8', '>=2.0.4'
+    gem 'ruby-oci8', '>=2.1.2'
   end
 
 end


### PR DESCRIPTION
To execute Oracle enhanced unit tests with rails4 branch, the jeweler gem is required.

``` ruby
$ rake spec
rake aborted!
cannot load such file -- jeweler

(See full trace by running task with --trace)
$
```

In addition the old version of jeweler does not work with bundler 1.1.3, which is installed with ruby 1.9.3.

``` ruby
$ bundle update
Updating git://github.com/rails/arel
Updating git://github.com/rails/journey
Updating git://github.com/rails/active_record_deprecated_finders
Fetching gem metadata from http://rubygems.org/......
Fetching gem metadata from http://rubygems.org/..
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    jeweler (~> 1.5.1) ruby depends on
      bundler (~> 1.0.0) ruby

  Current Bundler version:
    bundler (1.1.3)

This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?
$
```

This pull request also bump ruby-plsql and ruby-oci8 to the latest version.
