### PR TITLE
add_foreign_key fix when primary_key is not 'id'

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_dumper.rb
@@ -61,12 +61,13 @@ module ActiveRecord #:nodoc:
           add_foreign_key_statements = foreign_keys.map do |foreign_key|
             statement_parts = [ ('add_foreign_key ' + foreign_key.from_table.inspect) ]
             statement_parts << foreign_key.to_table.inspect
+            
             if foreign_key.options[:columns].size == 1
               column = foreign_key.options[:columns].first
               if column != "#{foreign_key.to_table.singularize}_id"
                 statement_parts << (':column => ' + column.inspect)
               end
-
+							
               if foreign_key.options[:references].first != 'id'
                 statement_parts << (':primary_key => ' + foreign_key.options[:references].first.inspect)
               end


### PR DESCRIPTION
When adding a foreign key and the foreign table's primary key is not 'id', the function `add_foreign_key` is setting `:primary_key => nil` . I printed the output of `foreign_key.options` on some of my tables:

`{:name=>"fk_instructor_person_id", :columns=>["person_id"], :references=>["personid"], :dependent=>nil}`

As you can see, there is no :primary_key key. This is on Oracle 11g release 2. 

Instead, I replaced it with `foreign_key.options[:references].first.inspect`, and now it is working.

PS I am sorry about all the commits, I was using github's editor.
