### PR TITLE
Use Arel::Visitors::Oracle12 when Oracle server version is 12c

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -390,7 +390,11 @@ module ActiveRecord
         @config = config
         @statements = StatementPool.new(connection, config.fetch(:statement_limit) { 250 })
         @enable_dbms_output = false
-        @visitor = Arel::Visitors::Oracle.new self
+        if supports_fetch_first_n_rows_and_offset?
+          @visitor = Arel::Visitors::Oracle12.new self
+        else
+          @visitor = Arel::Visitors::Oracle.new self
+        end
 
         if self.class.type_cast_config_to_boolean(config.fetch(:prepared_statements) { true })
           @prepared_statements = true
@@ -423,6 +427,14 @@ module ActiveRecord
 
       def supports_views?
         true
+      end
+
+      def supports_fetch_first_n_rows_and_offset?
+        if @connection.database_version == [12,1]
+          true
+        else
+          false
+        end
       end
 
       NUMBER_MAX_PRECISION = 38

--- a/lib/active_record/connection_adapters/oracle_enhanced_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_connection.rb
@@ -98,6 +98,10 @@ module ActiveRecord
         result.map { |r| r.values.first }
       end
 
+      # Returns array with major and minor version of database (e.g. [12, 1])
+      def database_version
+        raise NoMethodError, "Not implemented for this raw driver"
+      end
     end
     
     class OracleEnhancedConnectionException < StandardError #:nodoc:

--- a/lib/active_record/connection_adapters/oracle_enhanced_jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_jdbc_connection.rb
@@ -317,6 +317,10 @@ module ActiveRecord
         Cursor.new(self, @raw_connection.prepareStatement(sql))
       end
 
+      def database_version
+        @database_version ||= (md = raw_connection.getMetaData) && [md.getDatabaseMajorVersion, md.getDatabaseMinorVersion]
+      end
+
       class Cursor
         def initialize(connection, raw_statement)
           @connection = connection

--- a/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb
@@ -265,6 +265,10 @@ module ActiveRecord
         end
       end
 
+      def database_version
+        @database_version ||= (version = raw_connection.oracle_server_version) && [version.major, version.minor]
+      end
+
       private
 
       def date_without_time?(value)


### PR DESCRIPTION
This pull request supports [Oracle 12c better Top-N query] (http://oracle-base.com/articles/12c/row-limiting-clause-for-top-n-queries-12cr1.php) to Oracle enhanced adapter. 

To make this pull request work Arel needs support `Arel::Visitors::Oracle12`. I'll open another pull request to rails/arel.