### PR TITLE
Support add_foreign_key option :dependent => :delete and :nullify

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -399,6 +399,12 @@ module ActiveRecord
         end
 
         def add_foreign_key(from_table, to_table, options = {})
+          case options[:dependent]  
+          when :delete then options[:on_delete] = :cascade
+          when :nullify then options[:on_delete] = :nullify
+          else
+          end
+
           super
         end
 


### PR DESCRIPTION
This pull request addresses following failures.


```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:703
==> Loading config from ENV or use default
==> Running specs with MRI version 2.2.2
==> Selected Rails version 4.0-master
==> Effective ActiveRecord version 4.2.2
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb"=>[703]}}
F

Failures:

  1) OracleEnhancedAdapter schema definition foreign key constraints should add foreign key with delete dependency
     Failure/Error: TestPost.delete(p.id)
     ActiveRecord::StatementInvalid:
       OCIError: ORA-02292: integrity constraint (ORACLE_ENHANCED.FK_RAILS_CC939FC91F) violated - child record found: DELETE FROM "TEST_POSTS" WHERE "TEST_POSTS"."ID" = :a1
     # stmt.c:250:in oci8lib_220.so
     # /home/yahonda/git/ruby-oci8/lib/oci8/cursor.rb:129:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:155:in `exec_update'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:175:in `block in exec_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:473:in `block in log'
     # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:467:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1348:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:157:in `exec_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:119:in `delete'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `delete'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:477:in `delete_all'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:504:in `delete'
     # /home/yahonda/git/rails/activerecord/lib/active_record/querying.rb:8:in `delete'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:709:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.35671 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:703 # OracleEnhancedAdapter schema definition foreign key constraints should add foreign key with delete dependency
```

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:713
==> Loading config from ENV or use default
==> Running specs with MRI version 2.2.2
==> Selected Rails version 4.0-master
==> Effective ActiveRecord version 4.2.2
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb"=>[713]}}
F

Failures:

  1) OracleEnhancedAdapter schema definition foreign key constraints should add foreign key with nullify dependency
     Failure/Error: TestPost.delete(p.id)
     ActiveRecord::StatementInvalid:
       OCIError: ORA-02292: integrity constraint (ORACLE_ENHANCED.FK_RAILS_CC939FC91F) violated - child record found: DELETE FROM "TEST_POSTS" WHERE "TEST_POSTS"."ID" = :a1
     # stmt.c:250:in oci8lib_220.so
     # /home/yahonda/git/ruby-oci8/lib/oci8/cursor.rb:129:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:155:in `exec_update'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:175:in `block in exec_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:473:in `block in log'
     # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:467:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1348:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:157:in `exec_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:119:in `delete'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `delete'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:477:in `delete_all'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:504:in `delete'
     # /home/yahonda/git/rails/activerecord/lib/active_record/querying.rb:8:in `delete'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:719:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.3762 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:713 # OracleEnhancedAdapter schema definition foreign key constraints should add foreign key with nullify dependency
$
```