### PR TITLE
Rails4.2 Support to work with Rails foreien_key implementation

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_dumper.rb
@@ -7,6 +7,8 @@ module ActiveRecord #:nodoc:
           private
           alias_method_chain :tables, :oracle_enhanced
           alias_method_chain :indexes, :oracle_enhanced
+          alias_method_chain :indexes, :oracle_enhanced
+          alias_method_chain :foreign_keys, :oracle_enhanced
         end
       end
 
@@ -56,7 +58,7 @@ module ActiveRecord #:nodoc:
         end
       end
 
-      def foreign_keys(table_name, stream)
+      def foreign_keys_with_oracle_enhanced(table_name, stream)
         if @connection.respond_to?(:foreign_keys) && (foreign_keys = @connection.foreign_keys(table_name)).any?
           add_foreign_key_statements = foreign_keys.map do |foreign_key|
             statement_parts = [ ('add_foreign_key ' + foreign_key.from_table.inspect) ]


### PR DESCRIPTION
This pull request supports [Rails foreign_key implementation](https://github.com/rails/rails/commit/69c711f38cac85e9c8bdbe286591bf88ef720bfa)

It fixes following failure.

``` ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:179
==> Running specs with MRI version 2.1.2
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb"=>[179]}}
F

Failures:

  1) OracleEnhancedAdapter schema dump foreign key constraints should include foreign key in schema dump
     Failure/Error: ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, stream)
     NoMethodError:
       undefined method `column' for #<ActiveRecord::ConnectionAdapters::OracleEnhancedForeignKeyDefinition:0x000000021ac280>
     # /home/yahonda/git/rails/activerecord/lib/active_record/schema_dumper.rb:227:in `block in foreign_keys'
     # /home/yahonda/git/rails/activerecord/lib/active_record/schema_dumper.rb:219:in `map'
     # /home/yahonda/git/rails/activerecord/lib/active_record/schema_dumper.rb:219:in `foreign_keys'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_dumper.rb:43:in `block in tables_with_oracle_enhanced'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_dumper.rb:41:in `each'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_dumper.rb:41:in `tables_with_oracle_enhanced'
     # /home/yahonda/git/rails/activerecord/lib/active_record/schema_dumper.rb:38:in `dump'
     # /home/yahonda/git/rails/activerecord/lib/active_record/schema_dumper.rb:22:in `dump'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:16:in `standard_dump'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:183:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.38081 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:179 # OracleEnhancedAdapter schema dump foreign key constraints should include foreign key in schema dump
$
```

Also this commit fixes following test failures.

``` ruby
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:179
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:186
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:193
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:214
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:221
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:228
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:245
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:255
```
