### PR TITLE
Use arel nodes instead of raw sql for Oracle enhanced adapter.

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1212,6 +1212,7 @@ module ActiveRecord
           order_by
         end
         order_columns = order_columns.zip((0...order_columns.size).to_a).map do |c, i|
+          c = c.to_sql unless c.is_a?(String)
           # remove any ASC/DESC modifiers
           value = c =~ /^(.+)\s+(ASC|DESC)\s*$/i ? $1 : c
           "FIRST_VALUE(#{value}) OVER (PARTITION BY #{columns} ORDER BY #{c}) AS alias_#{i}__"


### PR DESCRIPTION
It also addresses ORA-911 at test_find_on_has_many_association_collection_with_include_and_conditions reported in #185
