### PR TITLE
Index support for virtual columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,9 +302,6 @@ For example it can be used to force foreign key constraint on polymorphic associ
     add_foreign_key :comments, :photos, :column => :subject_photo_id
     add_foreign_key :comments, :events, :column => :subject_event_id
 
-In the current adapter version it is not possible to set index on virtual column, because it is not correctly dumped to schema.rb.
-This restriction will be removed in the future version.
-
 For backward compatibility reasons it is possible to use `:default` option in the `create_table` instead of `:as` option.
 But this is deprecated and may be removed in the future version.
 

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -934,11 +934,14 @@ module ActiveRecord
             SELECT LOWER(i.table_name) AS table_name, LOWER(i.index_name) AS index_name, i.uniqueness,
               i.index_type, i.ityp_owner, i.ityp_name, i.parameters,
               LOWER(i.tablespace_name) AS tablespace_name,
-              LOWER(c.column_name) AS column_name, e.column_expression
+              LOWER(c.column_name) AS column_name, e.column_expression,
+              atc.virtual_column
             FROM all_indexes#{db_link} i
               JOIN all_ind_columns#{db_link} c ON c.index_name = i.index_name AND c.index_owner = i.owner
               LEFT OUTER JOIN all_ind_expressions#{db_link} e ON e.index_name = i.index_name AND
                 e.index_owner = i.owner AND e.column_position = c.column_position
+              LEFT OUTER JOIN all_tab_cols#{db_link} atc ON i.table_name = atc.table_name AND
+                c.column_name = atc.column_name AND i.owner = atc.owner AND atc.hidden_column = 'NO'
             WHERE i.owner = '#{owner}'
                AND i.table_owner = '#{owner}'
                AND NOT EXISTS (SELECT uc.index_name FROM all_constraints uc
@@ -973,7 +976,16 @@ module ActiveRecord
                 row['tablespace_name'] == default_tablespace_name ? nil : row['tablespace_name'], [])
               current_index = row['index_name']
             end
-            all_schema_indexes.last.columns << (row['column_expression'] || row['column_name'].downcase)
+
+            # Functional index columns and virtual columns both get stored as column expressions, 
+            # but re-creating a virtual column index as an expression (instead of using the virtual column's name)
+            # results in a ORA-54018 error.  Thus, we only want the column expression value returned
+            # when the column is not virtual.
+            if row['column_expression'] && row['virtual_column'] != 'YES'
+              all_schema_indexes.last.columns << row['column_expression']
+            else
+              all_schema_indexes.last.columns << row['column_name'].downcase
+            end
           end
         end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
@@ -405,6 +405,23 @@ describe "OracleEnhancedAdapter schema dump" do
         col.virtual_column_data_default.should_not =~ /:as/
       end
     end
+
+    context "with index on virtual column" do
+      before(:all) do
+        schema_define do 
+          add_index 'test_names', 'field_with_leading_space', :name => "index_on_virtual_col"
+        end
+      end
+      after(:all) do
+        schema_define do
+          remove_index 'test_names', :name => 'index_on_virtual_col'
+        end
+      end
+      it 'should dump correctly' do
+        standard_dump.should_not =~ /add_index "test_names".+FIRST_NAME.+$/
+        standard_dump.should     =~ /add_index "test_names".+field_with_leading_space.+$/
+      end
+    end
   end
 
 end


### PR DESCRIPTION
I've been dogged by ORA-54018, which is the error that prevents users from creating an index with the same expression as an existing virtual column.  I believe this is the problem that is referenced in the README (which says that indexes for virtual columns are not supported).  Here's a patch that addresses the issue - the schema dump for an index on a virtual column should reference the column name instead of the expression.
