### PR TITLE
Revert "Pending two tests which always fail when tested with Oracle 12c"

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
@@ -174,8 +174,6 @@ describe "OracleEnhancedAdapter context index" do
   describe "on multiple tables" do
     before(:all) do
       @conn = ActiveRecord::Base.connection
-      @oracle12c = !! @conn.select_value(
-                      "select * from product_component_version where product like 'Oracle%' and to_number(substr(version,1,2)) = 12")
       create_tables
       class ::Post < ActiveRecord::Base
         has_many :comments, dependent: :destroy
@@ -200,7 +198,6 @@ describe "OracleEnhancedAdapter context index" do
     end
 
     it "should create multiple table index with specified main index column" do
-      pending "It always fails when Oracle 12c 12.1.0 used." if @oracle12c
       @conn.add_context_index :posts,
         [:title, :body,
         # specify aliases always with AS keyword
@@ -218,7 +215,6 @@ describe "OracleEnhancedAdapter context index" do
     end
 
     it "should create multiple table index with specified main index column (when subquery has newlines)" do
-      pending "It always fails when Oracle 12c 12.1.0 used." if @oracle12c
       @conn.add_context_index :posts,
         [:title, :body,
          # specify aliases always with AS keyword


### PR DESCRIPTION
This reverts commit 346435b710091439a0f473f42be9772c944ee9d6.

Since both tests pass when tested with Oracle Database 12.1.0.2.0.
