### PR TITLE
Remove jeweler from gemspec and remove version constraint from jeweler i...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'http://rubygems.org'
 
 group :development do
-  gem 'jeweler'
+  gem 'jeweler', '~> 1.8'
   gem 'rspec', '~> 2.4'
   gem 'rdoc'
 

--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -89,6 +89,7 @@ This adapter is superset of original ActiveRecord Oracle adapter.
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      s.add_development_dependency(%q<jeweler>, ["~> 1.8"])
       s.add_development_dependency(%q<rspec>, ["~> 2.4"])
       s.add_development_dependency(%q<activerecord>, [">= 0"])
       s.add_development_dependency(%q<activemodel>, [">= 0"])
@@ -100,6 +101,7 @@ This adapter is superset of original ActiveRecord Oracle adapter.
       s.add_development_dependency(%q<ruby-plsql>, [">= 0.4.4"])
       s.add_development_dependency(%q<ruby-oci8>, [">= 2.0.4"])
     else
+      s.add_dependency(%q<jeweler>, ["~> 1.8"])
       s.add_dependency(%q<rspec>, ["~> 2.4"])
       s.add_dependency(%q<activerecord>, [">= 0"])
       s.add_dependency(%q<activemodel>, [">= 0"])
@@ -112,6 +114,7 @@ This adapter is superset of original ActiveRecord Oracle adapter.
       s.add_dependency(%q<ruby-oci8>, [">= 2.0.4"])
     end
   else
+    s.add_dependency(%q<jeweler>, ["~> 1.8"])
     s.add_dependency(%q<rspec>, ["~> 2.4"])
     s.add_dependency(%q<activerecord>, [">= 0"])
     s.add_dependency(%q<activemodel>, [">= 0"])


### PR DESCRIPTION
`bundle update` is not working on a fresh checkout of the repo because of a version conflict between bundler and jeweler: 

```
~/workspace/oracle-enhanced $ bundle
Fetching gem metadata from http://rubygems.org/.......
Fetching gem metadata from http://rubygems.org/..
Resolving dependencies...
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    jeweler (~> 1.5.1) ruby depends on
      bundler (~> 1.0.0) ruby

  Current Bundler version:
    bundler (1.3.0)

This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?
```

This commit gets bundle working again by removing the version constraint on jeweler from the Gemfile.  It also removes jeweler from the gemspec (it is unnecessary there).
