### PR TITLE
Deprecate #connection in favour of accessing it via the class

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -120,12 +120,12 @@ module ActiveRecord
     private
 
     def enhanced_write_lobs
-      if connection.is_a?(ConnectionAdapters::OracleEnhancedAdapter) && 
+      if self.class.connection.is_a?(ConnectionAdapters::OracleEnhancedAdapter) && 
           !(
             (self.class.custom_create_method || self.class.custom_create_method) ||
             (self.class.custom_update_method || self.class.custom_update_method)
           )
-        connection.write_lobs(self.class.table_name, self.class, attributes, @changed_lob_columns || self.class.lob_columns)
+        self.class.connection.write_lobs(self.class.table_name, self.class, attributes, @changed_lob_columns || self.class.lob_columns)
       end
     end
 


### PR DESCRIPTION
see rails/rails#9371

This pull request suppresses following `DEPRECATE WARNING`.

``` ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:885
==> Running specs with MRI version 2.0.0
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[885]}}
..DEPRECATION WARNING: #connection is deprecated in favour of accessing it via the class. (called from enhanced_write_lobs at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:123)
DEPRECATION WARNING: #connection is deprecated in favour of accessing it via the class. (called from enhanced_write_lobs at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:128)
..DEPRECATION WARNING: #connection is deprecated in favour of accessing it via the class. (called from enhanced_write_lobs at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:123)
reword 3818d6f Initial
Rebasing (1/1)
Deprecate #connection in favour of accessing it via the class
DEPRECATION WARNING: #connection is deprecated in favour of accessing it via the class. (called from enhanced_write_lobs at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:128)
.DEPRECATION WARNING: #connection is deprecated in favour of accessing it via the class. (called from enhanced_write_lobs at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:123)
DEPRECATION WARNING: #connection is deprecated in favour of accessing it via the class. (called from enhanced_write_lobs at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:128)
.DEPRECATION WARNING: #connection is deprecated in favour of accessing it via the class. (called from enhanced_write_lobs at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:123)
DEPRECATION WARNING: #connection is deprecated in favour of accessing it via the class. (called from enhanced_write_lobs at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:128)
.DEPRECATION WARNING: #connection is deprecated in favour of accessing it via the class. (called from enhanced_write_lobs at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:123)
DEPRECATION WARNING: #connection is deprecated in favour of accessing it via the class. (called from enhanced_write_lobs at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:128)
.DEPRECATION WARNING: #connection is deprecated in favour of accessing it via the class. (called from enhanced_write_lobs at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:123)
DEPRECATION WARNING: #connection is deprecated in favour of accessing it via the class. (called from enhanced_write_lobs at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:128)
.DEPRECATION WARNING: #connection is deprecated in favour of accessing it via the class. (called from enhanced_write_lobs at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:123)
DEPRECATION WARNING: #connection is deprecated in favour of accessing it via the class. (called from enhanced_write_lobs at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:128)
.DEPRECATION WARNING: #connection is deprecated in favour of accessing it via the class. (called from enhanced_write_lobs at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:123)
DEPRECATION WARNING: #connection is deprecated in favour of accessing it via the class. (called from enhanced_write_lobs at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:128)
.

Finished in 0.55475 seconds
11 examples, 0 failures
$
```
