### PR TITLE
Remove_column should raise an ArgumentError when no columns are passed

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
@@ -271,6 +271,8 @@ module ActiveRecord
       end
 
       def remove_column(table_name, *column_names) #:nodoc:
+        raise ArgumentError.new("You must specify at least one column name.  Example: remove_column(:people, :first_name)") if column_names.empty?
+
         major, minor = ActiveRecord::VERSION::MAJOR, ActiveRecord::VERSION::MINOR
         is_deprecated = (major == 3 and minor >= 2) or major > 3
 


### PR DESCRIPTION
This pull request addresses following test failure.

``` ruby
$ ARCONN=oracle  ruby -Ilib:test test/cases/migration_test.rb -n test_remove_column_no_second_parameter_raises_exception

*** Mocha deprecation warning: Change `require 'mocha'` to `require 'mocha/setup'`.

Using oracle with Identity Map off
Run options: -n test_remove_column_no_second_parameter_raises_exception

# Running tests:

F

Finished tests in 0.425817s, 2.3484 tests/s, 2.3484 assertions/s.

  1) Failure:
test_remove_column_no_second_parameter_raises_exception(MigrationTest) [test/cases/migration_test.rb:873]:
ArgumentError expected but nothing was raised.

1 tests, 1 assertions, 1 failures, 0 errors, 0 skips
$
```

See https://github.com/rails/rails/commit/e639536e for rails commit.
