### PR TITLE
Remove field_changed? method from rails4 branch

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_dirty.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_dirty.rb
@@ -37,10 +37,5 @@ end
 if ActiveRecord::Base.method_defined?(:changed?)
   ActiveRecord::Base.class_eval do
     include ActiveRecord::ConnectionAdapters::OracleEnhancedDirty::InstanceMethods
-    # Starting with rails 3.2.9 the method #field_changed?
-    # was renamed to #_field_changed?
-    if private_method_defined?(:field_changed?)
-      alias_method :field_changed?, :_field_changed?
-    end
   end
 end


### PR DESCRIPTION
Since Rails 3.2.9 and higher version only _field_changed? method should exist.
As of right now, rails4 branch does not support lower version of Rails, this alias_method should not exist.

This commit actually reverts part of ea66792262d21d72ce77d56f75f7e41ebc997fa1
