### PR TITLE
Read SYSTEM password from ENV ORACLE_SYSTEM_PASSWORD optionally

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_database_tasks.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_database_tasks.rb
@@ -9,8 +9,10 @@ module ActiveRecord
         end
 
         def create
-          print "Please provide the SYSTEM password for your Oracle installation\n>"
-          system_password = $stdin.gets.strip
+          system_password = ENV.fetch('ORACLE_SYSTEM_PASSWORD') {
+            print "Please provide the SYSTEM password for your Oracle installation\n>"
+            $stdin.gets.strip
+          }
           establish_connection(@config.merge('username' => 'SYSTEM', 'password' => system_password))
           begin
             connection.execute "CREATE USER #{@config['username']} IDENTIFIED BY #{@config['password']}"


### PR DESCRIPTION
This is useful when running scripts and no user is around to enter
a system password value. In particular, for various CI server setups.

Usage Example:

```
ORACLE_SYSTEM_PASSWORD=secret rake db:migrate
```
