### PR TITLE
Remove activerecord-deprecated_finders

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ group :development do
   gem 'arel',           github: 'rails/arel', branch: '6-0-stable'
   gem 'journey',        github: 'rails/journey'
 
-  gem 'activerecord-deprecated_finders'
   gem 'ruby-plsql', '>=0.5.0'
 
   platforms :ruby do


### PR DESCRIPTION
since it will not be supported in Rails 5