### PR TITLE
Support :bigint datatype

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -454,7 +454,8 @@ module ActiveRecord
         :date        => { :name => "DATE" },
         :binary      => { :name => "BLOB" },
         :boolean     => { :name => "NUMBER", :limit => 1 },
-        :raw         => { :name => "RAW", :limit => 2000 }
+        :raw         => { :name => "RAW", :limit => 2000 },
+        :bigint      => { :name => "NUMBER", :limit => 8 }
       }
       # if emulate_booleans_from_strings then store booleans in VARCHAR2
       NATIVE_DATABASE_TYPES_BOOLEAN_STRINGS = NATIVE_DATABASE_TYPES.dup.merge(


### PR DESCRIPTION
refer https://github.com/rails/rails/commit/574234be

`:bigint` mapped to `NUMBER(8)`. Here is a example.

```sql
   (10.1ms)  CREATE TABLE "TESTINGS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY, "EIGHT_INT" NUMBER(8))
```

This pull request also address this error.

```ruby
$ ARCONN=oracle ruby -Itest test/cases/migration/change_schema_test.rb -n test_create_table_with_bigint
Using oracle
Run options: -n test_create_table_with_bigint --seed 10139

# Running:

E

Finished in 0.010570s, 94.6097 runs/s, 0.0000 assertions/s.

  1) Error:
ActiveRecord::Migration::ChangeSchemaTest#test_create_table_with_bigint:
ActiveRecord::StatementInvalid: OCIError: ORA-00942: table or view does not exist: DROP TABLE "TESTINGS"
    stmt.c:250:in oci8lib_220.so
    /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/ruby-oci8-2.1.8/lib/oci8/cursor.rb:129:in `exec'
    /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/ruby-oci8-2.1.8/lib/oci8/oci8.rb:278:in `exec_internal'
    /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/ruby-oci8-2.1.8/lib/oci8/oci8.rb:269:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:431:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:90:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:10:in `block in execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:473:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:467:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1294:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:10:in `execute'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:117:in `drop_table'
    test/cases/migration/change_schema_test.rb:116:in `ensure in test_create_table_with_bigint'
    test/cases/migration/change_schema_test.rb:116:in `test_create_table_with_bigint'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$