### PR TITLE
Use Oracle BINARY_FLOAT datatype for Rails :float type

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -459,7 +459,7 @@ module ActiveRecord
         :string      => { :name => "VARCHAR2", :limit => 255 },
         :text        => { :name => "CLOB" },
         :integer     => { :name => "NUMBER", :limit => 38 },
-        :float       => { :name => "NUMBER" },
+        :float       => { :name => "BINARY_FLOAT" },
         :decimal     => { :name => "DECIMAL" },
         :datetime    => { :name => "DATE" },
         # changed to native TIMESTAMP type

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -1401,3 +1401,45 @@ describe "OracleEnhancedAdapter quoting of NCHAR and NVARCHAR2 columns" do
   end
 
 end
+
+describe "OracleEnhancedAdapter handling of BINARY_FLOAT columns" do
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @conn = ActiveRecord::Base.connection
+    @conn.execute "DROP TABLE test2_employees" rescue nil
+    @conn.execute <<-SQL
+      CREATE TABLE test2_employees (
+        id            NUMBER PRIMARY KEY,
+        first_name    VARCHAR2(20),
+        last_name     VARCHAR2(25),
+        email         VARCHAR2(25),
+        phone_number  VARCHAR2(20),
+        hire_date     DATE,
+        job_id        NUMBER,
+        salary        NUMBER,
+        commission_pct  NUMBER(2,2),
+        hourly_rate   BINARY_FLOAT,
+        manager_id    NUMBER(6),
+        is_manager    NUMBER(1),
+        department_id NUMBER(4,0),
+        created_at    DATE
+      )
+    SQL
+    @conn.execute "DROP SEQUENCE test2_employees_seq" rescue nil
+    @conn.execute <<-SQL
+      CREATE SEQUENCE test2_employees_seq  MINVALUE 1
+        INCREMENT BY 1 START WITH 10040 CACHE 20 NOORDER NOCYCLE
+    SQL
+  end
+  
+  after(:all) do
+    @conn.execute "DROP TABLE test2_employees"
+    @conn.execute "DROP SEQUENCE test2_employees_seq"
+  end
+
+  it "should set BINARY_FLOAT column type as float" do
+    columns = @conn.columns('test2_employees')
+    column = columns.detect{|c| c.name == "hourly_rate"}
+    column.type.should == :float
+  end
+end

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
@@ -453,4 +453,24 @@ describe "OracleEnhancedAdapter schema dump" do
       end
     end
   end
+
+  describe ":float datatype" do
+    before(:each) do
+      schema_define do
+        create_table :test_floats, force: true do |t|
+          t.float :hourly_rate
+        end
+      end
+    end
+
+    after(:each) do
+      schema_define do
+        drop_table :test_floats
+      end
+    end
+
+    it "should dump float type correctly" do
+      standard_dump.should =~ /t\.float "hourly_rate"$/
+    end
+  end
 end


### PR DESCRIPTION
This pull request changes mapping for Rails :float type from Oracle NUMBER to BINARY_FLOAT.

* Based on this document `BINARY_FLOAT` is supported from 10.1 (aka 10gR1).
http://docs.oracle.com/cd/B14117_01/server.101/b10759/wnsql.htm#sthref11
9iR2 or lower version cannot work but it should not be a problem since it was released on 2003.

* binary_float or binary_double

Based on Rails 4.2 implementation, `binary` is configured as a alias for `float`. Then it should be enough to support `BINARY_FLOAT` which should be corresponding to `float` in other databases.
https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L390-L419

* Compatibility
This pull request is for rails42 branch only. It should be released as Oracle enhanced adapter 1.6 to support Rails 4.2. I do not think to backport it Oracle enhanced adapter 1.5.0 since
it changes public behavior. As of right now :float is mapped to Oracle NUMBER datatype.

Also this pull request addresses following failure.

```ruby
$ ARCONN=oracle ruby -Itest test/cases/attributes_test.rb -n test_overloaded_properties_save
Using oracle
Run options: -n test_overloaded_properties_save --seed 53381

# Running:

F

Finished in 0.235332s, 4.2493 runs/s, 16.9972 assertions/s.

  1) Failure:
ActiveRecord::CustomPropertiesTest#test_overloaded_properties_save [test/cases/attributes_test.rb:43]:
Expected #<BigDecimal:1ee3300,'0.2E1',9(27)> to be a kind of Float, not BigDecimal.

1 runs, 4 assertions, 1 failures, 0 errors, 0 skips
$
```