### PR TITLE
Rails 4.2 Unit test updated to support `substitute_at` in Arel

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -626,7 +626,7 @@ describe "OracleEnhancedAdapter" do
 
     it "should clear older cursors when statement limit is reached" do
       pk = TestPost.columns_hash[TestPost.primary_key]
-      sub = @conn.substitute_at(pk, 0)
+      sub = @conn.substitute_at(pk, 0).to_sql
       binds = [[pk, 1]]
 
       lambda {
@@ -639,7 +639,7 @@ describe "OracleEnhancedAdapter" do
     it "should cache UPDATE statements with bind variables" do
       lambda {
         pk = TestPost.columns_hash[TestPost.primary_key]
-        sub = @conn.substitute_at(pk, 0)
+        sub = @conn.substitute_at(pk, 0).to_sql
         binds = [[pk, 1]]
         @conn.exec_update("UPDATE test_posts SET id = #{sub}", "SQL", binds)
       }.should change(@statements, :length).by(+1)


### PR DESCRIPTION
Refer https://github.com/rails/arel/commit/590c784a30b13153667f8db7915998d7731e24e5

This pull request addresses following failures.

``` ruby

head@rails42 [ rails42 ~/git/oracle-enhanced]$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:627

==> Running specs with MRI version 2.2.0
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb"=>[627]}}
F

Failures:

  1) OracleEnhancedAdapter with statement pool should clear older cursors when statement limit is reached
     Failure/Error: @conn.exec_query("SELECT * FROM test_posts WHERE #{i}=#{i} AND id = #{sub}", "SQL", binds)
     ActiveRecord::StatementInvalid:
       OCIError: ORA-00911: invalid character: SELECT * FROM test_posts WHERE 0=0 AND id = #<Arel::Nodes::BindParam:0x00000002c4d3b0>
     # stmt.c:230:in oci8lib_220.so
     # /home/yahonda/.rvm/gems/ruby-head@rails42/bundler/gems/ruby-oci8-6dc961bd0255/lib/oci8/cursor.rb:126:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:149:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:42:in `block in exec_query'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:466:in `block in log'
     # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:460:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1287:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:22:in `exec_query'
     # ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:634:in `block (5 levels) in <top (required)>'
     # ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:633:in `times'
     # ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:633:in `block (4 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/built_in/change.rb:18:in `call'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/built_in/change.rb:18:in `matches?'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/handler.rb:24:in `handle_matcher'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/syntax.rb:53:in `should'
     # ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:632:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `map'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `run'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.24239 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:627 # OracleEnhancedAdapter with statement pool should clear older cursors when statement limit is reached
```

``` ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:639

==> Running specs with MRI version 2.2.0
==> Running specs with Rails version 4.0-master
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb"=>[639]}}
F

Failures:

  1) OracleEnhancedAdapter with statement pool should cache UPDATE statements with bind variables
     Failure/Error: @conn.exec_update("UPDATE test_posts SET id = #{sub}", "SQL", binds)
     ActiveRecord::StatementInvalid:
       OCIError: ORA-00911: invalid character: UPDATE test_posts SET id = #<Arel::Nodes::BindParam:0x0000000261f060>
     # stmt.c:230:in oci8lib_220.so
     # /home/yahonda/.rvm/gems/ruby-head@rails42/bundler/gems/ruby-oci8-6dc961bd0255/lib/oci8/cursor.rb:129:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:153:in `exec_update'
     # ./lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:174:in `block in exec_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:466:in `block in log'
     # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:460:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1287:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:156:in `exec_update'
     # ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:644:in `block (4 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/built_in/change.rb:18:in `call'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/built_in/change.rb:18:in `matches?'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/handler.rb:24:in `handle_matcher'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/syntax.rb:53:in `should'
     # ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:640:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `map'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `run'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-head@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.26573 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:639 # OracleEnhancedAdapter with statement pool should cache UPDATE statements with bind variables
```
