### PR TITLE
Migrated versions should be dumped in order

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_structure_dump.rb
@@ -136,7 +136,7 @@ module ActiveRecord #:nodoc:
 
       def dump_schema_information #:nodoc:
         sm_table = ActiveRecord::Migrator.schema_migrations_table_name
-        migrated = select_values("SELECT version FROM #{sm_table}")
+        migrated = select_values("SELECT version FROM #{sm_table} ORDER BY version")
         join_with_statement_token(migrated.map{|v| "INSERT INTO #{sm_table} (version) VALUES ('#{v}')" })
       end
 


### PR DESCRIPTION
There is not any guarantees that versions comes in the same order they
are inserted without ordering them explicitely.
