### PR TITLE
Support named savepoints

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -941,15 +941,15 @@ module ActiveRecord
         @connection.autocommit = true
       end
 
-      def create_savepoint #:nodoc:
+      def create_savepoint(name = current_savepoint_name) #:nodoc:
         execute("SAVEPOINT #{current_savepoint_name}")
       end
 
-      def rollback_to_savepoint #:nodoc:
+      def rollback_to_savepoint(name = current_savepoint_name) #:nodoc:
         execute("ROLLBACK TO #{current_savepoint_name}")
       end
 
-      def release_savepoint #:nodoc:
+      def release_savepoint(name = current_savepoint_name) #:nodoc:
         # there is no RELEASE SAVEPOINT statement in Oracle
       end
 


### PR DESCRIPTION
This pull request supports names savepoints introduced rails by this commit https://github.com/rails/rails/commit/032998ad7460c59916b8268467251d78c6cd18b7

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/transactions_test.rb -n /named_savepoints/
Using oracle
Run options: -n /named_savepoints/ --seed 43449

# Running:

EE

Finished in 0.420482s, 4.7564 runs/s, 0.0000 assertions/s.

  1) Error:
TransactionTest#test_releasing_named_savepoints:
ArgumentError: wrong number of arguments (1 for 0)
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:944:in `create_savepoint'
    test/cases/transactions_test.rb:398:in `block in test_releasing_named_savepoints'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:200:in `block in transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:208:in `within_new_transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:200:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
    test/cases/transactions_test.rb:397:in `test_releasing_named_savepoints'


  2) Error:
TransactionTest#test_using_named_savepoints:
ArgumentError: wrong number of arguments (1 for 0)
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:944:in `create_savepoint'
    test/cases/transactions_test.rb:382:in `block in test_using_named_savepoints'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:200:in `block in transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:208:in `within_new_transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:200:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
    test/cases/transactions_test.rb:379:in `test_using_named_savepoints'

2 runs, 0 assertions, 0 failures, 2 errors, 0 skips
$
```
