### PR TITLE
Initial support for Rails 4.2

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb
@@ -16,6 +16,7 @@ module ActiveRecord
 
       def clear_cache!
         @statements.clear
+        reload_type_map
       end
 
       def exec_query(sql, name = 'SQL', binds = [])
@@ -109,7 +110,7 @@ module ActiveRecord
       def sql_for_insert(sql, pk, id_value, sequence_name, binds)
         unless id_value || pk.nil? || (defined?(CompositePrimaryKeys) && pk.kind_of?(CompositePrimaryKeys::CompositeKeys))
           sql = "#{sql} RETURNING #{quote_column_name(pk)} INTO :returning_id"
-          returning_id_col = OracleEnhancedColumn.new("returning_id", nil, "number", true, "dual", :integer, true, true)
+          returning_id_col = OracleEnhancedColumn.new("returning_id", nil, Type::Value.new, "number", true, "dual", :integer, true, true)
           (binds = binds.dup) << [returning_id_col, nil]
         end
         [sql, binds]

--- a/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
@@ -227,7 +227,7 @@ describe "OracleEnhancedConnection" do
 
     it "should execute prepared statement with decimal bind parameter " do
       cursor = @conn.prepare("INSERT INTO test_employees VALUES(:1)")
-      column = ActiveRecord::ConnectionAdapters::OracleEnhancedColumn.new('age', nil, 'NUMBER(10,2)')
+      column = ActiveRecord::ConnectionAdapters::OracleEnhancedColumn.new('age', nil, ActiveRecord::ConnectionAdapters::Type::Decimal.new, 'NUMBER(10,2)')
       column.type.should == :decimal
       cursor.bind_param(1, "1.5", column)
       cursor.exec


### PR DESCRIPTION
This commit supports following changes, still it needs to support date/time features such as `set_date_columns`
- BindSubstitution class removed
  https://github.com/rails/rails/commit/ee54e9bb3a6d7ffcf756ec1e385399b92354cb6b#diff-c226a4680f86689c3c170d4bc5911e96
- Delegate `Column#type` to the injected type object
  https://github.com/rails/rails/commit/0b682e4b05c8f58c77c655650af6638c483ac903
