### PR TITLE
Change add_index method to support changes at rails master

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
@@ -121,14 +121,22 @@ module ActiveRecord
       # clear cached indexes when adding new index
       def add_index(table_name, column_name, options = {}) #:nodoc:
         column_names = Array(column_name)
-        index_name   = index_name(table_name, :column => column_names)
+        index_name   = index_name(table_name, column: column_names)
 
         if Hash === options # legacy support, since this param was a string
+          options.assert_valid_keys(:unique, :order, :name, :where, :length, :tablespace, :options)
+
           index_type = options[:unique] ? "UNIQUE" : ""
           index_name = options[:name].to_s if options.key?(:name)
           tablespace = tablespace_for(:index, options[:tablespace])
           additional_options = options[:options]
         else
+          message = "Passing a string as third argument of `add_index` is deprecated and will" +
+            " be removed in Rails 4.1." +
+            " Use add_index(#{table_name.inspect}, #{column_name.inspect}, unique: true) instead"
+
+          ActiveSupport::Deprecation.warn message
+
           index_type = options
           additional_options = nil
         end


### PR DESCRIPTION
This pull request addresses following failures after these two commits at rails master.
- https://github.com/rails/rails/commit/8fc52706
  Raise an ArgumentError when passing an invalid option to add_index
- https://github.com/rails/rails/commit/7042fe2f
  Deprecate passing a string as third argument of `add_index`

``` ruby
$  ARCONN=oracle ruby -Ilib:test test/cases/migration/index_test.rb
Using oracle
    Run options: --seed 62785

# Running tests:

...SF........F

Finished tests in 13.890548s, 1.0079 tests/s, 1.2239 assertions/s.

  1) Failure:
test_deprecated_type_argument(ActiveRecord::Migration::IndexTest) [test/cases/migration/index_test.rb:105]:
Expected a deprecation warning within the block but received none

  2) Failure:
test_valid_index_options(ActiveRecord::Migration::IndexTest) [test/cases/migration/index_test.rb:95]:
ArgumentError expected but nothing was raised.

14 tests, 17 assertions, 2 failures, 0 errors, 1 skips
$
```
