### PR TITLE
Change OracleEnhancedOCIConnection#describe logic

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb
@@ -208,15 +208,19 @@ module ActiveRecord
       def write_lob(lob, value, is_binary = false)
         lob.write value
       end
-      
+
       def describe(name)
         # fall back to SELECT based describe if using database link
         return super if name.to_s.include?('@')
         quoted_name = OracleEnhancedAdapter.valid_table_name?(name) ? name : "\"#{name}\""
         @raw_connection.describe(quoted_name)
       rescue OCIException => e
-        # fall back to SELECT which can handle synonyms to database links
-        super
+        if e.code == 4043
+          raise OracleEnhancedConnectionException, %Q{"DESC #{name}" failed; does it exist?}
+        else
+          # fall back to SELECT which can handle synonyms to database links
+          super
+        end
       end
 
       # Return OCIError error code

--- a/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
@@ -330,6 +330,17 @@ describe "OracleEnhancedConnection" do
       @conn.describe("all_tables").should == ["SYS", "ALL_TABLES"]
     end
 
+    if defined?(OCI8)
+      context "OCI8 adapter" do
+
+        it "should not fallback to SELECT-based logic when querying non-existant table information" do
+          @conn.should_not_receive(:select_one)
+          @conn.describe("non_existant") rescue ActiveRecord::ConnectionAdapters::OracleEnhancedConnectionException
+        end
+
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
I would kindly ask you to review this patch, and backport it to 1.4.x branch.

Background:

Some time ago, while running migrations and test schema preparations on one of internal Oracle setups, job wallclock times increased dramatically (in order of 10x). After some investigation it became apparent that problem was in `OracleEnhancedSchemaStatements::create_table` method - it took 40+ seconds to execute `OracleEnhancedAdapter::table_exists?` which itself is wrapper for `OracleEnhancedOCIConnection::describe` Though most probably, the time increase isn't directly related to ruby-oci8 or oracle-enhanced, as same problem was replicated in SQL Developer (which internally also translates `DESC[RIBE]`to UNIONed SELECT), and likely stems from DB configuration changes/patches/size increases, current gem code can be improved a bit; patch provides solution for this isolated performance drop.

Proposal:

When using OCI8 interface and calling `#describe` on non-existant table (as is probably the most frequent case in
test DB preparations and migrations), oracle-enhanced should not retry describe via SELECT-based `super` when no db link is specified and `OCIException` code is 4043 (object does not exist)

Signed-off-by: Aleksandrs Ļedovskis aleksandrs@ledovskis.lv
