### PR TITLE
Use Arel::Visitors::Oracle12 to use better top-N query support

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -99,6 +99,11 @@ module ActiveRecord
       end
 
     end
+
+    # Returns array with major and minor version of database (e.g. [12, 1])
+    def database_version
+      raise NoMethodError, "Not implemented for this raw driver"
+    end 
     
     class OracleEnhancedConnectionException < StandardError #:nodoc:
     end

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -313,6 +313,10 @@ module ActiveRecord
         Cursor.new(self, @raw_connection.prepareStatement(sql))
       end
 
+      def database_version
+        @database_version ||= (md = raw_connection.getMetaData) && [md.getDatabaseMajorVersion, md.getDatabaseMinorVersion]
+      end
+
       class Cursor
         def initialize(connection, raw_statement)
           @connection = connection

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -267,6 +267,10 @@ module ActiveRecord
         end
       end
 
+      def database_version
+        @database_version ||= (version = raw_connection.oracle_server_version) && [version.major, version.minor]
+      end
+
       private
 
       def date_without_time?(value)


### PR DESCRIPTION
when Oracle server version is 12c

https://github.com/rails/arel/pull/337 has been merged to master. 