### PR TITLE
Support Rails native foreign key syntax

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -9,18 +9,17 @@ module ActiveRecord
       end
     end
 
-    class OracleEnhancedForeignKeyDefinition < ForeignKeyDefinition
-    end
-
-
     module OracleEnhanced
-    
+
+      class ForeignKeyDefinition < ActiveRecord::ConnectionAdapters::ForeignKeyDefinition
+      end
+
       class SynonymDefinition < Struct.new(:name, :table_owner, :table_name, :db_link) #:nodoc:
       end
 
       class IndexDefinition < ActiveRecord::ConnectionAdapters::IndexDefinition
         attr_accessor :table, :name, :unique, :type, :parameters, :statement_parameters, :tablespace, :columns
-  
+ 
         def initialize(table, name, unique, type, parameters, statement_parameters, tablespace, columns)
           @table = table
           @name = name
@@ -33,184 +32,36 @@ module ActiveRecord
           super(table, name, unique, columns, nil, nil, nil, nil)
         end
       end
-    end
 
-    module OracleEnhancedSchemaDefinitions #:nodoc:
-      def self.included(base)
-        base::TableDefinition.class_eval do
-          include OracleEnhancedTableDefinition
+      class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
+
+        def raw(name, options={})
+          column(name, :raw, options)
         end
 
-        # Available starting from ActiveRecord 2.1
-        base::Table.class_eval do
-          include OracleEnhancedTable
-        end if defined?(base::Table)
-      end
-    end
-  
-    module OracleEnhancedTableDefinition
-      class ForeignKey < Struct.new(:base, :to_table, :options) #:nodoc:
-        def to_sql
-          base.foreign_key_definition(to_table, options)
+        def virtual(* args)
+          options = args.extract_options!
+          column_names = args
+          column_names.each { |name| column(name, :virtual, options) }
         end
-        alias to_s :to_sql
-      end
 
-      def self.included(base) #:nodoc:
-        base.class_eval do
-          alias_method_chain :column, :virtual_columns
-        end
-      end
-
-      def raw(name, options={})
-        column(name, :raw, options)
-      end
-
-      def virtual(* args)
-        options = args.extract_options!
-        column_names = args
-        column_names.each { |name| column(name, :virtual, options) }
-      end
-
-      def column_with_virtual_columns(name, type, options = {})
-        if type == :virtual
-          default = {:type => options[:type]}
-          if options[:as]
-            default[:as] = options[:as]
-          elsif options[:default]
-            warn "[DEPRECATION] virtual column `:default` option is deprecated.  Please use `:as` instead."
-            default[:as] = options[:default]
-          else
-            raise "No virtual column definition found."
+        def column(name, type, options = {})
+          if type == :virtual
+            default = {:type => options[:type]}
+            if options[:as]
+              default[:as] = options[:as]
+            elsif options[:default]
+              warn "[DEPRECATION] virtual column `:default` option is deprecated.  Please use `:as` instead."
+              default[:as] = options[:default]
+            else
+              raise "No virtual column definition found."
+            end
+            options[:default] = default
           end
-          options[:default] = default
-        end
-        column_without_virtual_columns(name, type, options)
-      end
-    
-      # Adds a :foreign_key option to TableDefinition.references.
-      # If :foreign_key is true, a foreign key constraint is added to the table.
-      # You can also specify a hash, which is passed as foreign key options.
-      # 
-      # ===== Examples
-      # ====== Add goat_id column and a foreign key to the goats table.
-      #  t.references(:goat, :foreign_key => true)
-      # ====== Add goat_id column and a cascading foreign key to the goats table.
-      #  t.references(:goat, :foreign_key => {:dependent => :delete})
-      # 
-      # Note: No foreign key is created if :polymorphic => true is used.
-      # Note: If no name is specified, the database driver creates one for you!
-      def references(*args)
-        options = args.extract_options!
-        index_options = options[:index]
-        fk_options = options.delete(:foreign_key)
-
-        if fk_options && !options[:polymorphic]
-          fk_options = {} if fk_options == true
-          args.each do |to_table| 
-            foreign_key(to_table, fk_options) 
-            add_index(to_table, "#{to_table}_id", index_options.is_a?(Hash) ? index_options : nil) if index_options
-          end
+          super(name, type, options)
         end
 
