### PR TITLE
Map :bigint as NUMBER(19) sql_type not NUMBER(8)

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -472,7 +472,7 @@ module ActiveRecord
         :binary      => { :name => "BLOB" },
         :boolean     => { :name => "NUMBER", :limit => 1 },
         :raw         => { :name => "RAW", :limit => 2000 },
-        :bigint      => { :name => "NUMBER", :limit => 8 }
+        :bigint      => { :name => "NUMBER", :limit => 19 }
       }
       # if emulate_booleans_from_strings then store booleans in VARCHAR2
       NATIVE_DATABASE_TYPES_BOOLEAN_STRINGS = NATIVE_DATABASE_TYPES.dup.merge(
@@ -1284,6 +1284,8 @@ module ActiveRecord
 
       def extract_limit(sql_type) #:nodoc:
         case sql_type
+        when /^bigint/i
+          19
         when /\((.*)\)/
           $1.to_i
         end


### PR DESCRIPTION
by specifying `:limit => 19`

Bigint should be mapped to NUMBER(19,0) not NUMBER(8,0)
since it is not enough to store the maximum number of bigint.
Oracle NUMBER(p,0) as handled as integer
because there is no dedicated integer sql data type exist in Oracle database.

Also NUMBER(p,s) precision can take up to 38. p means the number of digits, not the byte length.
bigint type needs 19 digits as follows.

```ruby
$ irb
2.2.2 :001 > limit = 8
 => 8
2.2.2 :002 > maxvalue_of_bigint = 1 << ( limit * 8 - 1)
 => 9223372036854775808
2.2.2 :003 > puts maxvalue_of_bigint.to_s.length
19
 => nil
2.2.2 :004 >
```