### PR TITLE
Show original error message when loading ruby-oci8 library fails

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb
@@ -2,9 +2,11 @@ require 'delegate'
 
 begin
   require "oci8"
-rescue LoadError
-  # OCI8 driver is unavailable.
-  raise LoadError, "ERROR: ActiveRecord oracle_enhanced adapter could not load ruby-oci8 library. Please install ruby-oci8 gem."
+rescue LoadError => e
+  # OCI8 driver is unavailable or failed to load a required library.
+  raise LoadError, "ERROR: '#{e.message}'. "\
+    "ActiveRecord oracle_enhanced adapter could not load ruby-oci8 library. "\
+    "You may need install ruby-oci8 gem."
 end
 
 # check ruby-oci8 version
@@ -275,7 +277,7 @@ module ActiveRecord
           value.hour == 0 && value.min == 0 && value.sec == 0
         end
       end
-      
+
       def create_time_with_default_timezone(value)
         year, month, day, hour, min, sec, usec = case value
         when Time
@@ -295,7 +297,7 @@ module ActiveRecord
       end
 
     end
-    
+
     # The OracleEnhancedOCIFactory factors out the code necessary to connect and
     # configure an Oracle/OCI connection.
     class OracleEnhancedOCIFactory #:nodoc:
@@ -342,8 +344,8 @@ module ActiveRecord
         conn
       end
     end
-    
-    
+
+
   end
 end
 


### PR DESCRIPTION
While I had the ruby-oci8 library already installed, I was puzzled by this error:

> ERROR: ActiveRecord oracle_enhanced adapter could not load ruby-oci8 library. Please install ruby-oci8 gem.

After revealing the original load error received, I discovered that the original message was:

> LoadError: libaio.so.1: cannot open shared object file: No such file or directory

So I got rid of this (on Travis CI), by installing `libaio1` via `sudo apt-get install libaio1`