### PR TITLE
Call super when column typs is serialized

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -673,22 +673,26 @@ module ActiveRecord
 
       # Cast a +value+ to a type that the database understands.
       def type_cast(value, column)
-        case value
-        when true, false
-          if emulate_booleans_from_strings || column && column.type == :string
-            self.class.boolean_to_string(value)
-          else
-            value ? 1 : 0
-          end
-        when Date, Time
-          if value.acts_like?(:time)
-            zone_conversion_method = ActiveRecord::Base.default_timezone == :utc ? :getutc : :getlocal
-            value.respond_to?(zone_conversion_method) ? value.send(zone_conversion_method) : value
-          else
-            value
-          end
-        else
+        if column && column.cast_type.is_a?(Type::Serialized)
           super
+        else
+          case value
+          when true, false
+            if emulate_booleans_from_strings || column && column.type == :string
+              self.class.boolean_to_string(value)
+            else
+              value ? 1 : 0
+            end
+          when Date, Time
+            if value.acts_like?(:time)
+              zone_conversion_method = ActiveRecord::Base.default_timezone == :utc ? :getutc : :getlocal
+              value.respond_to?(zone_conversion_method) ? value.send(zone_conversion_method) : value
+            else
+              value
+            end
+          else
+            super
+          end
         end
       end
 


### PR DESCRIPTION
This pull request should address #563 and addresses these 3 failures.

```ruby
$ ARCONN=oracle ruby -Itest test/cases/serialized_attribute_test.rb -n /test_serialized/
Using oracle
Run options: -n /test_serialized/ --seed 8214

# Running:

.......FF......F

Finished in 0.510452s, 31.3448 runs/s, 66.6076 assertions/s.

  1) Failure:
SerializedAttributeTest#test_serialized_boolean_value_false [test/cases/serialized_attribute_test.rb:194]:
Expected: "N"
  Actual: false


  2) Failure:
SerializedAttributeTest#test_serialized_boolean_value_true [test/cases/serialized_attribute_test.rb:187]:
Expected: "Y"
  Actual: true


  3) Failure:
SerializedAttributeTest#test_serialized_time_attribute [test/cases/serialized_attribute_test.rb:118]:
--- expected
+++ actual
@@ -1 +1 @@
-2008-01-01 01:00:00 +0000
+"01-JAN-08 01.00.00.000000000 AM +00:00"


16 runs, 34 assertions, 3 failures, 0 errors, 0 skips
$