### PR TITLE
fix schema dump when oracle adapter used by other environment

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_column_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_column_dumper.rb
@@ -8,17 +8,19 @@ module ActiveRecord #:nodoc:
           alias_method_chain :column_spec,            :oracle_enhanced
           alias_method_chain :prepare_column_options, :oracle_enhanced
           alias_method_chain :migration_keys,         :oracle_enhanced
+
+          def oracle_enhanced_adaper?
+            rails_env = defined?(Rails.env) ? Rails.env : (defined?(RAILS_ENV) ? RAILS_ENV : nil)
+
+            ActiveRecord::Base.configurations[rails_env] && ActiveRecord::Base.configurations[rails_env]['adapter'] == 'oracle_enhanced'
+          end
         end
       end
 
       def column_spec_with_oracle_enhanced(column, types)
         # return original method if not using 'OracleEnhanced'
-        if (rails_env = defined?(Rails.env) ? Rails.env : (defined?(RAILS_ENV) ? RAILS_ENV : nil)) &&
-              ActiveRecord::Base.configurations[rails_env] &&
-              ActiveRecord::Base.configurations[rails_env]['adapter'] != 'oracle_enhanced'
-          return column_spec_with_oracle_enhanced(column, types)
-        end
-        
+        return column_spec_without_oracle_enhanced(column, types) unless oracle_enhanced_adaper?
+
         spec = prepare_column_options(column, types)
         (spec.keys - [:name, :type]).each do |k|
           key_s = (k == :virtual_type ? "type: " : "#{k.to_s}: ")
@@ -28,6 +30,8 @@ module ActiveRecord #:nodoc:
       end
 
       def prepare_column_options_with_oracle_enhanced(column, types)
+        return prepare_column_options_without_oracle_enhanced(column, types) unless oracle_enhanced_adaper?
+
         spec = {}
         spec[:name]      = column.name.inspect
         spec[:type]      = column.virtual? ? 'virtual' : column.type.to_s
@@ -42,6 +46,8 @@ module ActiveRecord #:nodoc:
       end
 
       def migration_keys_with_oracle_enhanced
+        return migration_keys_without_oracle_enhanced unless oracle_enhanced_adaper?
+
         # TODO `& column_specs.map(&:keys).flatten` should be exetuted here
         [:name, :limit, :precision, :scale, :default, :null, :as, :virtual_type]
       end


### PR DESCRIPTION
Without this fix schema dump looks like:

```
# Could not dump table "cms_blocks" because of following NoMethodError
#   undefined method `column_spec_with_oracle_enhanced' for #<ActiveRecord::ConnectionAdapters::SQLite3Adapter:0x0000000404c8e8>
```
