### PR TITLE
Address unnecessary warnings when option set to nil

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
@@ -130,6 +130,8 @@ module ActiveRecord
           index_name = options[:name].to_s if options.key?(:name)
           tablespace = tablespace_for(:index, options[:tablespace])
           additional_options = options[:options]
+        elsif NilClass === options
+          # To avoid unnecessary warnings when options set to nil.
         else
           message = "Passing a string as third argument of `add_index` is deprecated and will" +
             " be removed in Rails 4.1." +


### PR DESCRIPTION
This pull request addresses unnecessary warnings reported in #243
