### PR TITLE
Rename quote_value to quote_default_expression.

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -52,7 +52,7 @@ module ActiveRecord
             if type == :text
               sql << " DEFAULT #{@conn.quote(options[:default])}"
             else
-              sql << " DEFAULT #{@conn.quote(options[:default], options[:column])}"
+              sql << " DEFAULT #{quote_value(options[:default], options[:column])}"
             end
           end
           # must explicitly add NULL or NOT NULL to allow change_column to work on migrations

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -50,9 +50,9 @@ module ActiveRecord
           # handle case of defaults for CLOB columns, which would otherwise get "quoted" incorrectly
           if options_include_default?(options)
             if type == :text
-              sql << " DEFAULT #{@conn.quote(options[:default])}"
+              sql << " DEFAULT #{quote_default_expression(options[:default])}"
             else
-              sql << " DEFAULT #{quote_value(options[:default], options[:column])}"
+              sql << " DEFAULT #{quote_default_expression(options[:default], options[:column])}"
             end
           end
           # must explicitly add NULL or NOT NULL to allow change_column to work on migrations


### PR DESCRIPTION
This pull request reverts #647 and renames `quote_value` to `quote_default_expression`.
refer rails/rails#17799