### PR TITLE
enable inserting NULL to object type columns

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -614,7 +614,7 @@ module ActiveRecord
 
             binds.each_with_index do |bind, i|
               col, val = bind
-              cursor.bind_param(i + 1, type_cast(val, col), col && col.type)
+              cursor.bind_param(i + 1, type_cast(val, col), col)
             end
 
             cached = true
@@ -715,7 +715,7 @@ module ActiveRecord
               returning_id_index = i + 1
               cursor.bind_returning_param(returning_id_index, Integer)
             else
-              cursor.bind_param(i + 1, type_cast(val, col), col && col.type)
+              cursor.bind_param(i + 1, type_cast(val, col), col)
             end
           end
 
@@ -745,7 +745,7 @@ module ActiveRecord
 
             binds.each_with_index do |bind, i|
               col, val = bind
-              cursor.bind_param(i + 1, type_cast(val, col), col && col.type)
+              cursor.bind_param(i + 1, type_cast(val, col), col)
             end
             cached = true
           end
@@ -1077,7 +1077,7 @@ module ActiveRecord
         @@do_not_prefetch_primary_key[table_name] = nil
 
         table_cols = <<-SQL.strip.gsub(/\s+/, ' ')
-          SELECT column_name AS name, data_type AS sql_type, data_default, nullable, virtual_column, hidden_column,
+          SELECT column_name AS name, data_type AS sql_type, data_default, nullable, virtual_column, hidden_column, data_type_owner AS sql_type_owner,
                  DECODE(data_type, 'NUMBER', data_precision,
                                    'FLOAT', data_precision,
                                    'VARCHAR2', DECODE(char_used, 'C', char_length, data_length),
@@ -1099,6 +1099,10 @@ module ActiveRecord
           limit, scale = row['limit'], row['scale']
           if limit || scale
             row['sql_type'] += "(#{(limit || 38).to_i}" + ((scale = scale.to_i) > 0 ? ",#{scale})" : ")")
+          end
+
+          if row['sql_type_owner']
+            row['sql_type'] = row['sql_type_owner'] + '.' + row['sql_type']
           end
 
           is_virtual = row['virtual_column']=='YES'

--- a/lib/active_record/connection_adapters/oracle_enhanced_column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_column.rb
@@ -15,6 +15,7 @@ module ActiveRecord
         # Is column NCHAR or NVARCHAR2 (will need to use N'...' value quoting for these data types)?
         # Define only when needed as adapter "quote" method will check at first if instance variable is defined.
         @nchar = true if @type == :string && sql_type[0,1] == 'N'
+        @object_type = sql_type.include? '.'
       end
 
       def type_cast(value) #:nodoc:
@@ -33,6 +34,10 @@ module ActiveRecord
 
       def lob?
         self.sql_type =~ /LOB$/i
+      end
+
+      def object_type?
+        @object_type
       end
 
       # convert something to a boolean


### PR DESCRIPTION
This fixes #310 by allowing inserting NULL to object type such as MDSYS.SDO_GEOMETRY.
This patch works on jruby and latest ruby-oci8 in git master, which will be released as 2.1.6.

Note that this enables inserting NULL only. Not-null values cannot be inserted because they are converted to `String` by `YAML#dump` in `ActiveRecord::ConnectionAdapters::Quoting#type_cast`.
