### PR TITLE
Support allowed_index_name_length method

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -376,7 +376,17 @@ module ActiveRecord
         IDENTIFIER_MAX_LENGTH
       end
 
-      # the maximum length of an index name
+      # Returns the maximum allowed length for an index name. This
+      # limit is enforced by rails and Is less than or equal to
+      # <tt>index_name_length</tt>. The gap between
+      # <tt>index_name_length</tt> is to allow internal rails
+      # opreations to use prefixes in temporary opreations.
+      def allowed_index_name_length
+        index_name_length
+      end
+
+      # the maximum length of an index name 
+      # supported by this database
       def index_name_length
         IDENTIFIER_MAX_LENGTH
       end

--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
@@ -124,11 +124,12 @@ module ActiveRecord
         index_name   = index_name(table_name, column: column_names)
 
         if Hash === options # legacy support, since this param was a string
-          options.assert_valid_keys(:unique, :order, :name, :where, :length, :tablespace, :options)
+          options.assert_valid_keys(:unique, :order, :name, :where, :length, :internal, :tablespace, :options)
 
           index_type = options[:unique] ? "UNIQUE" : ""
           index_name = options[:name].to_s if options.key?(:name)
           tablespace = tablespace_for(:index, options[:tablespace])
+          max_index_length = options.fetch(:internal, false) ? index_name_length : allowed_index_name_length
           additional_options = options[:options]
         else
           if options
@@ -141,10 +142,11 @@ module ActiveRecord
 
           index_type = options
           additional_options = nil
+          max_index_length = allowed_index_name_length
         end
 
-        if index_name.to_s.length > index_name_length
-          raise ArgumentError, "Index name '#{index_name}' on table '#{table_name}' is too long; the limit is #{index_name_length} characters"
+        if index_name.to_s.length > max_index_length
+          raise ArgumentError, "Index name '#{index_name}' on table '#{table_name}' is too long; the limit is #{max_index_length} characters"
         end
         if index_name_exists?(table_name, index_name, false)
           raise ArgumentError, "Index name '#{index_name}' on table '#{table_name}' already exists"


### PR DESCRIPTION
This pull request address the error by supporing allowed_index_name_length method.

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/migration/index_test.rb -n test_internal_index_with_name_matching_database_limit
Using oracle
Run options: -n test_internal_index_with_name_matching_database_limit --seed 27961

# Running tests:

E

Finished tests in 0.045876s, 21.7979 tests/s, 0.0000 assertions/s.

  1) Error:
test_internal_index_with_name_matching_database_limit(ActiveRecord::Migration::IndexTest):
ArgumentError: Unknown key: internal
    /home/yahonda/git/rails/activesupport/lib/active_support/core_ext/hash/keys.rb:70:in `block in assert_valid_keys'
    /home/yahonda/git/rails/activesupport/lib/active_support/core_ext/hash/keys.rb:69:in `each_key'
    /home/yahonda/git/rails/activesupport/lib/active_support/core_ext/hash/keys.rb:69:in `assert_valid_keys'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:127:in `add_index'
    test/cases/migration/index_test.rb:79:in `test_internal_index_with_name_matching_database_limit'

1 tests, 0 assertions, 0 failures, 1 errors, 0 skips
```

Oracle enhanced adapter does not need extra length for index operations
this returns the index_name_length .

Refer https://github.com/rails/rails/pull/8613 for detail.
