### PR TITLE
Remove duplicate alias_method_chain for indexes

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_dumper.rb
@@ -7,7 +7,6 @@ module ActiveRecord #:nodoc:
           private
           alias_method_chain :tables, :oracle_enhanced
           alias_method_chain :indexes, :oracle_enhanced
-          alias_method_chain :indexes, :oracle_enhanced
           alias_method_chain :foreign_keys, :oracle_enhanced
         end
       end


### PR DESCRIPTION
This pull request removes duplicate `alias_method_chain :indexes, :oracle_enhanced` introduced by 
0fda4af27e22df654d67684c6c4fa8001c10ec04