### PR TITLE
Address test_integer_zero_to_integer_zero_not_marked_as_changed failure

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_dirty.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_dirty.rb
@@ -18,7 +18,7 @@ module ActiveRecord #:nodoc:
             # therefore need to convert empty string value to nil if old value is nil
             elsif column.type == :string && column.null && old.nil?
               value = nil if value == ''
-            elsif old == 0 && value.present? && value != '0'
+            elsif old == 0 && value.is_a?(String) && value.present? && value != '0'
               value = nil
             else
               value = column.type_cast(value)


### PR DESCRIPTION
This pull request addresses test_integer_zero_to_integer_zero_not_marked_as_changed failure.

See rails/rails#7237.

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/dirty_test.rb 
Using oracle
Run options: --seed 5902

# Running tests:

........F.....................

Finished tests in 1.371788s, 21.8693 tests/s, 123.1969 assertions/s.

  1) Failure:
test_integer_zero_to_integer_zero_not_marked_as_changed(DirtyTest) [test/cases/dirty_test.rb:225]:
Failed assertion, no message given.

30 tests, 169 assertions, 1 failures, 0 errors, 0 skips
$
```
