### PR TITLE
Skip since this test always fails with Oracle 12c

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
@@ -381,6 +381,9 @@ describe "OracleEnhancedAdapter context index" do
 
     describe "with table prefix and suffix" do
       before(:all) do
+        @conn = ActiveRecord::Base.connection
+        @oracle12c = !! @conn.select_value(
+                        "select * from product_component_version where product like 'Oracle%' and to_number(substr(version,1,2)) = 12")
         ActiveRecord::Base.table_name_prefix = 'xxx_'
         ActiveRecord::Base.table_name_suffix = '_xxx'
         create_tables
@@ -405,6 +408,7 @@ describe "OracleEnhancedAdapter context index" do
       end
 
       it "should dump definition of multiple table index with options" do
+        pending "It always fails when Oracle 12c 12.1.0 used." if @oracle12c
         options = {
           name: 'xxx_post_and_comments_i',
           index_column: :all_text, index_column_trigger_on: :updated_at,


### PR DESCRIPTION
This pull request skips one of context index test failure with Oracle 12c

``` ruby
$ rake spec
... snip ...
Failures:

  1) OracleEnhancedAdapter context index schema dump with table prefix and suffix should dump definition of multiple table index with options
     Failure/Error: add_context_index :posts,
     ActiveRecord::StatementInvalid:
       OCIError: ORA-29855: error occurred in the execution of ODCIINDEXCREATE routine
       ORA-20000: Oracle Text error:
       DRG-50857: oracle error in drixmd.PurgeKGL
       ORA-20000: Oracle Text error:
       DRG-50857: oracle error in drdmlpo
       ORA-20000: Oracle Text error:
       DRG-10502: index 18547 does not exist
       DRG-10507: duplicate index name: XXX_POST_AND_COMMENTS_I
       ORA-06512: at "CTXSYS.DRUE", line 160
       ORA-06512: at "CTXSYS.DRVXMD", line 44
       ORA-06512: at line 1
       ORA-06510: PL/SQL: unhandled use
       ORA-30576: ConText Option dictionary loading error
       ORA-06510: PL/SQL: unhandled user-defined exception
       ORA-00001: unique constraint (CTXSYS.DRC$IDX_COLSPEC) violated
       DRG-50610: internal error: kglpurge []
       ORA-06512: at "CTXSYS.DRUE", line 160
       ORA-06512: at "CTXSYS.TEXTINDEXMETHODS", line 366: CREATE INDEX "XXX_POST_AND_COMMENTS_I" ON "XXX_POSTS_XXX" ("ALL_TEXT") INDEXTYPE IS CTXSYS.CONTEXT PARAMETERS ('DATASTORE xxx_post_and_comments_i_dst SECTION GROUP CTXSYS.AUTO_SECTION_GROUP SYNC(ON COMMIT) LEXER xxx_post_and_comments_i_lex WORDLIST xxx_post_and_comments_i_wl')
     # stmt.c:230:in oci8lib_210.so
     # /home/yahonda/.rvm/gems/ruby-2.1.1@railsmaster/bundler/gems/ruby-oci8-fb913e32d8a0/lib/oci8/cursor.rb:129:in `exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.1@railsmaster/bundler/gems/ruby-oci8-fb913e32d8a0/lib/oci8/oci8.rb:278:in `exec_internal'
     # /home/yahonda/.rvm/gems/ruby-2.1.1@railsmaster/bundler/gems/ruby-oci8-fb913e32d8a0/lib/oci8/oci8.rb:269:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:429:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:88:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:727:in `block in execute'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:360:in `block in log'
     # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:354:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1495:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:727:in `execute'
     # ./lib/active_record/connection_adapters/oracle_enhanced_context_index.rb:125:in `add_context_index'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:649:in `block in method_missing'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:621:in `block in say_with_time'
     # /home/yahonda/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/benchmark.rb:279:in `measure'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:621:in `say_with_time'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:641:in `method_missing'
     # ./spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb:416:in `block (5 levels) in <top (required)>'
     # ./spec/spec_helper.rb:106:in `instance_eval'
     # ./spec/spec_helper.rb:106:in `block (2 levels) in schema_define'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:629:in `suppress_messages'
     # ./spec/spec_helper.rb:105:in `block in schema_define'
     # /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:42:in `instance_eval'
     # /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:42:in `define'
     # /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:62:in `define'
     # ./spec/spec_helper.rb:104:in `schema_define'
     # ./spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb:415:in `block (4 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.1@railsmaster/gems/rspec-core-2.14.8/lib/rspec/core/example.rb:114:in `instance_eval'
     # /home/yahonda/.rvm/gems/ruby-2.1.1@railsmaster/gems/rspec-core-2.14.8/lib/rspec/core/example.rb:114:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.1@railsmaster/gems/rspec-core-2.14.8/lib/rspec/core/example.rb:254:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.1@railsmaster/gems/rspec-core-2.14.8/lib/rspec/core/example.rb:111:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.1@railsmaster/gems/rspec-core-2.14.8/lib/rspec/core/example_group.rb:390:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.1@railsmaster/gems/rspec-core-2.14.8/lib/rspec/core/example_group.rb:386:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.1@railsmaster/gems/rspec-core-2.14.8/lib/rspec/core/example_group.rb:386:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.1@railsmaster/gems/rspec-core-2.14.8/lib/rspec/core/example_group.rb:371:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.1@railsmaster/gems/rspec-core-2.14.8/lib/rspec/core/example_group.rb:372:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.1@railsmaster/gems/rspec-core-2.14.8/lib/rspec/core/example_group.rb:372:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.1@railsmaster/gems/rspec-core-2.14.8/lib/rspec/core/example_group.rb:372:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.1@railsmaster/gems/rspec-core-2.14.8/lib/rspec/core/example_group.rb:372:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.1@railsmaster/gems/rspec-core-2.14.8/lib/rspec/core/example_group.rb:372:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.1@railsmaster/gems/rspec-core-2.14.8/lib/rspec/core/example_group.rb:372:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.1@railsmaster/gems/rspec-core-2.14.8/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.1@railsmaster/gems/rspec-core-2.14.8/lib/rspec/core/command_line.rb:28:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.1@railsmaster/gems/rspec-core-2.14.8/lib/rspec/core/command_line.rb:28:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.1@railsmaster/gems/rspec-core-2.14.8/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.1@railsmaster/gems/rspec-core-2.14.8/lib/rspec/core/command_line.rb:25:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.1@railsmaster/gems/rspec-core-2.14.8/lib/rspec/core/runner.rb:80:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.1@railsmaster/gems/rspec-core-2.14.8/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 3 minutes 9.3 seconds
367 examples, 1 failure, 2 pending

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb:407 # OracleEnhancedAdapter context index schema dump with table prefix and suffix should dump definition of multiple table index with options
```

Exact version is

``` sql
Oracle Database 12c Enterprise Edition Release 12.1.0.1.0 - 64bit Production
```
