### PR TITLE
Remove `:nls_characterset` and `:nls_nchar_characterset` from NLS optional parameters

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -86,7 +86,6 @@ module ActiveRecord
     # Optionals NLS parameters:
     # 
     # * <tt>:nls_calendar</tt>
-    # * <tt>:nls_characterset</tt>
     # * <tt>:nls_comp</tt>
     # * <tt>:nls_currency</tt>
     # * <tt>:nls_date_format</tt> - format for :date columns, defaults to <tt>YYYY-MM-DD HH24:MI:SS</tt>
@@ -96,7 +95,6 @@ module ActiveRecord
     # * <tt>:nls_language</tt>
     # * <tt>:nls_length_semantics</tt> - semantics of size of VARCHAR2 and CHAR columns, defaults to <tt>CHAR</tt>
     #   (meaning that size specifies number of characters and not bytes)
-    # * <tt>:nls_nchar_characterset</tt>
     # * <tt>:nls_nchar_conv_excp</tt>
     # * <tt>:nls_numeric_characters</tt>
     # * <tt>:nls_sort</tt>
@@ -299,7 +297,6 @@ module ActiveRecord
       #:stopdoc:
       DEFAULT_NLS_PARAMETERS = {
         :nls_calendar            => nil,
-        :nls_characterset        => nil,
         :nls_comp                => nil,
         :nls_currency            => nil,
         :nls_date_format         => 'YYYY-MM-DD HH24:MI:SS',
@@ -308,7 +305,6 @@ module ActiveRecord
         :nls_iso_currency        => nil,
         :nls_language            => nil,
         :nls_length_semantics    => 'CHAR',
-        :nls_nchar_characterset  => nil,
         :nls_nchar_conv_excp     => nil,
         :nls_numeric_characters  => nil,
         :nls_sort                => nil,


### PR DESCRIPTION
This pull request addresses issue #265.

Oracle does not support change these parameters at session level, getting `ORA-00922: missing or invalid option` error.

You can verify it by testing this kind of rspec test.

``` ruby
    it "should use NLS_CHARACTERSET environment variable" do
      ENV['NLS_CHARACTERSET'] = 'UTF8'
      @conn = ActiveRecord::ConnectionAdapters::OracleEnhancedConnection.create(CONNECTION_PARAMS)
      @conn.select("SELECT value FROM v$nls_parameters WHERE parameter = 'NLS_CHARACTERSET'").should == [{'value' => 'UTF8'}]
    end
```

``` ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
==> Running specs with MRI version 1.9.3
==> Running specs with Rails version 3.2.9
.....F........................

Failures:

  1) OracleEnhancedConnection create connection with NLS parameters should use NLS_CHARACTERSET environment variable
     Failure/Error: @conn = ActiveRecord::ConnectionAdapters::OracleEnhancedConnection.create(CONNECTION_PARAMS)
     OCIError:
       ORA-00922: missing or invalid option
     # stmt.c:230:in oci8lib_191.so
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p327@32stable/gems/ruby-oci8-2.1.3/lib/oci8/cursor.rb:129:in `exec'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p327@32stable/gems/ruby-oci8-2.1.3/lib/oci8/oci8.rb:286:in `exec_internal'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p327@32stable/gems/ruby-oci8-2.1.3/lib/oci8/oci8.rb:277:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:331:in `block in new_connection'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:328:in `each'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:328:in `new_connection'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:430:in `initialize'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:24:in `new'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:24:in `initialize'
     # ./lib/active_record/connection_adapters/oracle_enhanced_connection.rb:9:in `new'
     # ./lib/active_record/connection_adapters/oracle_enhanced_connection.rb:9:in `create'
     # ./spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb:48:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p327@32stable/gems/rspec-core-2.12.2/lib/rspec/core/example.rb:114:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p327@32stable/gems/rspec-core-2.12.2/lib/rspec/core/example.rb:114:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p327@32stable/gems/rspec-core-2.12.2/lib/rspec/core/example.rb:254:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p327@32stable/gems/rspec-core-2.12.2/lib/rspec/core/example.rb:111:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p327@32stable/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:388:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p327@32stable/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:384:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p327@32stable/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:384:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p327@32stable/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:369:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p327@32stable/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:370:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p327@32stable/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:370:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p327@32stable/gems/rspec-core-2.12.2/lib/rspec/core/example_group.rb:370:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p327@32stable/gems/rspec-core-2.12.2/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p327@32stable/gems/rspec-core-2.12.2/lib/rspec/core/command_line.rb:28:in `map'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p327@32stable/gems/rspec-core-2.12.2/lib/rspec/core/command_line.rb:28:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p327@32stable/gems/rspec-core-2.12.2/lib/rspec/core/reporter.rb:34:in `report'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p327@32stable/gems/rspec-core-2.12.2/lib/rspec/core/command_line.rb:25:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p327@32stable/gems/rspec-core-2.12.2/lib/rspec/core/runner.rb:80:in `run'
     # /home/yahonda/.rvm/gems/ruby-1.9.3-p327@32stable/gems/rspec-core-2.12.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 1.45 seconds
30 examples, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb:46 # OracleEnhancedConnection create connection with NLS parameters should use NLS_CHARACTERSET environment variable
$
```
