### PR TITLE
Shorten foreign key name if it is longer than 30 byte

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -12,6 +12,13 @@ module ActiveRecord
     module OracleEnhanced
 
       class ForeignKeyDefinition < ActiveRecord::ConnectionAdapters::ForeignKeyDefinition
+        def name
+          if options[:name].length > OracleEnhancedAdapter::IDENTIFIER_MAX_LENGTH
+            'c'+Digest::SHA1.hexdigest(options[:name])[0,OracleEnhancedAdapter::IDENTIFIER_MAX_LENGTH-1]
+          else
+            options[:name]
+          end
+        end
       end
 
       class SynonymDefinition < Struct.new(:name, :table_owner, :table_name, :db_link) #:nodoc:
@@ -61,6 +68,12 @@ module ActiveRecord
           super(name, type, options)
         end
 
+      end
+
+      class AlterTable < ActiveRecord::ConnectionAdapters::AlterTable
+        def add_foreign_key(to_table, options)
+          @foreign_key_adds << OracleEnhanced::ForeignKeyDefinition.new(name, to_table, options)
+        end
       end
     end
   end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -469,6 +469,10 @@ module ActiveRecord
 
         private
 
+        def create_alter_table(name)
+          OracleEnhanced::AlterTable.new create_table_definition(name, false, {})
+        end 
+
         def tablespace_for(obj_type, tablespace_option, table_name=nil, column_name=nil)
           tablespace_sql = ''
           if tablespace = (tablespace_option || default_tablespace_for(obj_type))


### PR DESCRIPTION
This pull request addresses the following failure.

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:684
==> Loading config from ENV or use default
==> Running specs with MRI version 2.2.2
==> Selected Rails version 4.0-master
==> Effective ActiveRecord version 4.2.2.beta
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb"=>[684]}}
F

Failures:

  1) OracleEnhancedAdapter schema definition foreign key constraints should add foreign key with very long name which is shortened
     Failure/Error: add_foreign_key :test_comments, :test_posts, :name => "long_prefix_test_comments_test_post_id_foreign_key"
     ActiveRecord::StatementInvalid:
       OCIError: ORA-00972: identifier is too long: ALTER TABLE "TEST_COMMENTS" ADD CONSTRAINT "LONG_PREFIX_TEST_COMMENTS_TEST_POST_ID_FOREIGN_KEY"
       FOREIGN KEY ("TEST_POST_ID")
         REFERENCES "TEST_POSTS" ("ID")
     # stmt.c:250:in oci8lib_220.so
     # /home/yahonda/git/ruby-oci8/lib/oci8/cursor.rb:129:in `exec'
     # /home/yahonda/git/ruby-oci8/lib/oci8/oci8.rb:278:in `exec_internal'
     # /home/yahonda/git/ruby-oci8/lib/oci8/oci8.rb:269:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:431:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:90:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `block in execute'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:473:in `block in log'
     # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:467:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1348:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `execute'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:762:in `add_foreign_key'
     # ./lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:398:in `add_foreign_key'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:661:in `block in method_missing'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:631:in `block in say_with_time'
     # /home/yahonda/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/benchmark.rb:288:in `measure'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:631:in `say_with_time'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:651:in `method_missing'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:686:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:117:in `instance_eval'
     # ./spec/spec_helper.rb:117:in `block (2 levels) in schema_define'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:639:in `suppress_messages'
     # ./spec/spec_helper.rb:116:in `block in schema_define'
     # /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:41:in `instance_eval'
     # /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:41:in `define'
     # /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:61:in `define'
     # ./spec/spec_helper.rb:115:in `schema_define'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:685:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.21431 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:684 # OracleEnhancedAdapter schema definition foreign key constraints should add foreign key with very long name which is shortened
$
```