### PR TITLE
Requires activerecord 4.2.1 or higher, not activemodel

### DIFF
--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -119,8 +119,8 @@ This adapter is superset of original ActiveRecord Oracle adapter.
   else
     s.add_dependency(%q<jeweler>, ["~> 2.0"])
     s.add_dependency(%q<rspec>, ["~> 2.4"])
-    s.add_dependency(%q<activerecord>, [">= 0"])
-    s.add_dependency(%q<activemodel>, ["~> 4.2.1"])
+    s.add_dependency(%q<activerecord>, ["~> 4.2.1"])
+    s.add_dependency(%q<activemodel>, [">= 0"])
     s.add_dependency(%q<activesupport>, [">= 0"])
     s.add_dependency(%q<actionpack>, [">= 0"])
     s.add_dependency(%q<railties>, [">= 0"])


### PR DESCRIPTION
This pull request follows up #652 since it added incorrect dependency. It requires activerecord, not activemodel.