### PR TITLE
Fix broken column remove in change_table block

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
@@ -270,8 +270,19 @@ module ActiveRecord
         clear_table_columns_cache(table_name)
       end
 
-      def remove_column(table_name, column_name) #:nodoc:
-        execute "ALTER TABLE #{quote_table_name(table_name)} DROP COLUMN #{quote_column_name(column_name)}"
+      def remove_column(table_name, *column_names) #:nodoc:
+        major, minor = ActiveRecord::VERSION::MAJOR, ActiveRecord::VERSION::MINOR
+        is_deprecated = (major == 3 and minor >= 2) or major > 3
+
+        if column_names.flatten! and is_deprecated
+          message = 'Passing array to remove_columns is deprecated, please use ' +
+            'multiple arguments, like: `remove_columns(:posts, :foo, :bar)`'
+          ActiveSupport::Deprecation.warn message, caller
+        end
+
+        column_names.each do |column_name|
+          execute "ALTER TABLE #{quote_table_name(table_name)} DROP COLUMN #{quote_column_name(column_name)}"
+        end
       ensure
         clear_table_columns_cache(table_name)
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -934,6 +934,7 @@ end
       schema_define do
         create_table :test_posts, :force => true do |t|
           t.string :title, :null => false
+          t.string :content
         end
       end
       class ::TestPost < ActiveRecord::Base; end
@@ -995,6 +996,26 @@ end
       TestPost.columns_hash['title'].should be_nil
     end
 
+    it "should remove column when using change_table" do
+      schema_define do
+        change_table :test_posts do |t|
+          t.remove :title
+        end
+      end
+      TestPost.reset_column_information
+      TestPost.columns_hash['title'].should be_nil
+    end
+
+    it "should remove multiple columns when using change_table" do
+      schema_define do
+        change_table :test_posts do |t|
+          t.remove :title, :content
+        end
+      end
+      TestPost.reset_column_information
+      TestPost.columns_hash['title'].should be_nil
+      TestPost.columns_hash['content'].should be_nil
+    end
   end
 
   describe 'virtual columns in create_table' do


### PR DESCRIPTION
This fix makes schema actions like this work:

``` ruby
change_table :posts do |t|
  t.remove :title
end
```
