### PR TITLE
ActiveRecord::Migrator.proper_table_name has been removed from Rails

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_statements_ext.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_statements_ext.rb
@@ -95,7 +95,8 @@ module ActiveRecord
           references_sql = quote_column_name(options[:primary_key] || references || "id")
         end
 
-        table_name = ActiveRecord::Migrator.proper_table_name(to_table)
+        table_name = to_table
+        # TODO: Needs support `table_name_prefix` and `table_name_suffix`
 
         sql = "FOREIGN KEY (#{columns_sql}) REFERENCES #{quote_table_name(table_name)}(#{references_sql})"
 


### PR DESCRIPTION
This pull request addresses most of issues reported in #480.
It has not supported `table_name_prefix` and `table_name_suffix` yet.
