### PR TITLE
Require 'active_record/base' in rake task

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_database_tasks.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_database_tasks.rb
@@ -1,3 +1,5 @@
+require 'active_record/base'
+
 module ActiveRecord
   module ConnectionAdapters
     class OracleEnhancedAdapter


### PR DESCRIPTION
This pull request backports #526 to `master` branch since https://github.com/rails/rails/commit/ee484ec04ceaaedcb9a92f0d8871f65b2a5e2a39 has been pushed to rails `4-1-stable` branch.

This may cause `Rails.application.config.active_record` inside of an initializer no effects.
