### PR TITLE
Revert "Implement possibility of handling of NUMBER columns as :float"

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_column.rb
@@ -41,24 +41,9 @@ module ActiveRecord
       end
 
       def type_cast(value) #:nodoc:
-        case type
-        when :raw
-          OracleEnhancedColumn.string_to_raw(value)
-        when :datetime
-          OracleEnhancedAdapter.emulate_dates ? guess_date_or_time(value) : super
-        when :float
-          !value.nil? ? self.class.value_to_decimal(value) : super
-        else
-          super
-        end
-      end
-
-      def type_cast_code(var_name)
-        type == :float ? "#{self.class.name}.value_to_decimal(#{var_name})" : super
-      end
-
-      def klass
-        type == :float ? BigDecimal : super
+        return OracleEnhancedColumn::string_to_raw(value) if type == :raw
+        return guess_date_or_time(value) if type == :datetime && OracleEnhancedAdapter.emulate_dates
+        super
       end
 
       def virtual?

--- a/lib/active_record/connection_adapters/oracle_enhanced_column_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_column_dumper.rb
@@ -39,9 +39,9 @@ module ActiveRecord #:nodoc:
         return prepare_column_options_without_oracle_enhanced(column, types) unless oracle_enhanced_adapter?
 
         spec = {}
-
         spec[:name]      = column.name.inspect
         spec[:type]      = column.virtual? ? 'virtual' : column.type.to_s
+        spec[:virtual_type] = column.type.inspect if column.virtual? && column.sql_type != 'NUMBER'
         spec[:limit]     = column.limit.inspect if column.limit != types[column.type][:limit] && column.type != :decimal
         spec[:precision] = column.precision.inspect if !column.precision.nil?
         spec[:scale]     = column.scale.inspect if !column.scale.nil?
@@ -49,14 +49,6 @@ module ActiveRecord #:nodoc:
         spec[:as]        = column.virtual_column_data_default if column.virtual?
         spec[:default]   = schema_default(column) if column.has_default? && !column.virtual?
         spec.delete(:default) if spec[:default].nil?
-
-        if column.virtual?
-          # Supports backwards compatibility with older OracleEnhancedAdapter versions where 'NUMBER' virtual column type is not included in dump
-          if column.sql_type != "NUMBER" || ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.number_datatype_coercion != :decimal
-            spec[:virtual_type] = column.type.inspect
-          end
-        end
-
         spec
       end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced_dirty.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_dirty.rb
@@ -17,7 +17,6 @@ module ActiveRecord #:nodoc:
             if column.type == :string && column.null && old_value.nil?
               new_value = nil if new_value == ''
             end
-
             column.changed?(old_value, new_value, raw_value)
           else
             new_value != old_value
@@ -26,8 +25,8 @@ module ActiveRecord #:nodoc:
 
         def non_zero?(value)
           value !~ /\A0+(\.0+)?\z/
-        end
-
+        end 
+        
       end
 
     end

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -689,29 +689,4 @@ describe "OracleEnhancedAdapter" do
       explain.should include("INDEX UNIQUE SCAN")
     end
   end if ENV['RAILS_GEM_VERSION'] >= '3.2'
-
-  describe ".is_integer_column?" do
-    before(:all) do
-      @adapter = ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter
-    end
-
-    it "should return TrueClass or FalseClass" do
-      @adapter.is_integer_column?("adapter_id").should be_a TrueClass
-      @adapter.is_integer_column?("").should be_a FalseClass
-    end
-
-    it "should return true if name is 'id'" do
-      @adapter.is_integer_column?("id").should be_true
-    end
-
-    it "should return true if name ends with '_id'" do
-      @adapter.is_integer_column?("_id").should be_true
-      @adapter.is_integer_column?("foo_id").should be_true
-    end
-
-    it "should return false if name is 'something_else'" do
-      @adapter.is_integer_column?("something_else").should be_false
-    end
-  end
-
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -206,7 +206,6 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
         job_id        NUMBER,
         salary        NUMBER,
         commission_pct  NUMBER(2,2),
-        unwise_name_id NUMBER(2,2),
         manager_id    NUMBER(6),
         is_manager    NUMBER(1),
         department_id NUMBER(4,0),
