### PR TITLE
Remove substitute_at method from Oracle enhanced adapter

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb
@@ -10,10 +10,6 @@ module ActiveRecord
         log(sql, name) { @connection.exec(sql) }
       end
 
-      def substitute_at(column, index = 0)
-        Arel::Nodes::BindParam.new (":a#{index + 1}")
-      end
-
       def clear_cache!
         @statements.clear
         reload_type_map


### PR DESCRIPTION
Now Arel takes care of it.
Refer https://github.com/rails/rails/commit/c01b20b658c9fe4b7d54f4a227a09cb090b5763d

Because of bind variable naming differences another pull request will be opened to rails/arel.
