### PR TITLE
text? has been removed from Column class

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -802,7 +802,7 @@ module ActiveRecord
           value = attributes[col.name]
           # changed sequence of next two lines - should check if value is nil before converting to yaml
           next if value.nil?  || (value == '')
-          value = value.to_yaml if col.text? && klass.serialized_attributes[col.name]
+          value = value.to_yaml if value.is_a?(String) && klass.serialized_attributes[col.name]
           uncached do
             sql = is_with_cpk ? "SELECT #{quote_column_name(col.name)} FROM #{quote_table_name(table_name)} WHERE #{klass.composite_where_clause(id)} FOR UPDATE" :
               "SELECT #{quote_column_name(col.name)} FROM #{quote_table_name(table_name)} WHERE #{quote_column_name(klass.primary_key)} = #{id} FOR UPDATE"


### PR DESCRIPTION
Detail can be found here: https://github.com/rails/rails/commit/d44702ee45219153c5e56da0a06ffe6ab5d14518

So writing a CLOB column might causing error in 4.2 beta 1. I am getting following error:

```
NoMethodError: undefined method `text?' for #<ActiveRecord::ConnectionAdapters::OracleEnhancedColumn:0x000001015dcf58>
```

Looks we don't need this check any longer, simply check it against String type might do the job.