@@ -219,46 +218,17 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
         INCREMENT BY 1 START WITH 10040 CACHE 20 NOORDER NOCYCLE
     SQL
   end
-
+  
   after(:all) do
     @conn.execute "DROP TABLE test2_employees"
     @conn.execute "DROP SEQUENCE test2_employees_seq"
   end
 
-  context "when number_datatype_coercion is :decimal" do
-    before { ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.stub(:number_datatype_coercion).and_return(:decimal) }
-
-    it "should set NUMBER column type as decimal if emulate_integers_by_column_name is false" do
-      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = false
-      columns = @conn.columns('test2_employees')
-      column = columns.detect{|c| c.name == "job_id"}
-      column.type.should == :decimal
-    end
-
-    it "should set NUMBER column type as decimal if column name is not 'id' and does not ends with '_id' and emulate_integers_by_column_name is true" do
-      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = true
-      columns = @conn.columns('test2_employees')
-      column = columns.detect{|c| c.name == "salary"}
-      column.type.should == :decimal
-    end
-  end
-
-  context "when number_datatype_coercion is :float" do
-    before { ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.stub(:number_datatype_coercion).and_return(:float) }
-
-    it "should set NUMBER column type as float if emulate_integers_by_column_name is false" do
-      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = false
-      columns = @conn.columns('test2_employees')
-      column = columns.detect{|c| c.name == "job_id"}
-      column.type.should == :float
-    end
-
-    it "should set NUMBER column type as float if column name is not 'id' and does not ends with '_id' and emulate_integers_by_column_name is true" do
-      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = true
-      columns = @conn.columns('test2_employees')
-      column = columns.detect{|c| c.name == "salary"}
-      column.type.should == :float
-    end
+  it "should set NUMBER column type as decimal if emulate_integers_by_column_name is false" do
+    ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = false
+    columns = @conn.columns('test2_employees')
+    column = columns.detect{|c| c.name == "job_id"}
+    column.type.should == :decimal
   end
 
   it "should set NUMBER column type as integer if emulate_integers_by_column_name is true" do
@@ -270,24 +240,10 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
     column.type.should == :integer
   end
 
-  it "should set NUMBER(p,0) column type as integer" do
+  it "should set NUMBER column type as decimal if column name does not contain 'id' and emulate_integers_by_column_name is true" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = true
     columns = @conn.columns('test2_employees')
-    column = columns.detect{|c| c.name == "department_id"}
-    column.type.should == :integer
-  end
-
-  it "should set NUMBER(p,s) column type as integer if column name ends with '_id' and emulate_integers_by_column_name is true" do
-    ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = true
-    columns = @conn.columns('test2_employees')
-    column = columns.detect{|c| c.name == "unwise_name_id"}
-    column.type.should == :integer
-  end
-
-  it "should set NUMBER(p,s) column type as decimal if column name ends with '_id' and emulate_integers_by_column_name is false" do
-    ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = false
-    columns = @conn.columns('test2_employees')
-    column = columns.detect{|c| c.name == "unwise_name_id"}
+    column = columns.detect{|c| c.name == "salary"}
     column.type.should == :decimal
   end
 
@@ -298,7 +254,7 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
     column.type_cast_from_database(1.0).class.should == BigDecimal
   end
 
-  it "should return Fixnum value from NUMBER column if column name ends with '_id' and emulate_integers_by_column_name is true" do
+  it "should return Fixnum value from NUMBER column if column name contains 'id' and emulate_integers_by_column_name is true" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = true
     columns = @conn.columns('test2_employees')
     column = columns.detect{|c| c.name == "job_id"}
@@ -310,7 +266,7 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
       class ::Test2Employee < ActiveRecord::Base
       end
     end
-
+    
     after(:each) do
       Object.send(:remove_const, "Test2Employee")
       @conn.clear_types_for_columns
@@ -650,6 +606,7 @@ describe "OracleEnhancedAdapter timestamp with timezone support" do
 
 end
 
+
 describe "OracleEnhancedAdapter date and timestamp with different NLS date formats" do
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
@@ -906,7 +863,7 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
     @employee.reload
     @employee.last_login_at.should == @today.to_time
   end
