### PR TITLE
Create sequence when add primary column

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
@@ -278,6 +278,8 @@ module ActiveRecord
         add_column_sql << tablespace_for((type_to_sql(type).downcase.to_sym), nil, table_name, column_name) if type
 
         execute(add_column_sql)
+
+        create_sequence_and_trigger(table_name, options) if type && type.to_sym == :primary_key
       ensure
         clear_table_columns_cache(table_name)
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -10,6 +10,25 @@ describe "OracleEnhancedAdapter schema definition" do
       "select * from product_component_version where product like 'Oracle%' and to_number(substr(version,1,2)) >= 11")
   end
 
+  describe 'option to create sequence when adding a column' do
+    before do
+      @conn = ActiveRecord::Base.connection
+      schema_define do
+        create_table :keyboards, :force => true, :id  => false do |t|
+          t.string      :name
+        end
+        add_column :keyboards, :id, :primary_key
+      end
+      class ::Keyboard < ActiveRecord::Base; end
+    end
+
+    it 'creates a sequence when adding a column with create_sequence = true' do
+      _, sequence_name = ActiveRecord::Base.connection.pk_and_sequence_for_without_cache(:keyboards)
+
+      sequence_name.should == Keyboard.sequence_name
+    end
+  end
+
   describe "table and sequence creation with non-default primary key" do
 
     before(:all) do


### PR DESCRIPTION
To keep consistence with others adapters(mysql, mysql2, postgresql) add a sequence when add a primary key column on a table:

``` ruby
add_column :table_name, :id, :primary_key
```
