### PR TITLE
Add clear_logger  to address ArgumentError: wrong number of arguments (1 for 2)

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
@@ -297,6 +297,7 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
     }.should raise_error("Make the transaction rollback")
     @employee.id.should == empl_id
     TestEmployee.find_by_employee_id(empl_id).should_not be_nil
+    clear_logger
   end
 
   it "should set timestamps when creating record" do
@@ -332,6 +333,7 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
       :hire_date => @today
     )
     @logger.logged(:debug).last.should match(/^TestEmployee Create \(\d+\.\d+(ms)?\)  custom create method$/)
+    clear_logger
   end
 
   it "should log update record" do
@@ -344,6 +346,7 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
     set_logger
     @employee.save!
     @logger.logged(:debug).last.should match(/^TestEmployee Update \(\d+\.\d+(ms)?\)  custom update method with employee_id=#{@employee.id}$/)
+    clear_logger
   end
 
   it "should log delete record" do
@@ -355,6 +358,7 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
     set_logger
     @employee.destroy
     @logger.logged(:debug).last.should match(/^TestEmployee Destroy \(\d+\.\d+(ms)?\)  custom delete method with employee_id=#{@employee.id}$/)
+    clear_logger
   end
 
   it "should validate new record before creation" do


### PR DESCRIPTION
This pull request addresses the following error reported in #174.

``` ruby
$ ruby -S rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
==> Running specs with MRI version 1.9.3
==> Running specs with Rails version 4.0-master
........................*..........................................F.....

Pending:
  OracleEnhancedAdapter database session store should have one enhanced_write_lobs callback
    # Not in this ActiveRecord version
    # ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:100

Failures:

  1) OracleEnhancedAdapter eager loading should load included association with more than 1000 records
     Failure/Error: TestPost.create!(:id => id, :title => "Title #{id}")
     ArgumentError:
       wrong number of arguments (1 for 2)
     # ./spec/spec_helper.rb:65:in `method_missing'
     # /home/yahonda/git/rails/activemodel/lib/active_model/mass_assignment_security/sanitizer.rb:45:in `process_removed_attributes'
     # /home/yahonda/git/rails/activemodel/lib/active_model/mass_assignment_security/sanitizer.rb:10:in `sanitize'
     # /home/yahonda/git/rails/activemodel/lib/active_model/mass_assignment_security.rb:232:in `sanitize_for_mass_assignment'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_assignment.rb:75:in `assign_attributes'
     # /home/yahonda/git/rails/activerecord/lib/active_record/core.rb:185:in `initialize'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:39:in `new'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:39:in `create!'
     # ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:668:in `block (5 levels) in <top (required)>'
     # ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:667:in `each'
     # ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:667:in `block (4 levels) in <top (required)>'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:193:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:208:in `transaction'
     # ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:666:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/hooks.rb:23:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/hooks.rb:23:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/hooks.rb:74:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/hooks.rb:400:in `run_hook'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/example_group.rb:287:in `run_before_all_hooks'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/example_group.rb:334:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/example_group.rb:336:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/example_group.rb:336:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/example_group.rb:336:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/command_line.rb:28:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/command_line.rb:28:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/reporter.rb:34:in `report'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/command_line.rb:25:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/runner.rb:69:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p194@railsmaster/gems/rspec-core-2.10.1/lib/rspec/core/runner.rb:10:in `block in autorun'

Finished in 9.43 seconds
73 examples, 1 failure, 1 pending

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:684 # OracleEnhancedAdapter eager loading should load included association with more than 1000 records
$
```