-
+  
 end
 
 describe "OracleEnhancedAdapter handling of CLOB columns" do
@@ -1382,6 +1339,7 @@ describe "OracleEnhancedAdapter handling of RAW columns" do
     @employee.binary_data.should == @binary_data
   end
 end
+
 
 describe "OracleEnhancedAdapter quoting of NCHAR and NVARCHAR2 columns" do
   before(:all) do

--- a/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
@@ -16,7 +16,6 @@ if ActiveRecord::Base.method_defined?(:changed?)
           last_name     VARCHAR2(25),
           job_id        NUMBER(6,0) NULL,
           salary        NUMBER(8,2),
-          pto_per_hour  NUMBER,
           comments      CLOB,
           hire_date     DATE
         )
@@ -28,7 +27,7 @@ if ActiveRecord::Base.method_defined?(:changed?)
       class TestEmployee < ActiveRecord::Base
       end
     end
-
+  
     after(:all) do
       Object.send(:remove_const, "TestEmployee")
       @conn.execute "DROP TABLE test_employees"
@@ -60,16 +59,6 @@ if ActiveRecord::Base.method_defined?(:changed?)
       @employee.should_not be_changed
       @employee.reload
       @employee.salary = ''
-      @employee.should_not be_changed
-    end
-
-    it "should not mark empty float (stored as NULL) as changed when reassigning it" do
-      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.stub(:number_datatype_coercion) { :float }
-      @employee = TestEmployee.create!(:pto_per_hour => '')
-      @employee.pto_per_hour = ''
-      @employee.should_not be_changed
-      @employee.reload
-      @employee.pto_per_hour = ''
       @employee.should_not be_changed
     end
 
@@ -122,7 +111,7 @@ if ActiveRecord::Base.method_defined?(:changed?)
       @employee = TestEmployee.new
       @employee.job_id = 0
       @employee.save!.should be_true
-
+      
       @employee.should_not be_changed
 
       @employee.job_id = '0'

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
@@ -376,7 +376,7 @@ describe "OracleEnhancedAdapter schema dump" do
             t.virtual :full_name,        :as => "first_name || ', ' || last_name"
             t.virtual :short_name,       :as => "COALESCE(first_name, last_name)", :type => :string, :limit => 300
             t.virtual :abbrev_name,      :as => "SUBSTR(first_name,1,50) || ' ' || SUBSTR(last_name,1,1) || '.'", :type => "VARCHAR(100)"
-            t.virtual :name_ratio, :as=>'(LENGTH(first_name)/LENGTH(last_name))'
+            t.virtual :name_ratio, :as=>'(LENGTH(first_name)*10/LENGTH(last_name)*10)'
             t.column  :full_name_length, :virtual, :as => "length(first_name || ', ' || last_name)", :type => :integer
             t.virtual :field_with_leading_space, :as => "' ' || first_name || ' '", :limit => 300, :type => :string
           end
@@ -402,30 +402,13 @@ describe "OracleEnhancedAdapter schema dump" do
       end
     end
 
