### PR TITLE
Rails4.2 Fix create_savepoint and rollback_to_savepoint name

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb
@@ -215,11 +215,11 @@ module ActiveRecord
       end
 
       def create_savepoint(name = current_savepoint_name) #:nodoc:
-        execute("SAVEPOINT #{current_savepoint_name}")
+        execute("SAVEPOINT #{name}")
       end
 
       def rollback_to_savepoint(name = current_savepoint_name) #:nodoc:
-        execute("ROLLBACK TO #{current_savepoint_name}")
+        execute("ROLLBACK TO #{name}")
       end
 
       def release_savepoint(name = current_savepoint_name) #:nodoc:


### PR DESCRIPTION
https://github.com/rails/rails/commit/8298d3ad finds create_savepoint and rollback_to_savepoint issues.
It sets argument name as savepoint name.

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/adapter_test.rb -n test_foreign_key_violations_are_translated_to_specific_exception_with_validate_false
Using oracle
Run options: -n test_foreign_key_violations_are_translated_to_specific_exception_with_validate_false --seed 8664

# Running:

F

Finished in 0.127869s, 7.8205 runs/s, 7.8205 assertions/s.

  1) Failure:
ActiveRecord::AdapterTest#test_foreign_key_violations_are_translated_to_specific_exception_with_validate_false [test/cases/adapter_test.rb:162]:
[ActiveRecord::InvalidForeignKey] exception expected, not
Class: <ActiveRecord::StatementInvalid>
Message: <"OCIError: ORA-03001: unimplemented feature: SAVEPOINT ">
---Backtrace---
stmt.c:230:in oci8lib_220.so
/home/yahonda/.rvm/gems/ruby-head@rails42/gems/ruby-oci8-2.1.7/lib/oci8/cursor.rb:129:in `exec'
/home/yahonda/.rvm/gems/ruby-head@rails42/gems/ruby-oci8-2.1.7/lib/oci8/oci8.rb:278:in `exec_internal'
/home/yahonda/.rvm/gems/ruby-head@rails42/gems/ruby-oci8-2.1.7/lib/oci8/oci8.rb:269:in `exec'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:429:in `exec'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:88:in `exec'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:10:in `block in execute'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:464:in `block in log'
/home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:458:in `log'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1274:in `log'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:10:in `execute'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:218:in `create_savepoint'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:118:in `initialize'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:172:in `new'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:172:in `begin_transaction'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:187:in `within_new_transaction'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:208:in `transaction'
/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:218:in `transaction'
/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:342:in `with_transaction_returning_status'
/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:284:in `block in save'
/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:299:in `rollback_active_record_state!'
/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:283:in `save'
test/cases/adapter_test.rb:165:in `block in test_foreign_key_violations_are_translated_to_specific_exception_with_validate_false'
---------------

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```
