### PR TITLE
Foreign key name longer than 30 byte will be shortened using Digest::SHA1.hexdigest

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -680,7 +680,8 @@ end
       end
       lambda do
         TestComment.create(:body => "test", :test_post_id => 1)
-      end.should raise_error() {|e| e.message.should =~ /ORA-02291.*\.TES_COM_TES_POS_ID_FOR_KEY/}
+      end.should raise_error() {|e| e.message.should =~
+        /ORA-02291.*\.C#{Digest::SHA1.hexdigest("test_comments_test_post_id_foreign_key")[0,29].upcase}/}
     end
 
     it "should add foreign key with very long name which is shortened" do


### PR DESCRIPTION
Refer #621 and #636 

It addresses following failure.
```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:677
==> Loading config from ENV or use default
==> Running specs with MRI version 2.2.2
==> Selected Rails version 4.0-master
==> Effective ActiveRecord version 4.2.2
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb"=>[677]}}
DEPRECATION WARNING: Foreign key name test_comments_test_post_id_foreign_key is too long. It will not get shorten in later version of Oracle enhanced adapter. (called from name at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb:17)
F

Failures:

  1) OracleEnhancedAdapter schema definition foreign key constraints should add foreign key with long name which is shortened
     Failure/Error: lambda do
       expected: /ORA-02291.*\.TES_COM_TES_POS_ID_FOR_KEY/
            got: "OCIError: ORA-02291: integrity constraint (ORACLE_ENHANCED.C7043CD5444B3F29252E7FFB7C9B0F) violated - parent key not found: INSERT INTO \"TEST_COMMENTS\" (\"BODY\", \"TEST_POST_ID\", \"ID\") VALUES (:a1, :a2, :a3)" (using =~)
       Diff:
       @@ -1,2 +1,2 @@
       -/ORA-02291.*\.TES_COM_TES_POS_ID_FOR_KEY/
       +"OCIError: ORA-02291: integrity constraint (ORACLE_ENHANCED.C7043CD5444B3F29252E7FFB7C9B0F) violated - parent key not found: INSERT INTO \"TEST_COMMENTS\" (\"BODY\", \"TEST_POST_ID\", \"ID\") VALUES (:a1, :a2, :a3)"

     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/fail_with.rb:32:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/handler.rb:40:in `handle_matcher'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/syntax.rb:53:in `should'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:681:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 2.39 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:677 # OracleEnhancedAdapter schema definition foreign key constraints should add foreign key with long name which is shortened
$ 