### PR TITLE
Address 6 failures at oracle_enhanced_data_types_spec.rb

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -151,3 +151,8 @@ DATABASE_NON_DEFAULT_TABLESPACE = ENV['DATABASE_NON_DEFAULT_TABLESPACE'] || "SYS
 ENV['TZ'] ||= 'Europe/Riga'
 
 # ActiveRecord::Base.logger = Logger.new(STDOUT)
+
+# Set default_timezone :local explicitly 
+# because this default value has been changed to :utc atrails master branch 
+ActiveRecord::Base.default_timezone = :local
+


### PR DESCRIPTION
This pull request address 6 failures reported at #181.

At 3-2 stable branch, `ActiveRecord::Base.default_timezone` is `:local`. 
However, at the rails master branch this value is `:utc`. 

Therefore all these 6 failures reported at #181 can be addressed 
by setting `ActiveRecord::Base.default_timezone = :local` at the beginning of these tests.
