### PR TITLE
Fix broken column remove inside a change_table block.

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
@@ -270,8 +270,15 @@ module ActiveRecord
         clear_table_columns_cache(table_name)
       end
 
-      def remove_column(table_name, column_name) #:nodoc:
-        execute "ALTER TABLE #{quote_table_name(table_name)} DROP COLUMN #{quote_column_name(column_name)}"
+      def remove_column(table_name, *column_names) #:nodoc:
+        if column_names.flatten!
+          message = 'Passing array to remove_columns is deprecated, please use ' +
+                    'multiple arguments, like: `remove_columns(:posts, :foo, :bar)`'
+          ActiveSupport::Deprecation.warn message, caller
+        end
+        columns_for_remove(table_name, *column_names).map { |column_name|
+          execute "ALTER TABLE #{quote_table_name(table_name)} DROP COLUMN #{quote_column_name(column_name)}"
+        }
       ensure
         clear_table_columns_cache(table_name)
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -934,6 +934,7 @@ end
       schema_define do
         create_table :test_posts, :force => true do |t|
           t.string :title, :null => false
+          t.string :content
         end
       end
       class ::TestPost < ActiveRecord::Base; end
@@ -995,6 +996,26 @@ end
       TestPost.columns_hash['title'].should be_nil
     end
 
+    it "should remove column when using change_table" do
+      schema_define do
+        change_table :test_posts do |t|
+          t.remove :title
+        end
+      end
+      TestPost.reset_column_information
+      TestPost.columns_hash['title'].should be_nil
+    end
+
+    it "should remove multiple columns when using change_table" do
+      schema_define do
+        change_table :test_posts do |t|
+          t.remove :title, :content
+        end
+      end
+      TestPost.reset_column_information
+      TestPost.columns_hash['title'].should be_nil
+      TestPost.columns_hash['content'].should be_nil
+    end
   end
 
   describe 'virtual columns in create_table' do


### PR DESCRIPTION
This pull request supports remove_column with array as argument to Oracle enhanced master branch, which supports Rails 3.2.x and lower versions.

Thanks for @tomasv pull request #216.
In addition to this, squash commits and add deprecate warning asRails 3-2-stable branch does.

See also #216 and #172.
