### PR TITLE
Raise a better exception for renaming long indexes

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
@@ -259,11 +259,14 @@ module ActiveRecord
         result == 1
       end
 
-      def rename_index(table_name, index_name, new_index_name) #:nodoc:
-        unless index_name_exists?(table_name, index_name, true)
-          raise ArgumentError, "Index name '#{index_name}' on table '#{table_name}' does not exist"
+      def rename_index(table_name, old_name, new_name) #:nodoc:
+        unless index_name_exists?(table_name, old_name, true)
+          raise ArgumentError, "Index name '#{old_name}' on table '#{table_name}' does not exist"
         end
-        execute "ALTER INDEX #{quote_column_name(index_name)} rename to #{quote_column_name(new_index_name)}"
+        if new_name.length > allowed_index_name_length
+          raise ArgumentError, "Index name '#{new_name}' on table '#{table_name}' is too long; the limit is #{allowed_index_name_length} characters"
+        end
+        execute "ALTER INDEX #{quote_column_name(old_name)} rename to #{quote_column_name(new_name)}"
       ensure
         self.all_schema_indexes = nil
       end


### PR DESCRIPTION
This pull request addresses the following failure. Also use same method argument names as Rails.

```ruby
$ ARCONN=oracle ruby -Itest test/cases/migration/index_test.rb -n test_rename_index_too_long
Using oracle
Run options: -n test_rename_index_too_long --seed 11559

# Running:

F

Finished in 0.045530s, 21.9635 runs/s, 21.9635 assertions/s.

  1) Failure:
ActiveRecord::Migration::IndexTest#test_rename_index_too_long [test/cases/migration/index_test.rb:43]:
[ArgumentError] exception expected, not
Class: <ActiveRecord::StatementInvalid>
Message: <"OCIError: ORA-00972: identifier is too long: ALTER INDEX \"OLD_IDX\" rename to \"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\"">
---Backtrace---
stmt.c:250:in oci8lib_220.so
/home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/ruby-oci8-2.1.8/lib/oci8/cursor.rb:129:in `exec'
/home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/ruby-oci8-2.1.8/lib/oci8/oci8.rb:278:in `exec_internal'
/home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/ruby-oci8-2.1.8/lib/oci8/oci8.rb:269:in `exec'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:431:in `exec'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:90:in `exec'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:10:in `block in execute'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:473:in `block in log'
/home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:467:in `log'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1289:in `log'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:10:in `execute'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:266:in `rename_index'
test/cases/migration/index_test.rb:44:in `block in test_rename_index_too_long'
---------------

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$