### PR TITLE
Support OracleEnhancedAdapter.number_datatype_coercion for Rails 4.2

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1219,7 +1219,11 @@ module ActiveRecord
           if scale == 0
             Type::Integer.new(precision: precision)
           else
-            Type::Decimal.new(precision: precision, scale: scale)
+            if OracleEnhancedAdapter.number_datatype_coercion == :decimal
+              Type::Decimal.new(precision: precision, scale: scale)
+            elsif OracleEnhancedAdapter.number_datatype_coercion == :float
+              Type::Float.new(precision: precision, scale: scale)
+            end
           end
         end
         m.alias_type %r(NUMBER\(1\))i, 'boolean' if OracleEnhancedAdapter.emulate_booleans


### PR DESCRIPTION
This pull request addresses following failures by supporting `OracleEnhancedAdapter.number_datatype_coercion` for Rails 4.2
- Fixed failures by this pull request

``` ruby
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:249
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:256
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:496
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:529
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:554
```
- Detailed output of one failure

``` ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:249
==> Running specs with MRI version 2.1.3
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[249]}}
F

Failures:

  1) OracleEnhancedAdapter integer type detection based on column names when number_datatype_coercion is :float should set NUMBER column type as float if emulate_integers_by_column_name is false
     Failure/Error: column.type.should == :float
       expected: :float
            got: :decimal (using ==)
       Diff:
       @@ -1,2 +1,2 @@
       -:float
       +:decimal

     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/fail_with.rb:32:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:57:in `fail_with_message'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:98:in `__delegate_operator'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:89:in `eval_match'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:38:in `block in use_custom_matcher_or_delegate'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:253:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.1.3@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.15567 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:249 # OracleEnhancedAdapter integer type detection based on column names when number_datatype_coercion is :float should set NUMBER column type as float if emulate_integers_by_column_name is false
$
```

Unfortunately, this pull request does not address following failures. Will open another issue/pull request.

``` ruby
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:540
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:547
```
