### PR TITLE
Supports table_name prefix/suffix for add_foreign_key

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_statements_ext.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_statements_ext.rb
@@ -95,7 +95,7 @@ module ActiveRecord
           references_sql = quote_column_name(options[:primary_key] || references || "id")
         end
 
-        table_name = quote_table_name("#{ActiveRecord::Base.table_name_prefix}#{to_table}")
+        table_name = quote_table_name("#{ActiveRecord::Base.table_name_prefix}#{to_table}#{ActiveRecord::Base.table_name_suffix}")
 
         sql = "FOREIGN KEY (#{columns_sql}) REFERENCES #{table_name}(#{references_sql})"
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -537,9 +537,11 @@ end
 
   describe "foreign key constraints" do
     let(:table_name_prefix) { nil }
+    let(:table_name_suffix) { nil }
 
     before(:each) do
       ActiveRecord::Base.table_name_prefix = table_name_prefix
+      ActiveRecord::Base.table_name_suffix = table_name_suffix
       schema_define do
         create_table :test_posts, :force => true do |t|
           t.string :title
@@ -566,6 +568,7 @@ end
         drop_table :test_posts rescue nil
       end
       ActiveRecord::Base.table_name_prefix = nil
+      ActiveRecord::Base.table_name_suffix = nil
       ActiveRecord::Base.clear_cache! if ActiveRecord::Base.respond_to?(:"clear_cache!")
     end
 
@@ -589,6 +592,20 @@ end
         lambda do
           TestComment.create(:body => "test", :test_post_id => 1)
         end.should raise_error() {|e| e.message.should =~ /ORA-02291.*\.XXX_TES_COM_TES_POS_ID_FK/}
+      end
+    end
+
+    context "with table_name_suffix" do
+      let(:table_name_suffix) { '_xxx' }
+
+      it "should use table_name_prefix for foreign table" do
+        schema_define do
+          add_foreign_key :test_comments, :test_posts
+        end
+
+        lambda do
+          TestComment.create(:body => "test", :test_post_id => 1)
+        end.should raise_error() {|e| e.message.should =~ /ORA-02291.*\.TES_COM_XXX_TES_POS_ID_FK/}
       end
     end
 


### PR DESCRIPTION
This change will allow the `add_foreign_key` method to work with table name prefixes and suffixes.
With this code, it is now possible to change the suffix or prefix of tables without having to modify your migrations.
