### PR TITLE
Address        you can't redefine the primary key column 'id'. To define a custom primary key, pass { id: false } to create_table. 

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -1212,7 +1212,7 @@ end
       it "should use correct tablespace" do
         ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[:table] = DATABASE_NON_DEFAULT_TABLESPACE
         @conn.create_table :tablespace_tests do |t|
-          t.integer :id
+          t.string :foo
         end
         @would_execute_sql.should =~ /CREATE +TABLE .* \(.*\) TABLESPACE #{DATABASE_NON_DEFAULT_TABLESPACE}/
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
@@ -250,7 +250,7 @@ describe "OracleEnhancedAdapter structure dump" do
   describe "full drop" do
     before(:each) do 
       @conn.create_table :full_drop_test do |t|
-        t.integer :id
+        t.string :foo
       end
       @conn.create_table :full_drop_test_temp, :temporary => true do |t|
         t.string :foo


### PR DESCRIPTION
This pull request addresses following failures 

``` ruby
$ rake spec
/home/yahonda/.rvm/rubies/ruby-1.9.3-p286/bin/ruby -S rspec ./spec/active_record/connection_adapters/oracle_enhanced_cpk_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_emulate_oracle_adapter_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_core_ext_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_dbms_output_spec.rb
==> Running specs with MRI version 1.9.3
==> Running specs with Rails version 4.0-master
...............................
An error occurred in an after hook
  ActiveRecord::StatementInvalid: OCIError: ORA-00942: table or view does not exist: DROP TABLE "FULL_DROP_TEST"
  occurred at stmt.c:253:in oci8lib_191.so

F
An error occurred in an after hook
  ActiveRecord::StatementInvalid: OCIError: ORA-00942: table or view does not exist: DROP TABLE "FULL_DROP_TEST"
  occurred at stmt.c:253:in oci8lib_191.so

F..............................................................................................[DEPRECATION] virtual column `:default` option is deprecated.  Please use `:as` instead.
............F.............................................................................................................................................................................................................

Failures:

  1) OracleEnhancedAdapter structure dump full drop should contain correct sql
     Failure/Error: t.integer :id
     ArgumentError:
       you can't redefine the primary key column 'id'. To define a custom primary key, pass { id: false } to create_table.
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb:238:in `column'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_definitions.rb:92:in `column_with_virtual_columns'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:67:in `column'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb:261:in `block in integer'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb:261:in `each'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb:261:in `integer'
     # ./spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb:253:in `block (4 levels) in <top (required)>'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:71:in `call'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:71:in `create_table'
     # ./spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb:252:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:236:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:236:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/hooks.rb:23:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/hooks.rb:72:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/hooks.rb:72:in `each'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/hooks.rb:72:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/hooks.rb:424:in `run_hook'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:323:in `run_before_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:299:in `run_before_each'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:112:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:253:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:110:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:378:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:374:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:374:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:360:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:361:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:361:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:361:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:28:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:28:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/reporter.rb:34:in `report'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:25:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/runner.rb:69:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/runner.rb:8:in `block in autorun'

  2) OracleEnhancedAdapter structure dump full drop should not drop tables when preserve_tables is true
     Failure/Error: t.integer :id
     ArgumentError:
       you can't redefine the primary key column 'id'. To define a custom primary key, pass { id: false } to create_table.
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb:238:in `column'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_definitions.rb:92:in `column_with_virtual_columns'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:67:in `column'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb:261:in `block in integer'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb:261:in `each'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb:261:in `integer'
     # ./spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb:253:in `block (4 levels) in <top (required)>'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:71:in `call'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:71:in `create_table'
     # ./spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb:252:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:236:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:236:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/hooks.rb:23:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/hooks.rb:72:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/hooks.rb:72:in `each'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/hooks.rb:72:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/hooks.rb:424:in `run_hook'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:323:in `run_before_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:299:in `run_before_each'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:112:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:253:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:110:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:378:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:374:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:374:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:360:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:361:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:361:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:361:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:28:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:28:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/reporter.rb:34:in `report'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:25:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/runner.rb:69:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/runner.rb:8:in `block in autorun'

  3) OracleEnhancedAdapter schema definition miscellaneous options creating a table with a tablespace defaults set should use correct tablespace
     Failure/Error: t.integer :id
     ArgumentError:
       you can't redefine the primary key column 'id'. To define a custom primary key, pass { id: false } to create_table.
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb:238:in `column'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_definitions.rb:92:in `column_with_virtual_columns'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:67:in `column'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb:261:in `block in integer'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb:261:in `each'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb:261:in `integer'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1215:in `block (5 levels) in <top (required)>'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:71:in `call'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:71:in `create_table'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1214:in `block (4 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:113:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:113:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:253:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example.rb:110:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:378:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:374:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:374:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:360:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:361:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:361:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:361:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:361:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:361:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/example_group.rb:361:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:28:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:28:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/reporter.rb:34:in `report'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:25:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/runner.rb:69:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p286@railsmaster/gems/rspec-core-2.11.1/lib/rspec/core/runner.rb:8:in `block in autorun'

Finished in 1 minute 0.81723 seconds
345 examples, 3 failures

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb:320 # OracleEnhancedAdapter structure dump full drop should contain correct sql
rspec ./spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb:333 # OracleEnhancedAdapter structure dump full drop should not drop tables when preserve_tables is true
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1212 # OracleEnhancedAdapter schema definition miscellaneous options creating a table with a tablespace defaults set should use correct tablespace
rake aborted!
/home/yahonda/.rvm/rubies/ruby-1.9.3-p286/bin/ruby -S rspec ./spec/active_record/connection_adapters/oracle_enhanced_cpk_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_emulate_oracle_adapter_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_core_ext_spec.rb ./spec/active_record/connection_adapters/oracle_enhanced_dbms_output_spec.rb failed

Tasks: TOP => spec
(See full trace by running task with --trace)
$
```

See https://github.com/rails/rails/commit/e4790a2c5b99704f430c837d8f22fec418f2c8af for the original commit.
