### PR TITLE
create_table should use default tablespace values for lobs

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -5,38 +5,36 @@ module ActiveRecord
         private
 
         def visit_ColumnDefinition(o)
-          if o.type.to_sym == :virtual
-            sql_type = type_to_sql(o.default[:type], o.limit, o.precision, o.scale) if o.default[:type]
-            "#{quote_column_name(o.name)} #{sql_type} AS (#{o.default[:as]})"
-          else
-            super
+          case
+            when o.type.to_sym == :virtual
+              sql_type = type_to_sql(o.default[:type], o.limit, o.precision, o.scale) if o.default[:type]
+              return "#{quote_column_name(o.name)} #{sql_type} AS (#{o.default[:as]})"
+            when [:blob, :clob].include?(sql_type = type_to_sql(o.type.to_sym,  o.limit, o.precision, o.scale).downcase.to_sym)
+              if (tablespace = default_tablespace_for(sql_type))
+                @lob_tablespaces ||= {}
+                @lob_tablespaces[o.name] = tablespace
+              end
           end
+          super
         end
 
         def visit_TableDefinition(o)
-          tablespace = tablespace_for(:table, o.options[:tablespace])
           create_sql = "CREATE#{' GLOBAL TEMPORARY' if o.temporary} TABLE "
           create_sql << "#{quote_table_name(o.name)} ("
           create_sql << o.columns.map { |c| accept c }.join(', ')
           create_sql << ")"
+
           unless o.temporary
+            @lob_tablespaces.each do |lob_column, tablespace|
+              create_sql << " LOB (#{quote_column_name(lob_column)}) STORE AS (TABLESPACE #{tablespace}) \n"
+            end if defined?(@lob_tablespaces)
             create_sql << " ORGANIZATION #{o.options[:organization]}" if o.options[:organization]
-            create_sql << "#{tablespace}"
+            if (tablespace = o.options[:tablespace] || default_tablespace_for(:table))
+              create_sql << " TABLESPACE #{tablespace}"
+            end
           end
           create_sql << " #{o.options[:options]}"
           create_sql
-        end
-
-        def tablespace_for(obj_type, tablespace_option, table_name=nil, column_name=nil)
-          tablespace_sql = ''
-          if tablespace = (tablespace_option || default_tablespace_for(obj_type))
-            tablespace_sql << if [:blob, :clob].include?(obj_type.to_sym)
-              " LOB (#{quote_column_name(column_name)}) STORE AS #{column_name.to_s[0..10]}_#{table_name.to_s[0..14]}_ls (TABLESPACE #{tablespace})"
-            else
-              " TABLESPACE #{tablespace}"
-            end
-          end
-          tablespace_sql
         end
 
         def default_tablespace_for(type)

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -804,6 +804,45 @@ end
 
   end
 
+  describe "lob in table definition" do
+    before do
+      class ::TestPost < ActiveRecord::Base
+      end
+    end
+    it 'should use default tablespace for clobs' do
+      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[:clob] = DATABASE_NON_DEFAULT_TABLESPACE
+      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[:blob] = nil
+      schema_define do
+        create_table :test_posts, :force => true do |t|
+          t.text :test_clob
+          t.binary :test_blob
+        end
+      end
+      TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_CLOB'").should == DATABASE_NON_DEFAULT_TABLESPACE
+      TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_BLOB'").should_not == DATABASE_NON_DEFAULT_TABLESPACE
+    end
+
+    it 'should use default tablespace for blobs' do
+      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[:blob] = DATABASE_NON_DEFAULT_TABLESPACE
+      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[:clob] = nil
+      schema_define do
+        create_table :test_posts, :force => true do |t|
+          t.text :test_clob
+          t.binary :test_blob
+        end
+      end
+      TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_BLOB'").should == DATABASE_NON_DEFAULT_TABLESPACE
+      TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_CLOB'").should_not == DATABASE_NON_DEFAULT_TABLESPACE
+    end
+
+    after do
+      Object.send(:remove_const, "TestPost")
+      schema_define do
+        drop_table :test_posts rescue nil
+      end
+    end
+  end
+
   describe "foreign key in table definition" do
     before(:each) do
       schema_define do


### PR DESCRIPTION
Applying  #667 to master.

I couldn't do a bundle install using rails trunk:
```
└─╼ bundle update
Updating git://github.com/rails/rails.git
Updating git://github.com/rails/arel.git
Updating git://github.com/rails/journey.git
Updating git://github.com/kubo/ruby-oci8.git
Fetching gem metadata from http://rubygems.org/.........
Fetching version metadata from http://rubygems.org/...
Fetching dependency metadata from http://rubygems.org/..
Resolving dependencies...
Bundler could not find compatible versions for gem "arel":
  In Gemfile:
    arel (= 7.0.0.alpha) java

    activerecord (>= 0) ruby depends on
      arel (= 7.0.0.alpha) ruby

    arel (>= 0) java

    arel (>= 0) ruby
```

I ran tests against 4-2-stable:
```
  gem 'activerecord',   github: 'rails/rails', branch: '4-2-stable'
  gem 'activemodel',    github: 'rails/rails', branch: '4-2-stable'
  gem 'activesupport',  github: 'rails/rails', branch: '4-2-stable'
  gem 'actionpack',     github: 'rails/rails', branch: '4-2-stable'
  gem 'railties',       github: 'rails/rails', branch: '4-2-stable'

  gem 'arel',           github: 'rails/arel', branch: '6-0-stable'
```

Is this a problem for everyone or just me?