### PR TITLE
Fix bug in setting conn.non_blocking via config[:allow_concurrency]

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb
@@ -319,7 +319,7 @@ module ActiveRecord
 
         conn = OCI8.new username, password, connection_string, privilege
         conn.autocommit = true
-        conn.non_blocking = true if async
+        conn.non_blocking = !!async unless async.nil? 
         conn.prefetch_rows = prefetch_rows
         conn.exec "alter session set cursor_sharing = #{cursor_sharing}" rescue nil
         conn.exec "alter session set time_zone = '#{time_zone}'" unless time_zone.blank?


### PR DESCRIPTION
On my OCI8 (2.1.2) creating a new connection by default sets
non_blocking to true.  However, the line changed here would not
set non_blocking to false even if async was false, so there was
no way of overriding this gracefully from the passed in config.

    irb(main):004:0> c = OCI8.new 'username', 'password', 'DATABASE'
    => #<OCI8:DATABASE>
    irb(main):005:0> c.non_blocking?
    => true

The new behavior is to leave conn.non_blocking as the default if 
`config[:allow_concurrency]` is nil, and forcefully set it otherwise.
I think this aligns with what users would expect when adding that line
to their database.yml.