### PR TITLE
Support :timestamp datatype in Rails 4.2

### DIFF
--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -47,6 +47,7 @@ This adapter is superset of original ActiveRecord Oracle adapter.
     "lib/active_record/connection_adapters/oracle_enhanced_schema_statements_ext.rb",
     "lib/active_record/connection_adapters/oracle_enhanced_structure_dump.rb",
     "lib/active_record/connection_adapters/oracle_enhanced_version.rb",
+    "lib/active_record/type/timestamp.rb",
     "lib/active_record/type/raw.rb",
     "lib/activerecord-oracle_enhanced-adapter.rb",
     "spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb",

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1227,6 +1227,8 @@ module ActiveRecord
         # oracle
         register_class_with_limit m, %r(date)i, Type::DateTime
         register_class_with_limit m, %r(raw)i,  Type::Raw
+        register_class_with_limit m, %r(timestamp)i,      Type::Timestamp
+
         m.register_type(%r(NUMBER)i) do |sql_type|
           scale = extract_scale(sql_type)
           precision = extract_precision(sql_type)
@@ -1363,3 +1365,6 @@ require 'active_record/connection_adapters/oracle_enhanced_database_statements'
 
 # Add Type:Raw
 require 'active_record/type/raw'
+
+# Add Type:Timestamp
+require 'active_record/type/timestamp'

--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_definitions.rb
@@ -1,5 +1,14 @@
 module ActiveRecord
   module ConnectionAdapters
+    #TODO: Overriding `aliased_types` cause another database adapter behavior changes
+    #It should be addressed by supporting `create_table_definition`
+    class TableDefinition
+      private
+      def aliased_types(name, fallback)
+        fallback
+      end
+    end
+
     class OracleEnhancedForeignKeyDefinition < Struct.new(:from_table, :to_table, :options) #:nodoc:
     end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
@@ -272,6 +272,7 @@ module ActiveRecord
         if type.to_sym == :virtual
           type = options[:type]
         end
+        type = aliased_types(type.to_s, type)
         add_column_sql = "ALTER TABLE #{quote_table_name(table_name)} ADD #{quote_column_name(column_name)} "
         add_column_sql << type_to_sql(type, options[:limit], options[:precision], options[:scale]) if type
 
@@ -284,6 +285,10 @@ module ActiveRecord
         create_sequence_and_trigger(table_name, options) if type && type.to_sym == :primary_key
       ensure
         clear_table_columns_cache(table_name)
+      end
+
+      def aliased_types(name, fallback)
+        fallback
       end
 
       def change_column_default(table_name, column_name, default) #:nodoc:

--- a/lib/active_record/type/timestamp.rb
+++ b/lib/active_record/type/timestamp.rb
@@ -1,0 +1,9 @@
+module ActiveRecord
+  module Type
+    class Timestamp < Value # :nodoc:
+      def type
+        :timestamp
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request addresses #542 by supporting timestamp datatype in Rails 4.2.  

Due to current implementation restriction, it needs to override `aliased_types` method. Then those who uses Oracle and non-Oracle adapters at the same time c1722f0001a894d2f9899038e999ab41acebbe3b should be reverted when we support `create_table_definition` method.
