### PR TITLE
Address `add_column_options!': undefined method `quote_value'

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -52,7 +52,7 @@ module ActiveRecord
             if type == :text
               sql << " DEFAULT #{@conn.quote(options[:default])}"
             else
-              sql << " DEFAULT #{quote_value(options[:default], options[:column])}"
+              sql << " DEFAULT #{@conn.quote(options[:default], options[:column])}"
             end
           end
           # must explicitly add NULL or NOT NULL to allow change_column to work on migrations


### PR DESCRIPTION
This pull request addresses following error.

```ruby
$ cd activerecord
$ rake test_oracle
... snip ...
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb:55:in `add_column_options!': undefined method `quote_value' for #<ActiveRecord::ConnectionAdapters::OracleEnhanced::SchemaCreation:0x00000004669a28> (NoMethodError)
        from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:32:in `visit_ColumnDefinition'
        from /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb:12:in `visit_ColumnDefinition'
        from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:14:in `accept'
        from /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb:20:in `block in visit_TableDefinition'
        from /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb:20:in `map'
        from /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb:20:in `visit_TableDefinition'
        from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:14:in `accept'
        from /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:83:in `create_table'
        from /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:649:in `block in method_missing'
        from /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:619:in `block in say_with_time'
        from /home/yahonda/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/benchmark.rb:288:in `measure'
        from /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:619:in `say_with_time'
        from /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:639:in `method_missing'
        from /home/yahonda/git/rails/activerecord/test/schema/schema.rb:26:in `block in <top (required)>'
        from /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:41:in `instance_eval'
        from /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:41:in `define'
        from /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:61:in `define'
        from /home/yahonda/git/rails/activerecord/test/schema/schema.rb:2:in `<top (required)>'
        from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:268:in `load'
        from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:268:in `block in load'
        from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:240:in `load_dependency'
        from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:268:in `load'
        from /home/yahonda/git/rails/activerecord/test/cases/helper.rb:161:in `load_schema'
        from /home/yahonda/git/rails/activerecord/test/cases/helper.rb:170:in `<top (required)>'
        from /home/yahonda/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        from /home/yahonda/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        from /home/yahonda/git/rails/activerecord/test/cases/relations_test.rb:1:in `<top (required)>'
        from /home/yahonda/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        from /home/yahonda/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        from /home/yahonda/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/rake/rake_test_loader.rb:15:in `block in <main>'
        from /home/yahonda/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/rake/rake_test_loader.rb:4:in `select'
        from /home/yahonda/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/rake/rake_test_loader.rb:4:in `<main>'