-        super(*(args << options))
-      end
-  
-      # Defines a foreign key for the table. +to_table+ can be a single Symbol, or
-      # an Array of Symbols. See SchemaStatements#add_foreign_key
-      #
-      # ===== Examples
-      # ====== Creating a simple foreign key
-      #  t.foreign_key(:people)
-      # ====== Defining the column
-      #  t.foreign_key(:people, :column => :sender_id)
-      # ====== Creating a named foreign key
-      #  t.foreign_key(:people, :column => :sender_id, :name => 'sender_foreign_key')
-      # ====== Defining the column of the +to_table+.
-      #  t.foreign_key(:people, :column => :sender_id, :primary_key => :person_id)
-      def foreign_key(to_table, options = {})
-        #TODO
-        if ActiveRecord::Base.connection.supports_foreign_keys?
-          to_table = to_table.to_s.pluralize if ActiveRecord::Base.pluralize_table_names
-          foreign_keys << ForeignKey.new(@base, to_table, options)
-        else
-          raise ArgumentError, "this ActiveRecord adapter is not supporting foreign_key definition"
-        end
-      end
-    
-      def foreign_keys
-        @foreign_keys ||= []
-      end
-    end
-
-    module OracleEnhancedTable
-
-      # Adds a new foreign key to the table. +to_table+ can be a single Symbol, or
-      # an Array of Symbols. See SchemaStatements#add_foreign_key
-      #
-      # ===== Examples
-      # ====== Creating a simple foreign key
-      #  t.foreign_key(:people)
-      # ====== Defining the column
-      #  t.foreign_key(:people, :column => :sender_id)
-      # ====== Creating a named foreign key
-      #  t.foreign_key(:people, :column => :sender_id, :name => 'sender_foreign_key')
-      # ====== Defining the column of the +to_table+.
-      #  t.foreign_key(:people, :column => :sender_id, :primary_key => :person_id)
-      def foreign_key(to_table, options = {})
-        if @base.respond_to?(:supports_foreign_keys?) && @base.supports_foreign_keys?
-          to_table = to_table.to_s.pluralize if ActiveRecord::Base.pluralize_table_names
-          @base.add_foreign_key(@table_name, to_table, options)
-        else
-          raise ArgumentError, "this ActiveRecord adapter is not supporting foreign_key definition"
-        end
-      end
-  
-      # Remove the given foreign key from the table.
-      #
-      # ===== Examples
-      # ====== Remove the suppliers_company_id_fk in the suppliers table.
-      #   t.remove_foreign_key :companies
-      # ====== Remove the foreign key named accounts_branch_id_fk in the accounts table.
-      #   remove_foreign_key :column => :branch_id
-      # ====== Remove the foreign key named party_foreign_key in the accounts table.
-      #   remove_index :name => :party_foreign_key
-      def remove_foreign_key(options = {})
-        @base.remove_foreign_key(@table_name, options)
-      end
-    
-      # Adds a :foreign_key option to TableDefinition.references.
-      # If :foreign_key is true, a foreign key constraint is added to the table.
-      # You can also specify a hash, which is passed as foreign key options.
-      # 
-      # ===== Examples
-      # ====== Add goat_id column and a foreign key to the goats table.
-      #  t.references(:goat, :foreign_key => true)
-      # ====== Add goat_id column and a cascading foreign key to the goats table.
-      #  t.references(:goat, :foreign_key => {:dependent => :delete})
-      # 
-      # Note: No foreign key is created if :polymorphic => true is used.
-      def references(*args)
-        options = args.extract_options!
-        polymorphic = options[:polymorphic]
-        index_options = options[:index]
-        fk_options = options.delete(:foreign_key)
-
-        super(*(args << options))
-        # references_without_foreign_keys adds {:type => :integer}
-        args.extract_options!
-        if fk_options && !polymorphic
-          fk_options = {} if fk_options == true
-          args.each do |to_table| 
-            foreign_key(to_table, fk_options) 
-            add_index(to_table, "#{to_table}_id", index_options.is_a?(Hash) ? index_options : nil) if index_options
-          end
-        end
       end
     end
   end
