### PR TITLE
Support ojdbc7.jar JDBC Driver

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_jdbc_connection.rb
@@ -7,8 +7,10 @@ begin
   java_version = java.lang.System.getProperty("java.version")
   ojdbc_jar = if java_version =~ /^1.5/
     "ojdbc5.jar"
-  elsif java_version >= '1.6'
+  elsif java_version =~ /^1.6/
     "ojdbc6.jar"
+  elsif java_version =~ /^1.7/
+    "ojdbc7.jar"
   else
     nil
   end


### PR DESCRIPTION
This pull requests supports ojdbc7.jar JDBC Driver.

You can download the ojdbc7.jar JDBC driver from [here](http://www.oracle.com/technetwork/database/features/jdbc/jdbc-drivers-12c-download-1958347.html)
