### PR TITLE
Do not dump schema information during structure dump

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_database_tasks.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_database_tasks.rb
@@ -45,9 +45,6 @@ module ActiveRecord
         def structure_dump(filename)
           establish_connection(@config)
           File.open(filename, 'w:utf-8') { |f| f << connection.structure_dump }
-          if connection.supports_migrations?
-            File.open(filename, 'a') { |f| f << connection.dump_schema_information }
-          end
           if @config['structure_dump'] == 'db_stored_code'
              File.open(filename, 'a') { |f| f << connection.structure_dump_db_stored_code }
           end

--- a/spec/active_record/connection_adapters/oracle_enhanced_database_tasks_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_database_tasks_spec.rb
@@ -56,13 +56,17 @@ describe "Oracle Enhanced adapter database tasks" do
 
     describe "structure" do
       let(:temp_file) { Tempfile.new(["oracle_enhanced", ".sql"]).path }
-      before { ActiveRecord::SchemaMigration.create_table }
+      before do
+        ActiveRecord::SchemaMigration.create_table
+        ActiveRecord::Base.connection.execute "INSERT INTO schema_migrations (version) VALUES ('20150101010000')"
+      end
 
       describe "structure_dump" do
         before { ActiveRecord::Tasks::DatabaseTasks.structure_dump(config, temp_file) }
-        it "dumps the database structure to a file" do
+        it "dumps the database structure to a file without the schema information" do
           contents = File.read(temp_file)
           contents.should include('CREATE TABLE "TEST_POSTS"')
+          contents.should_not include('INSERT INTO schema_migrations')
         end
       end
 


### PR DESCRIPTION
Right now, when you run `rake db:structure:dump` the schema information (i.e. which migrations have been run) are dumped twice when using sql as the schema format. This prevents you from loading the `structure.sql` file since it will try to run inserts that violate the uniqueness constraint on the `schema_migrations` table.

This happens because Rails is calling `connection.dump_schema_information` after we also call it in `connection.structure_dump`.

This change removes our call to `connection.dump_schema_information` so it is only called once, by Rails.

This fixes #460. This is the same change as in #470 but with tests.