### PR TITLE
Support :cascade option for drop_table

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb
@@ -113,14 +113,14 @@ module ActiveRecord
         rename_table_indexes(table_name, new_name)
       end
 
-      def drop_table(name, options = {}) #:nodoc:
-        super(name)
-        seq_name = options[:sequence_name] || default_sequence_name(name)
+      def drop_table(table_name, options = {}) #:nodoc:
+        execute "DROP TABLE #{quote_table_name(table_name)}#{' CASCADE CONSTRAINTS' if options[:force] == :cascade}"
+        seq_name = options[:sequence_name] || default_sequence_name(table_name)
         execute "DROP SEQUENCE #{quote_table_name(seq_name)}" rescue nil
       rescue ActiveRecord::StatementInvalid => e
         raise e unless options[:if_exists]
       ensure
-        clear_table_columns_cache(name)
+        clear_table_columns_cache(table_name)
         self.all_schema_indexes = nil
       end
 


### PR DESCRIPTION
This pull request addresses this error by supporting `:cascade` option for `drop_table`.

```ruby
$ ARCONN=oracle ruby -Itest test/cases/migration/change_schema_test.rb -n test_create_table_with_force_cascade_drops_dependent_objects
Using oracle
Run options: -n test_create_table_with_force_cascade_drops_dependent_objects --seed 64310

# Running:

E

Finished in 0.081517s, 12.2673 runs/s, 12.2673 assertions/s.

  1) Error:
ActiveRecord::Migration::ChangeSchemaWithDependentObjectsTest#test_create_table_with_force_cascade_drops_dependent_objects:
ActiveRecord::StatementInvalid: OCIError: ORA-02449: unique/primary keys in table referenced by foreign keys: DROP TABLE "TRAINS"
    stmt.c:250:in oci8lib_220.so
    /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/ruby-oci8-2.1.8/lib/oci8/cursor.rb:129:in `exec'
    /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/ruby-oci8-2.1.8/lib/oci8/oci8.rb:278:in `exec_internal'
    /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/ruby-oci8-2.1.8/lib/oci8/oci8.rb:269:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:431:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:90:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:10:in `block in execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:473:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:467:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1294:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:10:in `execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:385:in `drop_table'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:117:in `drop_table'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:79:in `create_table'
    test/cases/migration/change_schema_test.rb:444:in `test_create_table_with_force_cascade_drops_dependent_objects'

1 runs, 1 assertions, 0 failures, 1 errors, 0 skips
$
```