### PR TITLE
Update the error message to support JDBC and OCI connections

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
@@ -619,7 +619,7 @@ describe "OracleEnhancedAdapter schema dump" do
             number2 = TestNumber.new(value: value_exceeding_max_precision)
             lambda do
               number2.save!
-            end.should raise_error() { |e| e.message.should =~ /ORA-01438.*"VALUE"/m }
+            end.should raise_error() { |e| e.message.should =~ /ORA-01438/ }
           end
         end
       end # context (:decimal)


### PR DESCRIPTION
This pull request addresses a failure when tested with JRuby.
As long as this test checks to see if `ORA-1438` generated in the error message it satisfies the test purpose.
