### PR TITLE
Supports table_name prefix/suffix for add_foreign_key

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_statements_ext.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_statements_ext.rb
@@ -94,9 +94,11 @@ module ActiveRecord
           references = options[:references] ? options[:references].first : nil
           references_sql = quote_column_name(options[:primary_key] || references || "id")
         end
-        
-        sql = "FOREIGN KEY (#{columns_sql}) REFERENCES #{quote_table_name(to_table)}(#{references_sql})"
-        
+
+        table_name = ActiveRecord::Migrator.proper_table_name(to_table)
+
+        sql = "FOREIGN KEY (#{columns_sql}) REFERENCES #{quote_table_name(table_name)}(#{references_sql})"
+
         case options[:dependent]
         when :nullify
           sql << " ON DELETE SET NULL"

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -545,7 +545,12 @@ end
   end
 
   describe "foreign key constraints" do
+    let(:table_name_prefix) { nil }
+    let(:table_name_suffix) { nil }
+
     before(:each) do
+      ActiveRecord::Base.table_name_prefix = table_name_prefix
+      ActiveRecord::Base.table_name_suffix = table_name_suffix
       schema_define do
         create_table :test_posts, :force => true do |t|
           t.string :title
@@ -571,6 +576,8 @@ end
         drop_table :test_comments rescue nil
         drop_table :test_posts rescue nil
       end
+      ActiveRecord::Base.table_name_prefix = nil
+      ActiveRecord::Base.table_name_suffix = nil
       ActiveRecord::Base.clear_cache! if ActiveRecord::Base.respond_to?(:"clear_cache!")
     end
 
@@ -581,6 +588,34 @@ end
       lambda do
         TestComment.create(:body => "test", :test_post_id => 1)
       end.should raise_error() {|e| e.message.should =~ /ORA-02291.*\.TEST_COMMENTS_TEST_POST_ID_FK/}
+    end
+
+    context "with table_name_prefix" do
+      let(:table_name_prefix) { 'xxx_' }
+
+      it "should use table_name_prefix for foreign table" do
+        schema_define do
+          add_foreign_key :test_comments, :test_posts
+        end
+
+        lambda do
+          TestComment.create(:body => "test", :test_post_id => 1)
+        end.should raise_error() {|e| e.message.should =~ /ORA-02291.*\.XXX_TES_COM_TES_POS_ID_FK/}
+      end
+    end
+
+    context "with table_name_suffix" do
+      let(:table_name_suffix) { '_xxx' }
+
+      it "should use table_name_suffix for foreign table" do
+        schema_define do
+          add_foreign_key :test_comments, :test_posts
+        end
+
+        lambda do
+          TestComment.create(:body => "test", :test_post_id => 1)
+        end.should raise_error() {|e| e.message.should =~ /ORA-02291.*\.TES_COM_XXX_TES_POS_ID_FK/}
+      end
     end
 
     it "should add foreign key with name" do


### PR DESCRIPTION
## Problem:

The following issue exists when `ActiveRecord::Base.table_name_prefix` is set and `add_foreign_key` is called.

Assume the following code:

``` ruby
ActiveRecord::Base.table_name_prefix = 'reenhanced_'

add_foreign_key("clients", "records", {:name=>"clients_record_id_fk"})
```

When `rake db:migrate` is run:

```
rake aborted!
NativeException: java.sql.SQLSyntaxErrorException: ORA-00942: table or view does not exist
: ALTER TABLE "REENHANCED_CLIENTS" ADD CONSTRAINT "CLIENTS_RECORD_ID_FK" FOREIGN KEY ("RECORD_ID") REFERENCES "RECORDS"("ID")
```
## Solution:

This change will allow the `add_foreign_key` method to work with table name prefixes and suffixes.
With this code, it is now possible to change the suffix or prefix of tables without having to modify your migrations.

---

Closes reenhanced/oracle-enhanced#1

LGTM given by: @codenamev

``` text
Squashed commit of the following:

commit b1c0fedfca69cde2d20ea362ea738afd422e516e
Author: Nicholas Hance <nhance@reenhanced.com>
Date:   Tue Dec 11 11:16:39 2012 -0500

    typo

commit 6f776e4589a2a0e6873d1d624428db29bfae904d
Author: Nicholas Hance <nhance@reenhanced.com>
Date:   Tue Dec 11 11:07:25 2012 -0500

    Supports table_name_suffix for add_foreign key

commit db3c2655a7717905443348f576e4a278942ce903
Author: Nicholas Hance <nhance@reenhanced.com>
Date:   Tue Dec 11 10:44:34 2012 -0500

    Support table prefix for add_foreign_key
```
