### PR TITLE
Issue #134 :returning_id column should be of type Column.

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -46,7 +46,7 @@ module ActiveRecord
     # Oracle enhanced adapter will work with both
     # Ruby 1.8/1.9 ruby-oci8 gem (which provides interface to Oracle OCI client)
     # or with JRuby and Oracle JDBC driver.
-    # 
+    #
     # It should work with Oracle 9i, 10g and 11g databases.
     # Limited set of functionality should work on Oracle 8i as well but several features
     # rely on newer functionality in Oracle database.
@@ -71,9 +71,9 @@ module ActiveRecord
     # * <tt>:username</tt>
     # * <tt>:password</tt>
     # * <tt>:database</tt> - either TNS alias or connection string for OCI client or database name in JDBC connection string
-    # 
+    #
     # Optional parameters:
-    # 
+    #
     # * <tt>:host</tt> - host name for JDBC connection, defaults to "localhost"
     # * <tt>:port</tt> - port number for JDBC connection, defaults to 1521
     # * <tt>:privilege</tt> - set "SYSDBA" if you want to connect with this privilege
@@ -82,9 +82,9 @@ module ActiveRecord
     # * <tt>:cursor_sharing</tt> - cursor sharing mode to minimize amount of unique statements, defaults to "force"
     # * <tt>:time_zone</tt> - database session time zone
     #   (it is recommended to set it using ENV['TZ'] which will be then also used for database session time zone)
-    # 
+    #
     # Optionals NLS parameters:
-    # 
+    #
     # * <tt>:nls_calendar</tt>
     # * <tt>:nls_characterset</tt>
     # * <tt>:nls_comp</tt>
@@ -105,7 +105,7 @@ module ActiveRecord
     # * <tt>:nls_timestamp_tz_format</tt>
     # * <tt>:nls_time_format</tt>
     # * <tt>:nls_time_tz_format</tt>
-    # 
+    #
     class OracleEnhancedAdapter < AbstractAdapter
 
       ##
@@ -126,12 +126,12 @@ module ActiveRecord
       # to Date then you can add the following line to your initializer file:
       #
       #   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates = true
-      # 
+      #
       # As this option can have side effects when unnecessary typecasting is done it is recommended
       # that Date columns are explicily defined with +set_date_columns+ method.
       cattr_accessor :emulate_dates
       self.emulate_dates = false
-      
+
        ##
         # :singleton-method:
         # OracleEnhancedAdapter will use the default tablespace, but if you want specific types of
@@ -139,7 +139,7 @@ module ActiveRecord
         #
         #   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces =
         #  {:clob => 'TS_LOB', :blob => 'TS_LOB', :index => 'TS_INDEX', :table => 'TS_DATA'}
-        # 
+        #
         # Using the :tablespace option where available (e.g create_table) will take precedence
         # over these settings.
       cattr_accessor :default_tablespaces
@@ -153,7 +153,7 @@ module ActiveRecord
       # to Date then you can add the following line to your initializer file:
       #
       #   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = true
-      # 
+      #
       # As this option can have side effects when unnecessary typecasting is done it is recommended
       # that Date columns are explicily defined with +set_date_columns+ method.
       cattr_accessor :emulate_dates_by_column_name
@@ -212,7 +212,7 @@ module ActiveRecord
         return true if ["CHAR(1)","VARCHAR2(1)"].include?(field_type)
         field_type =~ /^VARCHAR2/ && (name =~ /_flag$/i || name =~ /_yn$/i)
       end
-      
+
       # How boolean value should be quoted to String.
       # Used if +emulate_booleans_from_strings+ option is set to +true+.
       def self.boolean_to_string(bool)
@@ -222,15 +222,15 @@ module ActiveRecord
       ##
       # :singleton-method:
       # Specify non-default date format that should be used when assigning string values to :date columns, e.g.:
-      # 
+      #
       #   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.string_to_date_format = “%d.%m.%Y”
       cattr_accessor :string_to_date_format
       self.string_to_date_format = nil
-      
+
       ##
       # :singleton-method:
       # Specify non-default time format that should be used when assigning string values to :datetime columns, e.g.:
-      # 
+      #
       #   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.string_to_time_format = “%d.%m.%Y %H:%M:%S”
       cattr_accessor :string_to_time_format
       self.string_to_time_format = nil
