### PR TITLE
Rails 4.2 Support OracleEnhancedAdapter.emulate_dates_by_column_name

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_column.rb
@@ -20,6 +20,9 @@ module ActiveRecord
           cast_type = ActiveRecord::Type::Integer.new
         end
 
+        if OracleEnhancedAdapter.emulate_dates_by_column_name && OracleEnhancedAdapter.is_date_column?(name, table_name)
+          cast_type = ActiveRecord::Type::Date.new
+        end
         super(name, default_value, cast_type, sql_type, null)
         # Is column NCHAR or NVARCHAR2 (will need to use N'...' value quoting for these data types)?
         # Define only when needed as adapter "quote" method will check at first if instance variable is defined.


### PR DESCRIPTION
This commit implements OracleEnhancedAdapter.emulate_dates_by_column_name, which addresses following failures. This commit has one regression explained later.

``` ruby
2.1.2@rails42 [ rails42 ~/git/oracle-enhanced]$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:45
==> Running specs with MRI version 2.1.2
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[45]}}
F

Failures:

  1) OracleEnhancedAdapter date type detection based on column names should set DATE column type as date if column name contains '_date_' and emulate_dates_by_column_name is true
     Failure/Error: column.type.should == :date
       expected: :date
            got: :datetime (using ==)
       Diff:
       @@ -1,2 +1,2 @@
       -:date
       +:datetime

     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/fail_with.rb:32:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:57:in `fail_with_message'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:98:in `__delegate_operator'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:89:in `eval_match'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:38:in `block in use_custom_matcher_or_delegate'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:49:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.15158 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:45 # OracleEnhancedAdapter date type detection based on column names should set DATE column type as date if column name contains '_date_' and emulate_dates_by_column_name is true
2.1.2@rails42 [ rails42 ~/git/oracle-enhanced]$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:73
==> Running specs with MRI version 2.1.2
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[73]}}
F

Failures:

  1) OracleEnhancedAdapter date type detection based on column names should return Date value from DATE column if column name contains 'date' and emulate_dates_by_column_name is true
     Failure/Error: column.type_cast_from_database(Time.now).class.should == Date
       expected: Date
            got: Time (using ==)
       Diff:
       @@ -1,2 +1,2 @@
       -Date
       +Time

     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/fail_with.rb:32:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:57:in `fail_with_message'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:98:in `__delegate_operator'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:89:in `eval_match'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:38:in `block in use_custom_matcher_or_delegate'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:77:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.13925 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:73 # OracleEnhancedAdapter date type detection based on column names should return Date value from DATE column if column name contains 'date' and emulate_dates_by_column_name is true
2.1.2@rails42 [ rails42 ~/git/oracle-enhanced]$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:80
==> Running specs with MRI version 2.1.2
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[80]}}
F

Failures:

  1) OracleEnhancedAdapter date type detection based on column names should typecast DateTime value to Date value from DATE column if column name contains 'date' and emulate_dates_by_column_name is true
     Failure/Error: column.type_cast_from_database(DateTime.new(1900,1,1)).class.should == Date
       expected: Date
            got: DateTime (using ==)
       Diff:
       @@ -1,2 +1,2 @@
       -Date
       +DateTime

     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/fail_with.rb:32:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:57:in `fail_with_message'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:98:in `__delegate_operator'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:89:in `eval_match'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:38:in `block in use_custom_matcher_or_delegate'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:84:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.15403 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:80 # OracleEnhancedAdapter date type detection based on column names should typecast DateTime value to Date value from DATE column if column name contains 'date' and emulate_dates_by_column_name is true
2.1.2@rails42 [ rails42 ~/git/oracle-enhanced]$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:121
==> Running specs with MRI version 2.1.2
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[121]}}
F

Failures:

  1) OracleEnhancedAdapter date type detection based on column names / DATE values from ActiveRecord model should return Date value from DATE column if column name contains 'date' and emulate_dates_by_column_name is true
     Failure/Error: @employee.hire_date.class.should == Date
       expected: Date
            got: Time (using ==)
       Diff:
       @@ -1,2 +1,2 @@
       -Date
       +Time

     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/fail_with.rb:32:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:57:in `fail_with_message'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:98:in `__delegate_operator'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:89:in `eval_match'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:38:in `block in use_custom_matcher_or_delegate'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:124:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.31479 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:121 # OracleEnhancedAdapter date type detection based on column names / DATE values from ActiveRecord model should return Date value from DATE column if column name contains 'date' and emulate_dates_by_column_name is true
2.1.2@rails42 [ rails42 ~/git/oracle-enhanced]$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:127
==> Running specs with MRI version 2.1.2
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[127]}}
F

Failures:

  1) OracleEnhancedAdapter date type detection based on column names / DATE values from ActiveRecord model should return Date value from DATE column with old date value if column name contains 'date' and emulate_dates_by_column_name is true
     Failure/Error: @employee.hire_date.class.should == Date
       expected: Date
            got: Time (using ==)
       Diff:
       @@ -1,2 +1,2 @@
       -Date
       +Time

     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/fail_with.rb:32:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:57:in `fail_with_message'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:98:in `__delegate_operator'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:89:in `eval_match'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:38:in `block in use_custom_matcher_or_delegate'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:130:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.27241 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:127 # OracleEnhancedAdapter date type detection based on column names / DATE values from ActiveRecord model should return Date value from DATE column with old date value if column name contains 'date' and emulate_dates_by_column_name is true
2.1.2@rails42 [ rails42 ~/git/oracle-enhanced]$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:722
==> Running specs with MRI version 2.1.2
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[722]}}
F

