### PR TITLE
Fix schema dump works when non Oracle adapter used

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_column_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_column_dumper.rb
@@ -8,16 +8,23 @@ module ActiveRecord #:nodoc:
           alias_method_chain :column_spec,            :oracle_enhanced
           alias_method_chain :prepare_column_options, :oracle_enhanced
           alias_method_chain :migration_keys,         :oracle_enhanced
+
+          def oracle_enhanced_adapter?
+          # return original method if not using 'OracleEnhanced'
+            if (rails_env = defined?(Rails.env) ? Rails.env : (defined?(RAILS_ENV) ? RAILS_ENV : nil)) &&
+                ActiveRecord::Base.configurations[rails_env] &&
+                ActiveRecord::Base.configurations[rails_env]['adapter'] != 'oracle_enhanced'
+              return false
+            else
+              return true
+            end
+          end
         end
       end
 
       def column_spec_with_oracle_enhanced(column, types)
         # return original method if not using 'OracleEnhanced'
-        if (rails_env = defined?(Rails.env) ? Rails.env : (defined?(RAILS_ENV) ? RAILS_ENV : nil)) &&
-              ActiveRecord::Base.configurations[rails_env] &&
-              ActiveRecord::Base.configurations[rails_env]['adapter'] != 'oracle_enhanced'
-          return column_spec_with_oracle_enhanced(column, types)
-        end
+        return column_spec_without_oracle_enhanced(column, types) unless oracle_enhanced_adapter?
         
         spec = prepare_column_options(column, types)
         (spec.keys - [:name, :type]).each do |k|
@@ -28,6 +35,9 @@ module ActiveRecord #:nodoc:
       end
 
       def prepare_column_options_with_oracle_enhanced(column, types)
+        # return original method if not using 'OracleEnhanced'
+        return prepare_column_options_without_oracle_enhanced(column, types) unless oracle_enhanced_adapter?
+
         spec = {}
         spec[:name]      = column.name.inspect
         spec[:type]      = column.virtual? ? 'virtual' : column.type.to_s
@@ -43,8 +53,12 @@ module ActiveRecord #:nodoc:
 
       def migration_keys_with_oracle_enhanced
         # TODO `& column_specs.map(&:keys).flatten` should be exetuted here
+        # return original method if not using 'OracleEnhanced'
+        return migration_keys_without_oracle_enhanced unless oracle_enhanced_adapter?
+
         [:name, :limit, :precision, :scale, :default, :null, :as, :virtual_type]
       end
+
 
     end
   end


### PR DESCRIPTION
This pull request addresses `NoMethodError undefined method` when `rake db:schema:dump` command executed for non Oracle database adapters, such as sqlite3 and postgresql.

As an exception, this pull request does not have unit tests but I already confirmed:
- No regression found in ActiveRecord and Oracle enhanced unit tests
- Tested by @stefanvr 

It should resolve issues reported #366 #407.