-end
-
-ActiveRecord::ConnectionAdapters.class_eval do
-  include ActiveRecord::ConnectionAdapters::OracleEnhancedSchemaDefinitions
 end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -58,42 +58,7 @@ module ActiveRecord #:nodoc:
       end
 
       def foreign_keys_with_oracle_enhanced(table_name, stream)
-        # return original method if not using oracle_enhanced
-        if (rails_env = defined?(Rails.env) ? Rails.env : (defined?(RAILS_ENV) ? RAILS_ENV : nil)) &&
-              ActiveRecord::Base.configurations[rails_env] &&
-              ActiveRecord::Base.configurations[rails_env]['adapter'] != 'oracle_enhanced'
-          return foreign_keys_without_oracle_enhanced(table_name, stream)
-        end
-        if @connection.respond_to?(:foreign_keys) && (foreign_keys = @connection.foreign_keys(table_name)).any?
-          add_foreign_key_statements = foreign_keys.map do |foreign_key|
-            statement_parts = [ ('add_foreign_key ' + foreign_key.from_table.inspect) ]
-            statement_parts << foreign_key.to_table.inspect
-
-            if foreign_key.options[:columns].size == 1
-              column = foreign_key.options[:columns].first
-              if column != "#{foreign_key.to_table.singularize}_id"
-                statement_parts << ('column: ' + column.inspect)
-              end
-
-              if foreign_key.options[:references].first != 'id'
-                statement_parts << ('primary_key: ' + foreign_key.options[:references].first.inspect)
-              end
-            else
-              statement_parts << ('columns: ' + foreign_key.options[:columns].inspect)
-            end
-
-            statement_parts << ('name: ' + foreign_key.options[:name].inspect)
-            
-            unless foreign_key.options[:dependent].blank?
-              statement_parts << ('dependent: ' + foreign_key.options[:dependent].inspect)
-            end
-
-            '  ' + statement_parts.join(', ')
-          end
-
-          stream.puts add_foreign_key_statements.sort.join("\n")
-          stream.puts
-        end
+        return foreign_keys_without_oracle_enhanced(table_name, stream)
       end
 
       def synonyms(stream)

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -90,15 +90,13 @@ module ActiveRecord
           end
           td.indexes.each_pair { |c,o| add_index table_name, c, o }
 
-          unless td.foreign_keys.nil?
-            td.foreign_keys.each do |foreign_key|
-              add_foreign_key(td.table_name, foreign_key.to_table, foreign_key.options)
-            end
+          td.foreign_keys.each_pair do |other_table_name, foreign_key_options|
+            add_foreign_key(table_name, other_table_name, foreign_key_options)
           end
         end
 
         def create_table_definition(name, temporary, options)
-          TableDefinition.new native_database_types, name, temporary, options
+          ActiveRecord::ConnectionAdapters::OracleEnhanced::TableDefinition.new native_database_types, name, temporary, options
         end
 
         def rename_table(table_name, new_name) #:nodoc:
@@ -396,127 +394,13 @@ module ActiveRecord
           SQL
         end
 
