### PR TITLE
Add `null: true` to avoid DEPRECATION WARNING

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -473,7 +473,7 @@ describe "OracleEnhancedAdapter" do
         t.string      :title
         # cannot update LOBs over database link
         t.string      :body
-        t.timestamps
+        t.timestamps null: true
       end
       @db_link_username = SYSTEM_CONNECTION_PARAMS[:username]
       @db_link_password = SYSTEM_CONNECTION_PARAMS[:password]

--- a/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
@@ -11,7 +11,7 @@ describe "OracleEnhancedAdapter context index" do
         t.string :title
         t.text :body
         t.integer :comments_count
-        t.timestamps
+        t.timestamps null: true
         t.string :all_text, limit: 2 # will be used for multi-column index
       end
     end
@@ -23,7 +23,7 @@ describe "OracleEnhancedAdapter context index" do
         t.integer :post_id
         t.string :author
         t.text :body
-        t.timestamps
+        t.timestamps null: true
       end
     end
   end

--- a/spec/active_record/connection_adapters/oracle_enhanced_cpk_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_cpk_spec.rb
@@ -67,12 +67,12 @@ describe "OracleEnhancedAdapter composite_primary_keys support" do
           t.string  :type_category, :limit => 15, :null => false  
           t.date    :date_value, :null => false
           t.text    :results, :null => false
-          t.timestamps
+          t.timestamps null: true
         end
         create_table :non_cpk_write_lobs_test, :force => true do |t|
           t.date    :date_value, :null => false
           t.text    :results, :null => false
-          t.timestamps
+          t.timestamps null: true
         end
       end
       class ::CpkWriteLobsTest < ActiveRecord::Base


### PR DESCRIPTION
This pull request addresses following deprecation warning by setting `null: true`.

``` ruby
DEPRECATION WARNING: `timestamp` was called without specifying an option for `null`. In Rails
5.0, this behavior will change to `null: false`. You should manually
specify `null: true` to prevent the behavior of your existing migrations
```
