### PR TITLE
Prevent text being replaced with empty_clob() when quoting if the value is not empty

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -586,7 +586,13 @@ module ActiveRecord
       def quote(value, column = nil) #:nodoc:
         if value && column
           case column.type
-          when :text, :binary
+          when :text
+            if value.empty?
+              %Q{empty_#{ type_to_sql(column.type.to_sym).downcase rescue 'clob' }()}
+            else
+              super
+            end
+          when :binary
             %Q{empty_#{ type_to_sql(column.type.to_sym).downcase rescue 'blob' }()}
           # NLS_DATE_FORMAT independent TIMESTAMP support
           when :timestamp

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -1048,6 +1048,19 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
     @employee.reload
     @employee.comments.should == "initial serialized data"
   end
+
+  it "should not replace text query string with empty_clob()" do
+    employee = TestEmployee.arel_table
+    matcher = employee[:comments].matches("%foo%")
+    TestEmployee.where(matcher).to_sql.should_not =~ /empty_clob/
+    TestEmployee.where(matcher).to_sql.should =~ /%foo%/
+  end
+
+  it "should replace empty text query string with empty_clob()" do
+    employee = TestEmployee.arel_table
+    matcher = employee[:comments].matches("")
+    TestEmployee.where(matcher).to_sql.should =~ /empty_clob/
+  end
 end
 
 describe "OracleEnhancedAdapter handling of BLOB columns" do


### PR DESCRIPTION
The initial problem that we ran into was that doing a Ransack search in a Rails 4 app on a text column was always resulting in a query with empty_clob() replacing the actual query value.

Searching all the way down into the Oracle Enhanced Adapter, we found this piece of code that looks like it always replaces text type columns with "empty_clob()" which seems to be the source of the problem. We found that a column is not passed as an argument to the quote() method in normal Rails calls (which is perhaps why this hasn't caused problems previously), only when the query is built with Arel:

```
$ model = Model.arel_table
$ matcher = model[:attribute].matches("%foo%")
$ Model.where(matcher).to_sql #=> ... WHERE model.attribute LIKE empty_clob())
```

I'm not particularly familiar with this code base but this fix resolved the issue for us. Maybe a similar fix would be needed for the binary column type too?
