### PR TITLE
Suppress `warning: assigned but unused variable - tablespace`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -74,7 +74,6 @@ module ActiveRecord
           yield td if block_given?
           create_sequence = create_sequence || td.create_sequence
           column_comments = td.column_comments if td.column_comments
-          tablespace = tablespace_for(:table, options[:tablespace])
 
           if options[:force] && table_exists?(table_name)
             drop_table(table_name, options)


### PR DESCRIPTION
This pull request suppress the warning message below.

```ruby
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:77: warning: assigned but unused variable - tablespace
```