### PR TITLE
Add support for tables version-enabled with Oracle Workspace Manager

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -760,8 +760,13 @@ module ActiveRecord
         if do_not_prefetch.nil?
           owner, desc_table_name, db_link = @connection.describe(table_name)
           @@do_not_prefetch_primary_key[table_name] = do_not_prefetch =
-            !has_primary_key?(table_name, owner, desc_table_name, db_link) ||
-            has_primary_key_trigger?(table_name, owner, desc_table_name, db_link)
+            # Check if table is version-enabled with Workspace Manager
+            if table_exists?("#{table_name}_lt")
+              false
+            else
+              !has_primary_key?(table_name, owner, desc_table_name, db_link) ||
+              has_primary_key_trigger?(table_name, owner, desc_table_name, db_link)
+            end
         end
         !do_not_prefetch
       end


### PR DESCRIPTION
I wrote a simple patch to enable insertions into version-enabled tables. Version-enabled tables must always have next_sequence_value called to generate an id value.

Workspace Manager renames the table to \<table_name\>_lt and creates a view under the name of \<table_name\>. The view does not have an associated primary key. Because of that, has_primary_key? fails and next_sequence_value is never called. My change checks for the existence of a version-enabled table, i.e. \<table_name\>_lt, and returns false if the table exists.

This is the preferred method of detecting if a table is version-enabled according to the Oracle Workspace Manual.

_"(If you ever need to find the name of the \<table_name\>_LT table associated with a version-enabled table, or if you want to find out if a table is version-enabled by checking for the existence of a \<table_name\>_LT table, use the GetPhysicalTableName function.)"_ http://docs.oracle.com/cd/B19306_01/appdev.102/b14253/long_intro.htm 