### PR TITLE
Use arel master branch for rails5 development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :development do
   gem 'actionpack',     github: 'rails/rails'
   gem 'railties',       github: 'rails/rails'
 
-  gem 'arel',           github: 'rails/arel', branch: '6-0-stable'
+  gem 'arel',           github: 'rails/arel', branch: 'master'
   gem 'journey',        github: 'rails/journey'
 
   gem 'activerecord-deprecated_finders'


### PR DESCRIPTION
First pull request for `rails5` branch to start developing to support Rails 5.