### PR TITLE
structure:dump works only when the schema migration table exists

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_database_tasks.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_database_tasks.rb
@@ -40,7 +40,8 @@ module ActiveRecord
         def structure_dump(filename)
           establish_connection(@config)
           File.open(filename, 'w:utf-8') { |f| f << connection.structure_dump }
-          if connection.supports_migrations?
+          if connection.supports_migrations? &&
+             ActiveRecord::SchemaMigration.table_exists?
             File.open(filename, 'a') { |f| f << connection.dump_schema_information }
           end
           if @config['structure_dump'] == 'db_stored_code'


### PR DESCRIPTION
See rails/rails#14217 and rsim/oracle-enhanced#440