Failures:

  1) OracleEnhancedAdapter date and timestamp with different NLS date formats should return Date value from DATE column if column name contains 'date' and emulate_dates_by_column_name is true
     Failure/Error: @employee.hire_date.class.should == Date
       expected: Date
            got: Time (using ==)
       Diff:
       @@ -1,2 +1,2 @@
       -Date
       +Time

     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/fail_with.rb:32:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:57:in `fail_with_message'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:98:in `__delegate_operator'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:89:in `eval_match'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:38:in `block in use_custom_matcher_or_delegate'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:725:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.27793 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:722 # OracleEnhancedAdapter date and timestamp with different NLS date formats should return Date value from DATE column if column name contains 'date' and emulate_dates_by_column_name is true
2.1.2@rails42 [ rails42 ~/git/oracle-enhanced]$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:804
==> Running specs with MRI version 2.1.2
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[804]}}
F

Failures:

  1) OracleEnhancedAdapter assign string to :date and :datetime columns should assign ISO string to date column
     Failure/Error: @employee.hire_date.should == @today
       expected: Sat, 28 Jun 2008
            got: 2008-06-28 00:00:00 +0900 (using ==)
       Diff:
       @@ -1,2 +1,2 @@
       -Sat, 28 Jun 2008
       +2008-06-28 00:00:00 +0900

     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/fail_with.rb:32:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:57:in `fail_with_message'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:98:in `__delegate_operator'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:89:in `eval_match'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:38:in `block in use_custom_matcher_or_delegate'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:810:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.24898 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:804 # OracleEnhancedAdapter assign string to :date and :datetime columns should assign ISO string to date column
2.1.2@rails42 [ rails42 ~/git/oracle-enhanced]$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:815
==> Running specs with MRI version 2.1.2
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[815]}}
F

Failures:

  1) OracleEnhancedAdapter assign string to :date and :datetime columns should assign NLS string to date column
     Failure/Error: @employee.hire_date.should == @today
       expected: Sat, 28 Jun 2008
            got: 2008-06-28 00:00:00 +0900 (using ==)
       Diff:
       @@ -1,2 +1,2 @@
       -Sat, 28 Jun 2008
       +2008-06-28 00:00:00 +0900

     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/fail_with.rb:32:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:57:in `fail_with_message'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:98:in `__delegate_operator'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:89:in `eval_match'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:38:in `block in use_custom_matcher_or_delegate'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:822:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.25605 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:815 # OracleEnhancedAdapter assign string to :date and :datetime columns should assign NLS string to date column
2.1.2@rails42 [ rails42 ~/git/oracle-enhanced]$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:827
==> Running specs with MRI version 2.1.2
==> Running specs with Rails version 4.0-master

Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[827]}}
F

Failures:

  1) OracleEnhancedAdapter assign string to :date and :datetime columns should assign ISO time string to date column
     Failure/Error: @employee.hire_date.should == @today
       expected: Sat, 28 Jun 2008
            got: 2008-06-28 13:34:33 +0900 (using ==)
       Diff:
       @@ -1,2 +1,2 @@
       -Sat, 28 Jun 2008
       +2008-06-28 13:34:33 +0900

     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/fail_with.rb:32:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:57:in `fail_with_message'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:98:in `__delegate_operator'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:89:in `eval_match'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:38:in `block in use_custom_matcher_or_delegate'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:833:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.25424 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:827 # OracleEnhancedAdapter assign string to :date and :datetime columns should assign ISO time string to date column
2.1.2@rails42 [ rails42 ~/git/oracle-enhanced]$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:838
==> Running specs with MRI version 2.1.2
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[838]}}
F

Failures:

  1) OracleEnhancedAdapter assign string to :date and :datetime columns should assign NLS time string to date column
     Failure/Error: @employee.hire_date.should == @today
       expected: Sat, 28 Jun 2008
            got: 2008-06-28 13:34:33 +0900 (using ==)
       Diff:
       @@ -1,2 +1,2 @@
       -Sat, 28 Jun 2008
       +2008-06-28 13:34:33 +0900

     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/fail_with.rb:32:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:57:in `fail_with_message'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:98:in `__delegate_operator'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:89:in `eval_match'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:38:in `block in use_custom_matcher_or_delegate'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:846:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.27731 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:838 # OracleEnhancedAdapter assign string to :date and :datetime columns should assign NLS time string to date column
2.1.2@rails42 [ rails42 ~/git/oracle-enhanced]$
```
- Regression introduced by this commit. It needs fix later.

``` ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:167
==> Running specs with MRI version 2.1.2
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[167]}}
F

Failures:

  1) OracleEnhancedAdapter date type detection based on column names / DATE values from ActiveRecord model should return Time value from DATE column if emulate_dates_by_column_name is true but column is defined as datetime
     Failure/Error: @employee.hire_date.class.should == Time
       expected: Time
            got: Date (using ==)
       Diff:
       @@ -1,2 +1,2 @@
       -Time
       +Date

     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/fail_with.rb:32:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:57:in `fail_with_message'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:98:in `__delegate_operator'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:89:in `eval_match'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:38:in `block in use_custom_matcher_or_delegate'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:173:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.32049 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:167 # OracleEnhancedAdapter date type detection based on column names / DATE values from ActiveRecord model should return Time value from DATE column if emulate_dates_by_column_name is true but column is defined as datetime
2.1.2@rails42 [ rails42_emulate_dates_by_column_name ~/git/oracle-enhanced]$
```
