### PR TITLE
Set sequence name automatically when new table name is longer than 26 bytes

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -103,11 +103,8 @@ module ActiveRecord
           if new_name.to_s.length > table_name_length
             raise ArgumentError, "New table name '#{new_name}' is too long; the limit is #{table_name_length} characters"
           end
-          if "#{new_name}_seq".to_s.length > sequence_name_length
-            raise ArgumentError, "New sequence name '#{new_name}_seq' is too long; the limit is #{sequence_name_length} characters"
-          end
           execute "RENAME #{quote_table_name(table_name)} TO #{quote_table_name(new_name)}"
-          execute "RENAME #{quote_table_name("#{table_name}_seq")} TO #{quote_table_name("#{new_name}_seq")}" rescue nil
+          execute "RENAME #{quote_table_name("#{table_name}_seq")} TO #{default_sequence_name(new_name)}" rescue nil
 
           rename_table_indexes(table_name, new_name)
         end

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -438,10 +438,10 @@ describe "OracleEnhancedAdapter schema definition" do
       end.should raise_error
     end
 
-    it "should raise error when new sequence name length is too long" do
+    it "should not raise error when new sequence name length is too long" do
       lambda do
         @conn.rename_table("test_employees","a"*27)
-      end.should raise_error
+      end.should_not raise_error
     end
 
     it "should rename table when table has no primary key and sequence" do


### PR DESCRIPTION
This pull request is based on #475 since it requires to change file name to `schema_statements.rb`

It also addresses #547 and #588