### PR TITLE
Rails4.2 Use quote_value method to avoid undefined method `type_cast_for_database' for nil:NilClass

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_creation.rb
@@ -54,10 +54,9 @@ module ActiveRecord
           # handle case of defaults for CLOB columns, which would otherwise get "quoted" incorrectly
           if options_include_default?(options)
             if type == :text
-              sql << " DEFAULT #{@conn.quote(options[:default])}"
+              sql << " DEFAULT #{quote_value(options[:default])}"
             else
-              # from abstract adapter
-              sql << " DEFAULT #{@conn.quote(options[:default], options[:column])}"
+              sql << " DEFAULT #{quote_value(options[:default], options[:column])}"
             end
           end
           # must explicitly add NULL or NOT NULL to allow change_column to work on migrations


### PR DESCRIPTION
This pull request addresses following error since https://github.com/rails/rails/commit/b404613c977a5cc31c6748723e903fa5a0709c3b has been merged to Rails.

``` ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:72
==> Running specs with MRI version 2.1.2
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb"=>[72]}}

An error occurred in an after hook
  ActiveRecord::StatementInvalid: OCIError: ORA-00942: table or view does not exist: DROP TABLE "TEST_DEFAULTS"
  occurred at stmt.c:230:in oci8lib_210.so

F

Failures:

  1) OracleEnhancedAdapter schema dump dumping default values should be able to dump default values using special characters
     Failure/Error: create_table "test_defaults", force: true do |t|
     NoMethodError:
       undefined method `type_cast_for_database' for nil:NilClass
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:13:in `quote'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:611:in `quote'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_creation.rb:60:in `add_column_options!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:33:in `visit_ColumnDefinition'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_creation.rb:12:in `visit_ColumnDefinition'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:12:in `accept'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_creation.rb:20:in `block in visit_TableDefinition'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_creation.rb:20:in `map'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_creation.rb:20:in `visit_TableDefinition'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:12:in `accept'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:82:in `create_table'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:659:in `block in method_missing'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:629:in `block in say_with_time'
     # /home/yahonda/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/benchmark.rb:279:in `measure'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:629:in `say_with_time'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:649:in `method_missing'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:59:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:106:in `instance_eval'
     # ./spec/spec_helper.rb:106:in `block (2 levels) in schema_define'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:637:in `suppress_messages'
     # ./spec/spec_helper.rb:105:in `block in schema_define'
     # /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:41:in `instance_eval'
     # /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:41:in `define'
     # /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:61:in `define'
     # ./spec/spec_helper.rb:104:in `schema_define'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:58:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:241:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/hooks.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/hooks.rb:85:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/hooks.rb:85:in `each'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/hooks.rb:85:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/hooks.rb:446:in `run_hook'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:468:in `run_before_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:288:in `run_before_each'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:115:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.10721 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:72 # OracleEnhancedAdapter schema dump dumping default values should be able to dump default values using special characters
$
```
