### PR TITLE
Support virtual columns rails4

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1568,6 +1568,15 @@ module ActiveRecord
       class SchemaCreation < AbstractAdapter::SchemaCreation
         private
 
+        def visit_ColumnDefinition(o)
+          if o.type.to_sym == :virtual
+            sql_type = type_to_sql(o.default[:type], o.limit, o.precision, o.scale) if o.default[:type]
+            "#{quote_column_name(o.name)} #{sql_type} AS (#{o.default[:as]})"
+          else
+            super
+          end
+        end
+
         def visit_TableDefinition(o)
           tablespace = tablespace_for(:table, o.options[:tablespace])
           create_sql = "CREATE#{' GLOBAL TEMPORARY' if o.temporary} TABLE "


### PR DESCRIPTION
This pull request supports virtual columns for rails4 branch, in other words it addresses following failures.

```
$ rspec
... snip ...
Failures:

  1) OracleEnhancedAdapter schema dump virtual columns should dump correctly
     Failure/Error: create_table :test_names, :force => true do |t|
     ActiveRecord::StatementInvalid:
       OCIError: ORA-00902: invalid datatype: CREATE TABLE "TEST_NAMES" ("ID" NUMBER(38) NOT NULL PRIMARY KEY, "FIRST_NAME" VARCHAR2(255), "LAST_NAME" VARCHAR2(255), "FULL_NAME" virtual DEFAULT '---
       :type:
       :as: first_name || '', '' || last_name
       ', "SHORT_NAME" virtual DEFAULT '---
       :type: :string
       :as: COALESCE(first_name, last_name)
       ', "ABBREV_NAME" virtual DEFAULT '---
       :type: VARCHAR(100)
       :as: SUBSTR(first_name,1,50) || '' '' || SUBSTR(last_name,1,1) || ''.''
       ', "NAME_RATIO" virtual DEFAULT '---
       :type:
       :as: (LENGTH(first_name)*10/LENGTH(last_name)*10)
       ', "FULL_NAME_LENGTH" virtual DEFAULT '---
       :type: :integer
       :as: length(first_name || '', '' || last_name)
       ', "FIELD_WITH_LEADING_SPACE" virtual DEFAULT '---
       :type: :string
       :as: '''''' '''' || first_name || '''' ''''''
       ')
     # stmt.c:230:in oci8lib_200.so
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/ruby-oci8-2.1.5/lib/oci8/cursor.rb:129:in `exec'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/ruby-oci8-2.1.5/lib/oci8/oci8.rb:278:in `exec_internal'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/ruby-oci8-2.1.5/lib/oci8/oci8.rb:269:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:472:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:88:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:727:in `block in execute'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:432:in `block in log'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:427:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1497:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:727:in `execute'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:82:in `create_table'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:625:in `block in method_missing'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:597:in `block in say_with_time'
     # /home/yahonda/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/benchmark.rb:281:in `measure'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:597:in `say_with_time'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:617:in `method_missing'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:353:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:106:in `instance_eval'
     # ./spec/spec_helper.rb:106:in `block (2 levels) in schema_define'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:605:in `suppress_messages'
     # ./spec/spec_helper.rb:105:in `block in schema_define'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/schema.rb:42:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/schema.rb:42:in `define'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/schema.rb:62:in `define'
     # ./spec/spec_helper.rb:104:in `schema_define'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:352:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:21:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:119:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:446:in `run_hook'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:331:in `block in run_before_all_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/memoized_helpers.rb:107:in `block in isolate_for_before_all'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/memoized_helpers.rb:103:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/memoized_helpers.rb:103:in `isolate_for_before_all'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:330:in `run_before_all_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:370:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:25:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/runner.rb:80:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/runner.rb:17:in `block in autorun'

  2) OracleEnhancedAdapter schema dump virtual columns with column cache should not change column defaults after several dumps
     Failure/Error: create_table :test_names, :force => true do |t|
     ActiveRecord::StatementInvalid:
       OCIError: ORA-00902: invalid datatype: CREATE TABLE "TEST_NAMES" ("ID" NUMBER(38) NOT NULL PRIMARY KEY, "FIRST_NAME" VARCHAR2(255), "LAST_NAME" VARCHAR2(255), "FULL_NAME" virtual DEFAULT '---
       :type:
       :as: first_name || '', '' || last_name
       ', "SHORT_NAME" virtual DEFAULT '---
       :type: :string
       :as: COALESCE(first_name, last_name)
       ', "ABBREV_NAME" virtual DEFAULT '---
       :type: VARCHAR(100)
       :as: SUBSTR(first_name,1,50) || '' '' || SUBSTR(last_name,1,1) || ''.''
       ', "NAME_RATIO" virtual DEFAULT '---
       :type:
       :as: (LENGTH(first_name)*10/LENGTH(last_name)*10)
       ', "FULL_NAME_LENGTH" virtual DEFAULT '---
       :type: :integer
       :as: length(first_name || '', '' || last_name)
       ', "FIELD_WITH_LEADING_SPACE" virtual DEFAULT '---
       :type: :string
       :as: '''''' '''' || first_name || '''' ''''''
       ')
     # stmt.c:230:in oci8lib_200.so
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/ruby-oci8-2.1.5/lib/oci8/cursor.rb:129:in `exec'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/ruby-oci8-2.1.5/lib/oci8/oci8.rb:278:in `exec_internal'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/ruby-oci8-2.1.5/lib/oci8/oci8.rb:269:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:472:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:88:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:727:in `block in execute'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:432:in `block in log'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:427:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1497:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:727:in `execute'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:82:in `create_table'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:625:in `block in method_missing'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:597:in `block in say_with_time'
     # /home/yahonda/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/benchmark.rb:281:in `measure'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:597:in `say_with_time'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:617:in `method_missing'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:353:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:106:in `instance_eval'
     # ./spec/spec_helper.rb:106:in `block (2 levels) in schema_define'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:605:in `suppress_messages'
     # ./spec/spec_helper.rb:105:in `block in schema_define'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/schema.rb:42:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/schema.rb:42:in `define'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/schema.rb:62:in `define'
     # ./spec/spec_helper.rb:104:in `schema_define'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:352:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:21:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:119:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:446:in `run_hook'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:331:in `block in run_before_all_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/memoized_helpers.rb:107:in `block in isolate_for_before_all'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/memoized_helpers.rb:103:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/memoized_helpers.rb:103:in `isolate_for_before_all'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:330:in `run_before_all_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:370:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:25:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/runner.rb:80:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/runner.rb:17:in `block in autorun'

  3) OracleEnhancedAdapter schema dump virtual columns with index on virtual column should dump correctly
     Failure/Error: create_table :test_names, :force => true do |t|
     ActiveRecord::StatementInvalid:
       OCIError: ORA-00902: invalid datatype: CREATE TABLE "TEST_NAMES" ("ID" NUMBER(38) NOT NULL PRIMARY KEY, "FIRST_NAME" VARCHAR2(255), "LAST_NAME" VARCHAR2(255), "FULL_NAME" virtual DEFAULT '---
       :type:
       :as: first_name || '', '' || last_name
       ', "SHORT_NAME" virtual DEFAULT '---
       :type: :string
       :as: COALESCE(first_name, last_name)
       ', "ABBREV_NAME" virtual DEFAULT '---
       :type: VARCHAR(100)
       :as: SUBSTR(first_name,1,50) || '' '' || SUBSTR(last_name,1,1) || ''.''
       ', "NAME_RATIO" virtual DEFAULT '---
       :type:
       :as: (LENGTH(first_name)*10/LENGTH(last_name)*10)
       ', "FULL_NAME_LENGTH" virtual DEFAULT '---
       :type: :integer
       :as: length(first_name || '', '' || last_name)
       ', "FIELD_WITH_LEADING_SPACE" virtual DEFAULT '---
       :type: :string
       :as: '''''' '''' || first_name || '''' ''''''
       ')
     # stmt.c:230:in oci8lib_200.so
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/ruby-oci8-2.1.5/lib/oci8/cursor.rb:129:in `exec'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/ruby-oci8-2.1.5/lib/oci8/oci8.rb:278:in `exec_internal'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/ruby-oci8-2.1.5/lib/oci8/oci8.rb:269:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:472:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:88:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:727:in `block in execute'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:432:in `block in log'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:427:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1497:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:727:in `execute'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:82:in `create_table'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:625:in `block in method_missing'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:597:in `block in say_with_time'
     # /home/yahonda/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/benchmark.rb:281:in `measure'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:597:in `say_with_time'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:617:in `method_missing'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:353:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:106:in `instance_eval'
     # ./spec/spec_helper.rb:106:in `block (2 levels) in schema_define'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:605:in `suppress_messages'
     # ./spec/spec_helper.rb:105:in `block in schema_define'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/schema.rb:42:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/schema.rb:42:in `define'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/schema.rb:62:in `define'
     # ./spec/spec_helper.rb:104:in `schema_define'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:352:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:21:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:119:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:446:in `run_hook'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:331:in `block in run_before_all_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/memoized_helpers.rb:107:in `block in isolate_for_before_all'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/memoized_helpers.rb:103:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/memoized_helpers.rb:103:in `isolate_for_before_all'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:330:in `run_before_all_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:370:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:25:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/runner.rb:80:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/runner.rb:17:in `block in autorun'

  4) OracleEnhancedAdapter schema definition virtual columns in create_table should create virtual column with old syntax
     Failure/Error: create_table :test_fractions, :force => true do |t|
     ActiveRecord::StatementInvalid:
       OCIError: ORA-00902: invalid datatype: CREATE TABLE "TEST_FRACTIONS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY, "FIELD1" NUMBER(38), "FIELD2" virtual DEFAULT '---
       :type:
       :as: field1 + 1
       ')
     # stmt.c:230:in oci8lib_200.so
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/ruby-oci8-2.1.5/lib/oci8/cursor.rb:129:in `exec'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/ruby-oci8-2.1.5/lib/oci8/oci8.rb:278:in `exec_internal'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/ruby-oci8-2.1.5/lib/oci8/oci8.rb:269:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:472:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:88:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:727:in `block in execute'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:432:in `block in log'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:427:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1497:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:727:in `execute'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:82:in `create_table'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:625:in `block in method_missing'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:597:in `block in say_with_time'
     # /home/yahonda/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/benchmark.rb:281:in `measure'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:597:in `say_with_time'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:617:in `method_missing'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1071:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:106:in `instance_eval'
     # ./spec/spec_helper.rb:106:in `block (2 levels) in schema_define'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:605:in `suppress_messages'
     # ./spec/spec_helper.rb:105:in `block in schema_define'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/schema.rb:42:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/schema.rb:42:in `define'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/schema.rb:62:in `define'
     # ./spec/spec_helper.rb:104:in `schema_define'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1070:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:114:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:114:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:254:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:111:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:390:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:386:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:386:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:371:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:25:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/runner.rb:80:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/runner.rb:17:in `block in autorun'

  5) OracleEnhancedAdapter schema definition virtual columns should include virtual columns and not try to update them
     Failure/Error: create_table :test_fractions, :force => true do |t|
     ActiveRecord::StatementInvalid:
       OCIError: ORA-00902: invalid datatype: CREATE TABLE "TEST_FRACTIONS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY, "NUMERATOR" NUMBER(38) DEFAULT 0, "DENOMINATOR" NUMBER(38) DEFAULT 0, "PERCENT" virtual DEFAULT '---
       :type:
       :as: ( numerator/NULLIF(denominator,0) )*100
       ')
     # stmt.c:230:in oci8lib_200.so
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/ruby-oci8-2.1.5/lib/oci8/cursor.rb:129:in `exec'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/ruby-oci8-2.1.5/lib/oci8/oci8.rb:278:in `exec_internal'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/ruby-oci8-2.1.5/lib/oci8/oci8.rb:269:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:472:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:88:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:727:in `block in execute'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:432:in `block in log'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:427:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1497:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:727:in `execute'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:82:in `create_table'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:625:in `block in method_missing'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:597:in `block in say_with_time'
     # /home/yahonda/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/benchmark.rb:281:in `measure'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:597:in `say_with_time'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:617:in `method_missing'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1119:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:106:in `instance_eval'
     # ./spec/spec_helper.rb:106:in `block (2 levels) in schema_define'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:605:in `suppress_messages'
     # ./spec/spec_helper.rb:105:in `block in schema_define'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/schema.rb:42:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/schema.rb:42:in `define'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/schema.rb:62:in `define'
     # ./spec/spec_helper.rb:104:in `schema_define'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1118:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:237:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:237:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:85:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:85:in `each'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:85:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:446:in `run_hook'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:345:in `run_before_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:300:in `run_before_each'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:113:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:254:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:111:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:390:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:386:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:386:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:371:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:25:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/runner.rb:80:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/runner.rb:17:in `block in autorun'

  6) OracleEnhancedAdapter schema definition virtual columns should add virtual column
     Failure/Error: create_table :test_fractions, :force => true do |t|
     ActiveRecord::StatementInvalid:
       OCIError: ORA-00902: invalid datatype: CREATE TABLE "TEST_FRACTIONS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY, "NUMERATOR" NUMBER(38) DEFAULT 0, "DENOMINATOR" NUMBER(38) DEFAULT 0, "PERCENT" virtual DEFAULT '---
       :type:
       :as: ( numerator/NULLIF(denominator,0) )*100
       ')
     # stmt.c:230:in oci8lib_200.so
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/ruby-oci8-2.1.5/lib/oci8/cursor.rb:129:in `exec'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/ruby-oci8-2.1.5/lib/oci8/oci8.rb:278:in `exec_internal'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/ruby-oci8-2.1.5/lib/oci8/oci8.rb:269:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:472:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:88:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:727:in `block in execute'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:432:in `block in log'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:427:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1497:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:727:in `execute'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:82:in `create_table'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:625:in `block in method_missing'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:597:in `block in say_with_time'
     # /home/yahonda/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/benchmark.rb:281:in `measure'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:597:in `say_with_time'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:617:in `method_missing'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1119:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:106:in `instance_eval'
     # ./spec/spec_helper.rb:106:in `block (2 levels) in schema_define'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:605:in `suppress_messages'
     # ./spec/spec_helper.rb:105:in `block in schema_define'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/schema.rb:42:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/schema.rb:42:in `define'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/schema.rb:62:in `define'
     # ./spec/spec_helper.rb:104:in `schema_define'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1118:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:237:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:237:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:85:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:85:in `each'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:85:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:446:in `run_hook'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:345:in `run_before_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:300:in `run_before_each'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:113:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:254:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:111:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:390:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:386:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:386:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:371:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:25:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/runner.rb:80:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/runner.rb:17:in `block in autorun'

  7) OracleEnhancedAdapter schema definition virtual columns should add virtual column with explicit type
     Failure/Error: create_table :test_fractions, :force => true do |t|
     ActiveRecord::StatementInvalid:
       OCIError: ORA-00902: invalid datatype: CREATE TABLE "TEST_FRACTIONS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY, "NUMERATOR" NUMBER(38) DEFAULT 0, "DENOMINATOR" NUMBER(38) DEFAULT 0, "PERCENT" virtual DEFAULT '---
       :type:
       :as: ( numerator/NULLIF(denominator,0) )*100
       ')
     # stmt.c:230:in oci8lib_200.so
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/ruby-oci8-2.1.5/lib/oci8/cursor.rb:129:in `exec'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/ruby-oci8-2.1.5/lib/oci8/oci8.rb:278:in `exec_internal'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/ruby-oci8-2.1.5/lib/oci8/oci8.rb:269:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:472:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:88:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:727:in `block in execute'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:432:in `block in log'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:427:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1497:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:727:in `execute'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:82:in `create_table'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:625:in `block in method_missing'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:597:in `block in say_with_time'
     # /home/yahonda/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/benchmark.rb:281:in `measure'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:597:in `say_with_time'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:617:in `method_missing'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1119:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:106:in `instance_eval'
     # ./spec/spec_helper.rb:106:in `block (2 levels) in schema_define'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:605:in `suppress_messages'
     # ./spec/spec_helper.rb:105:in `block in schema_define'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/schema.rb:42:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/schema.rb:42:in `define'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/schema.rb:62:in `define'
     # ./spec/spec_helper.rb:104:in `schema_define'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1118:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:237:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:237:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:85:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:85:in `each'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:85:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:446:in `run_hook'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:345:in `run_before_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:300:in `run_before_each'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:113:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:254:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:111:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:390:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:386:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:386:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:371:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:25:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/runner.rb:80:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/runner.rb:17:in `block in autorun'

  8) OracleEnhancedAdapter schema definition virtual columns should change virtual column definition
     Failure/Error: create_table :test_fractions, :force => true do |t|
     ActiveRecord::StatementInvalid:
       OCIError: ORA-00902: invalid datatype: CREATE TABLE "TEST_FRACTIONS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY, "NUMERATOR" NUMBER(38) DEFAULT 0, "DENOMINATOR" NUMBER(38) DEFAULT 0, "PERCENT" virtual DEFAULT '---
       :type:
       :as: ( numerator/NULLIF(denominator,0) )*100
       ')
     # stmt.c:230:in oci8lib_200.so
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/ruby-oci8-2.1.5/lib/oci8/cursor.rb:129:in `exec'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/ruby-oci8-2.1.5/lib/oci8/oci8.rb:278:in `exec_internal'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/ruby-oci8-2.1.5/lib/oci8/oci8.rb:269:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:472:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:88:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:727:in `block in execute'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:432:in `block in log'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:427:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1497:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:727:in `execute'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:82:in `create_table'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:625:in `block in method_missing'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:597:in `block in say_with_time'
     # /home/yahonda/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/benchmark.rb:281:in `measure'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:597:in `say_with_time'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:617:in `method_missing'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1119:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:106:in `instance_eval'
     # ./spec/spec_helper.rb:106:in `block (2 levels) in schema_define'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:605:in `suppress_messages'
     # ./spec/spec_helper.rb:105:in `block in schema_define'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/schema.rb:42:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/schema.rb:42:in `define'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/schema.rb:62:in `define'
     # ./spec/spec_helper.rb:104:in `schema_define'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1118:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:237:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:237:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:85:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:85:in `each'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:85:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:446:in `run_hook'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:345:in `run_before_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:300:in `run_before_each'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:113:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:254:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:111:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:390:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:386:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:386:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:371:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:25:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/runner.rb:80:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/runner.rb:17:in `block in autorun'

  9) OracleEnhancedAdapter schema definition virtual columns should change virtual column type
     Failure/Error: create_table :test_fractions, :force => true do |t|
     ActiveRecord::StatementInvalid:
       OCIError: ORA-00902: invalid datatype: CREATE TABLE "TEST_FRACTIONS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY, "NUMERATOR" NUMBER(38) DEFAULT 0, "DENOMINATOR" NUMBER(38) DEFAULT 0, "PERCENT" virtual DEFAULT '---
       :type:
       :as: ( numerator/NULLIF(denominator,0) )*100
       ')
     # stmt.c:230:in oci8lib_200.so
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/ruby-oci8-2.1.5/lib/oci8/cursor.rb:129:in `exec'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/ruby-oci8-2.1.5/lib/oci8/oci8.rb:278:in `exec_internal'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/ruby-oci8-2.1.5/lib/oci8/oci8.rb:269:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:472:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:88:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:727:in `block in execute'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:432:in `block in log'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:427:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1497:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:727:in `execute'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:82:in `create_table'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:625:in `block in method_missing'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:597:in `block in say_with_time'
     # /home/yahonda/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/benchmark.rb:281:in `measure'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:597:in `say_with_time'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:617:in `method_missing'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1119:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:106:in `instance_eval'
     # ./spec/spec_helper.rb:106:in `block (2 levels) in schema_define'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/migration.rb:605:in `suppress_messages'
     # ./spec/spec_helper.rb:105:in `block in schema_define'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/schema.rb:42:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/schema.rb:42:in `define'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/bundler/gems/rails-d58b720f596c/activerecord/lib/active_record/schema.rb:62:in `define'
     # ./spec/spec_helper.rb:104:in `schema_define'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1118:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:237:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:237:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:85:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:85:in `each'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:85:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/hooks.rb:446:in `run_hook'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:345:in `run_before_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:300:in `run_before_each'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:113:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:254:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:111:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:390:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:386:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:386:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:371:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:25:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/runner.rb:80:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v400/gems/rspec-core-2.14.5/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 1 minute 37.27 seconds
358 examples, 9 failures, 2 pending

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:389 # OracleEnhancedAdapter schema dump virtual columns should dump correctly
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:406 # OracleEnhancedAdapter schema dump virtual columns with column cache should not change column defaults after several dumps
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:434 # OracleEnhancedAdapter schema dump virtual columns with index on virtual column should dump correctly
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1069 # OracleEnhancedAdapter schema definition virtual columns in create_table should create virtual column with old syntax
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1143 # OracleEnhancedAdapter schema definition virtual columns should include virtual columns and not try to update them
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1157 # OracleEnhancedAdapter schema definition virtual columns should add virtual column
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1174 # OracleEnhancedAdapter schema definition virtual columns should add virtual column with explicit type
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1193 # OracleEnhancedAdapter schema definition virtual columns should change virtual column definition
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1214 # OracleEnhancedAdapter schema definition virtual columns should change virtual column type
$
```
