### PR TITLE
Clear index cache when any table is dropped

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
@@ -115,6 +115,7 @@ module ActiveRecord
         execute "DROP SEQUENCE #{quote_table_name(seq_name)}" rescue nil
       ensure
         clear_table_columns_cache(name)
+        self.all_schema_indexes = nil
       end
 
       # clear cached indexes when adding new index


### PR DESCRIPTION
This pull request addresses a failure at the `test_create_join_table_with_index` reported in #199.

`indexes` method caches all indexes but not cleared when the table which has these indexes is dropped.
So, `indexes` method shows non-existent indexes just after the table is dropped.
