### PR TITLE
rails4: Address 3 failures after #173 merged.

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_dbms_output_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_dbms_output_spec.rb
@@ -42,7 +42,7 @@ describe "OracleEnhancedAdapter logging dbms_output from plsql" do
   it "should NOT log dbms output when dbms output is disabled" do
     @conn.disable_dbms_output
 
-    @conn.select_all("select more_than_five_characters_long('hi there') is_it_long from dual").should == [{'is_it_long'=>1}]
+    @conn.select_all("select more_than_five_characters_long('hi there') is_it_long from dual").to_a.should == [{'is_it_long'=>1}]
 
     @logger.output(:debug).should_not match(/^DBMS_OUTPUT/)
   end
@@ -50,7 +50,7 @@ describe "OracleEnhancedAdapter logging dbms_output from plsql" do
   it "should log dbms output lines to the rails log" do
     @conn.enable_dbms_output
 
-    @conn.select_all("select more_than_five_characters_long('hi there') is_it_long from dual").should == [{'is_it_long'=>1}]
+    @conn.select_all("select more_than_five_characters_long('hi there') is_it_long from dual").to_a.should == [{'is_it_long'=>1}]
     
     @logger.output(:debug).should match(/^DBMS_OUTPUT: before the if -hi there-$/)
     @logger.output(:debug).should match(/^DBMS_OUTPUT: it is longer than 5$/)
@@ -60,7 +60,7 @@ describe "OracleEnhancedAdapter logging dbms_output from plsql" do
   it "should log dbms output lines to the rails log" do
     @conn.enable_dbms_output
 
-    @conn.select_all("select more_than_five_characters_long('short') is_it_long from dual").should == [{'is_it_long'=>0}]
+    @conn.select_all("select more_than_five_characters_long('short') is_it_long from dual").to_a.should == [{'is_it_long'=>0}]
     
     @logger.output(:debug).should match(/^DBMS_OUTPUT: before the if -short-$/)
     @logger.output(:debug).should match(/^DBMS_OUTPUT: it is 5 or shorter$/)


### PR DESCRIPTION
Rails 4 `select_all` should return `ActiveRecord::Result` but these tests are still expecting `Array`. Therefore select_all return value casted to Array.
