### PR TITLE
Rails 4.2 Handle NUMBER sql_type as `Type::Integer` cast type

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1213,6 +1213,15 @@ module ActiveRecord
         # oracle
         register_class_with_limit m, %r(date)i, Type::DateTime
         register_class_with_limit m, %r(raw)i,  Type::Raw
+        m.register_type(%r(NUMBER)i) do |sql_type|
+          scale = extract_scale(sql_type)
+          precision = extract_precision(sql_type)
+          if scale == 0
+            Type::Integer.new(precision: precision)
+          else
+            Type::Decimal.new(precision: precision, scale: scale)
+          end
+        end
         m.alias_type %r(NUMBER\(1\))i, 'boolean' if OracleEnhancedAdapter.emulate_booleans
       end
 


### PR DESCRIPTION
This pull request  handles NUMBER sql_type as `Type::Integer` cast type since Oracle database NUMBER datatype handles interger and decimal.

Then this pull request fixes following failures since this commit has been merged.
https://github.com/rails/rails/commit/6b2ff4fa2082a51915d1c3e526b9194df44682de

``` ruby
ARCONN=oracle ruby -Itest test/cases/core_test.rb -n test_inspect_class

ARCONN=oracle ruby -Itest test/cases/migration/change_schema_test.rb -n test_column_exists_with_definition

ARCONN=oracle ruby -Itest test/cases/migration/columns_test.rb -n test_change_column

ARCONN=oracle ruby -Itest test/cases/migration/references_statements_test.rb -n test_add_belongs_to_alias

ARCONN=oracle ruby -Itest test/cases/migration/references_statements_test.rb -n test_creates_reference_id_column

ARCONN=oracle ruby -Itest test/cases/reflection_test.rb -n test_integer_columns

ARCONN=oracle ruby -Itest test/cases/view_test.rb -n test_column_definitions

ARCONN=oracle ruby -Itest test/cases/view_test.rb -n test_column_definitions

ARCONN=oracle ruby -Itest test/cases/xml_serialization_test.rb -n test_to_xml
```

This commit creates a regression, I'm not sure if we can fix it since Oracle NUMBER
datatype can handle integer and decimal.

``` ruby
ARCONN=oracle ruby -Itest test/cases/connection_adapters/type_lookup_test.rb -n test_decimal_without_scale
```
