### PR TITLE
Update README to support assignment methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,29 @@ If you want to put Oracle enhanced adapter on top of existing schema tables then
 
     class Employee < ActiveRecord::Base
       # specify schema and table name
+      self.table_name "hr.hr_employees"
+      # specify primary key name
+      self.primary_key "employee_id"
+      # specify sequence name
+      self.sequence_name "hr.hr_employee_s"
+      # set which DATE columns should be converted to Ruby Date
+      set_date_columns :hired_on, :birth_date_on
+      # set which DATE columns should be converted to Ruby Time
+      set_datetime_columns :last_login_time
+      # set which VARCHAR2 columns should be converted to true and false
+      set_boolean_columns :manager, :active
+      # set which columns should be ignored in ActiveRecord
+      ignore_table_columns :attribute1, :attribute2
+    end
+
+You can also access remote tables over database link using
+
+    self.table_name "hr_employees@db_link"
+
+Examples for Rails 3.2 and lower version of Rails
+
+    class Employee < ActiveRecord::Base
+      # specify schema and table name
       set_table_name "hr.hr_employees"
       # specify primary key name
       set_primary_key "employee_id"


### PR DESCRIPTION
This pull request updates README to support assignment methods, such as self.table_name instead of set_table_name. It should address #363
