### PR TITLE
Remove warning message when JDK 8 is used

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_jdbc_connection.rb
@@ -26,10 +26,6 @@ begin
       # check any compatible JDBC driver in the priority order
       ojdbc_jars.any? do |ojdbc_jar|
         if File.exists?(file_path = File.join(dir, ojdbc_jar))
-          if java_version >= '1.8'
-            puts "WARNING: JDK #{java_version} is not officially supported by #{ojdbc_jar}"
-            puts "See http://www.oracle.com/technetwork/database/enterprise-edition/jdbc-faq-090281.html#01_03 for supported versions"
-          end
           require file_path
           true
         end


### PR DESCRIPTION
since Oracle JDBC Driver 12.1.0 supports JDK 8.

Refer Starting With Oracle JDBC Drivers (Doc ID 401934.1) from http:/support.oracle.com which
requires support contracts.
