### PR TITLE
Removing the trailing semi-colon chop on statements in db/structure.sql

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_structure_dump.rb
@@ -240,7 +240,6 @@ module ActiveRecord #:nodoc:
 
       def execute_structure_dump(string)
         string.split(STATEMENT_TOKEN).each do |ddl|
-          ddl.chop! if ddl[-1,1] == ';'
           execute(ddl) unless ddl.blank?
         end
       end


### PR DESCRIPTION
Removing the trailing semi-colon causes Oracle to improperly declare procedures and functions
defined within the dumped structure when loading the structure file.  This change removes the functionality that removes the trailing semi-colon.

See https://github.com/rsim/oracle-enhanced/issues/454
