### PR TITLE
Tag bind params with a bind param object

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -737,7 +737,7 @@ module ActiveRecord
       end
 
       def substitute_at(column, index)
-        Arel.sql(":a#{index + 1}")
+        Arel::Nodes::BindParam.new (":a#{index + 1}")
       end
 
       def clear_cache!


### PR DESCRIPTION
This pull request addresses a failure reported in #442 by implementing https://github.com/rails/rails/commit/f48a33be7db20db753ff06f430daf71ba31b0770

This commit enables to handle bind value as `Arel::Nodes::BindParam`. Before this commit it was `Arel::Nodes::SqlLiteral`

Unfortunately Oracle enhanced adapter needs actual support for `unprepared_statements` method by implementing to handle `without_prepared_statement?` method in `exec_insert` and/or `exec_query`. I'll open another issue soon.
