### PR TITLE
Reconnect connection if it goes inactive after `set_logger` called

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -190,6 +190,7 @@ describe "OracleEnhancedAdapter schema definition" do
 
       it "should not generate NoMethodError for :returning_id:Symbol" do
         set_logger
+        @conn.reconnect! unless @conn.active?
         insert_id = @conn.insert("INSERT INTO test_employees (first_name) VALUES ('Yasuo')", nil, "id")
         @logger.output(:error).should_not match(/^Could not log "sql.active_record" event. NoMethodError: undefined method `name' for :returning_id:Symbol/)
         clear_logger


### PR DESCRIPTION
This pull request addresses a failure reported in #290 only when tested with Rails 2.3.
Because of some reason the connection goes inactive after `set_logger` executed.

As this failure does not reproduce with Rails 3.0, 3.1 and 3.2 versions, There may be something in Rails 2.3, but this version is supported only for security fixes only. No deep investigation done.
