### PR TITLE
Address test create table with defaults

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_creation.rb
@@ -72,6 +72,12 @@ module ActiveRecord
           end
         end
 
+        # This method does not exist in SchemaCreation at Rails 4.0
+        # It can be removed only when Oracle enhanced adapter supports Rails 4.1 and higher
+        def options_include_default?(options)
+          options.include?(:default) && !(options[:null] == false && options[:default].nil?)
+        end
+
       end
       
       def schema_creation


### PR DESCRIPTION
This pull request address the following failure when tested with rails master branch by moving add_column_options! into SchemaCreation class. 

To support Rails 4.0 `options_include_default!` method added, which can be removed Oracle enhanced adapter supports only Rails 4.1 and upper version of Rails.

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/migration/change_schema_test.rb -n test_create_table_with_defaults
Using oracle
Run options: -n test_create_table_with_defaults --seed 18272

# Running:

F

Finished in 0.082692s, 12.0931 runs/s, 60.4656 assertions/s.

  1) Failure:
ActiveRecord::Migration::ChangeSchemaTest#test_create_table_with_defaults [test/cases/migration/change_schema_test.rb:74]:
Expected: "hello"
  Actual: nil

1 runs, 5 assertions, 1 failures, 0 errors, 0 skips
$
```
