### PR TITLE
exec query was not retrying after lost connection

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1275,7 +1275,9 @@ module ActiveRecord
 
       def select(sql, name = nil, binds = [])
         if ActiveRecord.const_defined?(:Result)
-          exec_query(sql, name, binds).to_a
+          @connection.with_retry do
+            exec_query(sql, name, binds).to_a
+          end
         else
           log(sql, name) do
             @connection.select(sql, name, false)


### PR DESCRIPTION
We were having an issue on our rails 3.2 project where if the database connection was lost it would not attempt to retry because the exec_query codepath does not execute with_retry.
