### PR TITLE
Unique constraints not created when function unique index created

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -166,7 +166,9 @@ module ActiveRecord
           index_name, index_type, quoted_column_names, tablespace, index_options = add_index_options(table_name, column_name, options)
           execute "CREATE #{index_type} INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} (#{quoted_column_names})#{tablespace} #{index_options}"
           if index_type == 'UNIQUE'
-            execute "ALTER TABLE #{quote_table_name(table_name)} ADD CONSTRAINT #{quote_column_name(index_name)} #{index_type} (#{quoted_column_names})"
+            unless quoted_column_names =~ /\(.*\)/
+              execute "ALTER TABLE #{quote_table_name(table_name)} ADD CONSTRAINT #{quote_column_name(index_name)} #{index_type} (#{quoted_column_names})"
+            end
           end
         ensure
           self.all_schema_indexes = nil

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -1368,6 +1368,13 @@ end
       @would_execute_sql.should =~ /CREATE +INDEX .* ON .* \(.*\) TABLESPACE #{DATABASE_NON_DEFAULT_TABLESPACE}/
     end
 
+    it "should create unique function index but not create unique constraints" do
+      schema_define do
+        add_index :keyboards, 'lower(name)', unique: true, name: :index_keyboards_on_lower_name
+      end
+      @would_execute_sql.should_not =~ /ALTER +TABLE .* ADD CONSTRAINT .* UNIQUE \(.*\(.*\)\)/
+    end
+
     describe "#initialize_schema_migrations_table" do
       # In Rails 2.3 to 3.2.x the index name for the migrations
       # table is hard-coded. We can modify the index name here


### PR DESCRIPTION
Unique constraints not created when function unique index created due to it causes ORA-00904 reported in #662
Note: This attribute cannot be referenced by foreign key since it requires unique constraints created.