### PR TITLE
Clear query cache on rollback

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -205,7 +205,7 @@ module ActiveRecord
           @connection.autocommit = true
         end
 
-        def rollback_db_transaction #:nodoc:
+        def exec_rollback_db_transaction #:nodoc:
           @connection.rollback
         ensure
           @connection.autocommit = true
@@ -215,7 +215,7 @@ module ActiveRecord
           execute("SAVEPOINT #{name}")
         end
 
-        def rollback_to_savepoint(name = current_savepoint_name) #:nodoc:
+        def exec_rollback_to_savepoint(name = current_savepoint_name) #:nodoc:
           execute("ROLLBACK TO #{name}")
         end
 


### PR DESCRIPTION
This pull request addresses following failure.

```ruby
$ ARCONN=oracle ruby -Itest test/cases/query_cache_test.rb -n test_query_cache_doesnt_leak_cached_results_of_rolled_back_queries
Using oracle
Run options: -n test_query_cache_doesnt_leak_cached_results_of_rolled_back_queries --seed 23558

# Running:

F

Finished in 0.339571s, 2.9449 runs/s, 5.8898 assertions/s.

  1) Failure:
QueryCacheTest#test_query_cache_doesnt_leak_cached_results_of_rolled_back_queries [test/cases/query_cache_test.rb:226]:
Expected: 0
  Actual: 1

1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
$
```
Refer https://github.com/rails/rails/pull/17820 for detail.
