### PR TITLE
Address RangeError: <m> is out of range for ActiveRecord::Type::Integer with limit <n>

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1224,7 +1224,12 @@ module ActiveRecord
           scale = extract_scale(sql_type)
           precision = extract_precision(sql_type)
           if scale == 0
-            Type::Integer.new(precision: precision)
+            limit = case 
+            when precision <= 9 then 4
+            when precision <= 19 then 8
+            else 16
+            end
+            Type::Integer.new(precision: precision, limit: limit)
           else
             Type::Decimal.new(precision: precision, scale: scale)
           end


### PR DESCRIPTION
This pull request addresses #542 and following 3 errors.

```ruby
$ ARCONN=oracle ruby -Itest test/cases/base_test.rb
Using oracle
Run options: --seed 64413

# Running:

......E............E......................................................................................E........................................

Finished in 2.806855s, 52.3718 runs/s, 119.3507 assertions/s.

... snip ...


  2) Error:
BasicsTest#test_big_decimal_conditions:
RangeError: 6000000000 is out of range for ActiveRecord::Type::Integer with limit 4
    /home/yahonda/git/rails/activerecord/lib/active_record/type/integer.rb:45:in `ensure_in_range'
    /home/yahonda/git/rails/activerecord/lib/active_record/type/integer.rb:23:in `type_cast_for_database'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:28:in `type_cast'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:677:in `type_cast'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:118:in `block in exec_insert'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:117:in `map'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:117:in `exec_insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:108:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:64:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:523:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:139:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:75:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:131:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:306:in `block in _create_record'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:84:in `run_callbacks'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:306:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:57:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:503:in `create_or_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `block in create_or_update'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:84:in `run_callbacks'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `create_or_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:120:in `save'
    /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:37:in `save'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:21:in `save'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:286:in `block (2 levels) in save'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:351:in `block in with_transaction_returning_status'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `block in transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:184:in `within_new_transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:220:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:348:in `with_transaction_returning_status'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:286:in `block in save'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:301:in `rollback_active_record_state!'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:285:in `save'
    test/cases/base_test.rb:1004:in `test_big_decimal_conditions'


  3) Error:
BasicsTest#test_numeric_fields:
RangeError: 6000000000 is out of range for ActiveRecord::Type::Integer with limit 4
    /home/yahonda/git/rails/activerecord/lib/active_record/type/integer.rb:45:in `ensure_in_range'
    /home/yahonda/git/rails/activerecord/lib/active_record/type/integer.rb:23:in `type_cast_for_database'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:28:in `type_cast'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:677:in `type_cast'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:118:in `block in exec_insert'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:117:in `map'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:117:in `exec_insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:108:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:64:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:523:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:139:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:75:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:131:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:306:in `block in _create_record'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:84:in `run_callbacks'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:306:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:57:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:503:in `create_or_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `block in create_or_update'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:84:in `run_callbacks'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `create_or_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:120:in `save'
    /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:37:in `save'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:21:in `save'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:286:in `block (2 levels) in save'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:351:in `block in with_transaction_returning_status'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `block in transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:184:in `within_new_transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:220:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:348:in `with_transaction_returning_status'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:286:in `block in save'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:301:in `rollback_active_record_state!'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:285:in `save'
    test/cases/base_test.rb:1015:in `test_numeric_fields'

147 runs, 335 assertions, 0 failures, 3 errors, 0 skips
$
```

```ruby
$ ARCONN=oracle ruby -Itest test/cases/migration_test.rb -n test_add_table_with_decimals
Using oracle
Run options: -n test_add_table_with_decimals --seed 57781

# Running:

E

Finished in 0.482707s, 2.0716 runs/s, 2.0716 assertions/s.

  1) Error:
MigrationTest#test_add_table_with_decimals:
RangeError: 6000000000 is out of range for ActiveRecord::Type::Integer with limit 4
    /home/yahonda/git/rails/activerecord/lib/active_record/type/integer.rb:45:in `ensure_in_range'
    /home/yahonda/git/rails/activerecord/lib/active_record/type/integer.rb:23:in `type_cast_for_database'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:28:in `type_cast'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:677:in `type_cast'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:118:in `block in exec_insert'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:117:in `map'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:117:in `exec_insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:108:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:64:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:523:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:139:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:75:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:131:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:306:in `block in _create_record'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:84:in `run_callbacks'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:306:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:57:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:503:in `create_or_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `block in create_or_update'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:84:in `run_callbacks'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `create_or_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:120:in `save'
    /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:37:in `save'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:21:in `save'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:286:in `block (2 levels) in save'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:351:in `block in with_transaction_returning_status'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `block in transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:184:in `within_new_transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:220:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:348:in `with_transaction_returning_status'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:286:in `block in save'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:301:in `rollback_active_record_state!'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:285:in `save'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:34:in `create'
    test/cases/migration_test.rb:166:in `test_add_table_with_decimals'

1 runs, 1 assertions, 0 failures, 1 errors, 0 skips
$