### PR TITLE
Update Gemfile to use `bundle config --local`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,38 +5,19 @@ group :development do
   gem 'rspec', '~> 2.4'
   gem 'rdoc'
 
-  if ENV['RAILS_GEM_VERSION']
-    gem 'activerecord', "=#{ENV['RAILS_GEM_VERSION']}"
-    gem 'actionpack', "=#{ENV['RAILS_GEM_VERSION']}"
-    gem 'activesupport', "=#{ENV['RAILS_GEM_VERSION']}"
-    gem 'railties', "=#{ENV['RAILS_GEM_VERSION']}"
-  else
-    %w(activerecord activemodel activesupport actionpack railties).each do |gem_name|
-      if ENV['RAILS_GEM_PATH']
-        gem gem_name, :path => File.join(ENV['RAILS_GEM_PATH'], gem_name)
-      else
-        gem gem_name, :git => "git://github.com/rails/rails"
-      end
-    end
+  gem 'activerecord',   github: 'rails/rails'
+  gem 'activemodel',    github: 'rails/rails'
+  gem 'activesupport',  github: 'rails/rails'
+  gem 'actionpack',     github: 'rails/rails'
+  gem 'railties',       github: 'rails/rails'
 
-    if ENV['AREL_GEM_PATH']
-      gem 'arel', :path => ENV['AREL_GEM_PATH']
-    else
-      gem 'arel', :git => "git://github.com/rails/arel"
-    end
+  gem 'arel',           github: 'rails/arel'
+  gem 'journey',        github: 'rails/journey'
 
-    if ENV['JOURNEY_GEM_PATH']
-      gem 'journey', :path => ENV['JOURNEY_GEM_PATH']
-    else
-      gem "journey", :git => "git://github.com/rails/journey"
-    end
-  end
-
-  gem "activerecord-deprecated_finders"
+  gem 'activerecord-deprecated_finders'
   gem 'ruby-plsql', '>=0.5.0'
 
   platforms :ruby do
-    gem 'ruby-oci8', '>=2.1.2'
+    gem 'ruby-oci8',    github: 'kubo/ruby-oci8'
   end
-
 end


### PR DESCRIPTION
This pull request supports bundler feature to use local git repositories.

```
$ bundle config local.activerecord /path/to/rails
```

Although similar pull request #178 was closed Oracle enhanced adapter version 1.5 supports Rails 4.0 only I think we can support this feature.

For example ruby-oci8 master branch supports Ruby 2.1.0-preview1 in https://github.com/kubo/ruby-oci8/commit/80be58a0259b830db6a1f24ce0cb1020a42a5dd7 in the master branch. 
To test this commit we need to modify the Gemfile in Oracle enhanced adapter such as adding environment variables which shows the full path.

I prefer not to add any more environment variables to oracle enhanced adapter by making use of bundler standard features.