-        # Adds a new foreign key to the +from_table+, referencing the primary key of +to_table+
-        # (syntax and partial implementation taken from http://github.com/matthuhiggins/foreigner)
-        #
-        # The foreign key will be named after the from and to tables unless you pass
-        # <tt>:name</tt> as an option.
-        #
-        # === Examples
-        # ==== Creating a foreign key
-        #  add_foreign_key(:comments, :posts)
-        # generates
-        #  ALTER TABLE comments ADD CONSTRAINT
-        #     comments_post_id_fk FOREIGN KEY (post_id) REFERENCES posts (id)
-        #
-        # ==== Creating a named foreign key
-        #  add_foreign_key(:comments, :posts, :name => 'comments_belongs_to_posts')
-        # generates
-        #  ALTER TABLE comments ADD CONSTRAINT
-        #     comments_belongs_to_posts FOREIGN KEY (post_id) REFERENCES posts (id)
-        #
-        # ==== Creating a cascading foreign_key on a custom column
-        #  add_foreign_key(:people, :people, :column => 'best_friend_id', :dependent => :nullify)
-        # generates
-        #  ALTER TABLE people ADD CONSTRAINT
-        #     people_best_friend_id_fk FOREIGN KEY (best_friend_id) REFERENCES people (id)
-        #     ON DELETE SET NULL
-        #
-        # ==== Creating a composite foreign key
-        #  add_foreign_key(:comments, :posts, :columns => ['post_id', 'author_id'], :name => 'comments_post_fk')
-        # generates
-        #  ALTER TABLE comments ADD CONSTRAINT
-        #     comments_post_fk FOREIGN KEY (post_id, author_id) REFERENCES posts (post_id, author_id)
-        #
-        # === Supported options
-        # [:column]
-        #   Specify the column name on the from_table that references the to_table. By default this is guessed
-        #   to be the singular name of the to_table with "_id" suffixed. So a to_table of :posts will use "post_id"
-        #   as the default <tt>:column</tt>.
-        # [:columns]
-        #   An array of column names when defining composite foreign keys. An alias of <tt>:column</tt> provided for improved readability.
-        # [:primary_key]
-        #   Specify the column name on the to_table that is referenced by this foreign key. By default this is
-        #   assumed to be "id". Ignored when defining composite foreign keys.
-        # [:name]
-        #   Specify the name of the foreign key constraint. This defaults to use from_table and foreign key column.
-        # [:dependent]
-        #   If set to <tt>:delete</tt>, the associated records in from_table are deleted when records in to_table table are deleted.
-        #   If set to <tt>:nullify</tt>, the foreign key column is set to +NULL+.
         def add_foreign_key(from_table, to_table, options = {})
-          columns = options[:column] || options[:columns] || "#{to_table.to_s.singularize}_id"
-          constraint_name = foreign_key_constraint_name(from_table, columns, options)
-          sql = "ALTER TABLE #{quote_table_name(from_table)} ADD CONSTRAINT #{quote_column_name(constraint_name)} "
-          sql << foreign_key_definition(to_table, options)
-          execute sql
+          super
         end
 
-        def foreign_key_definition(to_table, options = {}) #:nodoc:
-          columns = Array(options[:column] || options[:columns])
-
-          if columns.size > 1
-            # composite foreign key
-            columns_sql = columns.map {|c| quote_column_name(c)}.join(',')
-            references = options[:references] || columns
-            references_sql = references.map {|c| quote_column_name(c)}.join(',')
-          else
-            columns_sql = quote_column_name(columns.first || "#{to_table.to_s.singularize}_id")
-            references = options[:references] ? options[:references].first : nil
-            references_sql = quote_column_name(options[:primary_key] || references || "id")
-          end
-
-          table_name = to_table
-          # TODO: Needs support `table_name_prefix` and `table_name_suffix`
-
-          sql = "FOREIGN KEY (#{columns_sql}) REFERENCES #{quote_table_name(table_name)}(#{references_sql})"
-
-          case options[:dependent]
-          when :nullify
-            sql << " ON DELETE SET NULL"
-          when :delete
-            sql << " ON DELETE CASCADE"
-          end
-          sql
+        def remove_foreign_key(from_table, options_or_to_table = {})
+          super
         end
-
-        # Remove the given foreign key from the table.
-        #
-        # ===== Examples
-        # ====== Remove the suppliers_company_id_fk in the suppliers table.
-        #   remove_foreign_key :suppliers, :companies
-        # ====== Remove the foreign key named accounts_branch_id_fk in the accounts table.
-        #   remove_foreign_key :accounts, :column => :branch_id
-        # ====== Remove the foreign key named party_foreign_key in the accounts table.
-        #   remove_foreign_key :accounts, :name => :party_foreign_key
-        def remove_foreign_key(from_table, options)
-          if Hash === options
-            constraint_name = foreign_key_constraint_name(from_table, options[:column], options)
-          else
-            constraint_name = foreign_key_constraint_name(from_table, "#{options.to_s.singularize}_id")
-          end
-          execute "ALTER TABLE #{quote_table_name(from_table)} DROP CONSTRAINT #{quote_column_name(constraint_name)}"
-        end
-
-        private
-
-        def foreign_key_constraint_name(table_name, columns, options = {})
-          columns = Array(columns)
-          constraint_name = original_name = options[:name] || "#{table_name}_#{columns.join('_')}_fk"
-
-          return constraint_name if constraint_name.length <= OracleEnhancedAdapter::IDENTIFIER_MAX_LENGTH
-
-          # leave just first three letters from each word
-          constraint_name = constraint_name.split('_').map{|w| w[0,3]}.join('_')
-          # generate unique name using hash function
-          if constraint_name.length > OracleEnhancedAdapter::IDENTIFIER_MAX_LENGTH
-            constraint_name = 'c'+Digest::SHA1.hexdigest(original_name)[0,OracleEnhancedAdapter::IDENTIFIER_MAX_LENGTH-1]
-          end
-          @logger.warn "#{adapter_name} shortened foreign key constraint name #{original_name} to #{constraint_name}" if @logger
-          constraint_name
-        end
-
-
-        public
 
         # get table foreign keys for schema dump
         def foreign_keys(table_name) #:nodoc:
