### PR TITLE
Rails4.2 Don't type cast the default on the column

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_column_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_column_dumper.rb
@@ -47,7 +47,8 @@ module ActiveRecord #:nodoc:
         spec[:scale]     = column.scale.inspect if !column.scale.nil?
         spec[:null]      = 'false' if !column.null
         spec[:as]        = column.virtual_column_data_default if column.virtual?
-        spec[:default]   = default_string(column.default) if column.has_default? && !column.virtual?
+        spec[:default]   = schema_default(column) if column.has_default? && !column.virtual?
+        spec.delete(:default) if spec[:default].nil?
 
         if column.virtual?
           # Supports backwards compatibility with older OracleEnhancedAdapter versions where 'NUMBER' virtual column type is not included in dump


### PR DESCRIPTION
This pull request supports https://github.com/rails/rails/commit/4d3e88fc757a1b6f6c468418af01dca677e41edf and fixes the following failure.

``` ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:72
==> Running specs with MRI version 2.1.3
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb"=>[72]}}
F

Failures:

  1) OracleEnhancedAdapter schema dump dumping default values should be able to dump default values using special characters
     Failure/Error: standard_dump.should =~ /t.string \"special_c\", default: "\\n"/
       expected: /t.string \"special_c\", default: "\\n"/
            got: "# encoding: UTF-8\n# This file is auto-generated from the current state of the database. Instead\n# of editing this file, please use the migrations feature of Active Record to\n# incrementally modify your database, and then regenerate this schema definition.\n#\n# Note that this schema.rb definition is the authoritative source for your\n# database schema. If you need to create the application database on another\n# system, you should be using db:schema:load, not running all the migrations\n# from scratch. The latter is a flawed and unsustainable approach (the more migrations\n# you'll amass, the slower it'll run and the greater likelihood for issues).\n#\n# It's strongly recommended that you check this file into your version control system.\n\nActiveRecord::Schema.define(version: 0) do\n\n# Could not dump table \"test_defaults\" because of following NoMethodError\n#   undefined method `default_string' for #<ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter:0x00000002bca0f0>\n\nend\n" (using =~)
       Diff:
       @@ -1,2 +1,20 @@
       -/t.string \"special_c\", default: "\\n"/
       +# encoding: UTF-8
       +# This file is auto-generated from the current state of the database. Instead
       +# of editing this file, please use the migrations feature of Active Record to
       +# incrementally modify your database, and then regenerate this schema definition.
       +#
       +# Note that this schema.rb definition is the authoritative source for your
       +# database schema. If you need to create the application database on another
       +# system, you should be using db:schema:load, not running all the migrations
       +# from scratch. The latter is a flawed and unsustainable approach (the more migrations
       +# you'll amass, the slower it'll run and the greater likelihood for issues).
       +#
       +# It's strongly recommended that you check this file into your version control system.
       +
       +ActiveRecord::Schema.define(version: 0) do
       +
       +# Could not dump table "test_defaults" because of following NoMethodError
       +#   undefined method `default_string' for #<ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter:0x00000002bca0f0>
       +
       +end

     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/fail_with.rb:32:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:57:in `fail_with_message'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:98:in `__delegate_operator'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:89:in `eval_match'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:38:in `block in use_custom_matcher_or_delegate'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:73:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.29125 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:72 # OracleEnhancedAdapter schema dump dumping default values should be able to dump default values using special characters
$
```
