### PR TITLE
Rename indexes when a table or column is renamed

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
@@ -98,15 +98,17 @@ module ActiveRecord
         
       end
 
-      def rename_table(name, new_name) #:nodoc:
+      def rename_table(table_name, new_name) #:nodoc:
         if new_name.to_s.length > table_name_length
           raise ArgumentError, "New table name '#{new_name}' is too long; the limit is #{table_name_length} characters"
         end
         if "#{new_name}_seq".to_s.length > sequence_name_length
           raise ArgumentError, "New sequence name '#{new_name}_seq' is too long; the limit is #{sequence_name_length} characters"
         end
-        execute "RENAME #{quote_table_name(name)} TO #{quote_table_name(new_name)}"
-        execute "RENAME #{quote_table_name("#{name}_seq")} TO #{quote_table_name("#{new_name}_seq")}"
+        execute "RENAME #{quote_table_name(table_name)} TO #{quote_table_name(new_name)}"
+        execute "RENAME #{quote_table_name("#{table_name}_seq")} TO #{quote_table_name("#{new_name}_seq")}"
+
+        rename_table_indexes(table_name, new_name)
       end
 
       def drop_table(name, options = {}) #:nodoc:
@@ -282,6 +284,8 @@ module ActiveRecord
 
       def rename_column(table_name, column_name, new_column_name) #:nodoc:
         execute "ALTER TABLE #{quote_table_name(table_name)} RENAME COLUMN #{quote_column_name(column_name)} to #{quote_column_name(new_column_name)}"
+        self.all_schema_indexes = nil
+        rename_column_indexes(table_name, column_name, new_column_name)
       ensure
         clear_table_columns_cache(table_name)
       end


### PR DESCRIPTION
This pull request addresses these three failures to support changes at rails in  https://github.com/rails/rails/pull/8645

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/migration/rename_table_test.rb -n test_rename_table_with_an_index
Using oracle
Run options: -n test_rename_table_with_an_index --seed 35446

# Running tests:

F

Finished tests in 58.340407s, 0.0171 tests/s, 0.0514 assertions/s.

  1) Failure:
test_rename_table_with_an_index(ActiveRecord::Migration::RenameTableTest) [test/cases/migration/rename_table_test.rb:68]:
Expected: "index_octopi_on_url"
  Actual: "index_test_models_on_url"

1 tests, 3 assertions, 1 failures, 0 errors, 0 skips
```

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/migration/columns_test.rb -n /test_rename_column_with/
Using oracle
Run options: -n /test_rename_column_with/ --seed 9957

# Running tests:

FF.

Finished tests in 118.423188s, 0.0253 tests/s, 0.0338 assertions/s.

  1) Failure:
test_rename_column_with_an_index(ActiveRecord::Migration::RenameColumnTest) [test/cases/migration/columns_test.rb:90]:
--- expected
+++ actual
@@ -1 +1 @@
-["index_test_models_on_name"]
+["index_test_models_on_hat_name"]


  2) Failure:
test_rename_column_with_multi_column_index(ActiveRecord::Migration::RenameColumnTest) [test/cases/migration/columns_test.rb:99]:
--- expected
+++ actual
@@ -1 +1 @@
-["index_test_models_on_hat_style_and_size"]
+["i_tes_mod_hat_sty_hat_siz"]


3 tests, 4 assertions, 2 failures, 0 errors, 0 skips
1.9.3-p385@railsmaster [ master ~/git/rails/activerecord]$ 
```

Though one of these failures exists as Oracle index name length limits 30 characters and Oracle enhanced adapter shortens its new index name.

`Oracle shortened default index name index_test_models_on_hat_style_and_size to i_test_models_hat_style_size`

``` ruby
 ARCONN=oracle ruby -Itest test/cases/migration/columns_test.rb -n /test_rename_column_with/
Using oracle
Run options: -n /test_rename_column_with/ --seed 19658

# Running tests:

.F.

Finished tests in 10.282526s, 0.2918 tests/s, 0.3890 assertions/s.

  1) Failure:
test_rename_column_with_multi_column_index(ActiveRecord::Migration::RenameColumnTest) [test/cases/migration/columns_test.rb:99]:
--- expected
+++ actual
@@ -1 +1 @@
-["index_test_models_on_hat_style_and_size"]
+["i_test_models_hat_style_size"]


3 tests, 4 assertions, 1 failures, 0 errors, 0 skips
```

Will open a pull request for this failure at rails.
