### PR TITLE
Assigning "0.0" to a nullable numeric column does not make it dirty

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_dirty.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_dirty.rb
@@ -18,7 +18,7 @@ module ActiveRecord #:nodoc:
             # therefore need to convert empty string value to nil if old value is nil
             elsif column.type == :string && column.null && old.nil?
               value = nil if value == ''
-            elsif old == 0 && value.is_a?(String) && value.present? && value != '0'
+            elsif old == 0 && value.is_a?(String) && value.present? && non_zero?(value)
               value = nil
             else
               value = column.type_cast(value)
@@ -27,6 +27,10 @@ module ActiveRecord #:nodoc:
 
           old != value
         end
+
+        def non_zero?(value)
+          value !~ /\A0+(\.0+)?\z/
+        end 
         
       end
 


### PR DESCRIPTION
This pull request address a failure to support changes done in rails/rails#9042.

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/dirty_test.rb -n test_float_zero_to_string_zero_not_marked_as_changed
Using oracle
Run options: -n test_float_zero_to_string_zero_not_marked_as_changed --seed 30948

# Running tests:

F

Finished tests in 0.162023s, 6.1720 tests/s, 30.8599 assertions/s.

  1) Failure:
DirtyTest#test_float_zero_to_string_zero_not_marked_as_changed [test/cases/dirty_test.rb:256]:
Expected {"temperature"=>[#<BigDecimal:405b870,'0.0',9(18)>, #<BigDecimal:405b4b0,'0.0',9(18)>]} to be empty.

1 tests, 5 assertions, 1 failures, 0 errors, 0 skips
$
```
