### PR TITLE
Add deprecation warnings for Oracle enhanced specific foreign key methods

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -78,11 +78,13 @@ module ActiveRecord
 
       class Table < ActiveRecord::ConnectionAdapters::Table
         def foreign_key(to_table, options = {})
+          ActiveSupport::Deprecation.warn "`foreign_key` option will be deprecated. Please use `references` option"
           to_table = to_table.to_s.pluralize if ActiveRecord::Base.pluralize_table_names
           @base.add_foreign_key(@name, to_table, options)
         end
 
         def remove_foreign_key(options = {})
+          ActiveSupport::Deprecation.warn "`remove_foreign_key` option will be deprecated. Please use `remove_references` option"
           @base.remove_foreign_key(@name, options)
         end
       end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -399,6 +399,9 @@ module ActiveRecord
         end
 
         def add_foreign_key(from_table, to_table, options = {})
+          if options[:dependent]
+            ActiveSupport::Deprecation.warn "`:dependent` option will be deprecated. Please use `:on_delete` option"
+          end
           case options[:dependent]  
           when :delete then options[:on_delete] = :cascade
           when :nullify then options[:on_delete] = :nullify


### PR DESCRIPTION
To keep Rails compatibility refer #625 and #626 