### PR TITLE
Rails 4.2 Remove redundant substitute index when constructing bind values

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb
@@ -10,7 +10,7 @@ module ActiveRecord
         log(sql, name) { @connection.exec(sql) }
       end
 
-      def substitute_at(column, index)
+      def substitute_at(column, index = 0)
         Arel::Nodes::BindParam.new (":a#{index + 1}")
       end
 


### PR DESCRIPTION
refer https://github.com/rails/rails/pull/17463
