### PR TITLE
Clear index cache when remove_column executed

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
@@ -289,6 +289,7 @@ module ActiveRecord
         column_names.each {|column_name| execute "ALTER TABLE #{quote_table_name(table_name)} DROP COLUMN #{quote_column_name(column_name)}"}
       ensure
         clear_table_columns_cache(table_name)
+        self.all_schema_indexes = nil
       end
 
       def add_comment(table_name, column_name, comment) #:nodoc:


### PR DESCRIPTION
This pull request addresses a failure since https://github.com/rails/rails/commit/d1f21552939c07cf7f12b9674793bb14c81eb912 has been merged to rails master branch.

Sometimes, remove_column drops indexed column, then this index dropped implicitly.

``` ruby
$ ARCONN=oracle  ruby -Itest test/cases/migration/rename_column_test.rb -n test_remove_column_with_index
Using oracle
Run options: -n test_remove_column_with_index --seed 25497

# Running tests:

F

Finished tests in 2.084763s, 0.4797 tests/s, 0.9593 assertions/s.

  1) Failure:
test_remove_column_with_index(ActiveRecord::Migration::RenameColumnTest) [test/cases/migration/rename_column_test.rb:99]:
Expected: 0
  Actual: 1

1 tests, 2 assertions, 1 failures, 0 errors, 0 skips
$
```
