### PR TITLE
Rails4.2 Support NCHAR correctly

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_column.rb
@@ -18,7 +18,7 @@ module ActiveRecord
         super(name, default_value, cast_type, sql_type, null)
         # Is column NCHAR or NVARCHAR2 (will need to use N'...' value quoting for these data types)?
         # Define only when needed as adapter "quote" method will check at first if instance variable is defined.
-        @nchar = true if @cast_type == :string && sql_type[0,1] == 'N'
+        @nchar = true if cast_type.class == ActiveRecord::Type::String && sql_type[0,1] == 'N'
         # TODO: Need to investigate when `sql_type` becomes nil
         @object_type = sql_type.include? '.' unless sql_type.nil?
       end


### PR DESCRIPTION
This pull request addresses following failure.

``` ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1378
==> Running specs with MRI version 2.1.2
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[1378]}}
F

Failures:

  1) OracleEnhancedAdapter quoting of NCHAR and NVARCHAR2 columns should set nchar instance variable
     Failure/Error: column.nchar.should == (col[0,1] == 'n' ? true : nil)
       expected: true
            got: nil (using ==)
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/fail_with.rb:32:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:57:in `fail_with_message'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:98:in `__delegate_operator'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:89:in `eval_match'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:38:in `block in use_custom_matcher_or_delegate'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1383:in `block (3 levels) in <top (required)>'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1380:in `each'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1380:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.13283 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1378 # OracleEnhancedAdapter quoting of NCHAR and NVARCHAR2 columns should set nchar instance variable
```
