### PR TITLE
Rename the partial_updates config to partial_writes

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_procedures.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_procedures.rb
@@ -149,7 +149,7 @@ module ActiveRecord #:nodoc:
             end
           end
           # update just dirty attributes
-          if partial_updates?
+          if partial_writes?
             # Serialized attributes should always be written in case they've been
             # changed in place.
             update_using_custom_method(changed | (attributes.keys & self.class.serialized_attributes.keys))

--- a/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
@@ -228,9 +228,9 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
     @employee.first_name.should == "First"
   end
 
-  it "should not update record if nothing is changed and partial updates are enabled" do
+  it "should not update record if nothing is changed and partial writes are enabled" do
     return pending("Not in this ActiveRecord version") unless TestEmployee.respond_to?(:partial_updates=)
-    TestEmployee.partial_updates = true
+    TestEmployee.partial_writes = true
     @employee = TestEmployee.create(
       :first_name => "First",
       :last_name => "Last",
@@ -242,9 +242,9 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
     @employee.version.should == 1
   end
 
-  it "should update record if nothing is changed and partial updates are disabled" do
+  it "should update record if nothing is changed and partial writes are disabled" do
     return pending("Not in this ActiveRecord version") unless TestEmployee.respond_to?(:partial_updates=)
-    TestEmployee.partial_updates = false
+    TestEmployee.partial_writes = false
     @employee = TestEmployee.create(
       :first_name => "First",
       :last_name => "Last",
@@ -337,7 +337,7 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
   end
 
   it "should log update record" do
-    (TestEmployee.partial_updates = false) rescue nil
+    (TestEmployee.partial_writes = false) rescue nil
     @employee = TestEmployee.create(
       :first_name => "First",
       :last_name => "Last",


### PR DESCRIPTION
This pull request addresses following errors and deprecation warnings
- `NoMethodError: undefined method`partial_updates?'`
- `DEPRECATION WARNING: partial_updates= is deprecated and will be removed from Rails 4.1 (use partial_writes= instead).`

See https://github.com/rails/rails/commit/7efb1feaa for Rails commit.

``` ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
==> Running specs with MRI version 1.9.3
==> Running specs with Rails version 4.0-master
..FFDEPRECATION WARNING: partial_updates= is deprecated and will be removed from Rails 4.1 (use partial_writes= instead). (called from block (2 levels) in <top (required)> at /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:233)
FDEPRECATION WARNING: partial_updates= is deprecated and will be removed from Rails 4.1 (use partial_writes= instead). (called from block (2 levels) in <top (required)> at /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:247)
F....F.DEPRECATION WARNING: partial_updates= is deprecated and will be removed from Rails 4.1 (use partial_writes= instead). (called from block (2 levels) in <top (required)> at /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:340)
F...

Failures:

  1) OracleEnhancedAdapter custom methods for create, update and destroy should update record
     Failure/Error: @employee.save!
     NoMethodError:
       undefined method `partial_updates?' for #<TestEmployee:0x000000028e6168>
     # /home/yahonda/git/rails/activemodel/lib/active_model/attribute_methods.rb:432:in `method_missing'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods.rb:131:in `method_missing'
     # ./lib/active_record/connection_adapters/oracle_enhanced_procedures.rb:152:in `block in update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:341:in `_run__1705812210894777744__update__callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:77:in `run_callbacks'
     # ./lib/active_record/connection_adapters/oracle_enhanced_procedures.rb:140:in `update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:372:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:301:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:341:in `_run__1705812210894777744__save__callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:77:in `run_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:301:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:96:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:57:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:46:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:264:in `block in save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:312:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:201:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:209:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:201:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:208:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:264:in `save!'
     # ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:207:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:113:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:113:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:253:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:110:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:378:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:374:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:374:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:360:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:28:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:28:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/reporter.rb:34:in `report'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:25:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/runner.rb:69:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/runner.rb:8:in `block in autorun'

  2) OracleEnhancedAdapter custom methods for create, update and destroy should rollback record when exception is raised in after_update callback
     Failure/Error: lambda {
       expected Exception with "Make the transaction rollback", got #<NoMethodError: undefined method `partial_updates?' for #<TestEmployee:0x00000002c05858>>
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-expectations-2.11.3/lib/rspec/expectations/fail_with.rb:33:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-expectations-2.11.3/lib/rspec/expectations/handler.rb:19:in `handle_matcher'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-expectations-2.11.3/lib/rspec/expectations/syntax.rb:53:in `should'
     # ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:224:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:113:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:113:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:253:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:110:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:378:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:374:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:374:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:360:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:28:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:28:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/reporter.rb:34:in `report'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:25:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/runner.rb:69:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/runner.rb:8:in `block in autorun'

  3) OracleEnhancedAdapter custom methods for create, update and destroy should not update record if nothing is changed and partial updates are enabled
     Failure/Error: @employee.save!
     NoMethodError:
       undefined method `partial_updates?' for #<TestEmployee:0x00000002ec63f8>
     # /home/yahonda/git/rails/activemodel/lib/active_model/attribute_methods.rb:432:in `method_missing'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods.rb:131:in `method_missing'
     # ./lib/active_record/connection_adapters/oracle_enhanced_procedures.rb:152:in `block in update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:341:in `_run__1705812210894777744__update__callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:77:in `run_callbacks'
     # ./lib/active_record/connection_adapters/oracle_enhanced_procedures.rb:140:in `update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:372:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:301:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:341:in `_run__1705812210894777744__save__callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:77:in `run_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:301:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:96:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:57:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:46:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:264:in `block in save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:312:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:201:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:209:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:201:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:208:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:264:in `save!'
     # ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:240:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:113:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:113:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:253:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:110:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:378:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:374:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:374:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:360:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:28:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:28:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/reporter.rb:34:in `report'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:25:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/runner.rb:69:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/runner.rb:8:in `block in autorun'

  4) OracleEnhancedAdapter custom methods for create, update and destroy should update record if nothing is changed and partial updates are disabled
     Failure/Error: @employee.save!
     NoMethodError:
       undefined method `partial_updates?' for #<TestEmployee:0x00000001dfc8d8>
     # /home/yahonda/git/rails/activemodel/lib/active_model/attribute_methods.rb:432:in `method_missing'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods.rb:131:in `method_missing'
     # ./lib/active_record/connection_adapters/oracle_enhanced_procedures.rb:152:in `block in update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:341:in `_run__1705812210894777744__update__callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:77:in `run_callbacks'
     # ./lib/active_record/connection_adapters/oracle_enhanced_procedures.rb:140:in `update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:372:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:301:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:341:in `_run__1705812210894777744__save__callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:77:in `run_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:301:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:96:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:57:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:46:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:264:in `block in save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:312:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:201:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:209:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:201:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:208:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:264:in `save!'
     # ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:254:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:113:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:113:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:253:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:110:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:378:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:374:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:374:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:360:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:28:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:28:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/reporter.rb:34:in `report'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:25:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/runner.rb:69:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/runner.rb:8:in `block in autorun'

  5) OracleEnhancedAdapter custom methods for create, update and destroy should set timestamps when updating record
     Failure/Error: @employee.save!
     NoMethodError:
       undefined method `partial_updates?' for #<TestEmployee:0x00000002eaa8b0>
     # /home/yahonda/git/rails/activemodel/lib/active_model/attribute_methods.rb:432:in `method_missing'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods.rb:131:in `method_missing'
     # ./lib/active_record/connection_adapters/oracle_enhanced_procedures.rb:152:in `block in update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:341:in `_run__1705812210894777744__update__callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:77:in `run_callbacks'
     # ./lib/active_record/connection_adapters/oracle_enhanced_procedures.rb:140:in `update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:372:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:301:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:341:in `_run__1705812210894777744__save__callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:77:in `run_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:301:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:96:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:57:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:46:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:264:in `block in save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:312:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:201:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:209:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:201:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:208:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:264:in `save!'
     # ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:323:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:113:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:113:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:253:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:110:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:378:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:374:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:374:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:360:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:28:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:28:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/reporter.rb:34:in `report'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:25:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/runner.rb:69:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/runner.rb:8:in `block in autorun'

  6) OracleEnhancedAdapter custom methods for create, update and destroy should log update record
     Failure/Error: @employee.save!
     NoMethodError:
       undefined method `partial_updates?' for #<TestEmployee:0x00000002dcd410>
     # /home/yahonda/git/rails/activemodel/lib/active_model/attribute_methods.rb:432:in `method_missing'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods.rb:131:in `method_missing'
     # ./lib/active_record/connection_adapters/oracle_enhanced_procedures.rb:152:in `block in update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:341:in `_run__1705812210894777744__update__callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:77:in `run_callbacks'
     # ./lib/active_record/connection_adapters/oracle_enhanced_procedures.rb:140:in `update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:372:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:301:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:341:in `_run__1705812210894777744__save__callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:77:in `run_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:301:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:96:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:57:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:46:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:264:in `block in save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:312:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:201:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:209:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:201:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:208:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:264:in `save!'
     # ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:347:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:113:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:113:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:253:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:110:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:378:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:374:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:374:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:360:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:28:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:28:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/reporter.rb:34:in `report'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:25:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/runner.rb:69:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/runner.rb:8:in `block in autorun'

Finished in 2.47 seconds
16 examples, 6 failures

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:198 # OracleEnhancedAdapter custom methods for create, update and destroy should update record
rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:212 # OracleEnhancedAdapter custom methods for create, update and destroy should rollback record when exception is raised in after_update callback
rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:231 # OracleEnhancedAdapter custom methods for create, update and destroy should not update record if nothing is changed and partial updates are enabled
rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:245 # OracleEnhancedAdapter custom methods for create, update and destroy should update record if nothing is changed and partial updates are disabled
rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:313 # OracleEnhancedAdapter custom methods for create, update and destroy should set timestamps when updating record
rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:339 # OracleEnhancedAdapter custom methods for create, update and destroy should log update record
$
```
