### PR TITLE
Rails 4.2 Add `connection.supports_views?`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -425,6 +425,10 @@ module ActiveRecord
         true
       end
 
+      def supports_views?
+        true
+      end
+
       NUMBER_MAX_PRECISION = 38
 
       #:stopdoc:


### PR DESCRIPTION
Refer https://github.com/rails/rails/commit/ae9412e857a78236b359eb1b636511d07fe45cf3
#### Before this commit no test executed as it says '0 runs`

``` ruby
$  ARCONN=oracle ruby -Itest test/cases/view_test.rb
Using oracle
Run options: --seed 39662

# Running:



Finished in 0.002029s, 0.0000 runs/s, 0.0000 assertions/s.

0 runs, 0 assertions, 0 failures, 0 errors, 0 skips
```
#### After this commit 10 runs executed and gets 2 failures

``` ruby
$  ARCONN=oracle ruby -Itest test/cases/view_test.rb
Using oracle
Run options: --seed 55837

# Running:

.F....F...

Finished in 4.979758s, 2.0081 runs/s, 2.2089 assertions/s.

  1) Failure:
ViewWithPrimaryKeyTest#test_column_definitions [test/cases/view_test.rb:36]:
--- expected
+++ actual
@@ -1 +1 @@
-[["id", :integer], ["name", :string], ["status", :integer]]
+[["id", :decimal], ["name", :string], ["status", :decimal]]



  2) Failure:
ViewWithoutPrimaryKeyTest#test_column_definitions [test/cases/view_test.rb:82]:
--- expected
+++ actual
@@ -1 +1 @@
-[["name", :string], ["status", :integer]]
+[["name", :string], ["status", :decimal]]


10 runs, 11 assertions, 2 failures, 0 errors, 0 skips
$
```

I'm aware of this issue between `:integer` and `:decimal` which needs addressed by separate pull requests.
