### PR TITLE
Address ORA-00955 error

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -393,6 +393,7 @@ describe "OracleEnhancedAdapter schema definition" do
         drop_table :test_employees rescue nil
         drop_table :new_test_employees rescue nil
         drop_table :test_employees_no_pkey rescue nil
+        drop_table :new_test_employees_no_pkey rescue nil
       end
     end
 


### PR DESCRIPTION
This pull request addresses the following failure which fails when executed more than twice.

``` ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:417
==> Running specs with MRI version 2.0.0
==> Running specs with Rails version 3.2.15.rc2
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb"=>[417]}}
F

Failures:

  1) OracleEnhancedAdapter schema definition rename tables and sequences should rename table when table has no primary key and sequence
     Failure/Error: lambda do
       expected no Exception, got #<ActiveRecord::StatementInvalid: OCIError: ORA-00955: name is already used by an existing object: RENAME "TEST_EMPLOYEES_NO_PKEY" TO "NEW_TEST_EMPLOYEES_NO_PKEY"> with backtrace:
         # stmt.c:230:in oci8lib_200.so
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/ruby-oci8-2.1.5/lib/oci8/cursor.rb:129:in `exec'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/ruby-oci8-2.1.5/lib/oci8/oci8.rb:278:in `exec_internal'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/ruby-oci8-2.1.5/lib/oci8/oci8.rb:269:in `exec'
         # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:478:in `exec'
         # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:88:in `exec'
         # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:591:in `block in execute'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/activerecord-3.2.15.rc2/lib/active_record/connection_adapters/abstract_adapter.rb:280:in `block in log'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/activesupport-3.2.15.rc2/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/activerecord-3.2.15.rc2/lib/active_record/connection_adapters/abstract_adapter.rb:275:in `log'
         # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1326:in `log'
         # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:591:in `execute'
         # ./lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:107:in `rename_table'
         # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:419:in `block (4 levels) in <top (required)>'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-expectations-2.14.3/lib/rspec/matchers/built_in/raise_error.rb:40:in `call'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-expectations-2.14.3/lib/rspec/matchers/built_in/raise_error.rb:40:in `matches?'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-expectations-2.14.3/lib/rspec/matchers/built_in/raise_error.rb:57:in `does_not_match?'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-expectations-2.14.3/lib/rspec/expectations/handler.rb:49:in `handle_matcher'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-expectations-2.14.3/lib/rspec/expectations/syntax.rb:57:in `should_not'
         # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:418:in `block (3 levels) in <top (required)>'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:114:in `instance_eval'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:114:in `block in run'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:254:in `with_around_each_hooks'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:111:in `run'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:390:in `block in run_examples'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:386:in `map'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:386:in `run_examples'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:371:in `run'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `block in run'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `map'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `run'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `map'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `block in run'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/reporter.rb:58:in `report'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:25:in `run'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/runner.rb:80:in `run'
         # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/runner.rb:17:in `block in autorun'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-expectations-2.14.3/lib/rspec/expectations/fail_with.rb:32:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-expectations-2.14.3/lib/rspec/expectations/handler.rb:62:in `handle_matcher'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-expectations-2.14.3/lib/rspec/expectations/syntax.rb:57:in `should_not'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:418:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:114:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:114:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:254:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/example.rb:111:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:390:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:386:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:386:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:371:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/example_group.rb:372:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:28:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:25:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/runner.rb:80:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.0.0-p247@v3215/gems/rspec-core-2.14.5/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.1807 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:417 # OracleEnhancedAdapter schema definition rename tables and sequences should rename table when table has no primary key and sequence
$
```
