### PR TITLE
Revert "Skip since this test always fails with Oracle 12c"

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
@@ -381,9 +381,6 @@ describe "OracleEnhancedAdapter context index" do
 
     describe "with table prefix and suffix" do
       before(:all) do
-        @conn = ActiveRecord::Base.connection
-        @oracle12c = !! @conn.select_value(
-                        "select * from product_component_version where product like 'Oracle%' and to_number(substr(version,1,2)) = 12")
         ActiveRecord::Base.table_name_prefix = 'xxx_'
         ActiveRecord::Base.table_name_suffix = '_xxx'
         create_tables
@@ -408,7 +405,6 @@ describe "OracleEnhancedAdapter context index" do
       end
 
       it "should dump definition of multiple table index with options" do
-        pending "It always fails when Oracle 12c 12.1.0 used." if @oracle12c
         options = {
           name: 'xxx_post_and_comments_i',
           index_column: :all_text, index_column_trigger_on: :updated_at,


### PR DESCRIPTION
This reverts commit 73ba558a3897dfd4bf6e1351489dbccd926ddc81.

Since it does work with Oracle Database 12.1.0.1.4.
