### PR TITLE
Document ORACLE_SYSTEM_PASSWORD env variable alternative in db:create

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_database_tasks.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_database_tasks.rb
@@ -12,7 +12,7 @@ module ActiveRecord
 
         def create
           system_password = ENV.fetch('ORACLE_SYSTEM_PASSWORD') {
-            print "Please provide the SYSTEM password for your Oracle installation\n>"
+            print "Please provide the SYSTEM password for your Oracle installation (set ORACLE_SYSTEM_PASSWORD to avoid this prompt)\n>"
             $stdin.gets.strip
           }
           establish_connection(@config.merge('username' => 'SYSTEM', 'password' => system_password))


### PR DESCRIPTION
Document ORACLE_SYSTEM_PASSWORD env variable alternative in `rake db:create`, so that the user is aware of the alternative method of setting the password while they are actually prompted to enter it.
