### PR TITLE
Remove RAILS_GEM_VERSION

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -600,7 +600,7 @@ describe "OracleEnhancedAdapter" do
       posts.size.should == @ids.size
     end
 
-  end if ENV['RAILS_GEM_VERSION'] >= '3.1'
+  end
 
   describe "with statement pool" do
     before(:all) do
@@ -654,7 +654,7 @@ describe "OracleEnhancedAdapter" do
         @conn.exec_update("UPDATE test_posts SET id = 1", "SQL", binds)
       }.should_not change(@statements, :length)
     end
-  end if ENV['RAILS_GEM_VERSION'] >= '3.1'
+  end
 
   describe "explain" do
     before(:all) do
@@ -688,7 +688,7 @@ describe "OracleEnhancedAdapter" do
       explain.should include("Cost")
       explain.should include("INDEX UNIQUE SCAN")
     end
-  end if ENV['RAILS_GEM_VERSION'] >= '3.2'
+  end
 
   describe "using offset and limit" do
     before(:all) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,10 +22,7 @@ elsif RUBY_ENGINE == 'jruby'
   puts "==> Running specs with JRuby version #{JRUBY_VERSION}"
 end
 
-ENV['RAILS_GEM_VERSION'] ||= config["rails"]["gem_version"] || 'master'
 NO_COMPOSITE_PRIMARY_KEYS = true
-
-puts "==> Selected Rails version #{ENV['RAILS_GEM_VERSION']}"
 
 require 'active_record'
 


### PR DESCRIPTION
This pull request removes `RAILS_GEM_VERSION` because of these reasons:

* It did not show correct Rails and/or ActiveRecord version tested. Also `Effective ActiveRecord version` shows the correct one.

```ruby
$ rake spec
==> Loading config from ENV or use default
==> Running specs with MRI version 2.2.3
==> Selected Rails version master
==> Effective ActiveRecord version 5.0.0.alpha
```

* All of `end if ENV['RAILS_GEM_VERSION']` statements are not necessary since these versions are 3.2 or older. 
