### PR TITLE
Rails4.2 Rename type_cast to type_cast_from_database

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -67,21 +67,21 @@ describe "OracleEnhancedAdapter date type detection based on column names" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = false
     columns = @conn.columns('test_employees')
     column = columns.detect{|c| c.name == "hire_date"}
-    column.type_cast(Time.now).class.should == Time
+    column.type_cast_from_database(Time.now).class.should == Time
   end
 
   it "should return Date value from DATE column if column name contains 'date' and emulate_dates_by_column_name is true" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = true
     columns = @conn.columns('test_employees')
     column = columns.detect{|c| c.name == "hire_date"}
-    column.type_cast(Time.now).class.should == Date
+    column.type_cast_from_database(Time.now).class.should == Date
   end
 
   it "should typecast DateTime value to Date value from DATE column if column name contains 'date' and emulate_dates_by_column_name is true" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = true
     columns = @conn.columns('test_employees')
     column = columns.detect{|c| c.name == "hire_date"}
-    column.type_cast(DateTime.new(1900,1,1)).class.should == Date
+    column.type_cast_from_database(DateTime.new(1900,1,1)).class.should == Date
   end
 
   describe "/ DATE values from ActiveRecord model" do
@@ -295,14 +295,14 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = false
     columns = @conn.columns('test2_employees')
     column = columns.detect{|c| c.name == "job_id"}
-    column.type_cast(1.0).class.should == BigDecimal
+    column.type_cast_from_database(1.0).class.should == BigDecimal
   end
 
   it "should return Fixnum value from NUMBER column if column name ends with '_id' and emulate_integers_by_column_name is true" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = true
     columns = @conn.columns('test2_employees')
     column = columns.detect{|c| c.name == "job_id"}
-    column.type_cast(1.0).class.should == Fixnum
+    column.type_cast_from_database(1.0).class.should == Fixnum
   end
 
   describe "/ NUMBER values from ActiveRecord model" do
@@ -452,7 +452,7 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
     columns = @conn.columns('test3_employees')
     %w(has_email has_phone active_flag manager_yn).each do |col|
       column = columns.detect{|c| c.name == col}
-      column.type_cast("Y").class.should == String
+      column.type_cast_from_database("Y").class.should == String
     end
   end
   
@@ -461,8 +461,8 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
     columns = @conn.columns('test3_employees')
     %w(has_email has_phone active_flag manager_yn).each do |col|
       column = columns.detect{|c| c.name == col}
-      column.type_cast("Y").class.should == TrueClass
-      column.type_cast("N").class.should == FalseClass
+      column.type_cast_from_database("Y").class.should == TrueClass
+      column.type_cast_from_database("N").class.should == FalseClass
     end
   end
 


### PR DESCRIPTION
This pull request addresses following failures introduced since https://github.com/rails/rails/commit/d24e6407a7f5d662cb52ed57efc4d8ee11758170

Actually these 3 tests pass successfully with this commit, other tests modified needs more fix which depends on each data type.

``` ruby
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:66
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:294 
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:450 
```

```
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:66
==> Running specs with MRI version 2.1.2
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[66]}}
F

Failures:

  1) OracleEnhancedAdapter date type detection based on column names should return Time value from DATE column if emulate_dates_by_column_name is false
     Failure/Error: column.type_cast(Time.now).class.should == Time
     NoMethodError:
       super: no superclass method `type_cast' for #<ActiveRecord::ConnectionAdapters::OracleEnhancedColumn:0x000000034df208>
     # ./lib/active_record/connection_adapters/oracle_enhanced_column.rb:31:in `type_cast'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:70:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.16947 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:66 # OracleEnhancedAdapter date type detection based on column names should return Time value from DATE column if emulate_dates_by_column_name is false
```

``` ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:294
==> Running specs with MRI version 2.1.2
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[294]}}
F

Failures:

  1) OracleEnhancedAdapter integer type detection based on column names should return BigDecimal value from NUMBER column if emulate_integers_by_column_name is false
     Failure/Error: column.type_cast(1.0).class.should == BigDecimal
     NoMethodError:
       super: no superclass method `type_cast' for #<ActiveRecord::ConnectionAdapters::OracleEnhancedColumn:0x00000001c17f90>
     # ./lib/active_record/connection_adapters/oracle_enhanced_column.rb:35:in `type_cast'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:298:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.13708 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:294 # OracleEnhancedAdapter integer type detection based on column names should return BigDecimal value from NUMBER column if emulate_integers_by_column_name is false
```

``` ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:450

==> Running specs with MRI version 2.1.2
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[450]}}
F

Failures:

  1) OracleEnhancedAdapter boolean type detection based on string column types and names should return string value from VARCHAR2 boolean column if emulate_booleans_from_strings is false
     Failure/Error: column.type_cast("Y").class.should == String
     NoMethodError:
       super: no superclass method `type_cast' for #<ActiveRecord::ConnectionAdapters::OracleEnhancedColumn:0x000000048ab098>
     # ./lib/active_record/connection_adapters/oracle_enhanced_column.rb:35:in `type_cast'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:455:in `block (3 levels) in <top (required)>'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:453:in `each'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:453:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.13525 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:450 # OracleEnhancedAdapter boolean type detection based on string column types and names should return string value from VARCHAR2 boolean column if emulate_booleans_from_strings is false
```
