### PR TITLE
Add `:if_exists` option to `drop_table` for compatibility with other adapters

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
@@ -117,6 +117,8 @@ module ActiveRecord
         super(name)
         seq_name = options[:sequence_name] || default_sequence_name(name)
         execute "DROP SEQUENCE #{quote_table_name(seq_name)}" rescue nil
+      rescue ActiveRecord::StatementInvalid => e
+        raise e unless options[:if_exists]
       ensure
         clear_table_columns_cache(name)
         self.all_schema_indexes = nil

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -385,6 +385,18 @@ describe "OracleEnhancedAdapter schema definition" do
 
   end
 
+  describe "drop tables" do
+    before(:each) do
+      @conn = ActiveRecord::Base.connection
+    end
+
+    it "should drop table with :if_exists option no raise error" do
+      lambda do
+        @conn.drop_table("nonexistent_table", if_exists: true)
+      end.should_not raise_error
+    end
+  end
+
   describe "rename tables and sequences" do
     before(:each) do
       @conn = ActiveRecord::Base.connection


### PR DESCRIPTION
`:if_exists` option introduced by https://github.com/rails/rails/pull/18597.
And it is used by test case already. https://github.com/rails/rails/commit/7675364

How about this pull request?