rake aborted!
Command failed with status (1): [ruby -w -I"lib:test"  "/home/yahonda/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/rake/rake_test_loader.rb" "test/cases/relations_test.rb" "test/cases/explain_subscriber_test.rb" "test/cases/multiparameter_attributes_test.rb" "test/cases/associations/nested_through_associations_test.rb" "test/cases/associations/eager_singularization_test.rb" "test/cases/associations/inverse_associations_test.rb" "test/cases/associations/has_many_associations_test.rb" "test/cases/associations/has_one_associations_test.rb" "test/cases/associations/has_many_through_associations_test.rb" "test/cases/associations/extension_test.rb" "test/cases/associations/eager_load_includes_full_sti_class_test.rb" "test/cases/associations/has_and_belongs_to_many_associations_test.rb" "test/cases/associations/callbacks_test.rb" "test/cases/associations/eager_test.rb" "test/cases/associations/eager_load_nested_include_test.rb" "test/cases/associations/required_test.rb" "test/cases/associations/inner_join_association_test.rb" "test/cases/associations/association_scope_test.rb" "test/cases/associations/belongs_to_associations_test.rb" "test/cases/associations/cascaded_eager_loading_test.rb" "test/cases/associations/has_one_through_associations_test.rb" "test/cases/associations/join_model_test.rb" "test/cases/connection_management_test.rb" "test/cases/invalid_connection_test.rb" "test/cases/serialized_attribute_test.rb" "test/cases/touch_later_test.rb" "test/cases/modules_test.rb" "test/cases/autosave_association_test.rb" "test/cases/relation_test.rb" "test/cases/scoping/relation_scoping_test.rb" "test/cases/scoping/named_scoping_test.rb" "test/cases/scoping/default_scoping_test.rb" "test/cases/enum_test.rb" "test/cases/schema_dumper_test.rb" "test/cases/attributes_test.rb" "test/cases/validations_test.rb" "test/cases/ar_schema_test.rb" "test/cases/date_time_test.rb" "test/cases/fixtures_test.rb" "test/cases/coders/yaml_column_test.rb" "test/cases/multiple_db_test.rb" "test/cases/hot_compatibility_test.rb" "test/cases/adapter_test.rb" "test/cases/query_cache_test.rb" "test/cases/types_test.rb" "test/cases/connection_specification/resolver_test.rb" "test/cases/mixin_test.rb" "test/cases/transaction_isolation_test.rb" "test/cases/i18n_test.rb" "test/cases/connection_pool_test.rb" "test/cases/tasks/postgresql_rake_test.rb" "test/cases/tasks/database_tasks_test.rb" "test/cases/tasks/sqlite_rake_test.rb" "test/cases/tasks/mysql_rake_test.rb" "test/cases/base_test.rb" "test/cases/reload_models_test.rb" "test/cases/finder_respond_to_test.rb" "test/cases/sanitize_test.rb" "test/cases/nested_attributes_test.rb" "test/cases/associations_test.rb" "test/cases/migration_test.rb" "test/cases/database_statements_test.rb" "test/cases/callbacks_test.rb" "test/cases/counter_cache_test.rb" "test/cases/time_precision_test.rb" "test/cases/custom_locking_test.rb" "test/cases/batches_test.rb" "test/cases/invertible_migration_test.rb" "test/cases/defaults_test.rb" "test/cases/connection_adapters/mysql_type_lookup_test.rb" "test/cases/connection_adapters/connection_specification_test.rb" "test/cases/connection_adapters/adapter_leasing_test.rb" "test/cases/connection_adapters/quoting_test.rb" "test/cases/connection_adapters/schema_cache_test.rb" "test/cases/connection_adapters/type_lookup_test.rb" "test/cases/connection_adapters/connection_handler_test.rb" "test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb" "test/cases/attribute_methods/read_test.rb" "test/cases/timestamp_test.rb" "test/cases/transactions_test.rb" "test/cases/calculations_test.rb" "test/cases/primary_keys_test.rb" "test/cases/quoting_test.rb" "test/cases/unconnected_test.rb" "test/cases/explain_test.rb" "test/cases/persistence_test.rb" "test/cases/attribute_decorators_test.rb" "test/cases/nested_attributes_with_callbacks_test.rb" "test/cases/date_time_precision_test.rb" "test/cases/migration/columns_test.rb" "test/cases/migration/command_recorder_test.rb" "test/cases/migration/logger_test.rb" "test/cases/migration/column_positioning_test.rb" "test/cases/migration/references_statements_test.rb" "test/cases/migration/table_and_index_test.rb" "test/cases/migration/create_join_table_test.rb" "test/cases/migration/change_table_test.rb" "test/cases/migration/column_attributes_test.rb" "test/cases/migration/references_index_test.rb" "test/cases/migration/foreign_key_test.rb" "test/cases/migration/pending_migrations_test.rb" "test/cases/migration/rename_table_test.rb" "test/cases/migration/index_test.rb" "test/cases/migration/change_schema_test.rb" "test/cases/migration/references_foreign_key_test.rb" "test/cases/clone_test.rb" "test/cases/type/string_test.rb" "test/cases/type/unsigned_integer_test.rb" "test/cases/type/type_map_test.rb" "test/cases/type/decimal_test.rb" "test/cases/type/adapter_specific_registry_test.rb" "test/cases/type/integer_test.rb" "test/cases/binary_test.rb" "test/cases/statement_cache_test.rb" "test/cases/view_test.rb" "test/cases/store_test.rb" "test/cases/migrator_test.rb" "test/cases/finder_test.rb" "test/cases/relation/predicate_builder_test.rb" "test/cases/relation/where_test.rb" "test/cases/relation/record_fetch_warning_test.rb" "test/cases/relation/delegation_test.rb" "test/cases/relation/or_test.rb" "test/cases/relation/where_clause_test.rb" "test/cases/relation/where_chain_test.rb" "test/cases/relation/merging_test.rb" "test/cases/relation/mutation_test.rb" "test/cases/attribute_test.rb" "test/cases/test_fixtures_test.rb" "test/cases/json_serialization_test.rb" "test/cases/fixture_set/file_test.rb" "test/cases/column_definition_test.rb" "test/cases/reaper_test.rb" "test/cases/bind_parameter_test.rb" "test/cases/result_test.rb" "test/cases/dirty_test.rb" "test/cases/reflection_test.rb" "test/cases/yaml_serialization_test.rb" "test/cases/habtm_destroy_order_test.rb" "test/cases/transaction_callbacks_test.rb" "test/cases/core_test.rb" "test/cases/pooled_connections_test.rb" "test/cases/column_alias_test.rb" "test/cases/forbidden_attributes_protection_test.rb" "test/cases/suppressor_test.rb" "test/cases/integration_test.rb" "test/cases/readonly_test.rb" "test/cases/dup_test.rb" "test/cases/validations/association_validation_test.rb" "test/cases/validations/uniqueness_validation_test.rb" "test/cases/validations/presence_validation_test.rb" "test/cases/validations/i18n_validation_test.rb" "test/cases/validations/i18n_generate_message_validation_test.rb" "test/cases/validations/absence_validation_test.rb" "test/cases/validations/length_validation_test.rb" "test/cases/secure_token_test.rb" "test/cases/attribute_set_test.rb" "test/cases/serialization_test.rb" "test/cases/inheritance_test.rb" "test/cases/locking_test.rb" "test/cases/xml_serialization_test.rb" "test/cases/attribute_methods_test.rb" "test/cases/type_test.rb" "test/cases/aggregations_test.rb" "test/cases/log_subscriber_test.rb" "test/cases/disconnected_test.rb" "test/cases/invalid_date_test.rb" ]

Tasks: TOP => test_oracle => test:oracle
(See full trace by running task with --trace)
$
```