### PR TITLE
Remove `serialized_attributes` which is removed in Rails 5

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
@@ -152,7 +152,7 @@ module ActiveRecord #:nodoc:
           if partial_writes?
             # Serialized attributes should always be written in case they've been
             # changed in place.
-            update_using_custom_method(changed | (attributes.keys & self.class.serialized_attributes.keys))
+            update_using_custom_method(changed | (attributes.keys & self.class.columns.select {|column| column.cast_type.is_a?(Type::Serialized)}))
           else
             update_using_custom_method(attribute_names)
           end


### PR DESCRIPTION
This pull request removes `serialized_attributes` method which has been deprecated in Rails 4.2 and will be removed in Rails 5.