### PR TITLE
removing dump_schema_information method

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_database_tasks.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_database_tasks.rb
@@ -40,9 +40,6 @@ module ActiveRecord
         def structure_dump(filename)
           establish_connection(@config)
           File.open(filename, 'w:utf-8') { |f| f << connection.structure_dump }
-          if connection.supports_migrations?
-            File.open(filename, 'a') { |f| f << connection.dump_schema_information }
-          end
           if @config['structure_dump'] == 'db_stored_code'
              File.open(filename, 'a') { |f| f << connection.structure_dump_db_stored_code }
           end


### PR DESCRIPTION
Removing dump_schema_information. The latest version of ActiveRecord already calls this method at a high level.  https://github.com/rails/rails/blob/35a9f7a6353ea12dd3103366e84ccc90123c3583/activerecord/lib/active_record/railties/databases.rake#L273-L288

Having this in the oracle-enhanced gem causes duplicate insert schema migrations in the structure.sql file.