### PR TITLE
Remove alias_method_chain :references, :foreign_keys

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_schema_definitions.rb
@@ -42,7 +42,6 @@ module ActiveRecord
 
       def self.included(base) #:nodoc:
         base.class_eval do
-          alias_method_chain :references, :foreign_keys
           alias_method_chain :column, :virtual_columns
         end
       end
@@ -85,7 +84,7 @@ module ActiveRecord
       # 
       # Note: No foreign key is created if :polymorphic => true is used.
       # Note: If no name is specified, the database driver creates one for you!
-      def references_with_foreign_keys(*args)
+      def references(*args)
         options = args.extract_options!
         index_options = options[:index]
         fk_options = options.delete(:foreign_key)
@@ -98,7 +97,7 @@ module ActiveRecord
           end
         end
 
-        references_without_foreign_keys(*(args << options))
+        super(*(args << options))
       end
   
       # Defines a foreign key for the table. +to_table+ can be a single Symbol, or
@@ -129,11 +128,6 @@ module ActiveRecord
     end
 
     module OracleEnhancedTable
-      def self.included(base) #:nodoc:
-        base.class_eval do
-          alias_method_chain :references, :foreign_keys
-        end
-      end
 
       # Adds a new foreign key to the table. +to_table+ can be a single Symbol, or
       # an Array of Symbols. See SchemaStatements#add_foreign_key
@@ -180,13 +174,13 @@ module ActiveRecord
       #  t.references(:goat, :foreign_key => {:dependent => :delete})
       # 
       # Note: No foreign key is created if :polymorphic => true is used.
-      def references_with_foreign_keys(*args)
+      def references(*args)
         options = args.extract_options!
         polymorphic = options[:polymorphic]
         index_options = options[:index]
         fk_options = options.delete(:foreign_key)
 
-        references_without_foreign_keys(*(args << options))
+        super(*(args << options))
         # references_without_foreign_keys adds {:type => :integer}
         args.extract_options!
         if fk_options && !polymorphic


### PR DESCRIPTION
since Rails 4.2 supports native foreign key. References can create foreign keys.
Also this pull request addresses following errors and failures.

```ruby
$ ARCONN=oracle ruby -Itest test/cases/migration/references_foreign_key_test.rb -n test_foreign_keys_can_be_created_while_changing_the_table
Using oracle
Run options: -n test_foreign_keys_can_be_created_while_changing_the_table --seed 25024

# Running:

E

Finished in 0.076251s, 13.1147 runs/s, 0.0000 assertions/s.

  1) Error:
ActiveRecord::Migration::ReferencesForeignKeyTest#test_foreign_keys_can_be_created_while_changing_the_table:
NoMethodError: undefined method `split' for nil:NilClass
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:593:in `quote_table_name'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:446:in `add_foreign_key'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_schema_definitions.rb:153:in `foreign_key'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_schema_definitions.rb:195:in `block in references_with_foreign_keys'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_schema_definitions.rb:194:in `each'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_schema_definitions.rb:194:in `references_with_foreign_keys'
    test/cases/migration/references_foreign_key_test.rb:59:in `block (2 levels) in <class:ReferencesForeignKeyTest>'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:363:in `change_table'
    test/cases/migration/references_foreign_key_test.rb:58:in `block in <class:ReferencesForeignKeyTest>'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```

```ruby
$ ARCONN=oracle ruby -Itest test/cases/migration/references_foreign_key_test.rb -n test_foreign_keys_cannot_be_added_to_polymorphic_relations_when_changing_the_table
Using oracle
Run options: -n test_foreign_keys_cannot_be_added_to_polymorphic_relations_when_changing_the_table --seed 6177

# Running:

F

Finished in 0.089658s, 11.1535 runs/s, 11.1535 assertions/s.

  1) Failure:
ActiveRecord::Migration::ReferencesForeignKeyTest#test_foreign_keys_cannot_be_added_to_polymorphic_relations_when_changing_the_table [test/cases/migration/references_foreign_key_test.rb:93]:
ArgumentError expected but nothing was raised.

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
```

```ruby
$ ARCONN=oracle ruby -Itest test/cases/migration/references_foreign_key_test.rb -n test_foreign_keys_cannot_be_added_to_polymorphic_relations_when_creating_the_table
Using oracle
Run options: -n test_foreign_keys_cannot_be_added_to_polymorphic_relations_when_creating_the_table --seed 17213

# Running:

F

Finished in 0.049514s, 20.1961 runs/s, 20.1961 assertions/s.

  1) Failure:
ActiveRecord::Migration::ReferencesForeignKeyTest#test_foreign_keys_cannot_be_added_to_polymorphic_relations_when_creating_the_table [test/cases/migration/references_foreign_key_test.rb:50]:
ArgumentError expected but nothing was raised.

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:863
==> Loading config from ENV or use default
==> Running specs with MRI version 2.2.2
==> Selected Rails version 4.0-master
==> Effective ActiveRecord version 4.2.2.beta
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb"=>[863]}}
F

Failures:

  1) OracleEnhancedAdapter schema definition foreign key in table definition should add foreign key in change_table references
     Failure/Error: t.references :test_post, :foreign_key => true
     NoMethodError:
       undefined method `split' for nil:NilClass
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:593:in `quote_table_name'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:446:in `add_foreign_key'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_definitions.rb:153:in `foreign_key'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_definitions.rb:195:in `block in references_with_foreign_keys'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_definitions.rb:194:in `each'
     # ./lib/active_record/connection_adapters/oracle_enhanced_schema_definitions.rb:194:in `references_with_foreign_keys'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:869:in `block (5 levels) in <top (required)>'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:363:in `change_table'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:662:in `block in method_missing'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:632:in `block in say_with_time'
     # /home/yahonda/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/benchmark.rb:288:in `measure'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:632:in `say_with_time'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:652:in `method_missing'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:868:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:117:in `instance_eval'
     # ./spec/spec_helper.rb:117:in `block (2 levels) in schema_define'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:640:in `suppress_messages'
     # ./spec/spec_helper.rb:116:in `block in schema_define'
     # /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:41:in `instance_eval'
     # /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:41:in `define'
     # /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:61:in `define'
     # ./spec/spec_helper.rb:115:in `schema_define'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:864:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.22588 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:863 # OracleEnhancedAdapter schema definition foreign key in table definition should add foreign key in change_table references
$
```