### PR TITLE
Rails 4.2 Add `null: true` to avoid DEPRECATION WARNING

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
@@ -22,7 +22,7 @@ describe "OracleEnhancedAdapter schema dump" do
     schema_define do
       create_table :test_posts, options do |t|
         t.string :title
-        t.timestamps
+        t.timestamps null: true
       end
       add_index :test_posts, :title
     end


### PR DESCRIPTION
This pull request addresses following deprecation warning.

``` ruby
.DEPRECATION WARNING: `timestamp` was called without specifying an option for `null`. In Rails 5.0, this behavior will change to `null: false`. You should manually specify `null: true` to prevent the behavior of your existing migrations from changing. (called from block (2 levels) in create_test_posts_table at /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:25)
```
