### PR TITLE
Add deprecate warning if foreign key name length is longer than 30 byte

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -14,6 +14,7 @@ module ActiveRecord
       class ForeignKeyDefinition < ActiveRecord::ConnectionAdapters::ForeignKeyDefinition
         def name
           if options[:name].length > OracleEnhancedAdapter::IDENTIFIER_MAX_LENGTH
+            ActiveSupport::Deprecation.warn "Foreign key name #{options[:name]} is too long. It will not get shorten in later version of Oracle enhanced adapter"
             'c'+Digest::SHA1.hexdigest(options[:name])[0,OracleEnhancedAdapter::IDENTIFIER_MAX_LENGTH-1]
           else
             options[:name]


### PR DESCRIPTION
This pull request adds deprecate warning if foreign key name length is longer than 30 byte.
In next version of Oracle enhanced adapter (1.7 or later) it will get simple 'it is too long' kind of error messages.