### PR TITLE
rails4: Support SqlBypassTest with Oracle

### DIFF
--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -45,6 +45,7 @@ This adapter is superset of original ActiveRecord Oracle adapter.
     "lib/active_record/connection_adapters/oracle_enhanced_schema_dumper.rb",
     "lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb",
     "lib/active_record/connection_adapters/oracle_enhanced_schema_statements_ext.rb",
+    "lib/active_record/connection_adapters/oracle_enhanced_session_store.rb",
     "lib/active_record/connection_adapters/oracle_enhanced_structure_dump.rb",
     "lib/active_record/connection_adapters/oracle_enhanced_tasks.rb",
     "lib/active_record/connection_adapters/oracle_enhanced_version.rb",

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1377,6 +1377,9 @@ require 'active_record/connection_adapters/oracle_enhanced_structure_dump'
 # Add BigDecimal#to_d, Fixnum#to_d and Bignum#to_d methods if not already present
 require 'active_record/connection_adapters/oracle_enhanced_core_ext'
 
+# Patches for the save method 
+require 'active_record/connection_adapters/oracle_enhanced_session_store'
+
 require 'active_record/connection_adapters/oracle_enhanced_version'
 
 module ActiveRecord

--- a/lib/active_record/connection_adapters/oracle_enhanced_session_store.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_session_store.rb
@@ -1,0 +1,49 @@
+module ActiveRecord #:nodoc:
+  module ConnectionAdapters #:nodoc:
+    module OracleEnhancedSqlBypass #:nodoc:
+
+      def self.included(base) #:nodoc:
+        base.class_eval do
+          private
+          alias_method_chain :save, :oracle_enhanced
+        end
+      end
+     
+      private
+
+      def save_with_oracle_enhanced
+        # return original method if not using 'Oracle' nor 'OracleEnhanced'
+        return save_without_oracle_enhanced unless connection.adapter_name.index('Oracle') == 0
+
+        return false unless loaded?
+        marshaled_data = self.class.marshal(data)
+        connect        = connection
+
+        # Insert statement explicitly requires the 'id' column and '#{table_name}_seq.nextval' value.
+        if @new_record
+          @new_record = false
+          connect.update <<-end_sql, 'Create session'
+            INSERT INTO #{table_name} (
+              id,
+              #{connect.quote_column_name(session_id_column)},
+              #{connect.quote_column_name(data_column)} )
+            VALUES (
+              #{table_name}_seq.nextval,
+              #{connect.quote(session_id)},
+              #{connect.quote(marshaled_data)} )
+          end_sql
+        else
+          connect.update <<-end_sql, 'Update session'
+            UPDATE #{table_name}
+              SET #{connect.quote_column_name(data_column)}=#{connect.quote(marshaled_data)}
+              WHERE #{connect.quote_column_name(session_id_column)}=#{connect.quote(session_id)}
+          end_sql
+        end
+      end
+    end
+  end
+end
+
+ActiveRecord::SessionStore::SqlBypass.class_eval do
+  include ActiveRecord::ConnectionAdapters::OracleEnhancedSqlBypass
+end


### PR DESCRIPTION
Address OCIError: ORA-01400 errors at the SqlBypassTest reported in issue #188.

This commit overrides the `save` method in `ActiveRecord::SessionStore::SqlBypass`.

`SqlBypass` test requires a raw insert statement, which explicitly insert the `id` column with `#{table_name}_seq.nextval` for Oracle database which does not have any auto_increment like features. 
