### PR TITLE
Allow service names in jruby without specifying a url

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ In Rails application `config/database.yml` use oracle_enhanced as adapter name, 
       username: user
       password: secret
 
+If you're connecting to a service name, indicate the service with a
+leading slash on the database parameter:
+
+    development:
+      adapter: oracle_enhanced
+      database: /xe
+      username: user
+      password: secret
+
 If `TNS_ADMIN` environment variable is pointing to directory where `tnsnames.ora` file is located then you can use TNS connection name in `database` parameter. Otherwise you can directly specify database host, port (defaults to 1521) and database name in the following way:
 
     development:

--- a/lib/active_record/connection_adapters/oracle_enhanced_jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_jdbc_connection.rb
@@ -95,15 +95,19 @@ module ActiveRecord
           # to_s needed if username, password or database is specified as number in database.yml file
           username = config[:username] && config[:username].to_s
           password = config[:password] && config[:password].to_s
-          database = config[:database] && config[:database].to_s
+          database = config[:database] && config[:database].to_s || 'XE'
           host, port = config[:host], config[:port]
           privilege = config[:privilege] && config[:privilege].to_s
 
           # connection using TNS alias
           if database && !host && !config[:url] && ENV['TNS_ADMIN']
-            url = "jdbc:oracle:thin:@#{database || 'XE'}"
+            url = "jdbc:oracle:thin:@#{database}"
           else
-            url = config[:url] || "jdbc:oracle:thin:@#{host || 'localhost'}:#{port || 1521}:#{database || 'XE'}"
+            unless database.match(/^(\:|\/)/)
+              # assume database is a SID if no colon or slash are supplied (backward-compatibility)
+              database = ":#{database}"
+            end
+            url = config[:url] || "jdbc:oracle:thin:@#{host || 'localhost'}:#{port || 1521}#{database}"
           end
 
           prefetch_rows = config[:prefetch_rows] || 100

--- a/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb
@@ -309,7 +309,8 @@ module ActiveRecord
           host ||= 'localhost'
           host = "[#{host}]" if host =~ /^[^\[].*:/  # IPv6
           port ||= 1521
-          "//#{host}:#{port}/#{database}"
+          database = "/#{database}" unless database.match(/^\//)
+          "//#{host}:#{port}#{database}"
         # if no host is specified then assume that
         # database parameter is TNS alias or TNS connection string
         else

--- a/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
@@ -74,6 +74,18 @@ describe "OracleEnhancedConnection" do
     end
   end
 
+  describe "with slash-prefixed database name (service name)" do
+    before(:all) do
+      params = CONNECTION_PARAMS.dup
+      params[:database] = "/#{params[:database]}" unless params[:database].match(/^\//)
+      @conn = ActiveRecord::ConnectionAdapters::OracleEnhancedConnection.create(params)
+    end
+
+    it "should create new connection" do
+      @conn.should be_active
+    end
+  end
+
   if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
 
     describe "create JDBC connection" do


### PR DESCRIPTION
This commit implements the slash-prefix specification of a service name as suggested by @rsim in issue #197.

This allows the use of a service name in jruby without specifying a url in database.yml. In MRI, the slash is stripped off to allow interoperability between jruby/mri. This is huge for folks that test in MRI, but deploy with jruby.
