### PR TITLE
Address numeric column changes failures

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_dirty.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_dirty.rb
@@ -18,7 +18,7 @@ module ActiveRecord #:nodoc:
             # therefore need to convert empty string value to nil if old value is nil
             elsif column.type == :string && column.null && old.nil?
               value = nil if value == ''
-            elsif old == 0 && value.present? && value != '0'
+            elsif old == 0 && value.is_a?(String) && value.present? && value != '0'
               value = nil
             else
               value = column.type_cast(value)


### PR DESCRIPTION
This pull request addresses following failure by chrry-picking  e354c82d and 57e14d92 which were already committed to rails4 branch. 

``` ruby
$ ARCONN=oracle  ruby -Ilib:test test/cases/nested_attributes_test.rb -n test_numeric_colum_changes_from_zero_to_no_empty_string

*** Mocha deprecation warning: Change `require 'mocha'` to `require 'mocha/setup'`.

Using oracle with Identity Map off
Run options: -n test_numeric_colum_changes_from_zero_to_no_empty_string

# Running tests:

FF

Finished tests in 0.709899s, 2.8173 tests/s, 5.6346 assertions/s.

  1) Failure:
test_numeric_colum_changes_from_zero_to_no_empty_string(TestNestedAttributesOnAHasAndBelongsToManyAssociation) [test/cases/nested_attributes_test.rb:782]:
Failed assertion, no message given.

  2) Failure:
test_numeric_colum_changes_from_zero_to_no_empty_string(TestNestedAttributesOnAHasManyAssociation) [test/cases/nested_attributes_test.rb:782]:
Failed assertion, no message given.

2 tests, 4 assertions, 2 failures, 0 errors, 0 skips
$
```
