### PR TITLE
Fix db:schema:dump when foreign key column name is not 'id'

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_dumper.rb
@@ -61,15 +61,15 @@ module ActiveRecord #:nodoc:
           add_foreign_key_statements = foreign_keys.map do |foreign_key|
             statement_parts = [ ('add_foreign_key ' + foreign_key.from_table.inspect) ]
             statement_parts << foreign_key.to_table.inspect
-            
+
             if foreign_key.options[:columns].size == 1
               column = foreign_key.options[:columns].first
               if column != "#{foreign_key.to_table.singularize}_id"
                 statement_parts << ('column: ' + column.inspect)
               end
-              
+
               if foreign_key.options[:references].first != 'id'
-                statement_parts << ('primary_key: ' + foreign_key.options[:primary_key].inspect)
+                statement_parts << ('primary_key: ' + foreign_key.options[:references].first.inspect)
               end
             else
               statement_parts << ('columns: ' + foreign_key.options[:columns].inspect)


### PR DESCRIPTION
This pull request should address #409. Actually #264 solves this error then added a test to avoid regressions.
