### PR TITLE
Rails4.2 Add Type::Raw type

### DIFF
--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -47,6 +47,7 @@ This adapter is superset of original ActiveRecord Oracle adapter.
     "lib/active_record/connection_adapters/oracle_enhanced_schema_statements_ext.rb",
     "lib/active_record/connection_adapters/oracle_enhanced_structure_dump.rb",
     "lib/active_record/connection_adapters/oracle_enhanced_version.rb",
+    "lib/active_record/type/raw.rb",
     "lib/activerecord-oracle_enhanced-adapter.rb",
     "spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb",
     "spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb",

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1212,6 +1212,7 @@ module ActiveRecord
         super
         # oracle
         register_class_with_limit m, %r(date)i, Type::DateTime
+        register_class_with_limit m, %r(raw)i,  Type::Raw
         m.alias_type %r(NUMBER\(1\))i, 'boolean' if OracleEnhancedAdapter.emulate_booleans
       end
 
@@ -1336,3 +1337,6 @@ require 'active_record/connection_adapters/oracle_enhanced_schema_creation'
 
 # Moved DatabaseStetements
 require 'active_record/connection_adapters/oracle_enhanced_database_statements'
+
+# Add Type:Raw
+require 'active_record/type/raw'

--- a/lib/active_record/type/raw.rb
+++ b/lib/active_record/type/raw.rb
@@ -1,0 +1,11 @@
+require 'active_record/type/string'
+ 
+module ActiveRecord
+  module Type
+    class Raw < String # :nodoc:
+      def type
+        :raw
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request addresses following failures by supporting `Type::Raw`

Refer https://github.com/rails/rails/commit/728fa69839d2c3b839391f9077896c06df80bddf for `Types`

``` ruby
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1258
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1268
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1294
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1307
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1320
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1333
```

``` ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1258
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1268
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1294
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1307
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1320
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1333==> Running specs with MRI version 2.1.3
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[1258]}}
F

Failures:

  1) OracleEnhancedAdapter handling of RAW columns should create record with RAW data
     Failure/Error: @employee = TestEmployee.create!(
     ActiveRecord::StatementInvalid:
       OCIError: ORA-01465: invalid hex number: INSERT INTO "TEST_EMPLOYEES" ("BINARY_DATA", "EMPLOYEE_ID", "FIRST_NAME", "LAST_NAME") VALUES (:a1, :a2, :a3, :a4)
     # stmt.c:230:in oci8lib_210.so
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/bundler/gems/ruby-oci8-bae5ff16097b/lib/oci8/cursor.rb:129:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:153:in `exec_update'
     # ./lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:147:in `block in exec_insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:464:in `block in log'
     # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:458:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1273:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:124:in `exec_insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:108:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:66:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:521:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:139:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:122:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:306:in `block in _create_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:88:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:88:in `_run_callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:731:in `run_create_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:306:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:57:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:501:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:88:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:88:in `_run_callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:731:in `run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:142:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:42:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:29:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:289:in `block in save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:345:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:188:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:218:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:342:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:289:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:51:in `create!'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1259:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.32197 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1258 # OracleEnhancedAdapter handling of RAW columns should create record with RAW data
2.1.3@rails42 [ rails42 ~/git/oracle-enhanced]$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1268
==> Running specs with MRI version 2.1.3
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[1268]}}
F

Failures:

  1) OracleEnhancedAdapter handling of RAW columns should update record with RAW data
     Failure/Error: @employee.save!
     ActiveRecord::StatementInvalid:
       OCIError: ORA-01465: invalid hex number: UPDATE "TEST_EMPLOYEES" SET "BINARY_DATA" = :a1 WHERE "TEST_EMPLOYEES"."EMPLOYEE_ID" = 1
     # stmt.c:230:in oci8lib_210.so
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/bundler/gems/ruby-oci8-bae5ff16097b/lib/oci8/cursor.rb:129:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:153:in `exec_update'
     # ./lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:178:in `block in exec_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:464:in `block in log'
     # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:458:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1273:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:160:in `exec_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:114:in `update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:86:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:512:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:70:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:118:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:310:in `block in _update_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:117:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:117:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:169:in `block in halting'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:219:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:219:in `block in halting_and_conditional'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:92:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:92:in `_run_callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:731:in `run_update_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:310:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:70:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:501:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:88:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:88:in `_run_callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:731:in `run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:142:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:42:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:29:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:289:in `block in save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:345:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:188:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:218:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:342:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:289:in `save!'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1276:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.27049 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1268 # OracleEnhancedAdapter handling of RAW columns should update record with RAW data
2.1.3@rails42 [ rails42 ~/git/oracle-enhanced]$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1294
==> Running specs with MRI version 2.1.3
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[1294]}}
F