@@ -279,7 +279,7 @@ module ActiveRecord
       end
 
       ADAPTER_NAME = 'OracleEnhanced'.freeze
-      
+
       def adapter_name #:nodoc:
         ADAPTER_NAME
       end
@@ -418,12 +418,12 @@ module ActiveRecord
       # Names must be from 1 to 30 bytes long with these exceptions:
       # * Names of databases are limited to 8 bytes.
       # * Names of database links can be as long as 128 bytes.
-      #  
+      #
       # Nonquoted identifiers cannot be Oracle Database reserved words
-      #  
+      #
       # Nonquoted identifiers must begin with an alphabetic character from
       # your database character set
-      #  
+      #
       # Nonquoted identifiers can contain only alphanumeric characters from
       # your database character set and the underscore (_), dollar sign ($),
       # and pound sign (#). Database links can also contain periods (.) and
@@ -438,7 +438,7 @@ module ActiveRecord
       # can be prefixed with schema name
       # CamelCase table names should be quoted
       def self.valid_table_name?(name) #:nodoc:
-        name = name.to_s 
+        name = name.to_s
         name =~ VALID_TABLE_NAME && !(name =~ /[A-Z]/ && name =~ /[a-z]/) ? true : false
       end
 
@@ -446,7 +446,7 @@ module ActiveRecord
         name = name.to_s
         @quoted_table_names[name] ||= name.split('.').map{|n| n.split('@').map{|m| quote_column_name(m)}.join('@')}.join('.')
       end
