### PR TITLE
Add integer.rb to gemspec

### DIFF
--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -48,6 +48,7 @@ This adapter is superset of original ActiveRecord Oracle adapter.
     "lib/active_record/connection_adapters/oracle_enhanced/schema_statements_ext.rb",
     "lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb",
     "lib/active_record/connection_adapters/oracle_enhanced/version.rb",
+    "lib/active_record/oracle_enhanced/type/integer.rb",
     "lib/active_record/oracle_enhanced/type/timestamp.rb",
     "lib/active_record/oracle_enhanced/type/raw.rb",
     "lib/activerecord-oracle_enhanced-adapter.rb",


### PR DESCRIPTION
#605 has missed adding the integer.rb to the gemspec.