### PR TITLE
Address undefined method `object_type?' for :decimal:Symbol

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
@@ -226,7 +226,9 @@ describe "OracleEnhancedConnection" do
 
     it "should execute prepared statement with decimal bind parameter " do
       cursor = @conn.prepare("INSERT INTO test_employees VALUES(:1)")
-      cursor.bind_param(1, "1.5", :decimal)
+      column = ActiveRecord::ConnectionAdapters::OracleEnhancedColumn.new('age', nil, 'NUMBER(10,2)')
+      column.type.should == :decimal
+      cursor.bind_param(1, "1.5", column)
       cursor.exec
       cursor.close
       cursor = @conn.prepare("SELECT age FROM test_employees")


### PR DESCRIPTION
This pull request address the following failure since rsim/oracle-enhanced#311 merged to master

``` ruby

vagrant@rails-dev-box:/vagrant/oracle-enhanced$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb:227
==> Running specs with MRI version 2.0.0
==> Running specs with Rails version 3.2.14
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb"=>[227]}}
F

Failures:

  1) OracleEnhancedConnection SQL with bind parameters when NLS_NUMERIC_CHARACTERS is set to ', ' should execute prepared statement with decimal bind parameter
     Failure/Error: cursor.bind_param(1, "1.5", :decimal)
     NoMethodError:
       undefined method `object_type?' for :decimal:Symbol
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:117:in `bind_param'
     # ./spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb:229:in `block (3 levels) in <top (required)>'
     # /home/vagrant/.rvm/gems/ruby-2.0.0-p247/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:114:in `instance_eval'
     # /home/vagrant/.rvm/gems/ruby-2.0.0-p247/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:114:in `block in run'
     # /home/vagrant/.rvm/gems/ruby-2.0.0-p247/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:254:in `with_around_each_hooks'
     # /home/vagrant/.rvm/gems/ruby-2.0.0-p247/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:111:in `run'
     # /home/vagrant/.rvm/gems/ruby-2.0.0-p247/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:390:in `block in run_examples'
     # /home/vagrant/.rvm/gems/ruby-2.0.0-p247/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:386:in `map'
     # /home/vagrant/.rvm/gems/ruby-2.0.0-p247/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:386:in `run_examples'
     # /home/vagrant/.rvm/gems/ruby-2.0.0-p247/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:371:in `run'
     # /home/vagrant/.rvm/gems/ruby-2.0.0-p247/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `block in run'
     # /home/vagrant/.rvm/gems/ruby-2.0.0-p247/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `map'
     # /home/vagrant/.rvm/gems/ruby-2.0.0-p247/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `run'
     # /home/vagrant/.rvm/gems/ruby-2.0.0-p247/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /home/vagrant/.rvm/gems/ruby-2.0.0-p247/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `map'
     # /home/vagrant/.rvm/gems/ruby-2.0.0-p247/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `block in run'
     # /home/vagrant/.rvm/gems/ruby-2.0.0-p247/gems/rspec-core-2.14.5/lib/rspec/core/reporter.rb:58:in `report'
     # /home/vagrant/.rvm/gems/ruby-2.0.0-p247/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:25:in `run'
     # /home/vagrant/.rvm/gems/ruby-2.0.0-p247/gems/rspec-core-2.14.5/lib/rspec/core/runner.rb:80:in `run'
     # /home/vagrant/.rvm/gems/ruby-2.0.0-p247/gems/rspec-core-2.14.5/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.25816 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb:227 # OracleEnhancedConnection SQL with bind parameters when NLS_NUMERIC_CHARACTERS is set to ', ' should execute prepared statement with decimal bind parameter
vagrant@rails-dev-box:/vagrant/oracle-enhanced$
```
