### PR TITLE
rails4: Ensure disconnecting or reconnecting resets the transaction state 

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -581,7 +581,7 @@ module ActiveRecord
 
       # Reconnects to the database.
       def reconnect! #:nodoc:
-        clear_cache!
+        super
         @connection.reset!
       rescue OracleEnhancedConnectionException => e
         @logger.warn "#{adapter_name} automatic reconnection failed: #{e.message}" if @logger
@@ -594,7 +594,7 @@ module ActiveRecord
 
       # Disconnects from the database.
       def disconnect! #:nodoc:
-        clear_cache!
+        super
         @connection.logoff rescue nil
       end
 


### PR DESCRIPTION
This pull request addresses following failure to support [https://github.com/rails/rails/commit/02f56554]

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/adapter_test.rb 
Using oracle
Run options: --seed 64819

# Running tests:

........FF

Finished tests in 4.111835s, 2.4320 tests/s, 5.3504 assertions/s.

  1) Failure:
test_0001_transaction state is reset after a reconnect(ActiveRecord::AdapterTestWithoutTransaction) [test/cases/adapter_test.rb:183]:
Failed assertion, no message given.

  2) Failure:
test_0002_transaction state is reset after a disconnect(ActiveRecord::AdapterTestWithoutTransaction) [test/cases/adapter_test.rb:192]:
Failed assertion, no message given.

10 tests, 22 assertions, 2 failures, 0 errors, 0 skips
$
```
