### PR TITLE
Dump views output alphabetically and FORCE option

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_structure_dump.rb
@@ -165,7 +165,7 @@ module ActiveRecord #:nodoc:
 
         # export views 
         select_all("SELECT view_name, text FROM user_views ORDER BY view_name ASC").each do |view|
-          structure << "CREATE OR REPLACE VIEW #{view['view_name']} AS\n #{view['text']}"
+          structure << "CREATE OR REPLACE FORCE VIEW #{view['view_name']} AS\n #{view['text']}"
         end
 
         # export synonyms

--- a/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
@@ -37,6 +37,8 @@ describe "OracleEnhancedAdapter structure dump" do
       @conn.execute "ALTER TABLE foos drop column baz_id" rescue nil
       @conn.execute "ALTER TABLE test_posts drop column fooz_id" rescue nil
       @conn.execute "ALTER TABLE test_posts drop column baz_id" rescue nil
+      @conn.execute "DROP VIEW test_posts_view_z" rescue nil
+      @conn.execute "DROP VIEW test_posts_view_a" rescue nil
     end
   
     it "should dump single primary key" do
@@ -137,6 +139,13 @@ describe "OracleEnhancedAdapter structure dump" do
       SQL
       dump = ActiveRecord::Base.connection.structure_dump_db_stored_code.gsub(/\n|\s+/,' ')
       dump.should =~ /CREATE OR REPLACE TYPE TEST_TYPE/
+    end
+
+    it "should dump views" do
+      @conn.execute "create or replace VIEW test_posts_view_z as select * from test_posts"
+      @conn.execute "create or replace VIEW test_posts_view_a as select * from test_posts_view_z"
+      dump = ActiveRecord::Base.connection.structure_dump_db_stored_code.gsub(/\n|\s+/,' ')
+      dump.should =~ /CREATE OR REPLACE FORCE VIEW TEST_POSTS_VIEW_A.*CREATE OR REPLACE FORCE VIEW TEST_POSTS_VIEW_Z/
     end
   
     it "should dump virtual columns" do


### PR DESCRIPTION
This pull request changes the dump file of views:
- Dump view order by view_name to make dump file consistent (cherry-pick #372)
- Add `FORCE` option at `CREATE OR REPLACE VIEW` in structure_dump_db_stored_code
  because it is quite difficult to dump views to satisfy dependencies.
