### PR TITLE
Use the index name explicitly provided in a migration when reverting

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
@@ -165,6 +165,14 @@ module ActiveRecord
       def remove_index(table_name, options = {}) #:nodoc:
         index_name = index_name(table_name, options)
         unless index_name_exists?(table_name, index_name, true)
+          # sometimes options can be String or Array with column names
+          options = {} unless options.is_a?(Hash)
+          if options.has_key? :name
+            options_without_column = options.dup
+            options_without_column.delete :column
+            index_name_without_column = index_name(table_name, options_without_column)
+            return index_name_without_column if index_name_exists?(table_name, index_name_without_column, false)
+          end
           raise ArgumentError, "Index name '#{index_name}' on table '#{table_name}' does not exist"
         end
         remove_index!(table_name, index_name)


### PR DESCRIPTION
This pull request supports a feature introduced in rails/rails#8868

It addresses the following error.

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/migration_test.rb -n test_drop_index_by_name
Using oracle
Run options: -n test_drop_index_by_name --seed 23114

# Running tests:

E

Finished tests in 0.037093s, 26.9593 tests/s, 0.0000 assertions/s.

  1) Error:
ExplicitlyNamedIndexMigrationTest#test_drop_index_by_name:
ArgumentError: Index name 'index_values_on_value' on table 'values' does not exist
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:168:in `remove_index'
    test/cases/migration_test.rb:474:in `block in test_drop_index_by_name'
    /home/yahonda/git/rails/activesupport/lib/active_support/test_case.rb:64:in `assert_nothing_raised'
    test/cases/migration_test.rb:472:in `test_drop_index_by_name'

1 tests, 0 assertions, 0 failures, 1 errors, 0 skips
$
```
