### PR TITLE
Change log method signiture to support Rails 4.2

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1285,12 +1285,8 @@ module ActiveRecord
       end
 
       protected
-      def log(sql, name, binds = nil) #:nodoc:
-        if binds
-          super sql, name, binds
-        else
-          super sql, name
-        end
+      def log(sql, name = "SQL", binds = [], statement_name = nil) #:nodoc:
+        super
       ensure
         log_dbms_output if dbms_output_enabled?
       end


### PR DESCRIPTION
This pull request addresses a following failure.

```ruby
$ ARCONN=oracle ruby -Itest test/cases/adapter_test.rb -n test_log_invalid_encoding
Using oracle
Run options: -n test_log_invalid_encoding --seed 36946

# Running:

F

Finished in 0.004685s, 213.4363 runs/s, 213.4363 assertions/s.

  1) Failure:
ActiveRecord::AdapterTest#test_log_invalid_encoding [test/cases/adapter_test.rb:221]:
[ActiveRecord::StatementInvalid] exception expected, not
Class: <ArgumentError>
Message: <"wrong number of arguments (1 for 2..3)">
---Backtrace---
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1288:in `log'
test/cases/adapter_test.rb:222:in `block in test_log_invalid_encoding'
---------------

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```
