### PR TITLE
Loading a schema file breaks when a table does not already exist

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
@@ -109,7 +109,7 @@ module ActiveRecord
       end
 
       def drop_table(name, options = {}) #:nodoc:
-        super(name)
+        super(name) rescue nil
         seq_name = options[:sequence_name] || default_sequence_name(name)
         execute "DROP SEQUENCE #{quote_table_name(seq_name)}" rescue nil
       ensure


### PR DESCRIPTION
When trying to load a schema file into Oracle, I got this error when a table did not exist:

    NativeException: java.sql.SQLSyntaxErrorException: ORA-00942: table or view does not exist: DROP TABLE "ORGANIZATIONS"

This change fixed this for me. It is modeled on a similar fix made a couple years ago to the activerecord-jdbc-adapter project: https://github.com/jruby/activerecord-jdbc-adapter/issues/48