-      
+
       def quote_string(s) #:nodoc:
         s.gsub(/'/, "''")
       end
@@ -696,17 +696,16 @@ module ActiveRecord
       def sql_for_insert(sql, pk, id_value, sequence_name, binds)
         unless id_value || pk.nil? || (defined?(CompositePrimaryKeys) && pk.kind_of?(CompositePrimaryKeys::CompositeKeys))
           sql = "#{sql} RETURNING #{quote_column_name(pk)} INTO :returning_id"
-          (binds = binds.dup) << [:returning_id, nil]
+          returning_id_col = OracleEnhancedColumn.new("returning_id", nil, "number", true, "dual", :integer, true, true)
+          (binds = binds.dup) << [returning_id_col, nil]
         end
         [sql, binds]
       end
 
-      EXEC_INSERT_RESULT_COLUMNS = %w(returning_id) #:nodoc:
-
       # New method in ActiveRecord 3.1
       def exec_insert(sql, name, binds)
         log(sql, name, binds) do
-          returning_id_index = nil
+          returning_id_col = returning_id_index = nil
           cursor = if @statements.key?(sql)
             @statements[sql]
           else
@@ -715,7 +714,8 @@ module ActiveRecord
 
           binds.each_with_index do |bind, i|
             col, val = bind
-            if col == :returning_id
+            if col.returning_id?
+              returning_id_col = [col]
               returning_id_index = i + 1
               cursor.bind_returning_param(returning_id_index, Integer)
             else
@@ -730,7 +730,7 @@ module ActiveRecord
             returning_id = cursor.get_returning_param(returning_id_index, Integer)
             rows << [returning_id]
           end
-          ActiveRecord::Result.new(EXEC_INSERT_RESULT_COLUMNS, rows)
+          ActiveRecord::Result.new(returning_id_col || [], rows)
         end
       end
 
@@ -977,7 +977,7 @@ module ActiveRecord
               current_index = row['index_name']
             end
 
-            # Functional index columns and virtual columns both get stored as column expressions, 
+            # Functional index columns and virtual columns both get stored as column expressions,
             # but re-creating a virtual column index as an expression (instead of using the virtual column's name)
             # results in a ORA-54018 error.  Thus, we only want the column expression value returned
             # when the column is not virtual.
@@ -1003,12 +1003,12 @@ module ActiveRecord
         @@ignore_table_columns[table_name] += args.map{|a| a.to_s.downcase}
         @@ignore_table_columns[table_name].uniq!
       end
-      
+
       def ignored_table_columns(table_name) #:nodoc:
         @@ignore_table_columns ||= {}
         @@ignore_table_columns[table_name]
       end
-      
+
       # used just in tests to clear ignored table columns
       def clear_ignored_table_columns #:nodoc:
         @@ignore_table_columns = nil
@@ -1024,7 +1024,7 @@ module ActiveRecord
           @@table_column_type[table_name][col.to_s.downcase] = column_type
         end
       end
-      
+
       def get_type_for_column(table_name, column_name) #:nodoc:
         @@table_column_type && @@table_column_type[table_name] && @@table_column_type[table_name][column_name.to_s.downcase]
       end
@@ -1111,7 +1111,7 @@ module ActiveRecord
           if row['data_default'] && !is_virtual
             row['data_default'].sub!(/^(.*?)\s*$/, '\1')
 
-            # If a default contains a newline these cleanup regexes need to 
+            # If a default contains a newline these cleanup regexes need to
             # match newlines.
             row['data_default'].sub!(/^'(.*)'$/m, '\1')
             row['data_default'] = nil if row['data_default'] =~ /^(null|empty_[bc]lob\(\))$/i
@@ -1150,7 +1150,7 @@ module ActiveRecord
       cattr_accessor :default_sequence_start_value
       self.default_sequence_start_value = 10000
 
-      # Find a table's primary key and sequence. 
+      # Find a table's primary key and sequence.
       # *Note*: Only primary key is implemented - sequence will be nil.
       def pk_and_sequence_for(table_name, owner=nil, desc_table_name=nil, db_link=nil) #:nodoc:
         if @@cache_columns
@@ -1198,7 +1198,7 @@ module ActiveRecord
       # Oracle requires the ORDER BY columns to be in the SELECT list for DISTINCT
       # queries. However, with those columns included in the SELECT DISTINCT list, you
       # won't actually get a distinct list of the column you want (presuming the column
-      # has duplicates with multiple values for the ordered-by columns. So we use the 
+      # has duplicates with multiple values for the ordered-by columns. So we use the
       # FIRST_VALUE function to get a single (first) value for each column, effectively
       # making every row the same.
       #
@@ -1296,7 +1296,7 @@ module ActiveRecord
       #
       # PL/SQL in Oracle uses dbms_output for logging print statements
       # These methods stick that output into the Rails log so Ruby and PL/SQL
-      # code can can be debugged together in a single application 
+      # code can can be debugged together in a single application
 
       # Maximum DBMS_OUTPUT buffer size
       DBMS_OUTPUT_BUFFER_SIZE = 10000  # can be 1-1000000
@@ -1328,7 +1328,7 @@ module ActiveRecord
       ensure
         log_dbms_output if dbms_output_enabled?
       end
-      
+
       private
 
       def set_dbms_output_plsql_connection

--- a/lib/active_record/connection_adapters/oracle_enhanced_column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_column.rb
@@ -2,13 +2,14 @@ module ActiveRecord
   module ConnectionAdapters #:nodoc:
     class OracleEnhancedColumn < Column
 
-      attr_reader :table_name, :forced_column_type, :nchar, :virtual_column_data_default #:nodoc:
+      attr_reader :table_name, :forced_column_type, :nchar, :virtual_column_data_default, :returning_id #:nodoc:
 
-      def initialize(name, default, sql_type = nil, null = true, table_name = nil, forced_column_type = nil, virtual=false) #:nodoc:
+      def initialize(name, default, sql_type = nil, null = true, table_name = nil, forced_column_type = nil, virtual=false, returning_id=false) #:nodoc:
         @table_name = table_name
         @forced_column_type = forced_column_type
         @virtual = virtual
         @virtual_column_data_default = default.inspect if virtual
+        @returning_id = returning_id
         default = nil if virtual
         super(name, default, sql_type, null)
         # Is column NCHAR or NVARCHAR2 (will need to use N'...' value quoting for these data types)?
@@ -24,6 +25,10 @@ module ActiveRecord
 
       def virtual?
         @virtual
+      end
+
+      def returning_id?
+        @returning_id
       end
 
       def lob?


### PR DESCRIPTION
Using rails 3.2.9 and this gem v1.4.1.

Feb 11, 2011 ActiveRecord LogSubscriber was changed to log the bind parameters, and assumes "binds" passes an AR Column object (or something that implements the "name" method).

So instead of a symbol :returning_id it should pass an instance of OracleEnhancedColumn.

Attached patch fixes this.
