### PR TITLE
Support `remove_columns`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
@@ -329,9 +329,8 @@ module ActiveRecord
         clear_table_columns_cache(table_name)
       end
 
-      def remove_column(table_name, *column_names) #:nodoc:
-        raise ArgumentError.new("You must specify at least one column name. Example: remove_column(:people, :first_name)") if column_names.empty?
-        column_names.each {|column_name| execute "ALTER TABLE #{quote_table_name(table_name)} DROP COLUMN #{quote_column_name(column_name)}"}
+      def remove_column(table_name, column_name, type = nil, options = {}) #:nodoc:
+        execute "ALTER TABLE #{quote_table_name(table_name)} DROP COLUMN #{quote_column_name(column_name)}"
       ensure
         clear_table_columns_cache(table_name)
         self.all_schema_indexes = nil

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -1067,6 +1067,14 @@ end
       TestPost.columns_hash['title'].should be_nil
       TestPost.columns_hash['content'].should be_nil
     end
+
+    it "should ignore type and options parameter and remove column" do
+      schema_define do
+        remove_column :test_posts, :title, :string, {}
+      end
+      TestPost.reset_column_information
+      TestPost.columns_hash['title'].should be_nil
+    end
   end
 
   describe 'virtual columns in create_table' do


### PR DESCRIPTION
This pull request supports `remove_columns` introduced in rails/rails#8267 and should address issue #373.

`def remove_columns(table_name, *column_names)` is defined in ActiveRecord::ConnectionAdapters::SchemaStatements, which does not
require Oracle enhanced specific implementation.

`def remove_column(table_name, column_name, type = nil, options = {})`
ignores `type` and `options` arguments to avoid ORA-00904 errors.

This commit should not backport into release14 branch.