-    context "when number_datatype_coercion is :float" do
-      before { ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.stub(:number_datatype_coercion).and_return(:float) }
-
-      it 'should dump correctly' do
-        standard_dump.should =~ /t\.virtual "full_name",(\s*)limit: 512,(\s*)as: "\\"FIRST_NAME\\"\|\|', '\|\|\\"LAST_NAME\\"",(\s*)type: :string/
-        standard_dump.should =~ /t\.virtual "short_name",(\s*)limit: 300,(\s*)as:(.*),(\s*)type: :string/
-        standard_dump.should =~ /t\.virtual "full_name_length",(\s*)precision: 38,(\s*)scale: 0,(\s*)as:(.*),(\s*)type: :integer/
-        standard_dump.should =~ /t\.virtual "name_ratio",(\s*)as:(.*),(\s*)type: :float$/
-        standard_dump.should =~ /t\.virtual "abbrev_name",(\s*)limit: 100,(\s*)as:(.*),(\s*)type: :string/
-        standard_dump.should =~ /t\.virtual "field_with_leading_space",(\s*)limit: 300,(\s*)as: "' '\|\|\\"FIRST_NAME\\"\|\|' '",(\s*)type: :string/
-      end
-    end
-
-    context "when number_datatype_coercion is :decimal" do
-      before { ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.stub(:number_datatype_coercion).and_return(:decimal) }
-
-      it 'should dump correctly' do
-        standard_dump.should =~ /t\.virtual "full_name",(\s*)limit: 512,(\s*)as: "\\"FIRST_NAME\\"\|\|', '\|\|\\"LAST_NAME\\"",(\s*)type: :string/
-        standard_dump.should =~ /t\.virtual "short_name",(\s*)limit: 300,(\s*)as:(.*),(\s*)type: :string/
-        standard_dump.should =~ /t\.virtual "full_name_length",(\s*)precision: 38,(\s*)scale: 0,(\s*)as:(.*),(\s*)type: :integer/
-        standard_dump.should =~ /t\.virtual "name_ratio",(\s*)as:(.*)\"$/
-        standard_dump.should =~ /t\.virtual "abbrev_name",(\s*)limit: 100,(\s*)as:(.*),(\s*)type: :string/
-        standard_dump.should =~ /t\.virtual "field_with_leading_space",(\s*)limit: 300,(\s*)as: "' '\|\|\\"FIRST_NAME\\"\|\|' '",(\s*)type: :string/
-      end
+    it 'should dump correctly' do
+      standard_dump.should =~ /t\.virtual "full_name",(\s*)limit: 512,(\s*)as: "\\"FIRST_NAME\\"\|\|', '\|\|\\"LAST_NAME\\"",(\s*)type: :string/
+      standard_dump.should =~ /t\.virtual "short_name",(\s*)limit: 300,(\s*)as:(.*),(\s*)type: :string/
+      standard_dump.should =~ /t\.virtual "full_name_length",(\s*)precision: 38,(\s*)scale: 0,(\s*)as:(.*),(\s*)type: :integer/
+      standard_dump.should =~ /t\.virtual "name_ratio",(\s*)as:(.*)\"$/ # no :type
+      standard_dump.should =~ /t\.virtual "abbrev_name",(\s*)limit: 100,(\s*)as:(.*),(\s*)type: :string/
+      standard_dump.should =~ /t\.virtual "field_with_leading_space",(\s*)limit: 300,(\s*)as: "' '\|\|\\"FIRST_NAME\\"\|\|' '",(\s*)type: :string/
     end
 
     context 'with column cache' do
@@ -470,161 +453,4 @@ describe "OracleEnhancedAdapter schema dump" do
       end
     end
   end
