### PR TITLE
Remove call to deprecated `serialized_attributes`.

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -131,7 +131,7 @@ module ActiveRecord
 
     def record_changed_lobs
       @changed_lob_columns = self.class.lob_columns.select do |col|
-        (self.class.serialized_attributes.keys.include?(col.name) || self.send(:"#{col.name}_changed?")) && !self.class.readonly_attributes.to_a.include?(col.name)
+        self.attribute_changed?(col.name) && !self.class.readonly_attributes.to_a.include?(col.name)
       end
     end
   end


### PR DESCRIPTION
Fixes https://github.com/rsim/oracle-enhanced/issues/548

According to http://edgeguides.rubyonrails.org/4_2_release_notes.html#active-record-notable-changes
(3rd point, "ActiveRecord::Dirty now detects in-place changes to mutable values.")
it should be no longer necessary to check whether the attribute is serialized.

Note: this change is probably incompatible with rails prior 4.2.0.