### PR TITLE
Ensure :name option is respected when using t.references to create a foreign key

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_statements_ext.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_statements_ext.rb
@@ -96,6 +96,7 @@ module ActiveRecord
         end
         
         sql = "FOREIGN KEY (#{columns_sql}) REFERENCES #{quote_table_name(to_table)}(#{references_sql})"
+        sql = "CONSTRAINT #{quote_table_name(options[:name])} #{sql}" if options[:name]
         
         case options[:dependent]
         when :nullify


### PR DESCRIPTION
When using t.references to create a foreign key, the :name option is ignored. This results in an undesirable system-generated constraint name.

This simple fix adds the desired foreign key name to the generated DDL by pre-pending 

CONSTRAINT "FK_NAME"

to the generated FOREIGN KEY clause as part of the CREATE TABLE statement.
