### PR TITLE
Log bind variables after they were type casted

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -736,7 +736,10 @@ module ActiveRecord
       end
 
       def exec_query(sql, name = 'SQL', binds = [])
-        log(sql, name, binds) do
+        type_casted_binds = binds.map { |col, val|
+          [col, type_cast(val, col)]
+        }
+        log(sql, name, type_casted_binds) do
           cursor = nil
           cached = false
           if binds.empty?


### PR DESCRIPTION
This pull request addresses the failure by supporting https://github.com/rails/rails/commit/97f0d9a0 into Oracle enhanced adapter.

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/bind_parameter_test.rb -n test_binds_are_logged_after_type_cast
Using oracle
Run options: -n test_binds_are_logged_after_type_cast --seed 21981

# Running:

F

Finished in 0.120339s, 8.3098 runs/s, 8.3098 assertions/s.

  1) Failure:
ActiveRecord::BindParameterTest#test_binds_are_logged_after_type_cast [test/cases/bind_parameter_test.rb:52]:
--- expected
+++ actual
@@ -1 +1 @@
-[[#<ActiveRecord::ConnectionAdapters::OracleEnhancedColumn:0xXXXXXX @table_name="topics", @forced_column_type=nil, @virtual=false, @returning_id=false, @name="id", @sql_type="NUMBER(38)", @null=false, @limit=38, @precision=38, @scale=0, @type=:integer, @default=nil, @default_function=nil, @primary=true, @coder=nil, @object_type=false>, 3]]
+[[#<ActiveRecord::ConnectionAdapters::OracleEnhancedColumn:0xXXXXXX @table_name="topics", @forced_column_type=nil, @virtual=false, @returning_id=false, @name="id", @sql_type="NUMBER(38)", @null=false, @limit=38, @precision=38, @scale=0, @type=:integer, @default=nil, @default_function=nil, @primary=true, @coder=nil, @object_type=false>, "3"]]


1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```
