### PR TITLE
New db/schema.rb files will be created with force: :cascade

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -173,7 +173,7 @@ module ActiveRecord #:nodoc:
           else
             tbl.print ", id: false"
           end
-          tbl.print ", force: true"
+          tbl.print ", force: :cascade"
           tbl.puts " do |t|"
 
           # then dump all non-primary key columns


### PR DESCRIPTION
Refer https://github.com/rails/rails/pull/18082

This pull request addresses following failure.

```ruby
$ ARCONN=oracle ruby -Itest test/cases/schema_dumper_test.rb -n test_schema_dump_uses_force_cascade_on_create_table
Using oracle
Run options: -n test_schema_dump_uses_force_cascade_on_create_table --seed 29245

# Running:

F

Finished in 1.403931s, 0.7123 runs/s, 1.4246 assertions/s.

  1) Failure:
SchemaDumperTest#test_schema_dump_uses_force_cascade_on_create_table [test/cases/schema_dumper_test.rb:45]:
Expected /create_table "authors", force: :cascade/ to match "# encoding: UTF-8\n# This file is auto-generated from the current state of the database. Instead\n# of editing this file, please use the migrations feature of Active Record to\n# incrementally modify your database, and then regenerate this schema definition.\n#\n# Note that this schema.rb definition is the authoritative source for your\n# database schema. If you need to create the application database on another\n# system, you should be using db:schema:load, not running all the migrations\n# from scratch. The latter is a flawed and unsustainable approach (the more migrations\n# you'll amass, the slower it'll run and the greater likelihood for issues).\n#\n# It's strongly recommended that you check this file into your version control system.\n\nActiveRecord::Schema.define(version: 0) do\n\n  create_table \"authors\", force: true do |t|\n    t.string  \"name\",                                              null: false\n    t.integer \"author_address_id\",       limit: 16, precision: 38\n    t.integer \"author_address_extra_id\", limit: 16, precision: 38\n    t.string  \"organization_id\"\n    t.string  \"owned_essay_id\"\n  end\n\n  add_foreign_key \"authors\", \"author_addresses\", name: \"authors_author_address_id_fk\"\n\nend\n".

1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
$
```
