### PR TITLE
Improved system password prompt

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_console.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_console.rb
@@ -1,0 +1,53 @@
+begin
+  require 'io/console'
+rescue LoadError
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    class OracleEnhancedAdapter
+
+      class Console
+
+        def self.query_secret(prompt)
+          make.query_secret(prompt)
+        end
+
+        def self.make
+          if capable?
+            new
+          else
+            LegacyConsole.new
+          end
+        end
+
+        def self.capable?
+          $stdin.respond_to?(:noecho)
+        end
+
+        def query_secret(prompt)
+          $stdout.puts prompt
+          $stdout.print ">"
+          $stdout.flush
+          $stdin.noecho(&:gets).chomp.tap do
+            $stdout.puts
+          end
+        end
+
+      end
+
+      class LegacyConsole
+
+        def query_secret(prompt)
+          $stdout.puts prompt
+          $stdout.puts "WARNING: Password will echo"
+          $stdout.print ">"
+          $stdout.flush
+          $stdin.gets.chomp
+        end
+
+      end
+
+    end
+  end
+end

--- a/lib/active_record/connection_adapters/oracle_enhanced_database_tasks.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_database_tasks.rb
@@ -1,3 +1,5 @@
+require 'active_record/connection_adapters/oracle_enhanced_secrets'
+
 module ActiveRecord
   module ConnectionAdapters
     class OracleEnhancedAdapter
@@ -9,8 +11,7 @@ module ActiveRecord
         end
 
         def create
-          print "Please provide the SYSTEM password for your Oracle installation\n>"
-          system_password = $stdin.gets.strip
+          system_password = Secrets::DATABASE_SYS_PASSWORD.get
           establish_connection(@config.merge('username' => 'SYSTEM', 'password' => system_password))
           begin
             connection.execute "CREATE USER #{@config['username']} IDENTIFIED BY #{@config['password']}"

--- a/lib/active_record/connection_adapters/oracle_enhanced_secrets.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_secrets.rb
@@ -1,0 +1,43 @@
+require 'active_record/connection_adapters/oracle_enhanced_console'
+
+module ActiveRecord
+  module ConnectionAdapters
+    class OracleEnhancedAdapter
+
+      module Secrets
+
+        class Secret
+
+          attr_accessor :environment_key
+          attr_accessor :prompt
+
+          def initialize
+            yield self if block_given?
+          end
+
+          def get
+            @value ||= get_from_environment || get_from_console
+          end
+
+          private
+
+          def get_from_environment
+            ENV[environment_key]
+          end
+
+          def get_from_console
+            Console.query_secret(prompt)
+          end
+
+        end
+
+        DATABASE_SYS_PASSWORD = Secret.new do |s|
+          s.environment_key = "DATABASE_SYS_PASSWORD"
+          s.prompt = "Please provide the SYSTEM password for your Oracle installation"
+        end
+
+      end  
+
+    end
+  end
+end


### PR DESCRIPTION
* Try to get the password from the environment variable
  DATABASE_SYS_PASSWORD

* When reading the password from the console, do not echo it

* Cache it, so that only one prompt is needed to do a "rake db:reset"