### PR TITLE
Schema dumper for :integer will not dump :precision 0

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
@@ -406,7 +406,7 @@ describe "OracleEnhancedAdapter schema dump" do
     it 'should dump correctly' do
       standard_dump.should =~ /t\.virtual "full_name",(\s*)limit: 512,(\s*)as: "\\"FIRST_NAME\\"\|\|', '\|\|\\"LAST_NAME\\"",(\s*)type: :string/
       standard_dump.should =~ /t\.virtual "short_name",(\s*)limit: 300,(\s*)as:(.*),(\s*)type: :string/
-      standard_dump.should =~ /t\.virtual "full_name_length",(\s*)precision: 38,(\s*)scale: 0,(\s*)as:(.*),(\s*)type: :integer/
+      standard_dump.should =~ /t\.virtual "full_name_length",(\s*)precision: 38,(\s*)as:(.*),(\s*)type: :integer/
       standard_dump.should =~ /t\.virtual "name_ratio",(\s*)as:(.*)\"$/ # no :type
       standard_dump.should =~ /t\.virtual "abbrev_name",(\s*)limit: 100,(\s*)as:(.*),(\s*)type: :string/
       standard_dump.should =~ /t\.virtual "field_with_leading_space",(\s*)limit: 300,(\s*)as: "' '\|\|\\"FIRST_NAME\\"\|\|' '",(\s*)type: :string/


### PR DESCRIPTION
Refer #605

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:406
==> Loading config from ENV or use default
==> Running specs with MRI version 2.2.2
==> Selected Rails version 4.0-master
==> Effective ActiveRecord version 4.2.2
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb"=>[406]}}
F

Failures:

  1) OracleEnhancedAdapter schema dump virtual columns should dump correctly
     Failure/Error: standard_dump.should =~ /t\.virtual "full_name_length",(\s*)precision: 38,(\s*)scale: 0,(\s*)as:(.*),(\s*)type: :integer/
       expected: /t\.virtual "full_name_length",(\s*)precision: 38,(\s*)scale: 0,(\s*)as:(.*),(\s*)type: :integer/
            got: "# encoding: UTF-8\n# This file is auto-generated from the current state of the database. Instead\n# of editing this file, please use the migrations feature of Active Record to\n# incrementally modify your database, and then regenerate this schema definition.\n#\n# Note that this schema.rb definition is the authoritative source for your\n# database schema. If you need to create the application database on another\n# system, you should be using db:schema:load, not running all the migrations\n# from scratch. The latter is a flawed and unsustainable approach (the more migrations\n# you'll amass, the slower it'll run and the greater likelihood for issues).\n#\n# It's strongly recommended that you check this file into your version control system.\n\nActiveRecord::Schema.define(version: 0) do\n\n  create_table \"test_names\", force: :cascade do |t|\n    t.string  \"first_name\"\n    t.string  \"last_name\"\n    t.virtual \"full_name\",                limit: 512,                as: \"\\\"FIRST_NAME\\\"||', '||\\\"LAST_NAME\\\"\",                              type: :string\n    t.virtual \"short_name\",               limit: 300,                as: \"COALESCE(\\\"FIRST_NAME\\\",\\\"LAST_NAME\\\")\",                           type: :string\n    t.virtual \"abbrev_name\",              limit: 100,                as: \"SUBSTR(\\\"FIRST_NAME\\\",1,50)||' '||SUBSTR(\\\"LAST_NAME\\\",1,1)||'.'\", type: :string\n    t.virtual \"name_ratio\",                                          as: \"LENGTH(\\\"FIRST_NAME\\\")*10/LENGTH(\\\"LAST_NAME\\\")*10\"\n    t.virtual \"full_name_length\",                     precision: 38, as: \"LENGTH(\\\"FIRST_NAME\\\"||', '||\\\"LAST_NAME\\\")\",                      type: :integer\n    t.virtual \"field_with_leading_space\", limit: 300,                as: \"' '||\\\"FIRST_NAME\\\"||' '\",                                         type: :string\n  end\n\nend\n" (using =~)
       Diff:
       @@ -1,2 +1,28 @@
       -/t\.virtual "full_name_length",(\s*)precision: 38,(\s*)scale: 0,(\s*)as:(.*),(\s*)type: :integer/
       +# encoding: UTF-8
       +# This file is auto-generated from the current state of the database. Instead
       +# of editing this file, please use the migrations feature of Active Record to
       +# incrementally modify your database, and then regenerate this schema definition.
       +#
       +# Note that this schema.rb definition is the authoritative source for your
       +# database schema. If you need to create the application database on another
       +# system, you should be using db:schema:load, not running all the migrations
       +# from scratch. The latter is a flawed and unsustainable approach (the more migrations
       +# you'll amass, the slower it'll run and the greater likelihood for issues).
       +#
       +# It's strongly recommended that you check this file into your version control system.
       +
       +ActiveRecord::Schema.define(version: 0) do
       +
       +  create_table "test_names", force: :cascade do |t|
       +    t.string  "first_name"
       +    t.string  "last_name"
       +    t.virtual "full_name",                limit: 512,                as: "\"FIRST_NAME\"||', '||\"LAST_NAME\"",                              type: :string
       +    t.virtual "short_name",               limit: 300,                as: "COALESCE(\"FIRST_NAME\",\"LAST_NAME\")",                           type: :string
       +    t.virtual "abbrev_name",              limit: 100,                as: "SUBSTR(\"FIRST_NAME\",1,50)||' '||SUBSTR(\"LAST_NAME\",1,1)||'.'", type: :string
       +    t.virtual "name_ratio",                                          as: "LENGTH(\"FIRST_NAME\")*10/LENGTH(\"LAST_NAME\")*10"
       +    t.virtual "full_name_length",                     precision: 38, as: "LENGTH(\"FIRST_NAME\"||', '||\"LAST_NAME\")",                      type: :integer
       +    t.virtual "field_with_leading_space", limit: 300,                as: "' '||\"FIRST_NAME\"||' '",                                         type: :string
       +  end
       +
       +end

     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/fail_with.rb:32:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:57:in `fail_with_message'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:98:in `__delegate_operator'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:89:in `eval_match'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:38:in `block in use_custom_matcher_or_delegate'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:409:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.40229 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:406 # OracleEnhancedAdapter schema dump virtual columns should dump correctly
$
``` 