Failures:

  1) OracleEnhancedAdapter handling of RAW columns should update record that has existing RAW data with different RAW data
     Failure/Error: @employee = TestEmployee.create!(
     ActiveRecord::StatementInvalid:
       OCIError: ORA-01465: invalid hex number: INSERT INTO "TEST_EMPLOYEES" ("BINARY_DATA", "EMPLOYEE_ID", "FIRST_NAME", "LAST_NAME") VALUES (:a1, :a2, :a3, :a4)
     # stmt.c:230:in oci8lib_210.so
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/bundler/gems/ruby-oci8-bae5ff16097b/lib/oci8/cursor.rb:129:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:153:in `exec_update'
     # ./lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:147:in `block in exec_insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:464:in `block in log'
     # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:458:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1273:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:124:in `exec_insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:108:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:66:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:521:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:139:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:122:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:306:in `block in _create_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:88:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:88:in `_run_callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:731:in `run_create_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:306:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:57:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:501:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:88:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:88:in `_run_callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:731:in `run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:142:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:42:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:29:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:289:in `block in save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:345:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:188:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:218:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:342:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:289:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:51:in `create!'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1295:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.34795 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1294 # OracleEnhancedAdapter handling of RAW columns should update record that has existing RAW data with different RAW data
2.1.3@rails42 [ rails42 ~/git/oracle-enhanced]$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1307
==> Running specs with MRI version 2.1.3
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[1307]}}
F

Failures:

  1) OracleEnhancedAdapter handling of RAW columns should update record that has existing RAW data with nil
     Failure/Error: @employee = TestEmployee.create!(
     ActiveRecord::StatementInvalid:
       OCIError: ORA-01465: invalid hex number: INSERT INTO "TEST_EMPLOYEES" ("BINARY_DATA", "EMPLOYEE_ID", "FIRST_NAME", "LAST_NAME") VALUES (:a1, :a2, :a3, :a4)
     # stmt.c:230:in oci8lib_210.so
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/bundler/gems/ruby-oci8-bae5ff16097b/lib/oci8/cursor.rb:129:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:153:in `exec_update'
     # ./lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:147:in `block in exec_insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:464:in `block in log'
     # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:458:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1273:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:124:in `exec_insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:108:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:66:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:521:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:139:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:122:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:306:in `block in _create_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:88:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:88:in `_run_callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:731:in `run_create_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:306:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:57:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:501:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:88:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:88:in `_run_callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:731:in `run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:142:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:42:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:29:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:289:in `block in save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:345:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:188:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:218:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:342:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:289:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:51:in `create!'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1308:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.32468 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1307 # OracleEnhancedAdapter handling of RAW columns should update record that has existing RAW data with nil
2.1.3@rails42 [ rails42 ~/git/oracle-enhanced]$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1320
==> Running specs with MRI version 2.1.3
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[1320]}}
F

Failures:

  1) OracleEnhancedAdapter handling of RAW columns should update record that has existing RAW data with zero-length RAW data
     Failure/Error: @employee = TestEmployee.create!(
     ActiveRecord::StatementInvalid:
       OCIError: ORA-01465: invalid hex number: INSERT INTO "TEST_EMPLOYEES" ("BINARY_DATA", "EMPLOYEE_ID", "FIRST_NAME", "LAST_NAME") VALUES (:a1, :a2, :a3, :a4)
     # stmt.c:230:in oci8lib_210.so
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/bundler/gems/ruby-oci8-bae5ff16097b/lib/oci8/cursor.rb:129:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:153:in `exec_update'
     # ./lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:147:in `block in exec_insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:464:in `block in log'
     # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:458:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1273:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:124:in `exec_insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:108:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:66:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:521:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:139:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:122:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:306:in `block in _create_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:88:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:88:in `_run_callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:731:in `run_create_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:306:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:57:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:501:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:88:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:88:in `_run_callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:731:in `run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:142:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:42:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:29:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:289:in `block in save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:345:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:188:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:218:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:342:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:289:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:51:in `create!'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1321:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.27312 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1320 # OracleEnhancedAdapter handling of RAW columns should update record that has existing RAW data with zero-length RAW data
2.1.3@rails42 [ rails42 ~/git/oracle-enhanced]$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1333
==> Running specs with MRI version 2.1.3
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[1333]}}
F

Failures:

  1) OracleEnhancedAdapter handling of RAW columns should update record that has zero-length BLOB data with non-empty RAW data
     Failure/Error: @employee.save!
     ActiveRecord::StatementInvalid:
       OCIError: ORA-01465: invalid hex number: UPDATE "TEST_EMPLOYEES" SET "BINARY_DATA" = :a1 WHERE "TEST_EMPLOYEES"."EMPLOYEE_ID" = 1
     # stmt.c:230:in oci8lib_210.so
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/bundler/gems/ruby-oci8-bae5ff16097b/lib/oci8/cursor.rb:129:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:153:in `exec_update'
     # ./lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:178:in `block in exec_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:464:in `block in log'
     # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:458:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1273:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:160:in `exec_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:114:in `update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:86:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:512:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:70:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:118:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:310:in `block in _update_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:117:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:117:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:169:in `block in halting'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:219:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:219:in `block in halting_and_conditional'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:92:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:92:in `_run_callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:731:in `run_update_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:310:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:70:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:501:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:88:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:88:in `_run_callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:731:in `run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:142:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:42:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:29:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:289:in `block in save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:345:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:188:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:218:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:342:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:289:in `save!'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1341:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.29019 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1333 # OracleEnhancedAdapter handling of RAW columns should update record that has zero-length BLOB data with non-empty RAW data
$
```
