### PR TITLE
Rails 4.2: Set @nchar and @object_type only when sql_type is true

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_column.rb
@@ -26,9 +26,11 @@ module ActiveRecord
         super(name, default_value, cast_type, sql_type, null)
         # Is column NCHAR or NVARCHAR2 (will need to use N'...' value quoting for these data types)?
         # Define only when needed as adapter "quote" method will check at first if instance variable is defined.
-        @nchar = true if cast_type.class == ActiveRecord::Type::String && sql_type[0,1] == 'N'
+        if sql_type 
+          @nchar = true if cast_type.class == ActiveRecord::Type::String && sql_type[0,1] == 'N'
+          @object_type = sql_type.include? '.'
+        end
         # TODO: Need to investigate when `sql_type` becomes nil
-        @object_type = sql_type.include? '.' unless sql_type.nil?
       end
 
       def type_cast(value) #:nodoc:


### PR DESCRIPTION
This pull request temporary addresses following error by checking `sql_type` exists.

``` ruby
$ rake test_oracle
... snip ...
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_column.rb:29:in `initialize': undefined method `[]' for nil:NilClass (NoMethodError)
        from /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1201:in `new'
        from /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1201:in `new_column'
        from /home/yahonda/git/rails/activerecord/lib/active_record/attributes.rb:80:in `attribute'
        from /home/yahonda/git/rails/activerecord/test/cases/attributes_test.rb:5:in `<class:OverloadedType>'
        from /home/yahonda/git/rails/activerecord/test/cases/attributes_test.rb:3:in `<top (required)>'
        from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:248:in `require'
        from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:248:in `block in require'
        from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:233:in `load_dependency'
        from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:248:in `require'
        from /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rake-10.3.2/lib/rake/rake_test_loader.rb:15:in `block in <main>'
        from /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rake-10.3.2/lib/rake/rake_test_loader.rb:4:in `select'
        from /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/rake-10.3.2/lib/rake/rake_test_loader.rb:4:in `<main>'
rake aborted!
```
