### PR TITLE
Rails 4.2 support foreign_key and remove_foreign_key in create_table

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -75,6 +75,18 @@ module ActiveRecord
           @foreign_key_adds << OracleEnhanced::ForeignKeyDefinition.new(name, to_table, options)
         end
       end
+
+      class Table < ActiveRecord::ConnectionAdapters::Table
+        def foreign_key(to_table, options = {})
+          to_table = to_table.to_s.pluralize if ActiveRecord::Base.pluralize_table_names
+          @base.add_foreign_key(@name, to_table, options)
+        end
+
+        def remove_foreign_key(options = {})
+          @base.remove_foreign_key(@name, options)
+        end
+      end
+
     end
   end
 end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -158,6 +158,10 @@ module ActiveRecord
           end
         end
 
+        def update_table_definition(table_name, base) #:nodoc:
+          OracleEnhanced::Table.new(table_name, base)
+        end
+
         def add_index(table_name, column_name, options = {}) #:nodoc:
           index_name, index_type, quoted_column_names, tablespace, index_options = add_index_options(table_name, column_name, options)
           execute "CREATE #{index_type} INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} (#{quoted_column_names})#{tablespace} #{index_options}"


### PR DESCRIPTION
This pull request addresses following failures.

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:848
==> Loading config from ENV or use default
==> Running specs with MRI version 2.2.2
==> Selected Rails version 4.0-master
==> Effective ActiveRecord version 4.2.2
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb"=>[848]}}
F

Failures:

  1) OracleEnhancedAdapter schema definition foreign key in table definition should add foreign key in change_table
     Failure/Error: t.foreign_key :test_posts
     NoMethodError:
       undefined method `foreign_key' for #<ActiveRecord::ConnectionAdapters::Table:0x00000002ffc948>
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:855:in `block (5 levels) in <top (required)>'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:363:in `change_table'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:661:in `block in method_missing'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:631:in `block in say_with_time'
     # /home/yahonda/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/benchmark.rb:288:in `measure'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:631:in `say_with_time'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:651:in `method_missing'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:854:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:117:in `instance_eval'
     # ./spec/spec_helper.rb:117:in `block (2 levels) in schema_define'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:639:in `suppress_messages'
     # ./spec/spec_helper.rb:116:in `block in schema_define'
     # /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:41:in `instance_eval'
     # /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:41:in `define'
     # /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:61:in `define'
     # ./spec/spec_helper.rb:115:in `schema_define'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:849:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.18946 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:848 # OracleEnhancedAdapter schema definition foreign key in table definition should add foreign key in change_table
```

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:877
==> Loading config from ENV or use default
==> Running specs with MRI version 2.2.2
==> Selected Rails version 4.0-master
==> Effective ActiveRecord version 4.2.2
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb"=>[877]}}
F

Failures:

  1) OracleEnhancedAdapter schema definition foreign key in table definition should remove foreign key by table name
     Failure/Error: t.foreign_key :test_posts
     NoMethodError:
       undefined method `foreign_key' for #<ActiveRecord::ConnectionAdapters::Table:0x000000032de738>
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:884:in `block (5 levels) in <top (required)>'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:363:in `change_table'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:661:in `block in method_missing'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:631:in `block in say_with_time'
     # /home/yahonda/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/benchmark.rb:288:in `measure'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:631:in `say_with_time'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:651:in `method_missing'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:883:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:117:in `instance_eval'
     # ./spec/spec_helper.rb:117:in `block (2 levels) in schema_define'
     # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:639:in `suppress_messages'
     # ./spec/spec_helper.rb:116:in `block in schema_define'
     # /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:41:in `instance_eval'
     # /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:41:in `define'
     # /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:61:in `define'
     # ./spec/spec_helper.rb:115:in `schema_define'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:878:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.19885 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:877 # OracleEnhancedAdapter schema definition foreign key in table definition should remove foreign key by table name
$
```