### PR TITLE
Rails 4.2 Address ArgumentError: wrong number of arguments (1 for 2) at `quote_val...

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_creation.rb
@@ -54,7 +54,7 @@ module ActiveRecord
           # handle case of defaults for CLOB columns, which would otherwise get "quoted" incorrectly
           if options_include_default?(options)
             if type == :text
-              sql << " DEFAULT #{quote_value(options[:default])}"
+              sql << " DEFAULT #{@conn.quote(options[:default])}"
             else
               sql << " DEFAULT #{quote_value(options[:default], options[:column])}"
             end


### PR DESCRIPTION
This pull request addresses the following error.

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/migration/change_schema_test.rb -n test_create_table_with_defaults
Using oracle
Run options: -n test_create_table_with_defaults --seed 21188

# Running:

E

Finished in 0.008734s, 114.4925 runs/s, 0.0000 assertions/s.

  1) Error:
ActiveRecord::Migration::ChangeSchemaTest#test_create_table_with_defaults:
ArgumentError: wrong number of arguments (1 for 2)
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:97:in `quote_value'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_schema_creation.rb:57:in `add_column_options!'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:35:in `visit_ColumnDefinition'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_schema_creation.rb:12:in `visit_ColumnDefinition'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:14:in `accept'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_schema_creation.rb:20:in `block in visit_TableDefinition'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_schema_creation.rb:20:in `map'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_schema_creation.rb:20:in `visit_TableDefinition'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:14:in `accept'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:82:in `create_table'
    test/cases/migration/change_schema_test.rb:55:in `test_create_table_with_defaults'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```
