### PR TITLE
Fix #320 'wrong number of arguments calling `bind_param` (2 for 3)' caused by #311

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_jdbc_connection.rb
@@ -309,7 +309,7 @@ module ActiveRecord
           @raw_statement = raw_statement
         end
 
-        def bind_param(position, value, column)
+        def bind_param(position, value, column = nil)
           col_type = column && column.type
           java_value = ruby_to_java_value(value, col_type)
           case value


### PR DESCRIPTION
Sorry I made a pull request #311 without running rspec.
I made a patch to fix #320.