-
-  describe "NUMBER columns" do
-    after(:each) do
-      schema_define do
-        drop_table "test_numbers"
-      end
-    end
-
-    let(:value_within_max_precision)    { (10 ** @conn.class::NUMBER_MAX_PRECISION) - 1 }
-    let(:value_exceeding_max_precision) { (10 ** @conn.class::NUMBER_MAX_PRECISION) + 1 }
-
-    context "when using ActiveRecord::Schema.define and ActiveRecord::ConnectionAdapters::TableDefinition#float" do
-      before :each do
-        schema_define do
-          create_table :test_numbers, :force => true do |t|
-            t.float :value
-          end
-        end
-      end
-
-      context "when number_datatype_coercion is :float" do
-        before { ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.stub(:number_datatype_coercion).and_return(:float) }
-
-        it "should dump correctly" do
-          standard_dump.should =~ /t\.float "value"$/
-        end
-      end
-
-      context "when number_datatype_coercion is :decimal" do
-        before { ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.stub(:number_datatype_coercion).and_return(:decimal) }
-
-        it "should dump correctly" do
-          standard_dump.should =~ /t\.decimal "value"$/
-        end
-      end
-    end
-
-    context "when using handwritten 'CREATE_TABLE' SQL" do
-      before :each do
-        ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-        @conn = ActiveRecord::Base.connection
-        @conn.execute <<-SQL
-          CREATE TABLE test_numbers (
-            id     NUMBER(#{@conn.class::NUMBER_MAX_PRECISION},0) PRIMARY KEY,
-            value  NUMBER
-          )
-        SQL
-        @conn.execute <<-SQL
-          CREATE SEQUENCE test_numbers_seq  MINVALUE 1
-            INCREMENT BY 1 START WITH 1 CACHE 20 NOORDER NOCYCLE
-        SQL
-      end
-
-      context "when number_datatype_coercion is :float" do
-        before { ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.stub(:number_datatype_coercion).and_return(:float) }
-
-        it "should dump correctly" do
-          standard_dump.should =~ /t\.float "value"$/
-        end
-
-        describe "ActiveRecord saving" do
-          before :each do
-            class ::TestNumber < ActiveRecord::Base
-              self.table_name = "test_numbers"
-            end
-          end
-
-          it "should allow saving of values within NUMBER_MAX_PRECISION" do
-            number = TestNumber.new(value: value_within_max_precision)
-            number.save!
-            number.reload
-            number.value.should eq(value_within_max_precision)
-          end
-
-          it "should allow saving of values larger than NUMBER_MAX_PRECISION" do
-            number = TestNumber.new(value: value_exceeding_max_precision)
-            number.save!
-            number.reload
-            number.value.should eq(value_exceeding_max_precision)
-          end
-
-          it "should be recreatable from dump and have same properties" do
-            # Simulating db:schema:dump & db:test:load
-            2.times do
-              create_table_dump = standard_dump[/(create_table.+?end)/m]
-
-              schema_define do
-                drop_table "test_numbers"
-              end
-
-              schema_define(&eval("-> * { #{create_table_dump} }"))
-            end
-
-            number = TestNumber.new(value: value_within_max_precision)
-            number.save!
-
-            number2 = TestNumber.new(value: value_exceeding_max_precision)
-            number2.save!
-          end
-        end
-      end
-
-      context "when number_datatype_coercion is :decimal" do
-        before { ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.stub(:number_datatype_coercion).and_return(:decimal) }
-
-        it "should dump correctly" do
-          standard_dump.should =~ /t\.decimal "value"$/
-        end
-
-        describe "ActiveRecord saving" do
-          before :each do
-            class ::TestNumber < ActiveRecord::Base
-              self.table_name = "test_numbers"
-            end
-          end
-
-          it "should allow saving of values within NUMBER_MAX_PRECISION" do
-            number = TestNumber.new(value: value_within_max_precision)
-            number.save!
-            number.reload
-            number.value.should eq(value_within_max_precision)
-          end
-
-          it "should allow saving of values larger than NUMBER_MAX_PRECISION" do
-            number = TestNumber.new(value: value_exceeding_max_precision)
-            number.save!
-            number.reload
-            number.value.should eq(value_exceeding_max_precision)
-          end
-
-          it "should be recreatable from dump and have same properties" do
-            # Simulating db:schema:dump & db:test:load
-            2.times do |i|
-              create_table_dump = standard_dump[/(create_table.+?end)/m]
-
-              schema_define do
-                drop_table "test_numbers"
-              end
-
-              schema_define(&eval("-> * { #{create_table_dump} }"))
-            end
-
-            number = TestNumber.new(value: value_within_max_precision)
-            number.save!
-
-            # Raises 'ORA-01438' as :value column type isn't FLOAT'ish
-            number2 = TestNumber.new(value: value_exceeding_max_precision)
-            lambda do
-              number2.save!
-            end.should raise_error() { |e| e.message.should =~ /ORA-01438/ }
-          end
-        end
-      end # context (:decimal)
-
-    end # context (handwritten)
-  end # describe (NUMBER columns)
-
 end


### PR DESCRIPTION
This pull request reverts #418 at rails42 branch. There are some reasons:

- Rails `:float` datatype should be mapped to Oracle `BINARY_FLOAT` or `BINARY_DOUBLE` datatype
- There are some technical difficulties such as #514

Discussed with @rsim and we agreed to revert this change.

This reverts commit f275bc74855c93ce1e0f686aa2dc9a9f4da02efb.

Conflicts:
	lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
	lib/active_record/connection_adapters/oracle_enhanced_column.rb
	lib/active_record/connection_adapters/oracle_enhanced_column_dumper.rb
	lib/active_record/connection_adapters/oracle_enhanced_dirty.rb
	spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb