### PR TITLE
Update matcher to skip sql statements to get `table` metadata

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
@@ -325,7 +325,8 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
       :last_name => "Last",
       :hire_date => @today
     )
-    @logger.logged(:debug).last.should match(/^TestEmployee Create \(\d+\.\d+(ms)?\)  custom create method$/)
+    #TODO: dirty workaround to remove sql statement for `table` method
+    @logger.logged(:debug)[-2].should match(/^TestEmployee Create \(\d+\.\d+(ms)?\)  custom create method$/)
     clear_logger
   end
 


### PR DESCRIPTION
This pull request temporary addresses following failure.

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:321
==> Loading config from ENV or use default
==> Running specs with MRI version 2.2.2
==> Selected Rails version 4.0-master
==> Effective ActiveRecord version 4.2.3
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb"=>[321]}}
F

Failures:

  1) OracleEnhancedAdapter custom methods for create, update and destroy should log create record
     Failure/Error: @logger.logged(:debug).last.should match(/^TestEmployee Create \(\d+\.\d+(ms)?\)  custom create method$/)
       expected "(57.1ms)  SELECT DECODE(table_name, UPPER(table_name), LOWER(table_name), table_name) FROM all_tables WHERE owner = SYS_CONTEXT('userenv', 'session_user') AND secondary = 'N'" to match /^TestEmployee Create \(\d+\.\d+(ms)?\)  custom create method$/
       Diff:
       @@ -1,2 +1,2 @@
       -/^TestEmployee Create \(\d+\.\d+(ms)?\)  custom create method$/
       +"(57.1ms)  SELECT DECODE(table_name, UPPER(table_name), LOWER(table_name), table_name) FROM all_tables WHERE owner = SYS_CONTEXT('userenv', 'session_user') AND secondary = 'N'"

     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/fail_with.rb:32:in `fail_with'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/handler.rb:37:in `handle_matcher'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/syntax.rb:53:in `should'
     # ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:328:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rvm/gems/ruby-2.2.2@rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.38041 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:321 # OracleEnhancedAdapter custom methods for create, update and destroy should log create record
$
```
