### PR TITLE
Address 2 failures since c4601179541a9fc2e3cd7828335cefe54f26969a merged

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_dumper.rb
@@ -116,7 +116,7 @@ module ActiveRecord #:nodoc:
             case index.type
             when nil
               # use table.inspect as it will remove prefix and suffix
-              statement_parts = [ ('add_index ' + remove_prefix_and_suffix(table).inspect) ]
+              statement_parts = [ ('add_index ' + table.inspect) ]
               statement_parts << index.columns.inspect
               statement_parts << (':name => ' + index.name.inspect)
               statement_parts << ':unique => true' if index.unique
@@ -154,7 +154,7 @@ module ActiveRecord #:nodoc:
             pk = @connection.primary_key(table)
           end
           
-          tbl.print "  create_table #{remove_prefix_and_suffix(table).inspect}"
+          tbl.print "  create_table #{table.inspect}"
           
           # addition to make temporary option work
           tbl.print ", :temporary => true" if @connection.temporary_table?(table)


### PR DESCRIPTION
This pull request address following 2 failures since c4601179541a9fc2e3cd7828335cefe54f26969a merged.

``` ruby
1.9.3-p194@railsmaster [ rails_issue_6819 ~/git/oracle-enhanced]$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
==> Running specs with MRI version 1.9.3
==> Running specs with Rails version 4.0-master
....F.F.........................

Failures:

  1) OracleEnhancedAdapter schema dump table prefixes and suffixes should remove table prefix with $ sign in schema dump
     Failure/Error: standard_dump.should =~ /create_table "test_posts".*add_index "test_posts"/m
       expected: /create_table "test_posts".*add_index "test_posts"/m
            got: "# encoding: UTF-8\n# This file is auto-generated from the current state of the database. Instead\n# of editing this file, please use the migrations feature of Active Record to\n# incrementally modify your database, and then regenerate this schema definition.\n#\n# Note that this schema.rb definition is the authoritative source for your\n# database schema. If you need to create the application database on another\n# system, you should be using db:schema:load, not running all the migrations\n# from scratch. The latter is a flawed and unsustainable approach (the more migrations\n# you'll amass, the slower it'll run and the greater likelihood for issues).\n#\n# It's strongly recommended that you check this file into your version control system.\n\nActiveRecord::Schema.define(:version => 0) do\n\n  create_table \"xxx$test_posts\", :force => true do |t|\n    t.string   \"title\"\n    t.datetime \"created_at\", :null => false\n    t.datetime \"updated_at\", :null => false\n  end\n\n  add_index \"xxx$test_posts\", [\"title\"], :name => \"index_xxx$test_posts_on_title\"\n\nend\n" (using =~)
       Diff:
       @@ -1,2 +1,25 @@
       -/create_table "test_posts".*add_index "test_posts"/m
       +# encoding: UTF-8
       +# This file is auto-generated from the current state of the database. Instead
       +# of editing this file, please use the migrations feature of Active Record to
       +# incrementally modify your database, and then regenerate this schema definition.
       +#
       +# Note that this schema.rb definition is the authoritative source for your
       +# database schema. If you need to create the application database on another
       +# system, you should be using db:schema:load, not running all the migrations
       +# from scratch. The latter is a flawed and unsustainable approach (the more migrations
       +# you'll amass, the slower it'll run and the greater likelihood for issues).
       +#
       +# It's strongly recommended that you check this file into your version control system.
       +
       +ActiveRecord::Schema.define(:version => 0) do
       +
       +  create_table "xxx$test_posts", :force => true do |t|
       +    t.string   "title"
       +    t.datetime "created_at", :null => false
       +    t.datetime "updated_at", :null => false
       +  end
       +
       +  add_index "xxx$test_posts", ["title"], :name => "index_xxx$test_posts_on_title"
       +
       +end
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-expectations-2.10.0/lib/rspec/expectations/fail_with.rb:33:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-expectations-2.10.0/lib/rspec/matchers/operator_matcher.rb:47:in `fail_with_message'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-expectations-2.10.0/lib/rspec/matchers/operator_matcher.rb:69:in `__delegate_operator'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-expectations-2.10.0/lib/rspec/matchers/operator_matcher.rb:59:in `eval_match'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-expectations-2.10.0/lib/rspec/matchers/operator_matcher.rb:28:in `block in use_custom_matcher_or_delegate'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:92:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/example.rb:87:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/example.rb:87:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/example.rb:195:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/example.rb:84:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/example_group.rb:353:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/example_group.rb:349:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/example_group.rb:349:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/example_group.rb:335:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/example_group.rb:336:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/example_group.rb:336:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/example_group.rb:336:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/command_line.rb:28:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/command_line.rb:28:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/reporter.rb:34:in `report'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/command_line.rb:25:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/runner.rb:69:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/runner.rb:10:in `block in autorun'

  2) OracleEnhancedAdapter schema dump table prefixes and suffixes should remove table suffix with $ sign in schema dump
     Failure/Error: standard_dump.should =~ /create_table "test_posts".*add_index "test_posts"/m
       expected: /create_table "test_posts".*add_index "test_posts"/m
            got: "# encoding: UTF-8\n# This file is auto-generated from the current state of the database. Instead\n# of editing this file, please use the migrations feature of Active Record to\n# incrementally modify your database, and then regenerate this schema definition.\n#\n# Note that this schema.rb definition is the authoritative source for your\n# database schema. If you need to create the application database on another\n# system, you should be using db:schema:load, not running all the migrations\n# from scratch. The latter is a flawed and unsustainable approach (the more migrations\n# you'll amass, the slower it'll run and the greater likelihood for issues).\n#\n# It's strongly recommended that you check this file into your version control system.\n\nActiveRecord::Schema.define(:version => 0) do\n\n  create_table \"test_posts$xxx\", :force => true do |t|\n    t.string   \"title\"\n    t.datetime \"created_at\", :null => false\n    t.datetime \"updated_at\", :null => false\n  end\n\n  add_index \"test_posts$xxx\", [\"title\"], :name => \"index_test_posts$xxx_on_title\"\n\nend\n" (using =~)
       Diff:
       @@ -1,2 +1,25 @@
       -/create_table "test_posts".*add_index "test_posts"/m
       +# encoding: UTF-8
       +# This file is auto-generated from the current state of the database. Instead
       +# of editing this file, please use the migrations feature of Active Record to
       +# incrementally modify your database, and then regenerate this schema definition.
       +#
       +# Note that this schema.rb definition is the authoritative source for your
       +# database schema. If you need to create the application database on another
       +# system, you should be using db:schema:load, not running all the migrations
       +# from scratch. The latter is a flawed and unsustainable approach (the more migrations
       +# you'll amass, the slower it'll run and the greater likelihood for issues).
       +#
       +# It's strongly recommended that you check this file into your version control system.
       +
       +ActiveRecord::Schema.define(:version => 0) do
       +
       +  create_table "test_posts$xxx", :force => true do |t|
       +    t.string   "title"
       +    t.datetime "created_at", :null => false
       +    t.datetime "updated_at", :null => false
       +  end
       +
       +  add_index "test_posts$xxx", ["title"], :name => "index_test_posts$xxx_on_title"
       +
       +end
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-expectations-2.10.0/lib/rspec/expectations/fail_with.rb:33:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-expectations-2.10.0/lib/rspec/matchers/operator_matcher.rb:47:in `fail_with_message'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-expectations-2.10.0/lib/rspec/matchers/operator_matcher.rb:69:in `__delegate_operator'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-expectations-2.10.0/lib/rspec/matchers/operator_matcher.rb:59:in `eval_match'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-expectations-2.10.0/lib/rspec/matchers/operator_matcher.rb:28:in `block in use_custom_matcher_or_delegate'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:104:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/example.rb:87:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/example.rb:87:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/example.rb:195:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/example.rb:84:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/example_group.rb:353:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/example_group.rb:349:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/example_group.rb:349:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/example_group.rb:335:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/example_group.rb:336:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/example_group.rb:336:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/example_group.rb:336:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/command_line.rb:28:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/command_line.rb:28:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/reporter.rb:34:in `report'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/command_line.rb:25:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/runner.rb:69:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/runner.rb:10:in `block in autorun'

Finished in 6 seconds
32 examples, 2 failures

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:89 # OracleEnhancedAdapter schema dump table prefixes and suffixes should remove table prefix with $ sign in schema dump
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:101 # OracleEnhancedAdapter schema dump table prefixes and suffixes should remove table suffix with $ sign in schema dump
1.9.3-p194@railsmaster [ rails_issue_6819 ~/git/oracle-enhanced]$ 
```
