### PR TITLE
Primary key additions for schema dumper

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1148,20 +1148,20 @@ module ActiveRecord
 
       # Find a table's primary key and sequence.
       # *Note*: Only primary key is implemented - sequence will be nil.
-      def pk_and_sequence_for(table_name, owner=nil, desc_table_name=nil, db_link=nil) #:nodoc:
+      def pk_and_sequence_for(table_name, owner=nil, desc_table_name=nil, db_link=nil, composite=false) #:nodoc:
         if @@cache_columns
           @@pk_and_sequence_for_cache ||= {}
           if @@pk_and_sequence_for_cache.key?(table_name)
             @@pk_and_sequence_for_cache[table_name]
           else
-            @@pk_and_sequence_for_cache[table_name] = pk_and_sequence_for_without_cache(table_name, owner, desc_table_name, db_link)
+            @@pk_and_sequence_for_cache[table_name] = pk_and_sequence_for_without_cache(table_name, owner, desc_table_name, db_link, composite)
           end
         else
-          pk_and_sequence_for_without_cache(table_name, owner, desc_table_name, db_link)
+          pk_and_sequence_for_without_cache(table_name, owner, desc_table_name, db_link, composite)
         end
       end
 
-      def pk_and_sequence_for_without_cache(table_name, owner=nil, desc_table_name=nil, db_link=nil) #:nodoc:
+      def pk_and_sequence_for_without_cache(table_name, owner=nil, desc_table_name=nil, db_link=nil, composite=false) #:nodoc:
         (owner, desc_table_name, db_link) = @connection.describe(table_name) unless owner
 
         # changed back from user_constraints to all_constraints for consistency
@@ -1175,8 +1175,13 @@ module ActiveRecord
              AND cc.constraint_name = c.constraint_name
         SQL
 
-        # only support single column keys
-        pks.size == 1 ? [oracle_downcase(pks.first), nil] : nil
+        unless composite
+          # only support single column keys
+          pks.size == 1 ? [oracle_downcase(pks.first), nil] : nil
+        else
+          pks
+        end
+        
       end
 
       # Returns just a table's primary key


### PR DESCRIPTION
We have run into a few issues trying to use the schema dumper on our legacy oracle tables that have some rails conventional tables, plus some older style composite key tables.  Also some of our legacy tables use guids which are a primary key with type string.  

I have updated the code to now support non-numeric primary keys and composite primary keys in the schema dumper.  This way we don't have to modify our schema.rb to run tests.

I have included tests for these new features in the dump spec.
- table with non-default primary key with non-numeric data type
- table with composite primary key

I would understand if this doesn't fit in with the "rails conventions" and therefore would not be helpful to be merged.  Either way, I thought it could be of use to someone else who has been working through legacy database issues.

Thanks!
Jason