### PR TITLE
Suppress `warning: assigned but unused variable`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -50,7 +50,7 @@ module ActiveRecord #:nodoc:
 
       def primary_key_trigger(table_name, stream)
         if @connection.respond_to?(:has_primary_key_trigger?) && @connection.has_primary_key_trigger?(table_name)
-          pk, pk_seq = @connection.pk_and_sequence_for(table_name)
+          pk, _pk_seq = @connection.pk_and_sequence_for(table_name)
           stream.print "  add_primary_key_trigger #{table_name.inspect}"
           stream.print ", primary_key: \"#{pk}\"" if pk != 'id'
           stream.print "\n\n"
@@ -121,7 +121,7 @@ module ActiveRecord #:nodoc:
 
           # first dump primary key column
           if @connection.respond_to?(:pk_and_sequence_for)
-            pk, pk_seq = @connection.pk_and_sequence_for(table)
+            pk, _pk_seq = @connection.pk_and_sequence_for(table)
           elsif @connection.respond_to?(:primary_key)
             pk = @connection.primary_key(table)
           end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -862,7 +862,7 @@ module ActiveRecord
 
       # Will return true if database object exists (to be able to use also views and synonyms for ActiveRecord models)
       def table_exists?(table_name)
-        (owner, table_name, db_link) = @connection.describe(table_name)
+        (_owner, table_name, _db_link) = @connection.describe(table_name)
         true
       rescue
         false


### PR DESCRIPTION
by starting variable name as understore for Ruby 2.0 and above

```ruby
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:865: warning: assigned but unused variable - owner
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:865: warning: assigned but unused variable - db_link
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb:53: warning: assigned but unused variable - pk_seq
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb:124: warning: assigned but unused variable - pk_seq
```

Refer https://bugs.ruby-lang.org/issues/6693 