### PR TITLE
Remove TRUE_VALUES from OracleEnhancedColumn

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column.rb
@@ -5,7 +5,6 @@ module ActiveRecord
       attr_reader :table_name, :nchar, :virtual_column_data_default, :returning_id #:nodoc:
 
       FALSE_VALUES << 'N'
-      TRUE_VALUES << 'Y'
 
       def initialize(name, default, cast_type, sql_type = nil, null = true, table_name = nil, virtual=false, returning_id=false) #:nodoc:
         @table_name = table_name


### PR DESCRIPTION
This pull request addresses following NameError.
```ruby
$ rake spec
==> Loading config from ENV or use default
==> Running specs with MRI version 2.2.2
==> Selected Rails version 4.0-master
rake aborted!
NameError: uninitialized constant ActiveRecord::ConnectionAdapters::OracleEnhancedColumn::TRUE_VALUES
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/column.rb:8:in `<class:OracleEnhancedColumn>'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/column.rb:3:in `<module:ConnectionAdapters>'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/column.rb:2:in `<module:ActiveRecord>'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/column.rb:1:in `<top (required)>'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:39:in `<top (required)>'
/home/yahonda/git/oracle-enhanced/spec/spec_helper.rb:41:in `require'
/home/yahonda/git/oracle-enhanced/spec/spec_helper.rb:41:in `<top (required)>'
/home/yahonda/git/oracle-enhanced/Rakefile:39:in `require'
/home/yahonda/git/oracle-enhanced/Rakefile:39:in `block in <top (required)>'
Tasks: TOP => spec => clear
(See full trace by running task with --trace)
$
```