### PR TITLE
Revert "Add options_include_default!"

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -71,12 +71,6 @@ module ActiveRecord
           end
         end
 
-        # This method does not exist in SchemaCreation at Rails 4.0
-        # It can be removed only when Oracle enhanced adapter supports Rails 4.1 and higher
-        def options_include_default?(options)
-          options.include?(:default) && !(options[:null] == false && options[:default].nil?)
-        end
-
       end
     end
   end


### PR DESCRIPTION
This reverts commit 480a30f443bb3777bf600bab99d562780b4e6225.

Refer #384 we can remove this method since `rails42` branch just supports Rails 4.2.