### PR TITLE
Require 'active_record/base' in rake task

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_database_tasks.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_database_tasks.rb
@@ -1,3 +1,5 @@
+require 'active_record/base'
+
 module ActiveRecord
   module ConnectionAdapters
     class OracleEnhancedAdapter


### PR DESCRIPTION
It closes #523

This may cause `Rails.application.config.active_record` inside of an initializer no effects since this commit
kind of reverting https://github.com/rails/rails/commit/9e9793b440c044b765f2d1f702feeb92aef2b139#commitcomment-8818319
