### PR TITLE
Rails4.2 Support OracleEnhancedAdapter.emulate_integers_by_column_name

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_column.rb
@@ -15,6 +15,11 @@ module ActiveRecord
         else
           default_value = self.class.extract_value_from_default(default)
         end
+        # TODO: Consider to extract to another method
+        if OracleEnhancedAdapter.emulate_integers_by_column_name && OracleEnhancedAdapter.is_integer_column?(name, table_name)
+          cast_type = ActiveRecord::Type::Integer.new
+        end
+
         super(name, default_value, cast_type, sql_type, null)
         # Is column NCHAR or NVARCHAR2 (will need to use N'...' value quoting for these data types)?
         # Define only when needed as adapter "quote" method will check at first if instance variable is defined.


### PR DESCRIPTION
This pull request supports `OracleEnhancedAdapter.emulate_integers_by_column_name`, which fixes following failures.

``` ruby
2.1.2@rails42 [ rails42 ~/git/oracle-enhanced]$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:264
==> Running specs with MRI version 2.1.2
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[264]}}
F

Failures:

  1) OracleEnhancedAdapter integer type detection based on column names should set NUMBER column type as integer if emulate_integers_by_column_name is true
     Failure/Error: column.type.should == :integer
       expected: :integer
            got: :decimal (using ==)
       Diff:
       @@ -1,2 +1,2 @@
       -:integer
       +:decimal

     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/fail_with.rb:32:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:57:in `fail_with_message'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:98:in `__delegate_operator'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:89:in `eval_match'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:38:in `block in use_custom_matcher_or_delegate'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:268:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.14856 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:264 # OracleEnhancedAdapter integer type detection based on column names should set NUMBER column type as integer if emulate_integers_by_column_name is true
2.1.2@rails42 [ rails42 ~/git/oracle-enhanced]$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:273
==> Running specs with MRI version 2.1.2
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[273]}}
F

Failures:

  1) OracleEnhancedAdapter integer type detection based on column names should set NUMBER(p,0) column type as integer
     Failure/Error: column.type.should == :integer
       expected: :integer
            got: :decimal (using ==)
       Diff:
       @@ -1,2 +1,2 @@
       -:integer
       +:decimal

     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/fail_with.rb:32:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:57:in `fail_with_message'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:98:in `__delegate_operator'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:89:in `eval_match'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:38:in `block in use_custom_matcher_or_delegate'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:277:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.16019 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:273 # OracleEnhancedAdapter integer type detection based on column names should set NUMBER(p,0) column type as integer
2.1.2@rails42 [ rails42 ~/git/oracle-enhanced]$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:280
==> Running specs with MRI version 2.1.2
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[280]}}
F

Failures:

  1) OracleEnhancedAdapter integer type detection based on column names should set NUMBER(p,s) column type as integer if column name ends with '_id' and emulate_integers_by_column_name is true
     Failure/Error: column.type.should == :integer
       expected: :integer
            got: :decimal (using ==)
       Diff:
       @@ -1,2 +1,2 @@
       -:integer
       +:decimal

     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/fail_with.rb:32:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:57:in `fail_with_message'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:98:in `__delegate_operator'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:89:in `eval_match'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:38:in `block in use_custom_matcher_or_delegate'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:284:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.15011 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:280 # OracleEnhancedAdapter integer type detection based on column names should set NUMBER(p,s) column type as integer if column name ends with '_id' and emulate_integers_by_column_name is true
2.1.2@rails42 [ rails42 ~/git/oracle-enhanced]$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:301
==> Running specs with MRI version 2.1.2
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[301]}}
F

Failures:

  1) OracleEnhancedAdapter integer type detection based on column names should return Fixnum value from NUMBER column if column name ends with '_id' and emulate_integers_by_column_name is true
     Failure/Error: column.type_cast_from_database(1.0).class.should == Fixnum
       expected: Fixnum
            got: BigDecimal (using ==)
       Diff:
       @@ -1,2 +1,2 @@
       -Fixnum
       +BigDecimal

     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/fail_with.rb:32:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:57:in `fail_with_message'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:98:in `__delegate_operator'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:89:in `eval_match'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:38:in `block in use_custom_matcher_or_delegate'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:305:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.15389 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:301 # OracleEnhancedAdapter integer type detection based on column names should return Fixnum value from NUMBER column if column name ends with '_id' and emulate_integers_by_column_name is true
2.1.2@rails42 [ rails42 ~/git/oracle-enhanced]$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:338
==> Running specs with MRI version 2.1.2
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[338]}}
F

Failures:

  1) OracleEnhancedAdapter integer type detection based on column names / NUMBER values from ActiveRecord model should return Fixnum value from NUMBER column if column name contains 'id' and emulate_integers_by_column_name is true
     Failure/Error: @employee2.job_id.class.should == Fixnum
       expected: Fixnum
            got: BigDecimal (using ==)
       Diff:
       @@ -1,2 +1,2 @@
       -Fixnum
       +BigDecimal

     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/fail_with.rb:32:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:57:in `fail_with_message'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:98:in `__delegate_operator'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:89:in `eval_match'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:38:in `block in use_custom_matcher_or_delegate'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:341:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.34986 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:338 # OracleEnhancedAdapter integer type detection based on column names / NUMBER values from ActiveRecord model should return Fixnum value from NUMBER column if column name contains 'id' and emulate_integers_by_column_name is true
2.1.2@rails42 [ rails42 ~/git/oracle-enhanced]$
```
