### PR TITLE
Automatically create indexes

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_definitions.rb
@@ -88,11 +88,15 @@ module ActiveRecord
       # Note: If no name is specified, the database driver creates one for you!
       def references_with_foreign_keys(*args)
         options = args.extract_options!
+        index_options = options[:index]
         fk_options = options.delete(:foreign_key)
 
         if fk_options && !options[:polymorphic]
           fk_options = {} if fk_options == true
-          args.each { |to_table| foreign_key(to_table, fk_options) }
+          args.each do |to_table| 
+            foreign_key(to_table, fk_options) 
+            add_index(to_table, "#{to_table}_id", index_options.is_a?(Hash) ? index_options : nil) if index_options
+          end
         end
 
         references_without_foreign_keys(*(args << options))
@@ -190,6 +194,7 @@ module ActiveRecord
       def references_with_foreign_keys(*args)
         options = args.extract_options!
         polymorphic = options[:polymorphic]
+        index_options = options[:index]
         fk_options = options.delete(:foreign_key)
 
         references_without_foreign_keys(*(args << options))
@@ -197,7 +202,10 @@ module ActiveRecord
         args.extract_options!
         if fk_options && !polymorphic
           fk_options = {} if fk_options == true
-          args.each { |to_table| foreign_key(to_table, fk_options) }
+          args.each do |to_table| 
+            foreign_key(to_table, fk_options) 
+            add_index(to_table, "#{to_table}_id", index_options.is_a?(Hash) ? index_options : nil) if index_options
+          end
         end
       end
     end

--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
@@ -94,6 +94,7 @@ module ActiveRecord
         column_comments.each do |column_name, comment|
           add_comment name, column_name, comment
         end
+        table_definition.indexes.each_pair { |c,o| add_index name, c, o }
         
       end
 
@@ -125,8 +126,10 @@ module ActiveRecord
           index_type = options[:unique] ? "UNIQUE" : ""
           index_name = options[:name].to_s if options.key?(:name)
           tablespace = tablespace_for(:index, options[:tablespace])
+          additional_options = options[:options]
         else
           index_type = options
+          additional_options = nil
         end
 
         if index_name.to_s.length > index_name_length
@@ -137,7 +140,7 @@ module ActiveRecord
         end
         quoted_column_names = column_names.map { |e| quote_column_name_or_expression(e) }.join(", ")
 
-        execute "CREATE #{index_type} INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} (#{quoted_column_names})#{tablespace} #{options[:options]}"
+        execute "CREATE #{index_type} INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} (#{quoted_column_names})#{tablespace} #{additional_options}"
       ensure
         self.all_schema_indexes = nil
       end


### PR DESCRIPTION
This pull request supports Automatically create indexes made at [rails master branch](https://github.com/rails/rails/commit/ca0af8221a3b704fa289afe7030a96dc8cec8a95#activerecord/test/cases/migration/references_index_test.rb).

Actually, I do not think it's good implementation `if .. else` at the `add_index` method. Therefore I'd like this commit to be reviewed.
