### PR TITLE
Use Rails foreign key name

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -627,12 +627,14 @@ end
     end
 
     it "should add foreign key" do
+      fk_name = "fk_rails_#{Digest::SHA256.hexdigest("test_comments_test_post_id_fk").first(10)}"
+
       schema_define do
         add_foreign_key :test_comments, :test_posts
       end
       lambda do
         TestComment.create(:body => "test", :test_post_id => 1)
-      end.should raise_error() {|e| e.message.should =~ /ORA-02291.*\.TEST_COMMENTS_TEST_POST_ID_FK/}
+      end.should raise_error() {|e| e.message.should =~ /ORA-02291.*\.#{fk_name}/i}
     end
 
     context "with table_name_prefix" do
@@ -692,12 +694,14 @@ end
     end
 
     it "should add foreign key with column" do
+      fk_name = "fk_rails_#{Digest::SHA256.hexdigest("test_comments_post_id_fk").first(10)}"
+
       schema_define do
         add_foreign_key :test_comments, :test_posts, :column => "post_id"
       end
       lambda do
         TestComment.create(:body => "test", :post_id => 1)
-      end.should raise_error() {|e| e.message.should =~ /ORA-02291.*\.TEST_COMMENTS_POST_ID_FK/}
+      end.should raise_error() {|e| e.message.should =~ /ORA-02291.*\.#{fk_name}/i}
     end
 
     it "should add foreign key with delete dependency" do


### PR DESCRIPTION
Refer https://github.com/rails/rails/pull/18791

Also this pull request addresses following failures.

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:629
==> Loading config from ENV or use default
==> Running specs with MRI version 2.2.2
==> Selected Rails version 4.0-master
==> Effective ActiveRecord version 4.2.2
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb"=>[629]}}
F

Failures:

  1) OracleEnhancedAdapter schema definition foreign key constraints should add foreign key
     Failure/Error: lambda do
       expected: /ORA-02291.*\.TEST_COMMENTS_TEST_POST_ID_FK/
            got: "OCIError: ORA-02291: integrity constraint (ORACLE_ENHANCED.FK_RAILS_CC939FC91F) violated - parent key not found: INSERT INTO \"TEST_COMMENTS\" (\"BODY\", \"TEST_POST_ID\", \"ID\") VALUES (:a1, :a2, :a3)" (using =~)
       Diff:
       @@ -1,2 +1,2 @@
       -/ORA-02291.*\.TEST_COMMENTS_TEST_POST_ID_FK/
       +"OCIError: ORA-02291: integrity constraint (ORACLE_ENHANCED.FK_RAILS_CC939FC91F) violated - parent key not found: INSERT INTO \"TEST_COMMENTS\" (\"BODY\", \"TEST_POST_ID\", \"ID\") VALUES (:a1, :a2, :a3)"

     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/fail_with.rb:32:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/handler.rb:40:in `handle_matcher'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/syntax.rb:53:in `should'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:633:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.3441 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:629 # OracleEnhancedAdapter schema definition foreign key constraints should add foreign key
$
```

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:694
==> Loading config from ENV or use default
==> Running specs with MRI version 2.2.2
==> Selected Rails version 4.0-master
==> Effective ActiveRecord version 4.2.2
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb"=>[694]}}
F

Failures:

  1) OracleEnhancedAdapter schema definition foreign key constraints should add foreign key with column
     Failure/Error: lambda do
       expected: /ORA-02291.*\.TEST_COMMENTS_POST_ID_FK/
            got: "OCIError: ORA-02291: integrity constraint (ORACLE_ENHANCED.FK_RAILS_7C0CEDF447) violated - parent key not found: INSERT INTO \"TEST_COMMENTS\" (\"BODY\", \"POST_ID\", \"ID\") VALUES (:a1, :a2, :a3)" (using =~)
       Diff:
       @@ -1,2 +1,2 @@
       -/ORA-02291.*\.TEST_COMMENTS_POST_ID_FK/
       +"OCIError: ORA-02291: integrity constraint (ORACLE_ENHANCED.FK_RAILS_7C0CEDF447) violated - parent key not found: INSERT INTO \"TEST_COMMENTS\" (\"BODY\", \"POST_ID\", \"ID\") VALUES (:a1, :a2, :a3)"

     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/fail_with.rb:32:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/handler.rb:40:in `handle_matcher'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/syntax.rb:53:in `should'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:698:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.32432 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:694 # OracleEnhancedAdapter schema definition foreign key constraints should add foreign key with column
$