@@ -543,24 +427,21 @@ module ActiveRecord
             ORDER BY name, to_table, column_name, references_column
           SQL
 
-          fks = {}
-
           fk_info.map do |row|
-            name = oracle_downcase(row['name'])
-            fks[name] ||= { :columns => [], :to_table => oracle_downcase(row['to_table']), :references => [] }
-            fks[name][:columns] << oracle_downcase(row['column_name'])
-            fks[name][:references] << oracle_downcase(row['references_column'])
-            case row['delete_rule']
-            when 'CASCADE'
-              fks[name][:dependent] = :delete
-            when 'SET NULL'
-              fks[name][:dependent] = :nullify
-            end
+            options = {
+              column: oracle_downcase(row['column_name']),
+              name: oracle_downcase(row['name']),
+              primary_key: oracle_downcase(row['references_column'])
+            }
+            options[:on_delete] = extract_foreign_key_action(row['delete_rule'])
+            OracleEnhanced::ForeignKeyDefinition.new(oracle_downcase(table_name), oracle_downcase(row['to_table']), options)
           end
+        end
 
-          fks.map do |k, v|
-            options = {:name => k, :columns => v[:columns], :references => v[:references], :dependent => v[:dependent]}
-            OracleEnhancedForeignKeyDefinition.new(table_name, v[:to_table], options)
+        def extract_foreign_key_action(specifier) # :nodoc:
+          case specifier
+          when 'CASCADE'; :cascade
+          when 'SET NULL'; :nullify
           end
         end
 


### PR DESCRIPTION
This pull request supports Rails native foreign key syntax.

Oracle enhanced adapter already has implemented its own foreign key support. These syntax and support feature is similar but some of them are not compatible with Rails implementation. 

* Foreign key name syntax is now `"fk_rails_#{hashed_identifier}"`

Also these tests are getting fail so far. I have been working to support both syntax but it is quite difficult for me, then I have decided to merge Rails native feature support first. 

These failing tests show some of incompatibilities. 
```ruby
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:179 # OracleEnhancedAdapter schema dump foreign key constraints should include foreign key in schema dump
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:186 # OracleEnhancedAdapter schema dump foreign key constraints should include foreign key with delete dependency in schema dump
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:193 # OracleEnhancedAdapter schema dump foreign key constraints should include foreign key with nullify dependency in schema dump
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:228 # OracleEnhancedAdapter schema dump foreign key constraints should include composite foreign keys
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:629 # OracleEnhancedAdapter schema definition foreign key constraints should add foreign key
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:675 # OracleEnhancedAdapter schema definition foreign key constraints should add foreign key with long name which is shortened
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:684 # OracleEnhancedAdapter schema definition foreign key constraints should add foreign key with very long name which is shortened
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:694 # OracleEnhancedAdapter schema definition foreign key constraints should add foreign key with column
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:703 # OracleEnhancedAdapter schema definition foreign key constraints should add foreign key with delete dependency
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:713 # OracleEnhancedAdapter schema definition foreign key constraints should add foreign key with nullify dependency
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:723 # OracleEnhancedAdapter schema definition foreign key constraints should add a composite foreign key
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:745 # OracleEnhancedAdapter schema definition foreign key constraints should add a composite foreign key with name
rspec ./spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb:64 # OracleEnhancedAdapter structure dump structure dump should dump foreign keys
rspec ./spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb:74 # OracleEnhancedAdapter structure dump structure dump should dump foreign keys when reference column name is not 'id'
rspec ./spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb:94 # OracleEnhancedAdapter structure dump structure dump should dump composite foreign keys
```