### PR TITLE
Order view output alphabetically

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_structure_dump.rb
@@ -164,7 +164,7 @@ module ActiveRecord #:nodoc:
         end
 
         # export views 
-        select_all("SELECT view_name, text FROM user_views").each do |view|
+        select_all("SELECT view_name, text FROM user_views ORDER BY view_name ASC").each do |view|
           structure << "CREATE OR REPLACE VIEW #{view['view_name']} AS\n #{view['text']}"
         end
 


### PR DESCRIPTION
We are creating views which have dependencies on other views and we are not getting consistent behavior across machines when doing `rake db:migrate` which produces the `development_structure.sql` file used by the `db:test:prepare` Rake task.

This change includes added the explicit `order by view_name` so that the views are exported alphabetically. This still means that dependent views need to be alphabetically after their dependencies, but we're happy with this for the mean time.

Thanks

Nigel and Robbie 
