### PR TITLE
Use RSpec 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'http://rubygems.org'
 
 group :development do
   gem 'jeweler', '~> 2.0'
-  gem 'rspec', '~> 2.4'
+  gem 'rspec', '~> 3.3'
   gem 'rdoc'
 
   gem 'activerecord',   github: 'rails/rails'

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -4,31 +4,31 @@ describe "OracleEnhancedAdapter establish connection" do
 
   it "should connect to database" do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    ActiveRecord::Base.connection.should_not be_nil
-    ActiveRecord::Base.connection.class.should == ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter
+    expect(ActiveRecord::Base.connection).not_to be_nil
+    expect(ActiveRecord::Base.connection.class).to eq(ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter)
   end
 
   it "should connect to database as SYSDBA" do
     ActiveRecord::Base.establish_connection(SYS_CONNECTION_PARAMS)
-    ActiveRecord::Base.connection.should_not be_nil
-    ActiveRecord::Base.connection.class.should == ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter
+    expect(ActiveRecord::Base.connection).not_to be_nil
+    expect(ActiveRecord::Base.connection.class).to eq(ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter)
   end
 
   it "should be active after connection to database" do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    ActiveRecord::Base.connection.should be_active
+    expect(ActiveRecord::Base.connection).to be_active
   end
 
   it "should not be active after disconnection to database" do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
     ActiveRecord::Base.connection.disconnect!
-    ActiveRecord::Base.connection.should_not be_active
+    expect(ActiveRecord::Base.connection).not_to be_active
   end
 
   it "should be active after reconnection to database" do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
     ActiveRecord::Base.connection.reconnect!
-    ActiveRecord::Base.connection.should be_active
+    expect(ActiveRecord::Base.connection).to be_active
   end
   
 end
@@ -83,7 +83,7 @@ describe "OracleEnhancedAdapter" do
       class ::TestEmployee < ActiveRecord::Base
         ignore_table_columns  :phone_number, :hire_date
       end
-      TestEmployee.connection.columns('test_employees').select{|c| ['phone_number','hire_date'].include?(c.name) }.should be_empty
+      expect(TestEmployee.connection.columns('test_employees').select{|c| ['phone_number','hire_date'].include?(c.name) }).to be_empty
     end
 
     it "should ignore specified table columns specified in several lines" do
@@ -91,14 +91,14 @@ describe "OracleEnhancedAdapter" do
         ignore_table_columns  :phone_number
         ignore_table_columns  :hire_date
       end
-      TestEmployee.connection.columns('test_employees').select{|c| ['phone_number','hire_date'].include?(c.name) }.should be_empty
+      expect(TestEmployee.connection.columns('test_employees').select{|c| ['phone_number','hire_date'].include?(c.name) }).to be_empty
     end
 
     it "should not ignore unspecified table columns" do
       class ::TestEmployee < ActiveRecord::Base
         ignore_table_columns  :phone_number, :hire_date
       end
-      TestEmployee.connection.columns('test_employees').select{|c| c.name == 'email' }.should_not be_empty
+      expect(TestEmployee.connection.columns('test_employees').select{|c| c.name == 'email' }).not_to be_empty
     end
 
     it "should ignore specified table columns in other connection" do
@@ -107,7 +107,7 @@ describe "OracleEnhancedAdapter" do
       end
       # establish other connection
       other_conn = ActiveRecord::Base.oracle_enhanced_connection(CONNECTION_PARAMS)
-      other_conn.columns('test_employees').select{|c| ['phone_number','hire_date'].include?(c.name) }.should be_empty
+      expect(other_conn.columns('test_employees').select{|c| ['phone_number','hire_date'].include?(c.name) }).to be_empty
     end
 
   end
@@ -171,39 +171,39 @@ describe "OracleEnhancedAdapter" do
       end
 
       it 'should identify virtual columns as such' do
-        pending "Not supported in this database version" unless @oracle11g_or_higher
+        skip "Not supported in this database version" unless @oracle11g_or_higher
         te = TestEmployee.connection.columns('test_employees').detect(&:virtual?)
-        te.name.should == 'full_name'
+        expect(te.name).to eq('full_name')
       end
 
       it "should get columns from database at first time" do
-        TestEmployee.connection.columns('test_employees').map(&:name).should == @column_names
-        @logger.logged(:debug).last.should =~ /select .* from all_tab_cols/im
+        expect(TestEmployee.connection.columns('test_employees').map(&:name)).to eq(@column_names)
+        expect(@logger.logged(:debug).last).to match(/select .* from all_tab_cols/im)
       end
 
       it "should get columns from database at second time" do
         TestEmployee.connection.columns('test_employees')
         @logger.clear(:debug)
-        TestEmployee.connection.columns('test_employees').map(&:name).should == @column_names
-        @logger.logged(:debug).last.should =~ /select .* from all_tab_cols/im
+        expect(TestEmployee.connection.columns('test_employees').map(&:name)).to eq(@column_names)
+        expect(@logger.logged(:debug).last).to match(/select .* from all_tab_cols/im)
       end
 
       it "should get primary key from database at first time" do
-        TestEmployee.connection.pk_and_sequence_for('test_employees').should == ['id', nil]
-        @logger.logged(:debug).last.should =~ /select .* from all_constraints/im
+        expect(TestEmployee.connection.pk_and_sequence_for('test_employees')).to eq(['id', nil])
+        expect(@logger.logged(:debug).last).to match(/select .* from all_constraints/im)
       end
 
       it "should get primary key from database at first time" do
-        TestEmployee.connection.pk_and_sequence_for('test_employees').should == ['id', nil]
+        expect(TestEmployee.connection.pk_and_sequence_for('test_employees')).to eq(['id', nil])
         @logger.clear(:debug)
-        TestEmployee.connection.pk_and_sequence_for('test_employees').should == ['id', nil]
-        @logger.logged(:debug).last.should =~ /select .* from all_constraints/im
+        expect(TestEmployee.connection.pk_and_sequence_for('test_employees')).to eq(['id', nil])
+        expect(@logger.logged(:debug).last).to match(/select .* from all_constraints/im)
       end
 
       it "should have correct sql types when 2 models are using the same table and AR query cache is enabled" do
         @conn.cache do
-          TestEmployee.columns.map(&:sql_type).should == @column_sql_types
-          TestEmployee2.columns.map(&:sql_type).should == @column_sql_types
+          expect(TestEmployee.columns.map(&:sql_type)).to eq(@column_sql_types)
+          expect(TestEmployee2.columns.map(&:sql_type)).to eq(@column_sql_types)
         end
       end
 
@@ -216,34 +216,34 @@ describe "OracleEnhancedAdapter" do
       end
 
       it "should get columns from database at first time" do
-        TestEmployee.connection.columns('test_employees').map(&:name).should == @column_names
-        @logger.logged(:debug).last.should =~ /select .* from all_tab_cols/im
+        expect(TestEmployee.connection.columns('test_employees').map(&:name)).to eq(@column_names)
+        expect(@logger.logged(:debug).last).to match(/select .* from all_tab_cols/im)
       end
 
       it "should get columns from cache at second time" do
         TestEmployee.connection.columns('test_employees')
         @logger.clear(:debug)
-        TestEmployee.connection.columns('test_employees').map(&:name).should == @column_names
-        @logger.logged(:debug).last.should be_blank
+        expect(TestEmployee.connection.columns('test_employees').map(&:name)).to eq(@column_names)
+        expect(@logger.logged(:debug).last).to be_blank
       end
 
       it "should get primary key from database at first time" do
-        TestEmployee.connection.pk_and_sequence_for('test_employees').should == ['id', nil]
-        @logger.logged(:debug).last.should =~ /select .* from all_constraints/im
+        expect(TestEmployee.connection.pk_and_sequence_for('test_employees')).to eq(['id', nil])
+        expect(@logger.logged(:debug).last).to match(/select .* from all_constraints/im)
       end
 
       it "should get primary key from cache at first time" do
-        TestEmployee.connection.pk_and_sequence_for('test_employees').should == ['id', nil]
+        expect(TestEmployee.connection.pk_and_sequence_for('test_employees')).to eq(['id', nil])
         @logger.clear(:debug)
-        TestEmployee.connection.pk_and_sequence_for('test_employees').should == ['id', nil]
-        @logger.logged(:debug).last.should be_blank
+        expect(TestEmployee.connection.pk_and_sequence_for('test_employees')).to eq(['id', nil])
+        expect(@logger.logged(:debug).last).to be_blank
       end
 
       it "should store primary key as nil in cache at first time for table without primary key" do
-        TestEmployee.connection.pk_and_sequence_for('test_employees_without_pk').should == nil
+        expect(TestEmployee.connection.pk_and_sequence_for('test_employees_without_pk')).to eq(nil)
         @logger.clear(:debug)
-        TestEmployee.connection.pk_and_sequence_for('test_employees_without_pk').should == nil
-        @logger.logged(:debug).last.should be_blank
+        expect(TestEmployee.connection.pk_and_sequence_for('test_employees_without_pk')).to eq(nil)
+        expect(@logger.logged(:debug).last).to be_blank
       end
 
     end
@@ -274,11 +274,11 @@ describe "OracleEnhancedAdapter" do
     end
 
     it "should tell ActiveRecord that count distinct is supported" do
-      ActiveRecord::Base.connection.supports_count_distinct?.should be_true
+      expect(ActiveRecord::Base.connection.supports_count_distinct?).to be_truthy
     end
 
     it "should execute correct SQL COUNT DISTINCT statement" do
-      lambda { TestEmployee.count(:employee_id, :distinct => true) }.should_not raise_error
+      expect { TestEmployee.count(:employee_id, :distinct => true) }.not_to raise_error
     end
 
   end
@@ -316,7 +316,7 @@ describe "OracleEnhancedAdapter" do
 
     it "should create table" do
       [:varchar2, :integer, :comment].each do |attr|
-        TestReservedWord.columns_hash[attr.to_s].name.should == attr.to_s
+        expect(TestReservedWord.columns_hash[attr.to_s].name).to eq(attr.to_s)
       end
     end
 
@@ -329,12 +329,12 @@ describe "OracleEnhancedAdapter" do
       record = TestReservedWord.create!(attrs)
       record.reload
       attrs.each do |k, v|
-        record.send(k).should == v
+        expect(record.send(k)).to eq(v)
       end
     end
 
     it "should remove double quotes in column quoting" do
-      ActiveRecord::Base.connection.quote_column_name('aaa "bbb" ccc').should == '"aaa bbb ccc"'
+      expect(ActiveRecord::Base.connection.quote_column_name('aaa "bbb" ccc')).to eq('"aaa bbb ccc"')
     end
 
   end
@@ -345,56 +345,56 @@ describe "OracleEnhancedAdapter" do
     end
 
     it "should be valid with letters and digits" do
-      @adapter.valid_table_name?("abc_123").should be_true
+      expect(@adapter.valid_table_name?("abc_123")).to be_truthy
     end
 
     it "should be valid with schema name" do
-      @adapter.valid_table_name?("abc_123.def_456").should be_true
+      expect(@adapter.valid_table_name?("abc_123.def_456")).to be_truthy
     end
 
     it "should be valid with $ in name" do
-      @adapter.valid_table_name?("sys.v$session").should be_true
+      expect(@adapter.valid_table_name?("sys.v$session")).to be_truthy
     end
 
     it "should be valid with upcase schema name" do
-      @adapter.valid_table_name?("ABC_123.DEF_456").should be_true
+      expect(@adapter.valid_table_name?("ABC_123.DEF_456")).to be_truthy
     end
 
     it "should be valid with irregular schema name and database links" do
-      @adapter.valid_table_name?('abc$#_123.abc$#_123@abc$#@._123').should be_true
+      expect(@adapter.valid_table_name?('abc$#_123.abc$#_123@abc$#@._123')).to be_truthy
     end
 
     it "should not be valid with two dots in name" do
-      @adapter.valid_table_name?("abc_123.def_456.ghi_789").should be_false
+      expect(@adapter.valid_table_name?("abc_123.def_456.ghi_789")).to be_falsey
     end
 
     it "should not be valid with invalid characters" do
-      @adapter.valid_table_name?("warehouse-things").should be_false
+      expect(@adapter.valid_table_name?("warehouse-things")).to be_falsey
     end
 
     it "should not be valid with for camel-case" do
-      @adapter.valid_table_name?("Abc").should be_false
-      @adapter.valid_table_name?("aBc").should be_false
-      @adapter.valid_table_name?("abC").should be_false
+      expect(@adapter.valid_table_name?("Abc")).to be_falsey
+      expect(@adapter.valid_table_name?("aBc")).to be_falsey
+      expect(@adapter.valid_table_name?("abC")).to be_falsey
     end
     
     it "should not be valid for names > 30 characters" do
-      @adapter.valid_table_name?("a" * 31).should be_false
+      expect(@adapter.valid_table_name?("a" * 31)).to be_falsey
     end
     
     it "should not be valid for schema names > 30 characters" do
-      @adapter.valid_table_name?(("a" * 31) + ".validname").should be_false
+      expect(@adapter.valid_table_name?(("a" * 31) + ".validname")).to be_falsey
     end
     
     it "should not be valid for database links > 128 characters" do
-      @adapter.valid_table_name?("name@" + "a" * 129).should be_false
+      expect(@adapter.valid_table_name?("name@" + "a" * 129)).to be_falsey
     end
     
     it "should not be valid for names that do not begin with alphabetic characters" do
-      @adapter.valid_table_name?("1abc").should be_false
-      @adapter.valid_table_name?("_abc").should be_false
-      @adapter.valid_table_name?("abc.1xyz").should be_false
-      @adapter.valid_table_name?("abc._xyz").should be_false
+      expect(@adapter.valid_table_name?("1abc")).to be_falsey
+      expect(@adapter.valid_table_name?("_abc")).to be_falsey
+      expect(@adapter.valid_table_name?("abc.1xyz")).to be_falsey
+      expect(@adapter.valid_table_name?("abc._xyz")).to be_falsey
     end
   end
 
@@ -444,9 +444,9 @@ describe "OracleEnhancedAdapter" do
       end
 
       wh = WarehouseThing.create!(:name => "Foo", :foo => 2)
-      wh.id.should_not be_nil
+      expect(wh.id).not_to be_nil
 
-      @conn.tables.should include("warehouse-things")
+      expect(@conn.tables).to include("warehouse-things")
     end
 
     it "should allow creation of a table with CamelCase name" do
@@ -456,13 +456,13 @@ describe "OracleEnhancedAdapter" do
       end
 
       cc = CamelCase.create!(:name => "Foo", :foo => 2)
-      cc.id.should_not be_nil
+      expect(cc.id).not_to be_nil
     
-      @conn.tables.should include("CamelCase")
+      expect(@conn.tables).to include("CamelCase")
     end
 
     it "properly quotes database links" do
-      @conn.quote_table_name('asdf@some.link').should eq('"ASDF"@"SOME.LINK"')
+      expect(@conn.quote_table_name('asdf@some.link')).to eq('"ASDF"@"SOME.LINK"')
     end
   end
 
@@ -504,13 +504,13 @@ describe "OracleEnhancedAdapter" do
     end
 
     it "should get column names" do
-      TestPost.column_names.should == ["id", "title", "body", "created_at", "updated_at"]
+      expect(TestPost.column_names).to eq(["id", "title", "body", "created_at", "updated_at"])
     end
 
     it "should create record" do
       p = TestPost.create(:title => "Title", :body => "Body")
-      p.id.should_not be_nil
-      TestPost.find(p.id).should_not be_nil
+      expect(p.id).not_to be_nil
+      expect(TestPost.find(p.id)).not_to be_nil
     end
 
   end
@@ -523,11 +523,11 @@ describe "OracleEnhancedAdapter" do
     it "should get current database name" do
       # get database name if using //host:port/database connection string
       database_name = CONNECTION_PARAMS[:database].split('/').last
-      @conn.current_database.upcase.should == database_name.upcase
+      expect(@conn.current_database.upcase).to eq(database_name.upcase)
     end
 
     it "should get current database session user" do
-      @conn.current_user.upcase.should == CONNECTION_PARAMS[:username].upcase
+      expect(@conn.current_user.upcase).to eq(CONNECTION_PARAMS[:username].upcase)
     end
   end
 
@@ -554,7 +554,7 @@ describe "OracleEnhancedAdapter" do
       @conn.create_table :foos, :temporary => true, :id => false do |t|
         t.integer :id
       end
-      @conn.temporary_table?("foos").should be_true
+      expect(@conn.temporary_table?("foos")).to be_truthy
     end
   end
 
@@ -597,7 +597,7 @@ describe "OracleEnhancedAdapter" do
 
     it "should load included association with more than 1000 records" do
       posts = TestPost.includes(:test_comments).to_a
-      posts.size.should == @ids.size
+      expect(posts.size).to eq(@ids.size)
     end
 
   end
@@ -632,27 +632,27 @@ describe "OracleEnhancedAdapter" do
       sub = @conn.substitute_at(pk, 0).to_sql
       binds = [[pk, 1]]
 
-      lambda {
+      expect {
         4.times do |i|
           @conn.exec_query("SELECT * FROM test_posts WHERE #{i}=#{i} AND id = #{sub}", "SQL", binds)
         end
-      }.should change(@statements, :length).by(+3)
+      }.to change(@statements, :length).by(+3)
     end
 
     it "should cache UPDATE statements with bind variables" do
-      lambda {
+      expect {
         pk = TestPost.columns_hash[TestPost.primary_key]
         sub = @conn.substitute_at(pk, 0).to_sql
         binds = [[pk, 1]]
         @conn.exec_update("UPDATE test_posts SET id = #{sub}", "SQL", binds)
-      }.should change(@statements, :length).by(+1)
+      }.to change(@statements, :length).by(+1)
     end
 
     it "should not cache UPDATE statements without bind variables" do
-      lambda {
+      expect {
         binds = []
         @conn.exec_update("UPDATE test_posts SET id = 1", "SQL", binds)
-      }.should_not change(@statements, :length)
+      }.not_to change(@statements, :length)
     end
   end
 
@@ -677,16 +677,16 @@ describe "OracleEnhancedAdapter" do
 
     it "should explain query" do
       explain = TestPost.where(:id => 1).explain
-      explain.should include("Cost")
-      explain.should include("INDEX UNIQUE SCAN")
+      expect(explain).to include("Cost")
+      expect(explain).to include("INDEX UNIQUE SCAN")
     end
 
     it "should explain query with binds" do
       pk = TestPost.columns_hash[TestPost.primary_key]
       sub = @conn.substitute_at(pk, 0)
       explain = TestPost.where(TestPost.arel_table[pk.name].eq(sub)).bind([pk, 1]).explain
-      explain.should include("Cost")
-      explain.should include("INDEX UNIQUE SCAN")
+      expect(explain).to include("Cost")
+      expect(explain).to include("INDEX UNIQUE SCAN")
     end
   end
 
@@ -731,18 +731,18 @@ describe "OracleEnhancedAdapter" do
     end
 
     it "should return n records with limit(n)" do
-      @employee.limit(3).to_a.size.should be(3)
+      expect(@employee.limit(3).to_a.size).to be(3)
     end
 
     it "should return less than n records with limit(n) if there exist less than n records" do
-      @employee.limit(10).to_a.size.should be(5)
+      expect(@employee.limit(10).to_a.size).to be(5)
     end
 
     it "should return the records starting from offset n with offset(n)" do
-      expect(@employee.order(:sort_order).first.first_name.should).to eq("Peter")
-      expect(@employee.order(:sort_order).offset(0).first.first_name.should).to eq("Peter")
-      expect(@employee.order(:sort_order).offset(1).first.first_name.should).to eq("Tony")
-      expect(@employee.order(:sort_order).offset(4).first.first_name.should).to eq("Natasha")
+      expect(expect(@employee.order(:sort_order).first.first_name).to).to eq("Peter")
+      expect(expect(@employee.order(:sort_order).offset(0).first.first_name).to).to eq("Peter")
+      expect(expect(@employee.order(:sort_order).offset(1).first.first_name).to).to eq("Tony")
+      expect(expect(@employee.order(:sort_order).offset(4).first.first_name).to).to eq("Natasha")
     end
   end
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -739,10 +739,10 @@ describe "OracleEnhancedAdapter" do
     end
 
     it "should return the records starting from offset n with offset(n)" do
-      expect(expect(@employee.order(:sort_order).first.first_name).to).to eq("Peter")
-      expect(expect(@employee.order(:sort_order).offset(0).first.first_name).to).to eq("Peter")
-      expect(expect(@employee.order(:sort_order).offset(1).first.first_name).to).to eq("Tony")
-      expect(expect(@employee.order(:sort_order).offset(4).first.first_name).to).to eq("Natasha")
+      expect(@employee.order(:sort_order).first.first_name).to eq("Peter")
+      expect(@employee.order(:sort_order).offset(0).first.first_name).to eq("Peter")
+      expect(@employee.order(:sort_order).offset(1).first.first_name).to eq("Tony")
+      expect(@employee.order(:sort_order).offset(4).first.first_name).to eq("Natasha")
     end
   end
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
@@ -12,25 +12,25 @@ describe "OracleEnhancedConnection" do
     end
 
     it "should create new connection" do
-      @conn.should be_active
+      expect(@conn).to be_active
     end
 
     it "should ping active connection" do
-      @conn.ping.should be_true
+      expect(@conn.ping).to be_truthy
     end
 
     it "should not ping inactive connection" do
       @conn.logoff
-      lambda { @conn.ping }.should raise_error(ActiveRecord::ConnectionAdapters::OracleEnhancedConnectionException)
+      expect { @conn.ping }.to raise_error(ActiveRecord::ConnectionAdapters::OracleEnhancedConnectionException)
     end
 
     it "should reset active connection" do
       @conn.reset!
-      @conn.should be_active
+      expect(@conn).to be_active
     end
 
     it "should be in autocommit mode after connection" do
-      @conn.should be_autocommit
+      expect(@conn).to be_autocommit
     end
 
   end
@@ -43,20 +43,20 @@ describe "OracleEnhancedConnection" do
     it "should use NLS_DATE_FORMAT environment variable" do
       ENV['NLS_DATE_FORMAT'] = 'YYYY-MM-DD'
       @conn = ActiveRecord::ConnectionAdapters::OracleEnhancedConnection.create(CONNECTION_PARAMS)
-      @conn.select("SELECT value FROM v$nls_parameters WHERE parameter = 'NLS_DATE_FORMAT'").should == [{'value' => 'YYYY-MM-DD'}]
+      expect(@conn.select("SELECT value FROM v$nls_parameters WHERE parameter = 'NLS_DATE_FORMAT'")).to eq([{'value' => 'YYYY-MM-DD'}])
     end
 
     it "should use configuration value and ignore NLS_DATE_FORMAT environment variable" do
       ENV['NLS_DATE_FORMAT'] = 'YYYY-MM-DD'
       @conn = ActiveRecord::ConnectionAdapters::OracleEnhancedConnection.create(CONNECTION_PARAMS.merge(:nls_date_format => 'YYYY-MM-DD HH24:MI'))
-      @conn.select("SELECT value FROM v$nls_parameters WHERE parameter = 'NLS_DATE_FORMAT'").should == [{'value' => 'YYYY-MM-DD HH24:MI'}]
+      expect(@conn.select("SELECT value FROM v$nls_parameters WHERE parameter = 'NLS_DATE_FORMAT'")).to eq([{'value' => 'YYYY-MM-DD HH24:MI'}])
     end
 
     it "should use default value when NLS_DATE_FORMAT environment variable is not set" do
       ENV['NLS_DATE_FORMAT'] = nil
       @conn = ActiveRecord::ConnectionAdapters::OracleEnhancedConnection.create(CONNECTION_PARAMS)
       default = ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter::DEFAULT_NLS_PARAMETERS[:nls_date_format]
-      @conn.select("SELECT value FROM v$nls_parameters WHERE parameter = 'NLS_DATE_FORMAT'").should == [{'value' => default}]
+      expect(@conn.select("SELECT value FROM v$nls_parameters WHERE parameter = 'NLS_DATE_FORMAT'")).to eq([{'value' => default}])
     end
   end
 
@@ -70,7 +70,7 @@ describe "OracleEnhancedConnection" do
     end
 
     it "should create new connection" do
-      @conn.should be_active
+      expect(@conn).to be_active
     end
   end
 
@@ -82,7 +82,7 @@ describe "OracleEnhancedConnection" do
     end
 
     it "should create new connection" do
-      @conn.should be_active
+      expect(@conn).to be_active
     end
   end
 
@@ -97,7 +97,7 @@ describe "OracleEnhancedConnection" do
         params[:host] = nil
         params[:database] = nil
         @conn = ActiveRecord::ConnectionAdapters::OracleEnhancedConnection.create(params)
-        @conn.should be_active
+        expect(@conn).to be_active
       end
 
       it "should create new connection using :url and tnsnames alias" do
@@ -106,14 +106,14 @@ describe "OracleEnhancedConnection" do
         params[:host] = nil
         params[:database] = nil
         @conn = ActiveRecord::ConnectionAdapters::OracleEnhancedConnection.create(params)
-        @conn.should be_active
+        expect(@conn).to be_active
       end
 
       it "should create new connection using just tnsnames alias" do
         params = CONNECTION_PARAMS.dup
         params[:host] = nil
         @conn = ActiveRecord::ConnectionAdapters::OracleEnhancedConnection.create(params)
-        @conn.should be_active
+        expect(@conn).to be_active
       end
 
       it "should create a new connection using JNDI" do
@@ -125,7 +125,7 @@ describe "OracleEnhancedConnection" do
           import 'org.apache.commons.dbcp.PoolableConnectionFactory'
           import 'org.apache.commons.dbcp.DriverManagerConnectionFactory'
         rescue NameError => e
-          return pending e.message
+          return skip e.message
         end
 
         class InitialContextMock
@@ -146,12 +146,12 @@ describe "OracleEnhancedConnection" do
           end
         end
 
-        javax.naming.InitialContext.stub!(:new).and_return(InitialContextMock.new)
+        allow(javax.naming.InitialContext).to receive(:new).and_return(InitialContextMock.new)
 
         params = {}
         params[:jndi] = 'java:comp/env/jdbc/test'
         @conn = ActiveRecord::ConnectionAdapters::OracleEnhancedConnection.create(params)
-        @conn.should be_active
+        expect(@conn).to be_active
       end
 
     end
@@ -161,9 +161,9 @@ describe "OracleEnhancedConnection" do
       params[:url] = "jdbc:oracle:thin:@#{DATABASE_HOST && "//#{DATABASE_HOST}#{DATABASE_PORT && ":#{DATABASE_PORT}"}/"}#{DATABASE_NAME}"
       params[:host] = nil
       params[:database] = nil
-      java.sql.DriverManager.stub!(:getConnection).and_raise('no suitable driver found')
+      allow(java.sql.DriverManager).to receive(:getConnection).and_raise('no suitable driver found')
       @conn = ActiveRecord::ConnectionAdapters::OracleEnhancedConnection.create(params)
-      @conn.should be_active
+      expect(@conn).to be_active
     end
 
   end
@@ -174,15 +174,15 @@ describe "OracleEnhancedConnection" do
     end
 
     it "should execute SQL statement" do
-      @conn.exec("SELECT * FROM dual").should_not be_nil
+      expect(@conn.exec("SELECT * FROM dual")).not_to be_nil
     end
 
     it "should execute SQL select" do
-      @conn.select("SELECT * FROM dual").should == [{'dummy' => 'X'}]
+      expect(@conn.select("SELECT * FROM dual")).to eq([{'dummy' => 'X'}])
     end
 
     it "should execute SQL select and return also columns" do
-      @conn.select("SELECT * FROM dual", nil, true).should == [ [{'dummy' => 'X'}], ['dummy'] ]
+      expect(@conn.select("SELECT * FROM dual", nil, true)).to eq([ [{'dummy' => 'X'}], ['dummy'] ])
     end
 
   end
@@ -196,8 +196,8 @@ describe "OracleEnhancedConnection" do
       cursor = @conn.prepare("SELECT * FROM dual WHERE :1 = 1")
       cursor.bind_param(1, 1)
       cursor.exec
-      cursor.get_col_names.should == ['DUMMY']
-      cursor.fetch.should == ["X"]
+      expect(cursor.get_col_names).to eq(['DUMMY'])
+      expect(cursor.fetch).to eq(["X"])
       cursor.close
     end
 
@@ -205,10 +205,10 @@ describe "OracleEnhancedConnection" do
       cursor = @conn.prepare("SELECT * FROM dual WHERE :1 = 1")
       cursor.bind_param(1, 1)
       cursor.exec
-      cursor.fetch.should == ["X"]
+      expect(cursor.fetch).to eq(["X"])
       cursor.bind_param(1, 0)
       cursor.exec
-      cursor.fetch.should be_nil
+      expect(cursor.fetch).to be_nil
       cursor.close
     end
   end
@@ -228,13 +228,13 @@ describe "OracleEnhancedConnection" do
     it "should execute prepared statement with decimal bind parameter " do
       cursor = @conn.prepare("INSERT INTO test_employees VALUES(:1)")
       column = ActiveRecord::ConnectionAdapters::OracleEnhancedColumn.new('age', nil, ActiveRecord::Type::Decimal.new, 'NUMBER(10,2)')
-      column.type.should == :decimal
+      expect(column.type).to eq(:decimal)
       cursor.bind_param(1, "1.5", column)
       cursor.exec
       cursor.close
       cursor = @conn.prepare("SELECT age FROM test_employees")
       cursor.exec
-      cursor.fetch.should == [1.5]
+      expect(cursor.fetch).to eq([1.5])
       cursor.close
     end
   end
@@ -262,28 +262,28 @@ describe "OracleEnhancedConnection" do
       # @conn.auto_retry = true
       ActiveRecord::Base.connection.auto_retry = true
       kill_current_session
-      @conn.exec("SELECT * FROM dual").should_not be_nil
+      expect(@conn.exec("SELECT * FROM dual")).not_to be_nil
     end
 
     it "should not reconnect and execute SQL statement if connection is lost and auto retry is disabled" do
       # @conn.auto_retry = false
       ActiveRecord::Base.connection.auto_retry = false
       kill_current_session
-      lambda { @conn.exec("SELECT * FROM dual") }.should raise_error
+      expect { @conn.exec("SELECT * FROM dual") }.to raise_error
     end
 
     it "should reconnect and execute SQL select if connection is lost and auto retry is enabled" do
       # @conn.auto_retry = true
       ActiveRecord::Base.connection.auto_retry = true
       kill_current_session
-      @conn.select("SELECT * FROM dual").should == [{'dummy' => 'X'}]
+      expect(@conn.select("SELECT * FROM dual")).to eq([{'dummy' => 'X'}])
     end
 
     it "should not reconnect and execute SQL select if connection is lost and auto retry is disabled" do
       # @conn.auto_retry = false
       ActiveRecord::Base.connection.auto_retry = false
       kill_current_session
-      lambda { @conn.select("SELECT * FROM dual") }.should raise_error
+      expect { @conn.select("SELECT * FROM dual") }.to raise_error
     end
 
   end
@@ -296,45 +296,45 @@ describe "OracleEnhancedConnection" do
 
     it "should describe existing table" do
       @conn.exec "CREATE TABLE test_employees (first_name VARCHAR2(20))" rescue nil
-      @conn.describe("test_employees").should == [@owner, "TEST_EMPLOYEES"]
+      expect(@conn.describe("test_employees")).to eq([@owner, "TEST_EMPLOYEES"])
       @conn.exec "DROP TABLE test_employees" rescue nil
     end
 
     it "should not describe non-existing table" do
-      lambda { @conn.describe("test_xxx") }.should raise_error(ActiveRecord::ConnectionAdapters::OracleEnhancedConnectionException)
+      expect { @conn.describe("test_xxx") }.to raise_error(ActiveRecord::ConnectionAdapters::OracleEnhancedConnectionException)
     end
 
     it "should describe table in other schema" do
-      @conn.describe("sys.dual").should == ["SYS", "DUAL"]
+      expect(@conn.describe("sys.dual")).to eq(["SYS", "DUAL"])
     end
 
     it "should describe existing view" do
       @conn.exec "CREATE TABLE test_employees (first_name VARCHAR2(20))" rescue nil
       @conn.exec "CREATE VIEW test_employees_v AS SELECT * FROM test_employees" rescue nil
-      @conn.describe("test_employees_v").should == [@owner, "TEST_EMPLOYEES_V"]
+      expect(@conn.describe("test_employees_v")).to eq([@owner, "TEST_EMPLOYEES_V"])
       @conn.exec "DROP VIEW test_employees_v" rescue nil
       @conn.exec "DROP TABLE test_employees" rescue nil
     end
 
     it "should describe view in other schema" do
-      @conn.describe("sys.v_$version").should == ["SYS", "V_$VERSION"]
+      expect(@conn.describe("sys.v_$version")).to eq(["SYS", "V_$VERSION"])
     end
 
     it "should describe existing private synonym" do
       @conn.exec "CREATE SYNONYM test_dual FOR sys.dual" rescue nil
-      @conn.describe("test_dual").should == ["SYS", "DUAL"]
+      expect(@conn.describe("test_dual")).to eq(["SYS", "DUAL"])
       @conn.exec "DROP SYNONYM test_dual" rescue nil
     end
 
     it "should describe existing public synonym" do
-      @conn.describe("all_tables").should == ["SYS", "ALL_TABLES"]
+      expect(@conn.describe("all_tables")).to eq(["SYS", "ALL_TABLES"])
     end
 
     if defined?(OCI8)
       context "OCI8 adapter" do
 
         it "should not fallback to SELECT-based logic when querying non-existant table information" do
-          @conn.should_not_receive(:select_one)
+          expect(@conn).not_to receive(:select_one)
           @conn.describe("non_existant") rescue ActiveRecord::ConnectionAdapters::OracleEnhancedConnectionException
         end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
@@ -88,7 +88,7 @@ describe "OracleEnhancedAdapter context index" do
     it "should create single VARCHAR2 column index" do
       @conn.add_context_index :posts, :title
       @title_words.each do |word|
-        Post.contains(:title, word).to_a.should == [@post2, @post1]
+        expect(Post.contains(:title, word).to_a).to eq([@post2, @post1])
       end
       @conn.remove_context_index :posts, :title
     end
@@ -96,28 +96,28 @@ describe "OracleEnhancedAdapter context index" do
     it "should create single CLOB column index" do
       @conn.add_context_index :posts, :body
       @body_words.each do |word|
-        Post.contains(:body, word).to_a.should == [@post2, @post1]
+        expect(Post.contains(:body, word).to_a).to eq([@post2, @post1])
       end
       @conn.remove_context_index :posts, :body
     end
 
     it "should not include text index secondary tables in user tables list" do
       @conn.add_context_index :posts, :title
-      @conn.tables.any?{|t| t =~ /^dr\$/i}.should be_false
+      expect(@conn.tables.any?{|t| t =~ /^dr\$/i}).to be_falsey
       @conn.remove_context_index :posts, :title
     end
 
     it "should create multiple column index" do
       @conn.add_context_index :posts, [:title, :body]
       (@title_words+@body_words).each do |word|
-        Post.contains(:title, word).to_a.should == [@post2, @post1]
+        expect(Post.contains(:title, word).to_a).to eq([@post2, @post1])
       end
       @conn.remove_context_index :posts, [:title, :body]
     end
 
     it "should index records with null values" do
       @conn.add_context_index :posts, [:title, :body]
-      Post.contains(:title, "withnull").to_a.should == [@post_with_null_body, @post_with_null_title]
+      expect(Post.contains(:title, "withnull").to_a).to eq([@post_with_null_body, @post_with_null_title])
       @conn.remove_context_index :posts, [:title, :body]
     end
 
@@ -125,14 +125,14 @@ describe "OracleEnhancedAdapter context index" do
       @conn.add_context_index :posts, [:title, :body],
         index_column: :all_text, sync: 'ON COMMIT'
       @post = Post.create(title: "abc", body: "def")
-      Post.contains(:all_text, "abc").to_a.should == [@post]
-      Post.contains(:all_text, "def").to_a.should == [@post]
+      expect(Post.contains(:all_text, "abc").to_a).to eq([@post])
+      expect(Post.contains(:all_text, "def").to_a).to eq([@post])
       @post.update_attributes!(title: "ghi")
       # index will not be updated as all_text column is not changed
-      Post.contains(:all_text, "ghi").to_a.should be_empty
+      expect(Post.contains(:all_text, "ghi").to_a).to be_empty
       @post.update_attributes!(all_text: "1")
       # index will be updated when all_text column is changed
-      Post.contains(:all_text, "ghi").to_a.should == [@post]
+      expect(Post.contains(:all_text, "ghi").to_a).to eq([@post])
       @conn.remove_context_index :posts, index_column: :all_text
     end
 
@@ -141,11 +141,11 @@ describe "OracleEnhancedAdapter context index" do
         index_column: :all_text, index_column_trigger_on: [:created_at, :updated_at],
         sync: 'ON COMMIT'
       @post = Post.create(title: "abc", body: "def")
-      Post.contains(:all_text, "abc").to_a.should == [@post]
-      Post.contains(:all_text, "def").to_a.should == [@post]
+      expect(Post.contains(:all_text, "abc").to_a).to eq([@post])
+      expect(Post.contains(:all_text, "def").to_a).to eq([@post])
       @post.update_attributes!(title: "ghi")
       # index should be updated as created_at column is changed
-      Post.contains(:all_text, "ghi").to_a.should == [@post]
+      expect(Post.contains(:all_text, "ghi").to_a).to eq([@post])
       @conn.remove_context_index :posts, index_column: :all_text
     end
 
@@ -153,9 +153,9 @@ describe "OracleEnhancedAdapter context index" do
       @post = Post.create!(title: "āčē", body: "dummy")
       @conn.add_context_index :posts, :title,
         lexer: { type: "BASIC_LEXER", base_letter_type: 'GENERIC', base_letter: true }
-      Post.contains(:title, "āčē").to_a.should == [@post]
-      Post.contains(:title, "ace").to_a.should == [@post]
-      Post.contains(:title, "ACE").to_a.should == [@post]
+      expect(Post.contains(:title, "āčē").to_a).to eq([@post])
+      expect(Post.contains(:title, "ace").to_a).to eq([@post])
+      expect(Post.contains(:title, "ACE").to_a).to eq([@post])
       @conn.remove_context_index :posts, :title
     end
 
@@ -163,9 +163,9 @@ describe "OracleEnhancedAdapter context index" do
       @conn.add_context_index :posts, :title, transactional: true
       Post.transaction do
         @post = Post.create(title: "abc")
-        Post.contains(:title, "abc").to_a.should == [@post]
+        expect(Post.contains(:title, "abc").to_a).to eq([@post])
         @post.update_attributes!(title: "ghi")
-        Post.contains(:title, "ghi").to_a.should == [@post]
+        expect(Post.contains(:title, "ghi").to_a).to eq([@post])
       end
       @conn.remove_context_index :posts, :title
     end
@@ -210,7 +210,7 @@ describe "OracleEnhancedAdapter context index" do
       @post.comments.create!(author: "ccc", body: "ddd")
       @post.comments.create!(author: "eee", body: "fff")
       ["aaa", "bbb", "ccc", "ddd", "eee", "fff"].each do |word|
-        Post.contains(:all_text, word).to_a.should == [@post]
+        expect(Post.contains(:all_text, word).to_a).to eq([@post])
       end
     end
 
@@ -231,7 +231,7 @@ describe "OracleEnhancedAdapter context index" do
       @post.comments.create!(author: "ccc", body: "ddd")
       @post.comments.create!(author: "eee", body: "fff")
       ["aaa", "bbb", "ccc", "ddd", "eee", "fff"].each do |word|
-        Post.contains(:all_text, word).to_a.should == [@post]
+        expect(Post.contains(:all_text, word).to_a).to eq([@post])
       end
     end
 
@@ -244,14 +244,14 @@ describe "OracleEnhancedAdapter context index" do
         "SELECT comments.author AS comment_author, comments.body AS comment_body FROM comments WHERE comments.post_id = :id"
         ],
         index_column: :all_text
-      Post.contains(:all_text, "aaa within title").to_a.should == [@post]
-      Post.contains(:all_text, "aaa within body").to_a.should be_empty
-      Post.contains(:all_text, "bbb within body").to_a.should == [@post]
-      Post.contains(:all_text, "bbb within title").to_a.should be_empty
-      Post.contains(:all_text, "ccc within comment_author").to_a.should == [@post]
-      Post.contains(:all_text, "ccc within comment_body").to_a.should be_empty
-      Post.contains(:all_text, "ddd within comment_body").to_a.should == [@post]
-      Post.contains(:all_text, "ddd within comment_author").to_a.should be_empty
+      expect(Post.contains(:all_text, "aaa within title").to_a).to eq([@post])
+      expect(Post.contains(:all_text, "aaa within body").to_a).to be_empty
+      expect(Post.contains(:all_text, "bbb within body").to_a).to eq([@post])
+      expect(Post.contains(:all_text, "bbb within title").to_a).to be_empty
+      expect(Post.contains(:all_text, "ccc within comment_author").to_a).to eq([@post])
+      expect(Post.contains(:all_text, "ccc within comment_body").to_a).to be_empty
+      expect(Post.contains(:all_text, "ddd within comment_body").to_a).to eq([@post])
+      expect(Post.contains(:all_text, "ddd within comment_author").to_a).to be_empty
     end
 
   end
@@ -281,22 +281,22 @@ describe "OracleEnhancedAdapter context index" do
 
     def verify_logged_statements
       ['K_TABLE_CLAUSE', 'R_TABLE_CLAUSE', 'N_TABLE_CLAUSE', 'I_INDEX_CLAUSE', 'P_TABLE_CLAUSE'].each do |clause|
-        @logger.output(:debug).should =~ /CTX_DDL\.SET_ATTRIBUTE\('index_posts_on_title_sto', '#{clause}', '.*TABLESPACE #{@tablespace}'\)/
+        expect(@logger.output(:debug)).to match(/CTX_DDL\.SET_ATTRIBUTE\('index_posts_on_title_sto', '#{clause}', '.*TABLESPACE #{@tablespace}'\)/)
       end
-      @logger.output(:debug).should =~ /CREATE INDEX .* PARAMETERS \('STORAGE index_posts_on_title_sto'\)/
+      expect(@logger.output(:debug)).to match(/CREATE INDEX .* PARAMETERS \('STORAGE index_posts_on_title_sto'\)/)
     end
 
     it "should create index on single column" do
       @conn.add_context_index :posts, :title, tablespace: @tablespace
       verify_logged_statements
-      Post.contains(:title, 'aaa').to_a.should == [@post]
+      expect(Post.contains(:title, 'aaa').to_a).to eq([@post])
       @conn.remove_context_index :posts, :title
     end
 
     it "should create index on multiple columns" do
       @conn.add_context_index :posts, [:title, :body], name: 'index_posts_text', tablespace: @conn.default_tablespace
       verify_logged_statements
-      Post.contains(:title, 'aaa AND bbb').to_a.should == [@post]
+      expect(Post.contains(:title, 'aaa AND bbb').to_a).to eq([@post])
       @conn.remove_context_index :posts, name: 'index_posts_text'
     end
 
@@ -324,13 +324,13 @@ describe "OracleEnhancedAdapter context index" do
 
       it "should dump definition of single column index" do
         @conn.add_context_index :posts, :title
-        standard_dump.should =~ /add_context_index "posts", \["title"\], name: \"index_posts_on_title\"$/
+        expect(standard_dump).to match(/add_context_index "posts", \["title"\], name: \"index_posts_on_title\"$/)
         @conn.remove_context_index :posts, :title
       end
 
       it "should dump definition of multiple column index" do
         @conn.add_context_index :posts, [:title, :body]
-        standard_dump.should =~ /add_context_index "posts", \[:title, :body\]$/
+        expect(standard_dump).to match(/add_context_index "posts", \[:title, :body\]$/)
         @conn.remove_context_index :posts, [:title, :body]
       end
 
@@ -343,7 +343,7 @@ describe "OracleEnhancedAdapter context index" do
         }
         sub_query = "SELECT comments.author AS comment_author, comments.body AS comment_body FROM comments WHERE comments.post_id = :id"
         @conn.add_context_index :posts, [:title, :body, sub_query], options
-        standard_dump.should =~ /add_context_index "posts", \[:title, :body, "#{sub_query}"\], #{options.inspect[1..-2]}$/
+        expect(standard_dump).to match(/add_context_index "posts", \[:title, :body, "#{sub_query}"\], #{options.inspect[1..-2]}$/)
         @conn.remove_context_index :posts, name: 'post_and_comments_index'
       end
 
@@ -356,7 +356,7 @@ describe "OracleEnhancedAdapter context index" do
         }
         sub_query = "SELECT comments.author AS comment_author, comments.body AS comment_body FROM comments WHERE comments.post_id = :id#{' AND 1=1' * 500}"
         @conn.add_context_index :posts, [:title, :body, sub_query], options
-        standard_dump.should =~ /add_context_index "posts", \[:title, :body, "#{sub_query}"\], #{options.inspect[1..-2]}$/
+        expect(standard_dump).to match(/add_context_index "posts", \[:title, :body, "#{sub_query}"\], #{options.inspect[1..-2]}$/)
         @conn.remove_context_index :posts, name: 'post_and_comments_index'
       end
 
@@ -369,7 +369,7 @@ describe "OracleEnhancedAdapter context index" do
         }
         sub_query = "SELECT comments.author AS comment_author, comments.body AS comment_body\nFROM comments\nWHERE comments.post_id = :id"
         @conn.add_context_index :posts, [:title, :body, sub_query], options
-        standard_dump.should =~ /add_context_index "posts", \[:title, :body, "#{sub_query.gsub(/\n/, ' ')}"\], #{options.inspect[1..-2]}$/
+        expect(standard_dump).to match(/add_context_index "posts", \[:title, :body, "#{sub_query.gsub(/\n/, ' ')}"\], #{options.inspect[1..-2]}$/)
         @conn.remove_context_index :posts, name: 'post_and_comments_index'
       end
 
@@ -390,13 +390,13 @@ describe "OracleEnhancedAdapter context index" do
 
       it "should dump definition of single column index" do
         schema_define { add_context_index :posts, :title }
-        standard_dump.should =~ /add_context_index "posts", \["title"\], name: "i_xxx_posts_xxx_title"$/
+        expect(standard_dump).to match(/add_context_index "posts", \["title"\], name: "i_xxx_posts_xxx_title"$/)
         schema_define { remove_context_index :posts, :title }
       end
 
       it "should dump definition of multiple column index" do
         schema_define { add_context_index :posts, [:title, :body] }
-        standard_dump.should =~ /add_context_index "posts", \[:title, :body\]$/
+        expect(standard_dump).to match(/add_context_index "posts", \[:title, :body\]$/)
         schema_define { remove_context_index :posts, [:title, :body] }
       end
 
@@ -414,8 +414,8 @@ describe "OracleEnhancedAdapter context index" do
             "SELECT comments.author AS comment_author, comments.body AS comment_body FROM comments WHERE comments.post_id = :id"
             ], options
         end
-        standard_dump.should =~ /add_context_index "posts", \[:title, :body, "SELECT comments.author AS comment_author, comments.body AS comment_body FROM comments WHERE comments.post_id = :id"\], #{
-          options.inspect[1..-2].gsub(/[{}]/){|s| '\\'<<s }}$/
+        expect(standard_dump).to match(/add_context_index "posts", \[:title, :body, "SELECT comments.author AS comment_author, comments.body AS comment_body FROM comments WHERE comments.post_id = :id"\], #{
+          options.inspect[1..-2].gsub(/[{}]/){|s| '\\'<<s }}$/)
         schema_define { remove_context_index :posts, name: 'xxx_post_and_comments_i' }
       end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_cpk_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_cpk_spec.rb
@@ -52,11 +52,11 @@ describe "OracleEnhancedAdapter composite_primary_keys support" do
     end
 
     it "should tell ActiveRecord that count distinct is not supported" do
-      ActiveRecord::Base.connection.supports_count_distinct?.should be_false
+      expect(ActiveRecord::Base.connection.supports_count_distinct?).to be_falsey
     end
 
     it "should execute correct SQL COUNT DISTINCT statement on table with composite primary keys" do
-      lambda { JobHistory.count(:distinct => true) }.should_not raise_error
+      expect { JobHistory.count(:distinct => true) }.not_to raise_error
     end
   end
 
@@ -94,15 +94,15 @@ describe "OracleEnhancedAdapter composite_primary_keys support" do
     end
 
     it "should create new record in table with CPK and LOB" do
-      lambda {
+      expect {
         CpkWriteLobsTest.create(:type_category => 'AAA', :date_value => Date.today, :results => 'DATA '*10)
-      }.should_not raise_error
+      }.not_to raise_error
     end
     
     it "should create new record in table without CPK and with LOB" do
-      lambda {
+      expect {
         NonCpkWriteLobsTest.create(:date_value => Date.today, :results => 'DATA '*10)
-      }.should_not raise_error
+      }.not_to raise_error
     end
   end
   

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -39,49 +39,49 @@ describe "OracleEnhancedAdapter date type detection based on column names" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = false
     columns = @conn.columns('test_employees')
     column = columns.detect{|c| c.name == "hire_date"}
-    column.type.should == :datetime
+    expect(column.type).to eq(:datetime)
   end
 
   it "should set DATE column type as date if column name contains '_date_' and emulate_dates_by_column_name is true" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = true
     columns = @conn.columns('test_employees')
     column = columns.detect{|c| c.name == "hire_date"}
-    column.type.should == :date
+    expect(column.type).to eq(:date)
   end
 
   it "should set DATE column type as datetime if column name does not contain '_date_' and emulate_dates_by_column_name is true" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = true
     columns = @conn.columns('test_employees')
     column = columns.detect{|c| c.name == "created_at"}
-    column.type.should == :datetime
+    expect(column.type).to eq(:datetime)
   end
 
   it "should set DATE column type as datetime if column name contains 'date' as part of other word and emulate_dates_by_column_name is true" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = true
     columns = @conn.columns('test_employees')
     column = columns.detect{|c| c.name == "updated_at"}
-    column.type.should == :datetime
+    expect(column.type).to eq(:datetime)
   end
 
   it "should return Time value from DATE column if emulate_dates_by_column_name is false" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = false
     columns = @conn.columns('test_employees')
     column = columns.detect{|c| c.name == "hire_date"}
-    column.type_cast_from_database(Time.now).class.should == Time
+    expect(column.type_cast_from_database(Time.now).class).to eq(Time)
   end
 
   it "should return Date value from DATE column if column name contains 'date' and emulate_dates_by_column_name is true" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = true
     columns = @conn.columns('test_employees')
     column = columns.detect{|c| c.name == "hire_date"}
-    column.type_cast_from_database(Time.now).class.should == Date
+    expect(column.type_cast_from_database(Time.now).class).to eq(Date)
   end
 
   it "should typecast DateTime value to Date value from DATE column if column name contains 'date' and emulate_dates_by_column_name is true" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = true
     columns = @conn.columns('test_employees')
     column = columns.detect{|c| c.name == "hire_date"}
-    column.type_cast_from_database(DateTime.new(1900,1,1)).class.should == Date
+    expect(column.type_cast_from_database(DateTime.new(1900,1,1)).class).to eq(Date)
   end
 
   describe "/ DATE values from ActiveRecord model" do
@@ -115,25 +115,25 @@ describe "OracleEnhancedAdapter date type detection based on column names" do
     it "should return Time value from DATE column if emulate_dates_by_column_name is false" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = false
       create_test_employee
-      @employee.hire_date.class.should == Time
+      expect(@employee.hire_date.class).to eq(Time)
     end
 
     it "should return Date value from DATE column if column name contains 'date' and emulate_dates_by_column_name is true" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = true
       create_test_employee
-      @employee.hire_date.class.should == Date
+      expect(@employee.hire_date.class).to eq(Date)
     end
 
     it "should return Date value from DATE column with old date value if column name contains 'date' and emulate_dates_by_column_name is true" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = true
       create_test_employee(:today => Date.new(1900,1,1))
-      @employee.hire_date.class.should == Date
+      expect(@employee.hire_date.class).to eq(Date)
     end
 
     it "should return Time value from DATE column if column name does not contain 'date' and emulate_dates_by_column_name is true" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = true
       create_test_employee
-      @employee.created_at.class.should == Time
+      expect(@employee.created_at.class).to eq(Time)
     end
 
     it "should return Date value from DATE column if emulate_dates_by_column_name is false but column is defined as date" do
@@ -142,7 +142,7 @@ describe "OracleEnhancedAdapter date type detection based on column names" do
       end
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = false
       create_test_employee
-      @employee.hire_date.class.should == Date
+      expect(@employee.hire_date.class).to eq(Date)
     end
 
     it "should return Date value from DATE column with old date value if emulate_dates_by_column_name is false but column is defined as date" do
@@ -151,7 +151,7 @@ describe "OracleEnhancedAdapter date type detection based on column names" do
       end
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = false
       create_test_employee(:today => Date.new(1900,1,1))
-      @employee.hire_date.class.should == Date
+      expect(@employee.hire_date.class).to eq(Date)
     end
 
     it "should see set_date_columns values in different connection" do
@@ -161,7 +161,7 @@ describe "OracleEnhancedAdapter date type detection based on column names" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = false
       # establish other connection
       other_conn = ActiveRecord::Base.oracle_enhanced_connection(CONNECTION_PARAMS)
-      other_conn.get_type_for_column('test_employees', 'hire_date').should == :date
+      expect(other_conn.get_type_for_column('test_employees', 'hire_date')).to eq(:date)
     end
 
     it "should return Time value from DATE column if emulate_dates_by_column_name is true but column is defined as datetime" do
@@ -170,20 +170,20 @@ describe "OracleEnhancedAdapter date type detection based on column names" do
       end
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = true
       create_test_employee
-      @employee.hire_date.class.should == Time
+      expect(@employee.hire_date.class).to eq(Time)
       # change to current time with hours, minutes and seconds
       @employee.hire_date = @now
       @employee.save!
       @employee.reload
-      @employee.hire_date.class.should == Time
-      @employee.hire_date.should == @now
+      expect(@employee.hire_date.class).to eq(Time)
+      expect(@employee.hire_date).to eq(@now)
     end
 
     it "should guess Date or Time value if emulate_dates is true" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates = true
       create_test_employee
-      @employee.hire_date.class.should == Date
-      @employee.created_at.class.should == Time
+      expect(@employee.hire_date.class).to eq(Date)
+      expect(@employee.created_at.class).to eq(Time)
     end
 
   end
@@ -228,37 +228,37 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = false
     columns = @conn.columns('test2_employees')
     column = columns.detect{|c| c.name == "job_id"}
-    column.type.should == :decimal
+    expect(column.type).to eq(:decimal)
   end
 
   it "should set NUMBER column type as integer if emulate_integers_by_column_name is true" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = true
     columns = @conn.columns('test2_employees')
     column = columns.detect{|c| c.name == "job_id"}
-    column.type.should == :integer
+    expect(column.type).to eq(:integer)
     column = columns.detect{|c| c.name == "id"}
-    column.type.should == :integer
+    expect(column.type).to eq(:integer)
   end
 
   it "should set NUMBER column type as decimal if column name does not contain 'id' and emulate_integers_by_column_name is true" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = true
     columns = @conn.columns('test2_employees')
     column = columns.detect{|c| c.name == "salary"}
-    column.type.should == :decimal
+    expect(column.type).to eq(:decimal)
   end
 
   it "should return BigDecimal value from NUMBER column if emulate_integers_by_column_name is false" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = false
     columns = @conn.columns('test2_employees')
     column = columns.detect{|c| c.name == "job_id"}
-    column.type_cast_from_database(1.0).class.should == BigDecimal
+    expect(column.type_cast_from_database(1.0).class).to eq(BigDecimal)
   end
 
   it "should return Fixnum value from NUMBER column if column name contains 'id' and emulate_integers_by_column_name is true" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = true
     columns = @conn.columns('test2_employees')
     column = columns.detect{|c| c.name == "job_id"}
-    column.type_cast_from_database(1.0).class.should == Fixnum
+    expect(column.type_cast_from_database(1.0).class).to eq(Fixnum)
   end
 
   describe "/ NUMBER values from ActiveRecord model" do
@@ -288,51 +288,51 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
     it "should return BigDecimal value from NUMBER column if emulate_integers_by_column_name is false" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = false
       create_employee2
-      @employee2.job_id.class.should == BigDecimal
+      expect(@employee2.job_id.class).to eq(BigDecimal)
     end
 
     it "should return Fixnum value from NUMBER column if column name contains 'id' and emulate_integers_by_column_name is true" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = true
       create_employee2
-      @employee2.job_id.class.should == Fixnum
+      expect(@employee2.job_id.class).to eq(Fixnum)
     end
 
     it "should return Fixnum value from NUMBER column with integer value using _before_type_cast method" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = true
       create_employee2
-      @employee2.job_id_before_type_cast.class.should == Fixnum
+      expect(@employee2.job_id_before_type_cast.class).to eq(Fixnum)
     end
 
     it "should return BigDecimal value from NUMBER column if column name does not contain 'id' and emulate_integers_by_column_name is true" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = true
       create_employee2
-      @employee2.salary.class.should == BigDecimal
+      expect(@employee2.salary.class).to eq(BigDecimal)
     end
 
     it "should return Fixnum value from NUMBER column if column specified in set_integer_columns" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = false
       Test2Employee.set_integer_columns :job_id
       create_employee2
-      @employee2.job_id.class.should == Fixnum
+      expect(@employee2.job_id.class).to eq(Fixnum)
     end
 
     it "should return Boolean value from NUMBER(1) column if emulate booleans is used" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans = true
       create_employee2
-      @employee2.is_manager.class.should == TrueClass
+      expect(@employee2.is_manager.class).to eq(TrueClass)
     end
 
     it "should return Fixnum value from NUMBER(1) column if emulate booleans is not used" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans = false
       create_employee2
-      @employee2.is_manager.class.should == Fixnum
+      expect(@employee2.is_manager.class).to eq(Fixnum)
     end
 
     it "should return Fixnum value from NUMBER(1) column if column specified in set_integer_columns" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans = true
       Test2Employee.set_integer_columns :is_manager
       create_employee2
-      @employee2.is_manager.class.should == Fixnum
+      expect(@employee2.is_manager.class).to eq(Fixnum)
     end
 
   end
@@ -381,7 +381,7 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
     columns = @conn.columns('test3_employees')
     %w(has_email has_phone active_flag manager_yn).each do |col|
       column = columns.detect{|c| c.name == col}
-      column.type.should == :string
+      expect(column.type).to eq(:string)
     end
   end
 
@@ -390,7 +390,7 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
     columns = @conn.columns('test3_employees')
     %w(has_email has_phone active_flag manager_yn).each do |col|
       column = columns.detect{|c| c.name == col}
-      column.type.should == :boolean
+      expect(column.type).to eq(:boolean)
     end
   end
 
@@ -399,7 +399,7 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
     columns = @conn.columns('test3_employees')
     %w(phone_number email).each do |col|
       column = columns.detect{|c| c.name == col}
-      column.type.should == :string
+      expect(column.type).to eq(:string)
     end
   end
 
@@ -408,7 +408,7 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
     columns = @conn.columns('test3_employees')
     %w(has_email has_phone active_flag manager_yn).each do |col|
       column = columns.detect{|c| c.name == col}
-      column.type_cast_from_database("Y").class.should == String
+      expect(column.type_cast_from_database("Y").class).to eq(String)
     end
   end
 
@@ -417,28 +417,28 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
     columns = @conn.columns('test3_employees')
     %w(has_email has_phone active_flag manager_yn).each do |col|
       column = columns.detect{|c| c.name == col}
-      column.type_cast_from_database("Y").class.should == TrueClass
-      column.type_cast_from_database("N").class.should == FalseClass
+      expect(column.type_cast_from_database("Y").class).to eq(TrueClass)
+      expect(column.type_cast_from_database("N").class).to eq(FalseClass)
     end
   end
 
   it "should translate boolean type to VARCHAR2(1) if emulate_booleans_from_strings is true" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = true
-    ActiveRecord::Base.connection.type_to_sql(
-      :boolean, nil, nil, nil).should == "VARCHAR2(1)"
+    expect(ActiveRecord::Base.connection.type_to_sql(
+      :boolean, nil, nil, nil)).to eq("VARCHAR2(1)")
   end
 
   it "should translate boolean type to NUMBER(1) if emulate_booleans_from_strings is false" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = false
-    ActiveRecord::Base.connection.type_to_sql(
-      :boolean, nil, nil, nil).should == "NUMBER(1)"
+    expect(ActiveRecord::Base.connection.type_to_sql(
+      :boolean, nil, nil, nil)).to eq("NUMBER(1)")
   end
 
   it "should get default value from VARCHAR2 boolean column if emulate_booleans_from_strings is true" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = true
     columns = @conn.columns('test3_employees')
-    columns.detect{|c| c.name == 'has_phone'}.default.should be_true
-    columns.detect{|c| c.name == 'manager_yn'}.default.should be_false
+    expect(columns.detect{|c| c.name == 'has_phone'}.default).to be_truthy
+    expect(columns.detect{|c| c.name == 'manager_yn'}.default).to be_falsey
   end
 
   describe "/ VARCHAR2 boolean values from ActiveRecord model" do
@@ -472,7 +472,7 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = false
       create_employee3
       %w(has_email has_phone active_flag manager_yn).each do |col|
-        @employee3.send(col.to_sym).class.should == String
+        expect(@employee3.send(col.to_sym).class).to eq(String)
       end
     end
 
@@ -480,43 +480,43 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = true
       create_employee3
       %w(has_email active_flag).each do |col|
-        @employee3.send(col.to_sym).class.should == TrueClass
-        @employee3.send((col+"_before_type_cast").to_sym).should == "Y"
+        expect(@employee3.send(col.to_sym).class).to eq(TrueClass)
+        expect(@employee3.send((col+"_before_type_cast").to_sym)).to eq("Y")
       end
       %w(has_phone manager_yn).each do |col|
-        @employee3.send(col.to_sym).class.should == FalseClass
-        @employee3.send((col+"_before_type_cast").to_sym).should == "N"
+        expect(@employee3.send(col.to_sym).class).to eq(FalseClass)
+        expect(@employee3.send((col+"_before_type_cast").to_sym)).to eq("N")
       end
     end
 
     it "should return string value from VARCHAR2 column if it is not boolean column and emulate_booleans_from_strings is true" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = true
       create_employee3
-      @employee3.first_name.class.should == String
+      expect(@employee3.first_name.class).to eq(String)
     end
 
     it "should return boolean value from VARCHAR2 boolean column if column specified in set_boolean_columns" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = true
       Test3Employee.set_boolean_columns :test_boolean
       create_employee3(:test_boolean => true)
-      @employee3.test_boolean.class.should == TrueClass
-      @employee3.test_boolean_before_type_cast.should == "Y"
+      expect(@employee3.test_boolean.class).to eq(TrueClass)
+      expect(@employee3.test_boolean_before_type_cast).to eq("Y")
       create_employee3(:test_boolean => false)
-      @employee3.test_boolean.class.should == FalseClass
-      @employee3.test_boolean_before_type_cast.should == "N"
+      expect(@employee3.test_boolean.class).to eq(FalseClass)
+      expect(@employee3.test_boolean_before_type_cast).to eq("N")
       create_employee3(:test_boolean => nil)
-      @employee3.test_boolean.class.should == NilClass
-      @employee3.test_boolean_before_type_cast.should == nil
+      expect(@employee3.test_boolean.class).to eq(NilClass)
+      expect(@employee3.test_boolean_before_type_cast).to eq(nil)
       create_employee3(:test_boolean => "")
-      @employee3.test_boolean.class.should == NilClass
-      @employee3.test_boolean_before_type_cast.should == nil
+      expect(@employee3.test_boolean.class).to eq(NilClass)
+      expect(@employee3.test_boolean_before_type_cast).to eq(nil)
     end
 
     it "should return string value from VARCHAR2 column with boolean column name but is specified in set_string_columns" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = true
       Test3Employee.set_string_columns :active_flag
       create_employee3
-      @employee3.active_flag.class.should == String
+      expect(@employee3.active_flag.class).to eq(String)
     end
 
   end
@@ -559,7 +559,7 @@ describe "OracleEnhancedAdapter timestamp with timezone support" do
   it "should set TIMESTAMP columns type as datetime" do
     columns = @conn.columns('test_employees')
     ts_columns = columns.select{|c| c.name =~ /created_at/}
-    ts_columns.each {|c| c.type.should == :timestamp}
+    ts_columns.each {|c| expect(c.type).to eq(:timestamp)}
   end
 
   describe "/ TIMESTAMP WITH TIME ZONE values from ActiveRecord model" do
@@ -583,8 +583,8 @@ describe "OracleEnhancedAdapter timestamp with timezone support" do
       )
       @employee.reload
       [:created_at, :created_at_tz, :created_at_ltz].each do |c|
-        @employee.send(c).class.should == Time
-        @employee.send(c).to_f.should == @now.to_f
+        expect(@employee.send(c).class).to eq(Time)
+        expect(@employee.send(c).to_f).to eq(@now.to_f)
       end
     end
 
@@ -597,8 +597,8 @@ describe "OracleEnhancedAdapter timestamp with timezone support" do
       )
       @employee.reload
       [:created_at, :created_at_tz, :created_at_ltz].each do |c|
-        @employee.send(c).class.should == Time
-        @employee.send(c).to_f.should == @now.to_f
+        expect(@employee.send(c).class).to eq(Time)
+        expect(@employee.send(c).to_f).to eq(@now.to_f)
       end
     end
 
@@ -672,43 +672,43 @@ describe "OracleEnhancedAdapter date and timestamp with different NLS date forma
   it "should return Time value from DATE column if emulate_dates_by_column_name is false" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = false
     create_test_employee
-    @employee.hire_date.class.should == Time
-    @employee.hire_date.should == @today.to_time
+    expect(@employee.hire_date.class).to eq(Time)
+    expect(@employee.hire_date).to eq(@today.to_time)
   end
 
   it "should return Date value from DATE column if column name contains 'date' and emulate_dates_by_column_name is true" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = true
     create_test_employee
-    @employee.hire_date.class.should == Date
-    @employee.hire_date.should == @today
+    expect(@employee.hire_date.class).to eq(Date)
+    expect(@employee.hire_date).to eq(@today)
   end
 
   it "should return Time value from DATE column if column name does not contain 'date' and emulate_dates_by_column_name is true" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = true
     create_test_employee
-    @employee.created_at.class.should == Time
-    @employee.created_at.should == @now
+    expect(@employee.created_at.class).to eq(Time)
+    expect(@employee.created_at).to eq(@now)
   end
 
   it "should return Time value from TIMESTAMP columns" do
     create_test_employee
-    @employee.created_at_ts.class.should == Time
-    @employee.created_at_ts.should == @now
+    expect(@employee.created_at_ts.class).to eq(Time)
+    expect(@employee.created_at_ts).to eq(@now)
   end
 
   it "should quote Date values with TO_DATE" do
-    @conn.quote(@today).should == "TO_DATE('#{@today.year}-#{"%02d" % @today.month}-#{"%02d" % @today.day}','YYYY-MM-DD HH24:MI:SS')"
+    expect(@conn.quote(@today)).to eq("TO_DATE('#{@today.year}-#{"%02d" % @today.month}-#{"%02d" % @today.day}','YYYY-MM-DD HH24:MI:SS')")
   end
 
   it "should quote Time values with TO_DATE" do
-    @conn.quote(@now).should == "TO_DATE('#{@now.year}-#{"%02d" % @now.month}-#{"%02d" % @now.day} "+
-                                "#{"%02d" % @now.hour}:#{"%02d" % @now.min}:#{"%02d" % @now.sec}','YYYY-MM-DD HH24:MI:SS')"
+    expect(@conn.quote(@now)).to eq("TO_DATE('#{@now.year}-#{"%02d" % @now.month}-#{"%02d" % @now.day} "+
+                                "#{"%02d" % @now.hour}:#{"%02d" % @now.min}:#{"%02d" % @now.sec}','YYYY-MM-DD HH24:MI:SS')")
   end
 
   it "should quote Time values with TO_TIMESTAMP" do
     @ts = @now + 0.1
-    @conn.quote(@ts).should == "TO_TIMESTAMP('#{@ts.year}-#{"%02d" % @ts.month}-#{"%02d" % @ts.day} "+
-                                "#{"%02d" % @ts.hour}:#{"%02d" % @ts.min}:#{"%02d" % @ts.sec}:100000','YYYY-MM-DD HH24:MI:SS:FF6')"
+    expect(@conn.quote(@ts)).to eq("TO_TIMESTAMP('#{@ts.year}-#{"%02d" % @ts.month}-#{"%02d" % @ts.day} "+
+                                "#{"%02d" % @ts.hour}:#{"%02d" % @ts.min}:#{"%02d" % @ts.sec}:100000','YYYY-MM-DD HH24:MI:SS:FF6')")
   end
 
 end
@@ -764,9 +764,9 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
       :last_name => "Last",
       :hire_date => @today_iso
     )
-    @employee.hire_date.should == @today
+    expect(@employee.hire_date).to eq(@today)
     @employee.reload
-    @employee.hire_date.should == @today
+    expect(@employee.hire_date).to eq(@today)
   end
 
   it "should assign NLS string to date column" do
@@ -776,9 +776,9 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
       :last_name => "Last",
       :hire_date => @today_nls
     )
-    @employee.hire_date.should == @today
+    expect(@employee.hire_date).to eq(@today)
     @employee.reload
-    @employee.hire_date.should == @today
+    expect(@employee.hire_date).to eq(@today)
   end
 
   it "should assign ISO time string to date column" do
@@ -787,9 +787,9 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
       :last_name => "Last",
       :hire_date => @now_iso
     )
-    @employee.hire_date.should == @today
+    expect(@employee.hire_date).to eq(@today)
     @employee.reload
-    @employee.hire_date.should == @today
+    expect(@employee.hire_date).to eq(@today)
   end
 
   it "should assign NLS time string to date column" do
@@ -800,9 +800,9 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
       :last_name => "Last",
       :hire_date => @now_nls
     )
-    @employee.hire_date.should == @today
+    expect(@employee.hire_date).to eq(@today)
     @employee.reload
-    @employee.hire_date.should == @today
+    expect(@employee.hire_date).to eq(@today)
   end
 
   it "should assign ISO time string to datetime column" do
@@ -811,9 +811,9 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
       :last_name => "Last",
       :last_login_at => @now_iso
     )
-    @employee.last_login_at.should == @now
+    expect(@employee.last_login_at).to eq(@now)
     @employee.reload
-    @employee.last_login_at.should == @now
+    expect(@employee.last_login_at).to eq(@now)
   end
 
   it "should assign NLS time string to datetime column" do
@@ -823,9 +823,9 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
       :last_name => "Last",
       :last_login_at => @now_nls
     )
-    @employee.last_login_at.should == @now
+    expect(@employee.last_login_at).to eq(@now)
     @employee.reload
-    @employee.last_login_at.should == @now
+    expect(@employee.last_login_at).to eq(@now)
   end
 
   it "should assign NLS time string with time zone to datetime column" do
@@ -835,9 +835,9 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
       :last_name => "Last",
       :last_login_at => @now_nls_with_tz
     )
-    @employee.last_login_at.should == @now_with_tz
+    expect(@employee.last_login_at).to eq(@now_with_tz)
     @employee.reload
-    @employee.last_login_at.should == @now_with_tz
+    expect(@employee.last_login_at).to eq(@now_with_tz)
   end
 
   it "should assign ISO date string to datetime column" do
@@ -846,9 +846,9 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
       :last_name => "Last",
       :last_login_at => @today_iso
     )
-    @employee.last_login_at.should == @today.to_time
+    expect(@employee.last_login_at).to eq(@today.to_time)
     @employee.reload
-    @employee.last_login_at.should == @today.to_time
+    expect(@employee.last_login_at).to eq(@today.to_time)
   end
 
   it "should assign NLS date string to datetime column" do
@@ -859,9 +859,9 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
       :last_name => "Last",
       :last_login_at => @today_nls
     )
-    @employee.last_login_at.should == @today.to_time
+    expect(@employee.last_login_at).to eq(@today.to_time)
     @employee.reload
-    @employee.last_login_at.should == @today.to_time
+    expect(@employee.last_login_at).to eq(@today.to_time)
   end
   
 end
@@ -943,16 +943,16 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
       :first_name => "First",
       :last_name => "Last"
     )
-    @employee.should be_valid
+    expect(@employee).to be_valid
     @employee.reload
-    @employee.comments.should be_nil
+    expect(@employee.comments).to be_nil
   end
 
   it "should accept Symbol value for CLOB column" do
     @employee = TestEmployee.create!(
       :comments => :test_comment
     )
-    @employee.should be_valid
+    expect(@employee).to be_valid
   end
 
   it "should respect attr_readonly setting for CLOB column" do
@@ -960,13 +960,13 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
       :first_name => "First",
       :comments => "initial"
     )
-    @employee.should be_valid
+    expect(@employee).to be_valid
     @employee.reload
-    @employee.comments.should == 'initial'
+    expect(@employee.comments).to eq('initial')
     @employee.comments = "changed"
-    @employee.save.should == true
+    expect(@employee.save).to eq(true)
     @employee.reload
-    @employee.comments.should == 'initial'
+    expect(@employee.comments).to eq('initial')
   end
 
   it "should work for serialized readonly CLOB columns", serialized: true do
@@ -974,16 +974,16 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
       :first_name => "First",
       :comments => nil
     )
-    @employee.comments.should be_nil
-    @employee.save.should == true
-    @employee.should be_valid
+    expect(@employee.comments).to be_nil
+    expect(@employee.save).to eq(true)
+    expect(@employee).to be_valid
     @employee.reload
-    @employee.comments.should be_nil
+    expect(@employee.comments).to be_nil
     @employee.comments = {}
-    @employee.save.should == true
+    expect(@employee.save).to eq(true)
     @employee.reload
     #should not set readonly
-    @employee.comments.should be_nil
+    expect(@employee.comments).to be_nil
   end
 
 
@@ -994,7 +994,7 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
       :comments => @char_data
     )
     @employee.reload
-    @employee.comments.should == @char_data
+    expect(@employee.comments).to eq(@char_data)
   end
 
   it "should update record with CLOB data" do
@@ -1003,11 +1003,11 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
       :last_name => "Last"
     )
     @employee.reload
-    @employee.comments.should be_nil
+    expect(@employee.comments).to be_nil
     @employee.comments = @char_data
     @employee.save!
     @employee.reload
-    @employee.comments.should == @char_data
+    expect(@employee.comments).to eq(@char_data)
   end
 
   it "should update record with zero-length CLOB data" do
@@ -1016,11 +1016,11 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
       :last_name => "Last"
     )
     @employee.reload
-    @employee.comments.should be_nil
+    expect(@employee.comments).to be_nil
     @employee.comments = ''
     @employee.save!
     @employee.reload
-    @employee.comments.should == ''
+    expect(@employee.comments).to eq('')
   end
 
   it "should update record that has existing CLOB data with different CLOB data" do
@@ -1033,7 +1033,7 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
     @employee.comments = @char_data2
     @employee.save!
     @employee.reload
-    @employee.comments.should == @char_data2
+    expect(@employee.comments).to eq(@char_data2)
   end
 
   it "should update record that has existing CLOB data with nil" do
@@ -1046,7 +1046,7 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
     @employee.comments = nil
     @employee.save!
     @employee.reload
-    @employee.comments.should be_nil
+    expect(@employee.comments).to be_nil
   end
 
   it "should update record that has existing CLOB data with zero-length CLOB data" do
@@ -1059,7 +1059,7 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
     @employee.comments = ''
     @employee.save!
     @employee.reload
-    @employee.comments.should == ''
+    expect(@employee.comments).to eq('')
   end
 
   it "should update record that has zero-length CLOB data with non-empty CLOB data" do
@@ -1069,11 +1069,11 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
       :comments => ''
     )
     @employee.reload
-    @employee.comments.should == ''
+    expect(@employee.comments).to eq('')
     @employee.comments = @char_data
     @employee.save!
     @employee.reload
-    @employee.comments.should == @char_data
+    expect(@employee.comments).to eq(@char_data)
   end
 
   it "should store serializable ruby data structures" do
@@ -1083,11 +1083,11 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
       :comments => ruby_data1
     )
     @employee.reload
-    @employee.comments.should == ruby_data1
+    expect(@employee.comments).to eq(ruby_data1)
     @employee.comments = ruby_data2
     @employee.save
     @employee.reload
-    @employee.comments.should == ruby_data2
+    expect(@employee.comments).to eq(ruby_data2)
   end
 
   it "should keep unchanged serialized data when other columns changed" do
@@ -1099,7 +1099,7 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
     @employee.first_name = "Steve"
     @employee.save
     @employee.reload
-    @employee.comments.should == "initial serialized data"
+    expect(@employee.comments).to eq("initial serialized data")
   end
 
   it "should keep serialized data after save" do
@@ -1107,11 +1107,11 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
     @employee.comments = {:length=>{:is=>1}}
     @employee.save
     @employee.reload
-    @employee.comments.should == {:length=>{:is=>1}}
+    expect(@employee.comments).to eq({:length=>{:is=>1}})
     @employee.comments = {:length=>{:is=>2}}
     @employee.save
     @employee.reload
-    @employee.comments.should == {:length=>{:is=>2}}
+    expect(@employee.comments).to eq({:length=>{:is=>2}})
   end
 end
 
@@ -1158,7 +1158,7 @@ describe "OracleEnhancedAdapter handling of BLOB columns" do
       :binary_data => @binary_data
     )
     @employee.reload
-    @employee.binary_data.should == @binary_data
+    expect(@employee.binary_data).to eq(@binary_data)
   end
 
   it "should update record with BLOB data" do
@@ -1167,11 +1167,11 @@ describe "OracleEnhancedAdapter handling of BLOB columns" do
       :last_name => "Last"
     )
     @employee.reload
-    @employee.binary_data.should be_nil
+    expect(@employee.binary_data).to be_nil
     @employee.binary_data = @binary_data
     @employee.save!
     @employee.reload
-    @employee.binary_data.should == @binary_data
+    expect(@employee.binary_data).to eq(@binary_data)
   end
 
   it "should update record with zero-length BLOB data" do
@@ -1180,11 +1180,11 @@ describe "OracleEnhancedAdapter handling of BLOB columns" do
       :last_name => "Last"
     )
     @employee.reload
-    @employee.binary_data.should be_nil
+    expect(@employee.binary_data).to be_nil
     @employee.binary_data = ''
     @employee.save!
     @employee.reload
-    @employee.binary_data.should == ''
+    expect(@employee.binary_data).to eq('')
   end
 
   it "should update record that has existing BLOB data with different BLOB data" do
@@ -1197,7 +1197,7 @@ describe "OracleEnhancedAdapter handling of BLOB columns" do
     @employee.binary_data = @binary_data2
     @employee.save!
     @employee.reload
-    @employee.binary_data.should == @binary_data2
+    expect(@employee.binary_data).to eq(@binary_data2)
   end
 
   it "should update record that has existing BLOB data with nil" do
@@ -1210,7 +1210,7 @@ describe "OracleEnhancedAdapter handling of BLOB columns" do
     @employee.binary_data = nil
     @employee.save!
     @employee.reload
-    @employee.binary_data.should be_nil
+    expect(@employee.binary_data).to be_nil
   end
 
   it "should update record that has existing BLOB data with zero-length BLOB data" do
@@ -1223,7 +1223,7 @@ describe "OracleEnhancedAdapter handling of BLOB columns" do
     @employee.binary_data = ''
     @employee.save!
     @employee.reload
-    @employee.binary_data.should == ''
+    expect(@employee.binary_data).to eq('')
   end
 
   it "should update record that has zero-length BLOB data with non-empty BLOB data" do
@@ -1233,11 +1233,11 @@ describe "OracleEnhancedAdapter handling of BLOB columns" do
       :binary_data => ''
     )
     @employee.reload
-    @employee.binary_data.should == ''
+    expect(@employee.binary_data).to eq('')
     @employee.binary_data = @binary_data
     @employee.save!
     @employee.reload
-    @employee.binary_data.should == @binary_data
+    expect(@employee.binary_data).to eq(@binary_data)
   end
 end
 
@@ -1284,7 +1284,7 @@ describe "OracleEnhancedAdapter handling of RAW columns" do
       :binary_data => @binary_data
     )
     @employee.reload
-    @employee.binary_data.should == @binary_data
+    expect(@employee.binary_data).to eq(@binary_data)
   end
 
   it "should update record with RAW data" do
@@ -1293,11 +1293,11 @@ describe "OracleEnhancedAdapter handling of RAW columns" do
       :last_name => "Last"
     )
     @employee.reload
-    @employee.binary_data.should be_nil
+    expect(@employee.binary_data).to be_nil
     @employee.binary_data = @binary_data
     @employee.save!
     @employee.reload
-    @employee.binary_data.should == @binary_data
+    expect(@employee.binary_data).to eq(@binary_data)
   end
 
   it "should update record with zero-length RAW data" do
@@ -1306,11 +1306,11 @@ describe "OracleEnhancedAdapter handling of RAW columns" do
       :last_name => "Last"
     )
     @employee.reload
-    @employee.binary_data.should be_nil
+    expect(@employee.binary_data).to be_nil
     @employee.binary_data = ''
     @employee.save!
     @employee.reload
-    @employee.binary_data.should.nil?
+    expect(@employee.binary_data).to.nil?
   end
 
   it "should update record that has existing RAW data with different RAW data" do
@@ -1323,7 +1323,7 @@ describe "OracleEnhancedAdapter handling of RAW columns" do
     @employee.binary_data = @binary_data2
     @employee.save!
     @employee.reload
-    @employee.binary_data.should == @binary_data2
+    expect(@employee.binary_data).to eq(@binary_data2)
   end
 
   it "should update record that has existing RAW data with nil" do
@@ -1336,7 +1336,7 @@ describe "OracleEnhancedAdapter handling of RAW columns" do
     @employee.binary_data = nil
     @employee.save!
     @employee.reload
-    @employee.binary_data.should be_nil
+    expect(@employee.binary_data).to be_nil
   end
 
   it "should update record that has existing RAW data with zero-length RAW data" do
@@ -1349,7 +1349,7 @@ describe "OracleEnhancedAdapter handling of RAW columns" do
     @employee.binary_data = ''
     @employee.save!
     @employee.reload
-    @employee.binary_data.should.nil?
+    expect(@employee.binary_data).to.nil?
   end
 
   it "should update record that has zero-length BLOB data with non-empty RAW data" do
@@ -1362,7 +1362,7 @@ describe "OracleEnhancedAdapter handling of RAW columns" do
     @employee.binary_data = @binary_data
     @employee.save!
     @employee.reload
-    @employee.binary_data.should == @binary_data
+    expect(@employee.binary_data).to eq(@binary_data)
   end
 end
 
@@ -1402,8 +1402,8 @@ describe "OracleEnhancedAdapter quoting of NCHAR and NVARCHAR2 columns" do
     columns = @conn.columns('test_items')
     %w(nchar_column nvarchar2_column char_column varchar2_column).each do |col|
       column = columns.detect{|c| c.name == col}
-      column.type.should == :string
-      column.nchar.should == (col[0,1] == 'n' ? true : nil)
+      expect(column.type).to eq(:string)
+      expect(column.nchar).to eq(col[0,1] == 'n' ? true : nil)
     end
   end
 
@@ -1411,8 +1411,8 @@ describe "OracleEnhancedAdapter quoting of NCHAR and NVARCHAR2 columns" do
     columns = @conn.columns('test_items')
     %w(nchar_column nvarchar2_column char_column varchar2_column).each do |col|
       column = columns.detect{|c| c.name == col}
-      @conn.quote('abc', column).should == (column.nchar ? "N'abc'" : "'abc'")
-      @conn.quote(nil, column).should == 'NULL'
+      expect(@conn.quote('abc', column)).to eq(column.nchar ? "N'abc'" : "'abc'")
+      expect(@conn.quote(nil, column)).to eq('NULL')
     end
   end
 
@@ -1422,8 +1422,8 @@ describe "OracleEnhancedAdapter quoting of NCHAR and NVARCHAR2 columns" do
       :nchar_column => nchar_data,
       :nvarchar2_column => nchar_data
     ).reload
-    item.nchar_column.should == nchar_data + ' '*17
-    item.nvarchar2_column.should == nchar_data
+    expect(item.nchar_column).to eq(nchar_data + ' '*17)
+    expect(item.nvarchar2_column).to eq(nchar_data)
   end
 
 end
@@ -1466,6 +1466,6 @@ describe "OracleEnhancedAdapter handling of BINARY_FLOAT columns" do
   it "should set BINARY_FLOAT column type as float" do
     columns = @conn.columns('test2_employees')
     column = columns.detect{|c| c.name == "hourly_rate"}
-    column.type.should == :float
+    expect(column.type).to eq(:float)
   end
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -1310,7 +1310,7 @@ describe "OracleEnhancedAdapter handling of RAW columns" do
     @employee.binary_data = ''
     @employee.save!
     @employee.reload
-    expect(@employee.binary_data).to.nil?
+    expect(@employee.binary_data).to be_nil
   end
 
   it "should update record that has existing RAW data with different RAW data" do
@@ -1349,7 +1349,7 @@ describe "OracleEnhancedAdapter handling of RAW columns" do
     @employee.binary_data = ''
     @employee.save!
     @employee.reload
-    expect(@employee.binary_data).to.nil?
+    expect(@employee.binary_data).to be_nil
   end
 
   it "should update record that has zero-length BLOB data with non-empty RAW data" do

--- a/spec/active_record/connection_adapters/oracle_enhanced_database_tasks_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_database_tasks_spec.rb
@@ -15,7 +15,7 @@ describe "Oracle Enhanced adapter database tasks" do
     end
     it "creates user" do
       query = "SELECT COUNT(*) FROM dba_users WHERE UPPER(username) = '#{new_user_config[:username].upcase}'"
-      ActiveRecord::Base.connection.select_value(query).should == 1
+      expect(ActiveRecord::Base.connection.select_value(query)).to eq(1)
     end
     after do
       ActiveRecord::Base.connection.execute("DROP USER #{new_user_config[:username]}");
@@ -42,15 +42,15 @@ describe "Oracle Enhanced adapter database tasks" do
     describe "drop" do
       before { ActiveRecord::Tasks::DatabaseTasks.drop(config) }
       it "drops all tables" do
-        ActiveRecord::Base.connection.table_exists?(:test_posts).should be_false
+        expect(ActiveRecord::Base.connection.table_exists?(:test_posts)).to be_falsey
       end
     end
 
     describe "purge" do
       before { ActiveRecord::Tasks::DatabaseTasks.purge(config) }
       it "drops all tables" do
-        ActiveRecord::Base.connection.table_exists?(:test_posts).should be_false
-        ActiveRecord::Base.connection.select_value("SELECT COUNT(*) FROM RECYCLEBIN").should == 0
+        expect(ActiveRecord::Base.connection.table_exists?(:test_posts)).to be_falsey
+        expect(ActiveRecord::Base.connection.select_value("SELECT COUNT(*) FROM RECYCLEBIN")).to eq(0)
       end
     end
 
@@ -65,8 +65,8 @@ describe "Oracle Enhanced adapter database tasks" do
         before { ActiveRecord::Tasks::DatabaseTasks.structure_dump(config, temp_file) }
         it "dumps the database structure to a file without the schema information" do
           contents = File.read(temp_file)
-          contents.should include('CREATE TABLE "TEST_POSTS"')
-          contents.should_not include('INSERT INTO schema_migrations')
+          expect(contents).to include('CREATE TABLE "TEST_POSTS"')
+          expect(contents).not_to include('INSERT INTO schema_migrations')
         end
       end
 
@@ -77,7 +77,7 @@ describe "Oracle Enhanced adapter database tasks" do
           ActiveRecord::Tasks::DatabaseTasks.structure_load(config, temp_file)
         end
         it "loads the database structure from a file" do
-          ActiveRecord::Base.connection.table_exists?(:test_posts).should be_true
+          expect(ActiveRecord::Base.connection.table_exists?(:test_posts)).to be_truthy
         end
       end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_dbms_output_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_dbms_output_spec.rb
@@ -42,28 +42,28 @@ describe "OracleEnhancedAdapter logging dbms_output from plsql" do
   it "should NOT log dbms output when dbms output is disabled" do
     @conn.disable_dbms_output
 
-    @conn.select_all("select more_than_five_characters_long('hi there') is_it_long from dual").to_a.should == [{'is_it_long'=>1}]
+    expect(@conn.select_all("select more_than_five_characters_long('hi there') is_it_long from dual").to_a).to eq([{'is_it_long'=>1}])
 
-    @logger.output(:debug).should_not match(/^DBMS_OUTPUT/)
+    expect(@logger.output(:debug)).not_to match(/^DBMS_OUTPUT/)
   end
 
   it "should log dbms output lines to the rails log" do
     @conn.enable_dbms_output
 
-    @conn.select_all("select more_than_five_characters_long('hi there') is_it_long from dual").to_a.should == [{'is_it_long'=>1}]
+    expect(@conn.select_all("select more_than_five_characters_long('hi there') is_it_long from dual").to_a).to eq([{'is_it_long'=>1}])
     
-    @logger.output(:debug).should match(/^DBMS_OUTPUT: before the if -hi there-$/)
-    @logger.output(:debug).should match(/^DBMS_OUTPUT: it is longer than 5$/)
-    @logger.output(:debug).should match(/^DBMS_OUTPUT: about to return: 1$/)
+    expect(@logger.output(:debug)).to match(/^DBMS_OUTPUT: before the if -hi there-$/)
+    expect(@logger.output(:debug)).to match(/^DBMS_OUTPUT: it is longer than 5$/)
+    expect(@logger.output(:debug)).to match(/^DBMS_OUTPUT: about to return: 1$/)
   end
 
   it "should log dbms output lines to the rails log" do
     @conn.enable_dbms_output
 
-    @conn.select_all("select more_than_five_characters_long('short') is_it_long from dual").to_a.should == [{'is_it_long'=>0}]
+    expect(@conn.select_all("select more_than_five_characters_long('short') is_it_long from dual").to_a).to eq([{'is_it_long'=>0}])
     
-    @logger.output(:debug).should match(/^DBMS_OUTPUT: before the if -short-$/)
-    @logger.output(:debug).should match(/^DBMS_OUTPUT: it is 5 or shorter$/)
-    @logger.output(:debug).should match(/^DBMS_OUTPUT: about to return: 0$/)
+    expect(@logger.output(:debug)).to match(/^DBMS_OUTPUT: before the if -short-$/)
+    expect(@logger.output(:debug)).to match(/^DBMS_OUTPUT: it is 5 or shorter$/)
+    expect(@logger.output(:debug)).to match(/^DBMS_OUTPUT: about to return: 0$/)
   end
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
@@ -130,7 +130,7 @@ if ActiveRecord::Base.method_defined?(:changed?)
       class << oci_conn
          def write_lob(lob, value, is_binary = false); raise "don't do this'"; end
       end
-      expect(@employee.save!).not_to raise_exception(RuntimeError, "don't do this'")
+      expect{@employee.save!}.not_to raise_exception(RuntimeError, "don't do this'")
       class << oci_conn
         remove_method :write_lob
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
@@ -38,99 +38,99 @@ if ActiveRecord::Base.method_defined?(:changed?)
     it "should not mark empty string (stored as NULL) as changed when reassigning it" do
       @employee = TestEmployee.create!(:first_name => '')
       @employee.first_name = ''
-      @employee.should_not be_changed
+      expect(@employee).not_to be_changed
       @employee.reload
       @employee.first_name = ''
-      @employee.should_not be_changed
+      expect(@employee).not_to be_changed
     end
 
     it "should not mark empty integer (stored as NULL) as changed when reassigning it" do
       @employee = TestEmployee.create!(:job_id => '')
       @employee.job_id = ''
-      @employee.should_not be_changed
+      expect(@employee).not_to be_changed
       @employee.reload
       @employee.job_id = ''
-      @employee.should_not be_changed
+      expect(@employee).not_to be_changed
     end
 
     it "should not mark empty decimal (stored as NULL) as changed when reassigning it" do
       @employee = TestEmployee.create!(:salary => '')
       @employee.salary = ''
-      @employee.should_not be_changed
+      expect(@employee).not_to be_changed
       @employee.reload
       @employee.salary = ''
-      @employee.should_not be_changed
+      expect(@employee).not_to be_changed
     end
 
     it "should not mark empty text (stored as NULL) as changed when reassigning it" do
       @employee = TestEmployee.create!(:comments => nil)
       @employee.comments = nil
-      @employee.should_not be_changed
+      expect(@employee).not_to be_changed
       @employee.reload
       @employee.comments = nil
-      @employee.should_not be_changed
+      expect(@employee).not_to be_changed
     end
 
     it "should not mark empty text (stored as empty_clob()) as changed when reassigning it" do
       @employee = TestEmployee.create!(:comments => '')
       @employee.comments = ''
-      @employee.should_not be_changed
+      expect(@employee).not_to be_changed
       @employee.reload
       @employee.comments = ''
-      @employee.should_not be_changed
+      expect(@employee).not_to be_changed
     end
 
     it "should mark empty text (stored as empty_clob()) as changed when assigning nil to it" do
       @employee = TestEmployee.create!(:comments => '')
       @employee.comments = nil
-      @employee.should be_changed
+      expect(@employee).to be_changed
       @employee.reload
       @employee.comments = nil
-      @employee.should be_changed
+      expect(@employee).to be_changed
     end
 
     it "should mark empty text (stored as NULL) as changed when assigning '' to it" do
       @employee = TestEmployee.create!(:comments => nil)
       @employee.comments = ''
-      @employee.should be_changed
+      expect(@employee).to be_changed
       @employee.reload
       @employee.comments = ''
-      @employee.should be_changed
+      expect(@employee).to be_changed
     end
 
     it "should not mark empty date (stored as NULL) as changed when reassigning it" do
       @employee = TestEmployee.create!(:hire_date => '')
       @employee.hire_date = ''
-      @employee.should_not be_changed
+      expect(@employee).not_to be_changed
       @employee.reload
       @employee.hire_date = ''
-      @employee.should_not be_changed
+      expect(@employee).not_to be_changed
     end
 
     it "should not mark integer as changed when reassigning it" do
       @employee = TestEmployee.new
       @employee.job_id = 0
-      @employee.save!.should be_true
+      expect(@employee.save!).to be_truthy
       
-      @employee.should_not be_changed
+      expect(@employee).not_to be_changed
 
       @employee.job_id = '0'
-      @employee.should_not be_changed
+      expect(@employee).not_to be_changed
     end
 
     it "should not update unchanged CLOBs" do
       @employee = TestEmployee.create!(
           :comments => "initial"
       )
-      @employee.save!.should be_true
+      expect(@employee.save!).to be_truthy
       @employee.reload
-      @employee.comments.should == 'initial'
+      expect(@employee.comments).to eq('initial')
 
       oci_conn = @conn.instance_variable_get('@connection')
       class << oci_conn
          def write_lob(lob, value, is_binary = false); raise "don't do this'"; end
       end
-      @employee.save!.should_not raise_exception(RuntimeError, "don't do this'")
+      expect(@employee.save!).not_to raise_exception(RuntimeError, "don't do this'")
       class << oci_conn
         remove_method :write_lob
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced_emulate_oracle_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_emulate_oracle_adapter_spec.rb
@@ -11,8 +11,8 @@ describe "OracleEnhancedAdapter emulate OracleAdapter" do
 
   it "should be an OracleAdapter" do
     @conn = ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(:emulate_oracle_adapter => true))
-    ActiveRecord::Base.connection.should_not be_nil
-    ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::OracleAdapter).should be_true
+    expect(ActiveRecord::Base.connection).not_to be_nil
+    expect(ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::OracleAdapter)).to be_truthy
   end
 
   after(:all) do

--- a/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
@@ -166,12 +166,12 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
       :hire_date => @today
     )
     @employee.reload
-    @employee.first_name.should == "First"
-    @employee.last_name.should == "Last"
-    @employee.hire_date.should == @today
-    @employee.description.should == "First Last"
-    @employee.create_time.should_not be_nil
-    @employee.update_time.should_not be_nil
+    expect(@employee.first_name).to eq("First")
+    expect(@employee.last_name).to eq("Last")
+    expect(@employee.hire_date).to eq(@today)
+    expect(@employee.description).to eq("First Last")
+    expect(@employee.create_time).not_to be_nil
+    expect(@employee.update_time).not_to be_nil
   end
 
   it "should rollback record when exception is raised in after_create callback" do
@@ -183,11 +183,11 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
       :hire_date => @today
     )
     employees_count = TestEmployee.count
-    lambda {
+    expect {
       @employee.save
-    }.should raise_error("Make the transaction rollback")
-    @employee.id.should == nil
-    TestEmployee.count.should == employees_count
+    }.to raise_error("Make the transaction rollback")
+    expect(@employee.id).to eq(nil)
+    expect(TestEmployee.count).to eq(employees_count)
   end
 
   it "should update record" do
@@ -201,7 +201,7 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
     @employee.first_name = "Second"
     @employee.save!
     @employee.reload
-    @employee.description.should == "Second Last"
+    expect(@employee.description).to eq("Second Last")
   end
 
   it "should rollback record when exception is raised in after_update callback" do
@@ -216,11 +216,11 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
     empl_id = @employee.id
     @employee.reload
     @employee.first_name = "Second"
-    lambda {
+    expect {
       @employee.save
-    }.should raise_error("Make the transaction rollback")
+    }.to raise_error("Make the transaction rollback")
     @employee.reload
-    @employee.first_name.should == "First"
+    expect(@employee.first_name).to eq("First")
   end
 
   it "should not update record if nothing is changed and partial writes are enabled" do
@@ -233,7 +233,7 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
     @employee.reload
     @employee.save!
     @employee.reload
-    @employee.version.should == 1
+    expect(@employee.version).to eq(1)
   end
 
   it "should update record if nothing is changed and partial writes are disabled" do
@@ -246,7 +246,7 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
     @employee.reload
     @employee.save!
     @employee.reload
-    @employee.version.should == 2
+    expect(@employee.version).to eq(2)
   end
 
   it "should delete record" do
@@ -258,12 +258,12 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
     @employee.reload
     empl_id = @employee.id
     @employee.destroy
-    @employee.should be_frozen
-    TestEmployee.find_by_employee_id(empl_id).should be_nil
+    expect(@employee).to be_frozen
+    expect(TestEmployee.find_by_employee_id(empl_id)).to be_nil
   end
 
   it "should delete record and set destroyed flag" do
-    return pending("Not in this ActiveRecord version (requires >= 2.3.5)") unless TestEmployee.method_defined?(:destroyed?)
+    return skip("Not in this ActiveRecord version (requires >= 2.3.5)") unless TestEmployee.method_defined?(:destroyed?)
     @employee = TestEmployee.create(
       :first_name => "First",
       :last_name => "Last",
@@ -271,7 +271,7 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
     )
     @employee.reload
     @employee.destroy
-    @employee.should be_destroyed
+    expect(@employee).to be_destroyed
   end
 
   it "should rollback record when exception is raised in after_destroy callback" do
@@ -285,11 +285,11 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
     )
     @employee.reload
     empl_id = @employee.id
-    lambda {
+    expect {
       @employee.destroy
-    }.should raise_error("Make the transaction rollback")
-    @employee.id.should == empl_id
-    TestEmployee.find_by_employee_id(empl_id).should_not be_nil
+    }.to raise_error("Make the transaction rollback")
+    expect(@employee.id).to eq(empl_id)
+    expect(TestEmployee.find_by_employee_id(empl_id)).not_to be_nil
     clear_logger
   end
 
@@ -299,8 +299,8 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
       :last_name => "Last",
       :hire_date => @today
     )
-    @employee.created_at.should_not be_nil
-    @employee.updated_at.should_not be_nil
+    expect(@employee.created_at).not_to be_nil
+    expect(@employee.updated_at).not_to be_nil
   end
 
   it "should set timestamps when updating record" do
@@ -310,12 +310,12 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
       :hire_date => @today
     )
     @employee.reload
-    @employee.created_at.should be_nil
-    @employee.updated_at.should be_nil
+    expect(@employee.created_at).to be_nil
+    expect(@employee.updated_at).to be_nil
     @employee.first_name = "Second"
     @employee.save!
-    @employee.created_at.should be_nil
-    @employee.updated_at.should_not be_nil
+    expect(@employee.created_at).to be_nil
+    expect(@employee.updated_at).not_to be_nil
   end
 
   it "should log create record" do
@@ -326,7 +326,7 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
       :hire_date => @today
     )
     #TODO: dirty workaround to remove sql statement for `table` method
-    @logger.logged(:debug)[-2].should match(/^TestEmployee Create \(\d+\.\d+(ms)?\)  custom create method$/)
+    expect(@logger.logged(:debug)[-2]).to match(/^TestEmployee Create \(\d+\.\d+(ms)?\)  custom create method$/)
     clear_logger
   end
 
@@ -339,7 +339,7 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
     )
     set_logger
     @employee.save!
-    @logger.logged(:debug).last.should match(/^TestEmployee Update \(\d+\.\d+(ms)?\)  custom update method with employee_id=#{@employee.id}$/)
+    expect(@logger.logged(:debug).last).to match(/^TestEmployee Update \(\d+\.\d+(ms)?\)  custom update method with employee_id=#{@employee.id}$/)
     clear_logger
   end
 
@@ -351,7 +351,7 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
     )
     set_logger
     @employee.destroy
-    @logger.logged(:debug).last.should match(/^TestEmployee Destroy \(\d+\.\d+(ms)?\)  custom delete method with employee_id=#{@employee.id}$/)
+    expect(@logger.logged(:debug).last).to match(/^TestEmployee Destroy \(\d+\.\d+(ms)?\)  custom delete method with employee_id=#{@employee.id}$/)
     clear_logger
   end
 
@@ -360,8 +360,8 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
       :last_name => "Last",
       :hire_date => @today
     )
-    @employee.save.should be_false
-    @employee.errors[:first_name].should_not be_blank
+    expect(@employee.save).to be_falsey
+    expect(@employee.errors[:first_name]).not_to be_blank
   end
 
   it "should validate existing record before update" do
@@ -371,8 +371,8 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
       :hire_date => @today
     )
     @employee.first_name = nil
-    @employee.save.should be_false
-    @employee.errors[:first_name].should_not be_blank
+    expect(@employee.save).to be_falsey
+    expect(@employee.errors[:first_name]).not_to be_blank
   end
   
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
@@ -43,12 +43,12 @@ describe "OracleEnhancedAdapter schema dump" do
 
     it "should not include ignored table names in schema dump" do
       create_test_posts_table
-      standard_dump(ignore_tables: %w(test_posts)).should_not =~ /create_table "test_posts"/
+      expect(standard_dump(ignore_tables: %w(test_posts))).not_to match(/create_table "test_posts"/)
     end
 
     it "should not include ignored table regexes in schema dump" do
       create_test_posts_table
-      standard_dump(ignore_tables: [ /test_posts/i ]).should_not =~ /create_table "test_posts"/
+      expect(standard_dump(ignore_tables: [ /test_posts/i ])).not_to match(/create_table "test_posts"/)
     end
 
   end
@@ -70,7 +70,7 @@ describe "OracleEnhancedAdapter schema dump" do
     end
 
     it "should be able to dump default values using special characters" do
-      standard_dump.should =~ /t.string \"special_c\", default: "\\n"/
+      expect(standard_dump).to match(/t.string \"special_c\", default: "\\n"/)
     end
   end
   describe "table prefixes and suffixes" do
@@ -84,37 +84,37 @@ describe "OracleEnhancedAdapter schema dump" do
     it "should remove table prefix in schema dump" do
       ActiveRecord::Base.table_name_prefix = 'xxx_'
       create_test_posts_table
-      standard_dump.should =~ /create_table "test_posts".*add_index "test_posts"/m
+      expect(standard_dump).to match(/create_table "test_posts".*add_index "test_posts"/m)
     end
 
     it "should remove table prefix with $ sign in schema dump" do
       ActiveRecord::Base.table_name_prefix = 'xxx$'
       create_test_posts_table
-      standard_dump.should =~ /create_table "test_posts".*add_index "test_posts"/m
+      expect(standard_dump).to match(/create_table "test_posts".*add_index "test_posts"/m)
     end
 
     it "should remove table suffix in schema dump" do
       ActiveRecord::Base.table_name_suffix = '_xxx'
       create_test_posts_table
-      standard_dump.should =~ /create_table "test_posts".*add_index "test_posts"/m
+      expect(standard_dump).to match(/create_table "test_posts".*add_index "test_posts"/m)
     end
 
     it "should remove table suffix with $ sign in schema dump" do
       ActiveRecord::Base.table_name_suffix = '$xxx'
       create_test_posts_table
-      standard_dump.should =~ /create_table "test_posts".*add_index "test_posts"/m
+      expect(standard_dump).to match(/create_table "test_posts".*add_index "test_posts"/m)
     end
 
     it "should not include schema_migrations table with prefix in schema dump" do
       ActiveRecord::Base.table_name_prefix = 'xxx_'
       @conn.initialize_schema_migrations_table
-      standard_dump.should_not =~ /schema_migrations/
+      expect(standard_dump).not_to match(/schema_migrations/)
     end
 
     it "should not include schema_migrations table with suffix in schema dump" do
       ActiveRecord::Base.table_name_suffix = '_xxx'
       @conn.initialize_schema_migrations_table
-      standard_dump.should_not =~ /schema_migrations/
+      expect(standard_dump).not_to match(/schema_migrations/)
     end
 
   end
@@ -126,7 +126,7 @@ describe "OracleEnhancedAdapter schema dump" do
 
     it "should include non-default primary key in schema dump" do
       create_test_posts_table(primary_key: 'post_id')
-      standard_dump.should =~ /create_table "test_posts", primary_key: "post_id"/
+      expect(standard_dump).to match(/create_table "test_posts", primary_key: "post_id"/)
     end
 
   end
@@ -140,12 +140,12 @@ describe "OracleEnhancedAdapter schema dump" do
 
     it "should include primary key trigger in schema dump" do
       create_test_posts_table(primary_key_trigger: true)
-      standard_dump.should =~ /create_table "test_posts".*add_primary_key_trigger "test_posts"/m
+      expect(standard_dump).to match(/create_table "test_posts".*add_primary_key_trigger "test_posts"/m)
     end
 
     it "should include primary key trigger with non-default primary key in schema dump" do
       create_test_posts_table(primary_key_trigger: true, primary_key: 'post_id')
-      standard_dump.should =~ /create_table "test_posts", primary_key: "post_id".*add_primary_key_trigger "test_posts", primary_key: "post_id"/m
+      expect(standard_dump).to match(/create_table "test_posts", primary_key: "post_id".*add_primary_key_trigger "test_posts", primary_key: "post_id"/m)
     end
 
   end
@@ -180,53 +180,53 @@ describe "OracleEnhancedAdapter schema dump" do
       schema_define do
         add_foreign_key :test_comments, :test_posts
       end
-      standard_dump.should =~ /add_foreign_key "test_comments", "test_posts"/
+      expect(standard_dump).to match(/add_foreign_key "test_comments", "test_posts"/)
     end
 
     it "should include foreign key with delete dependency in schema dump" do
       schema_define do
         add_foreign_key :test_comments, :test_posts, dependent: :delete
       end
-      standard_dump.should =~ /add_foreign_key "test_comments", "test_posts", on_delete: :cascade/
+      expect(standard_dump).to match(/add_foreign_key "test_comments", "test_posts", on_delete: :cascade/)
     end
 
     it "should include foreign key with nullify dependency in schema dump" do
       schema_define do
         add_foreign_key :test_comments, :test_posts, dependent: :nullify
       end
-      standard_dump.should =~ /add_foreign_key "test_comments", "test_posts", on_delete: :nullify/
+      expect(standard_dump).to match(/add_foreign_key "test_comments", "test_posts", on_delete: :nullify/)
     end
 
     it "should not include foreign keys on ignored table names in schema dump" do
       schema_define do
         add_foreign_key :test_comments, :test_posts
       end
-      standard_dump(ignore_tables: %w(test_comments)).should_not =~ /add_foreign_key "test_comments"/
+      expect(standard_dump(ignore_tables: %w(test_comments))).not_to match(/add_foreign_key "test_comments"/)
     end
 
     it "should not include foreign keys on ignored table regexes in schema dump" do
       schema_define do
         add_foreign_key :test_comments, :test_posts
       end
-      standard_dump(ignore_tables: [ /test_comments/i ]).should_not =~ /add_foreign_key "test_comments"/
+      expect(standard_dump(ignore_tables: [ /test_comments/i ])).not_to match(/add_foreign_key "test_comments"/)
     end
 
     it "should include foreign keys referencing ignored table names in schema dump" do
       schema_define do
         add_foreign_key :test_comments, :test_posts
       end
-      standard_dump(ignore_tables: %w(test_posts)).should =~ /add_foreign_key "test_comments"/
+      expect(standard_dump(ignore_tables: %w(test_posts))).to match(/add_foreign_key "test_comments"/)
     end
 
     it "should include foreign keys referencing ignored table regexes in schema dump" do
       schema_define do
         add_foreign_key :test_comments, :test_posts
       end
-      standard_dump(ignore_tables: [ /test_posts/i ]).should =~ /add_foreign_key "test_comments"/
+      expect(standard_dump(ignore_tables: [ /test_posts/i ])).to match(/add_foreign_key "test_comments"/)
     end
 
     it "should include composite foreign keys" do
-      pending "Composite foreign keys are not supported in this version"
+      skip "Composite foreign keys are not supported in this version"
       schema_define do
         add_column :test_posts, :baz_id, :integer
         add_column :test_posts, :fooz_id, :integer
@@ -241,7 +241,7 @@ describe "OracleEnhancedAdapter schema dump" do
 
         add_foreign_key :test_comments, :test_posts, columns: ["baz_id", "fooz_id"], name: 'comments_posts_baz_fooz_fk'
       end
-      standard_dump.should =~ /add_foreign_key "test_comments", "test_posts", columns: \["baz_id", "fooz_id"\], name: "comments_posts_baz_fooz_fk"/
+      expect(standard_dump).to match(/add_foreign_key "test_comments", "test_posts", columns: \["baz_id", "fooz_id"\], name: "comments_posts_baz_fooz_fk"/)
     end
     it "should include foreign keys following all tables" do
       # if foreign keys preceed declaration of all tables
@@ -250,7 +250,7 @@ describe "OracleEnhancedAdapter schema dump" do
         add_foreign_key :test_comments, :test_posts
       end
       dump = standard_dump
-      dump.rindex("create_table").should < dump.index("add_foreign_key")
+      expect(dump.rindex("create_table")).to be < dump.index("add_foreign_key")
     end
  
     it "should include primary_key when reference column name is not 'id'" do
@@ -269,7 +269,7 @@ describe "OracleEnhancedAdapter schema dump" do
         ADD CONSTRAINT TEST_COMMENTS_BAZ_ID_FK FOREIGN KEY (baz_id) REFERENCES test_posts(baz_id)
       SQL
 
-      standard_dump.should =~ /add_foreign_key "test_comments", "test_posts", column: "baz_id", primary_key: "baz_id", name: "test_comments_baz_id_fk"/
+      expect(standard_dump).to match(/add_foreign_key "test_comments", "test_posts", column: "baz_id", primary_key: "baz_id", name: "test_comments_baz_id_fk"/)
     end
     
   end
@@ -285,35 +285,35 @@ describe "OracleEnhancedAdapter schema dump" do
       schema_define do
         add_synonym :test_synonym, "schema_name.table_name", force: true
       end
-      standard_dump.should =~ /add_synonym "test_synonym", "schema_name.table_name", force: true/
+      expect(standard_dump).to match(/add_synonym "test_synonym", "schema_name.table_name", force: true/)
     end
 
     it "should include synonym to other database table in schema dump" do
       schema_define do
         add_synonym :test_synonym, "table_name@link_name", force: true
       end
-      standard_dump.should =~ /add_synonym "test_synonym", "table_name@link_name(\.[-A-Za-z0-9_]+)*", force: true/
+      expect(standard_dump).to match(/add_synonym "test_synonym", "table_name@link_name(\.[-A-Za-z0-9_]+)*", force: true/)
     end
 
     it "should not include ignored table names in schema dump" do
       schema_define do
         add_synonym :test_synonym, "schema_name.table_name", force: true
       end
-      standard_dump(ignore_tables: %w(test_synonym)).should_not =~ /add_synonym "test_synonym"/
+      expect(standard_dump(ignore_tables: %w(test_synonym))).not_to match(/add_synonym "test_synonym"/)
     end
 
     it "should not include ignored table regexes in schema dump" do
       schema_define do
         add_synonym :test_synonym, "schema_name.table_name", force: true
       end
-      standard_dump(ignore_tables: [ /test_synonym/i ]).should_not =~ /add_synonym "test_synonym"/
+      expect(standard_dump(ignore_tables: [ /test_synonym/i ])).not_to match(/add_synonym "test_synonym"/)
     end
 
     it "should include synonyms to ignored table regexes in schema dump" do
       schema_define do
         add_synonym :test_synonym, "schema_name.table_name", force: true
       end
-      standard_dump(ignore_tables: [ /table_name/i ]).should =~ /add_synonym "test_synonym"/
+      expect(standard_dump(ignore_tables: [ /table_name/i ])).to match(/add_synonym "test_synonym"/)
     end
 
   end
@@ -325,7 +325,7 @@ describe "OracleEnhancedAdapter schema dump" do
 
     it "should include temporary options" do
       create_test_posts_table(temporary: true)
-      standard_dump.should =~ /create_table "test_posts", temporary: true/
+      expect(standard_dump).to match(/create_table "test_posts", temporary: true/)
     end
   end
 
@@ -336,20 +336,20 @@ describe "OracleEnhancedAdapter schema dump" do
 
     it "should not specify default tablespace in add index" do
       create_test_posts_table
-      standard_dump.should =~ /add_index "test_posts", \["title"\], name: "index_test_posts_on_title"$/
+      expect(standard_dump).to match(/add_index "test_posts", \["title"\], name: "index_test_posts_on_title"$/)
     end
 
     it "should specify non-default tablespace in add index" do
       tablespace_name = @conn.default_tablespace
-      @conn.stub!(:default_tablespace).and_return('dummy')
+      allow(@conn).to receive(:default_tablespace).and_return('dummy')
       create_test_posts_table
-      standard_dump.should =~ /add_index "test_posts", \["title"\], name: "index_test_posts_on_title", tablespace: "#{tablespace_name}"$/
+      expect(standard_dump).to match(/add_index "test_posts", \["title"\], name: "index_test_posts_on_title", tablespace: "#{tablespace_name}"$/)
     end
 
     it "should create and dump function-based indexes" do
       create_test_posts_table
       @conn.add_index :test_posts, "NVL(created_at, updated_at)", name: "index_test_posts_cr_upd_at"
-      standard_dump.should =~ /add_index "test_posts", \["NVL\(\\"CREATED_AT\\",\\"UPDATED_AT\\"\)"\], name: "index_test_posts_cr_upd_at"$/
+      expect(standard_dump).to match(/add_index "test_posts", \["NVL\(\\"CREATED_AT\\",\\"UPDATED_AT\\"\)"\], name: "index_test_posts_cr_upd_at"$/)
     end
 
   end
@@ -363,7 +363,7 @@ describe "OracleEnhancedAdapter schema dump" do
     it "should not include materialized views in schema dump" do
       create_test_posts_table
       @conn.execute "CREATE MATERIALIZED VIEW test_posts_mv AS SELECT * FROM test_posts"
-      standard_dump.should_not =~ /create_table "test_posts_mv"/
+      expect(standard_dump).not_to match(/create_table "test_posts_mv"/)
     end
   end
 
@@ -383,7 +383,7 @@ describe "OracleEnhancedAdapter schema dump" do
           end
         end
       else
-        pending "Not supported in this database version"
+        skip "Not supported in this database version"
       end
     end
 
@@ -404,12 +404,12 @@ describe "OracleEnhancedAdapter schema dump" do
     end
 
     it 'should dump correctly' do
-      standard_dump.should =~ /t\.virtual "full_name",(\s*)limit: 512,(\s*)as: "\\"FIRST_NAME\\"\|\|', '\|\|\\"LAST_NAME\\"",(\s*)type: :string/
-      standard_dump.should =~ /t\.virtual "short_name",(\s*)limit: 300,(\s*)as:(.*),(\s*)type: :string/
-      standard_dump.should =~ /t\.virtual "full_name_length",(\s*)precision: 38,(\s*)as:(.*),(\s*)type: :integer/
-      standard_dump.should =~ /t\.virtual "name_ratio",(\s*)as:(.*)\"$/ # no :type
-      standard_dump.should =~ /t\.virtual "abbrev_name",(\s*)limit: 100,(\s*)as:(.*),(\s*)type: :string/
-      standard_dump.should =~ /t\.virtual "field_with_leading_space",(\s*)limit: 300,(\s*)as: "' '\|\|\\"FIRST_NAME\\"\|\|' '",(\s*)type: :string/
+      expect(standard_dump).to match(/t\.virtual "full_name",(\s*)limit: 512,(\s*)as: "\\"FIRST_NAME\\"\|\|', '\|\|\\"LAST_NAME\\"",(\s*)type: :string/)
+      expect(standard_dump).to match(/t\.virtual "short_name",(\s*)limit: 300,(\s*)as:(.*),(\s*)type: :string/)
+      expect(standard_dump).to match(/t\.virtual "full_name_length",(\s*)precision: 38,(\s*)as:(.*),(\s*)type: :integer/)
+      expect(standard_dump).to match(/t\.virtual "name_ratio",(\s*)as:(.*)\"$/) # no :type
+      expect(standard_dump).to match(/t\.virtual "abbrev_name",(\s*)limit: 100,(\s*)as:(.*),(\s*)type: :string/)
+      expect(standard_dump).to match(/t\.virtual "field_with_leading_space",(\s*)limit: 300,(\s*)as: "' '\|\|\\"FIRST_NAME\\"\|\|' '",(\s*)type: :string/)
     end
 
     context 'with column cache' do
@@ -422,14 +422,14 @@ describe "OracleEnhancedAdapter schema dump" do
       end
       it 'should not change column defaults after several dumps' do
         col = TestName.columns.detect{|c| c.name == 'full_name'}
-        col.should_not be_nil
-        col.virtual_column_data_default.should_not =~ /:as/
+        expect(col).not_to be_nil
+        expect(col.virtual_column_data_default).not_to match(/:as/)
 
         standard_dump
-        col.virtual_column_data_default.should_not =~ /:as/
+        expect(col.virtual_column_data_default).not_to match(/:as/)
 
         standard_dump
-        col.virtual_column_data_default.should_not =~ /:as/
+        expect(col.virtual_column_data_default).not_to match(/:as/)
       end
     end
 
@@ -449,8 +449,8 @@ describe "OracleEnhancedAdapter schema dump" do
         end
       end
       it 'should dump correctly' do
-        standard_dump.should_not =~ /add_index "test_names".+FIRST_NAME.+$/
-        standard_dump.should     =~ /add_index "test_names".+field_with_leading_space.+$/
+        expect(standard_dump).not_to match(/add_index "test_names".+FIRST_NAME.+$/)
+        expect(standard_dump).to     match(/add_index "test_names".+field_with_leading_space.+$/)
       end
     end
   end
@@ -471,7 +471,7 @@ describe "OracleEnhancedAdapter schema dump" do
     end
 
     it "should dump float type correctly" do
-      standard_dump.should =~ /t\.float "hourly_rate"$/
+      expect(standard_dump).to match(/t\.float "hourly_rate"$/)
     end
   end
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -25,7 +25,7 @@ describe "OracleEnhancedAdapter schema definition" do
     it 'creates a sequence when adding a column with create_sequence = true' do
       _, sequence_name = ActiveRecord::Base.connection.pk_and_sequence_for_without_cache(:keyboards)
 
-      sequence_name.should == Keyboard.sequence_name
+      expect(sequence_name).to eq(Keyboard.sequence_name)
     end
   end
 
@@ -60,11 +60,11 @@ describe "OracleEnhancedAdapter schema definition" do
     end
 
     it "should create sequence for non-default primary key" do
-      ActiveRecord::Base.connection.next_sequence_value(Keyboard.sequence_name).should_not be_nil
+      expect(ActiveRecord::Base.connection.next_sequence_value(Keyboard.sequence_name)).not_to be_nil
     end
 
     it "should create sequence for default primary key" do
-      ActiveRecord::Base.connection.next_sequence_value(IdKeyboard.sequence_name).should_not be_nil
+      expect(ActiveRecord::Base.connection.next_sequence_value(IdKeyboard.sequence_name)).not_to be_nil
     end
   end
 
@@ -73,7 +73,7 @@ describe "OracleEnhancedAdapter schema definition" do
     it "should return sequence name without truncating too much" do
       seq_name_length = ActiveRecord::Base.connection.sequence_name_length
       tname = "#{DATABASE_USER}" + "." +"a"*(seq_name_length - DATABASE_USER.length) + "z"*(DATABASE_USER).length
-      ActiveRecord::Base.connection.default_sequence_name(tname).should match (/z_seq$/)
+      expect(ActiveRecord::Base.connection.default_sequence_name(tname)).to match (/z_seq$/)
     end
   end
 
@@ -114,13 +114,13 @@ describe "OracleEnhancedAdapter schema definition" do
     end
 
     it "should use default sequence start value 10000" do
-      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_sequence_start_value.should == 10000
+      expect(ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_sequence_start_value).to eq(10000)
 
       create_test_employees_table
       class ::TestEmployee < ActiveRecord::Base; end
 
       employee = TestEmployee.create!
-      employee.id.should == 10000
+      expect(employee.id).to eq(10000)
     end
 
     it "should use specified default sequence start value" do
@@ -130,7 +130,7 @@ describe "OracleEnhancedAdapter schema definition" do
       class ::TestEmployee < ActiveRecord::Base; end
 
       employee = TestEmployee.create!
-      employee.id.should == 1
+      expect(employee.id).to eq(1)
     end
 
     it "should use sequence start value from table definition" do
@@ -138,7 +138,7 @@ describe "OracleEnhancedAdapter schema definition" do
       class ::TestEmployee < ActiveRecord::Base; end
 
       employee = TestEmployee.create!
-      employee.id.should == 10
+      expect(employee.id).to eq(10)
     end
 
     it "should use sequence start value and other options from table definition" do
@@ -146,9 +146,9 @@ describe "OracleEnhancedAdapter schema definition" do
       class ::TestEmployee < ActiveRecord::Base; end
 
       employee = TestEmployee.create!
-      employee.id.should == 100
+      expect(employee.id).to eq(100)
       employee = TestEmployee.create!
-      employee.id.should == 110
+      expect(employee.id).to eq(110)
     end
 
   end
@@ -198,26 +198,26 @@ describe "OracleEnhancedAdapter schema definition" do
       end
 
       it "should populate primary key using trigger" do
-        lambda do
+        expect do
           @conn.execute "INSERT INTO test_employees (first_name) VALUES ('Raimonds')"
-        end.should_not raise_error
+        end.not_to raise_error
       end
 
       it "should return new key value using connection insert method" do
         insert_id = @conn.insert("INSERT INTO test_employees (first_name) VALUES ('Raimonds')", nil, "id")
-        @conn.select_value("SELECT test_employees_seq.currval FROM dual").should == insert_id
+        expect(@conn.select_value("SELECT test_employees_seq.currval FROM dual")).to eq(insert_id)
       end
 
       it "should create new record for model" do
         e = TestEmployee.create!(:first_name => 'Raimonds')
-        @conn.select_value("SELECT test_employees_seq.currval FROM dual").should == e.id
+        expect(@conn.select_value("SELECT test_employees_seq.currval FROM dual")).to eq(e.id)
       end
 
       it "should not generate NoMethodError for :returning_id:Symbol" do
         set_logger
         @conn.reconnect! unless @conn.active?
         insert_id = @conn.insert("INSERT INTO test_employees (first_name) VALUES ('Yasuo')", nil, "id")
-        @logger.output(:error).should_not match(/^Could not log "sql.active_record" event. NoMethodError: undefined method `name' for :returning_id:Symbol/)
+        expect(@logger.output(:error)).not_to match(/^Could not log "sql.active_record" event. NoMethodError: undefined method `name' for :returning_id:Symbol/)
         clear_logger
       end
 
@@ -237,19 +237,19 @@ describe "OracleEnhancedAdapter schema definition" do
       end
 
       it "should populate primary key using trigger" do
-        lambda do
+        expect do
           @conn.execute "INSERT INTO test_employees (first_name) VALUES ('Raimonds')"
-        end.should_not raise_error
+        end.not_to raise_error
       end
 
       it "should return new key value using connection insert method" do
         insert_id = @conn.insert("INSERT INTO test_employees (first_name) VALUES ('Raimonds')", nil, "id")
-        @conn.select_value("SELECT test_employees_seq.currval FROM dual").should == insert_id
+        expect(@conn.select_value("SELECT test_employees_seq.currval FROM dual")).to eq(insert_id)
       end
 
       it "should create new record for model" do
         e = TestEmployee.create!(:first_name => 'Raimonds')
-        @conn.select_value("SELECT test_employees_seq.currval FROM dual").should == e.id
+        expect(@conn.select_value("SELECT test_employees_seq.currval FROM dual")).to eq(e.id)
       end
     end
 
@@ -270,19 +270,19 @@ describe "OracleEnhancedAdapter schema definition" do
       end
 
       it "should populate primary key using trigger" do
-        lambda do
+        expect do
           @conn.execute "INSERT INTO test_employees (first_name) VALUES ('Raimonds')"
-        end.should_not raise_error
+        end.not_to raise_error
       end
 
       it "should return new key value using connection insert method" do
         insert_id = @conn.insert("INSERT INTO test_employees (first_name) VALUES ('Raimonds')", nil, @primary_key)
-        @conn.select_value("SELECT #{@sequence_name}.currval FROM dual").should == insert_id
+        expect(@conn.select_value("SELECT #{@sequence_name}.currval FROM dual")).to eq(insert_id)
       end
 
       it "should create new record for model with autogenerated sequence option" do
         e = TestEmployee.create!(:first_name => 'Raimonds')
-        @conn.select_value("SELECT #{@sequence_name}.currval FROM dual").should == e.id
+        expect(@conn.select_value("SELECT #{@sequence_name}.currval FROM dual")).to eq(e.id)
       end
     end
 
@@ -302,19 +302,19 @@ describe "OracleEnhancedAdapter schema definition" do
       end
 
       it "should populate primary key using trigger" do
-        lambda do
+        expect do
           @conn.execute "INSERT INTO test_employees (first_name) VALUES ('Raimonds')"
-        end.should_not raise_error
+        end.not_to raise_error
       end
 
       it "should return new key value using connection insert method" do
         insert_id = @conn.insert("INSERT INTO test_employees (first_name) VALUES ('Raimonds')", nil, "id")
-        @conn.select_value("SELECT #{@sequence_name}.currval FROM dual").should == insert_id
+        expect(@conn.select_value("SELECT #{@sequence_name}.currval FROM dual")).to eq(insert_id)
       end
 
       it "should create new record for model with autogenerated sequence option" do
         e = TestEmployee.create!(:first_name => 'Raimonds')
-        @conn.select_value("SELECT #{@sequence_name}.currval FROM dual").should == e.id
+        expect(@conn.select_value("SELECT #{@sequence_name}.currval FROM dual")).to eq(e.id)
       end
     end
 
@@ -349,8 +349,8 @@ describe "OracleEnhancedAdapter schema definition" do
       create_test_employees_table(table_comment)
       class ::TestEmployee < ActiveRecord::Base; end
 
-      @conn.table_comment("test_employees").should == table_comment
-      TestEmployee.table_comment.should == table_comment
+      expect(@conn.table_comment("test_employees")).to eq(table_comment)
+      expect(TestEmployee.table_comment).to eq(table_comment)
     end
 
     it "should create table with columns comment" do
@@ -359,10 +359,10 @@ describe "OracleEnhancedAdapter schema definition" do
       class ::TestEmployee < ActiveRecord::Base; end
 
       [:first_name, :last_name].each do |attr|
-        @conn.column_comment("test_employees", attr.to_s).should == column_comments[attr]
+        expect(@conn.column_comment("test_employees", attr.to_s)).to eq(column_comments[attr])
       end
       [:first_name, :last_name].each do |attr|
-        TestEmployee.columns_hash[attr.to_s].comment.should == column_comments[attr]
+        expect(TestEmployee.columns_hash[attr.to_s].comment).to eq(column_comments[attr])
       end
     end
 
@@ -373,13 +373,13 @@ describe "OracleEnhancedAdapter schema definition" do
       create_test_employees_table(table_comment, column_comments)
       class ::TestEmployee < ActiveRecord::Base; end
 
-      @conn.table_comment(TestEmployee.table_name).should == table_comment
-      TestEmployee.table_comment.should == table_comment
+      expect(@conn.table_comment(TestEmployee.table_name)).to eq(table_comment)
+      expect(TestEmployee.table_comment).to eq(table_comment)
       [:first_name, :last_name].each do |attr|
-        @conn.column_comment(TestEmployee.table_name, attr.to_s).should == column_comments[attr]
+        expect(@conn.column_comment(TestEmployee.table_name, attr.to_s)).to eq(column_comments[attr])
       end
       [:first_name, :last_name].each do |attr|
-        TestEmployee.columns_hash[attr.to_s].comment.should == column_comments[attr]
+        expect(TestEmployee.columns_hash[attr.to_s].comment).to eq(column_comments[attr])
       end
     end
 
@@ -391,9 +391,9 @@ describe "OracleEnhancedAdapter schema definition" do
     end
 
     it "should drop table with :if_exists option no raise error" do
-      lambda do
+      expect do
         @conn.drop_table("nonexistent_table", if_exists: true)
-      end.should_not raise_error
+      end.not_to raise_error
     end
   end
 
@@ -427,27 +427,27 @@ describe "OracleEnhancedAdapter schema definition" do
     end
 
     it "should rename table name with new one" do
-      lambda do
+      expect do
         @conn.rename_table("test_employees","new_test_employees")
-      end.should_not raise_error
+      end.not_to raise_error
     end
 
     it "should raise error when new table name length is too long" do
-      lambda do
+      expect do
         @conn.rename_table("test_employees","a"*31)
-      end.should raise_error
+      end.to raise_error
     end
 
     it "should not raise error when new sequence name length is too long" do
-      lambda do
+      expect do
         @conn.rename_table("test_employees","a"*27)
-      end.should_not raise_error
+      end.not_to raise_error
     end
 
     it "should rename table when table has no primary key and sequence" do
-      lambda do
+      expect do
         @conn.rename_table("test_employees_no_pkey","new_test_employees_no_pkey")
-      end.should_not raise_error
+      end.not_to raise_error
     end
 
   end
@@ -474,7 +474,7 @@ describe "OracleEnhancedAdapter schema definition" do
     end
 
     it "should create table trigger with :new reference" do
-      lambda do
+      expect do
         @conn.execute <<-SQL
         CREATE OR REPLACE TRIGGER test_employees_pkt
         BEFORE INSERT ON test_employees FOR EACH ROW
@@ -486,7 +486,7 @@ describe "OracleEnhancedAdapter schema definition" do
           END IF;
         END;
         SQL
-      end.should_not raise_error
+      end.not_to raise_error
     end
   end
 
@@ -496,20 +496,21 @@ describe "OracleEnhancedAdapter schema definition" do
     end
 
     it "should return default index name if it is not larger than 30 characters" do
-      @conn.index_name("employees", :column => "first_name").should == "index_employees_on_first_name"
+      expect(@conn.index_name("employees", :column => "first_name")).to eq("index_employees_on_first_name")
     end
 
     it "should return shortened index name by removing 'index', 'on' and 'and' keywords" do
-      @conn.index_name("employees", :column => ["first_name", "email"]).should == "i_employees_first_name_email"
+      expect(@conn.index_name("employees", :column => ["first_name", "email"])).to eq("i_employees_first_name_email")
     end
 
     it "should return shortened index name by shortening table and column names" do
-      @conn.index_name("employees", :column => ["first_name", "last_name"]).should == "i_emp_fir_nam_las_nam"
+      expect(@conn.index_name("employees", :column => ["first_name", "last_name"])).to eq("i_emp_fir_nam_las_nam")
     end
 
     it "should raise error if too large index name cannot be shortened" do
-      @conn.index_name("test_employees", :column => ["first_name", "middle_name", "last_name"]).should ==
+      expect(@conn.index_name("test_employees", :column => ["first_name", "middle_name", "last_name"])).to eq(
         'i'+Digest::SHA1.hexdigest("index_test_employees_on_first_name_and_middle_name_and_last_name")[0,29]
+      )
     end
 
   end
@@ -536,27 +537,27 @@ describe "OracleEnhancedAdapter schema definition" do
     end
 
     it "should raise error when current index name and new index name are identical" do
-      lambda do
+      expect do
         @conn.rename_index("test_employees","i_test_employees_first_name","i_test_employees_first_name")
-      end.should raise_error
+      end.to raise_error
     end
 
     it "should raise error when new index name length is too long" do
-      lambda do
+      expect do
         @conn.rename_index("test_employees","i_test_employees_first_name","a"*31)
-      end.should raise_error
+      end.to raise_error
     end
 
     it "should raise error when current index name does not exist" do
-      lambda do
+      expect do
         @conn.rename_index("test_employees","nonexist_index_name","new_index_name")
-      end.should raise_error
+      end.to raise_error
     end
 
     it "should rename index name with new one" do
-      lambda do
+      expect do
         @conn.rename_index("test_employees","i_test_employees_first_name","new_index_name")
-      end.should_not raise_error
+      end.not_to raise_error
     end
 end
 
@@ -568,23 +569,23 @@ end
     end
 
     it "should ignore :limit option for :text column" do
-      lambda do
+      expect do
         schema_define do
           create_table :test_posts, :force => true do |t|
             t.text :body, :limit => 10000
           end
         end
-      end.should_not raise_error
+      end.not_to raise_error
     end
 
     it "should ignore :limit option for :binary column" do
-      lambda do
+      expect do
         schema_define do
           create_table :test_posts, :force => true do |t|
             t.binary :picture, :limit => 10000
           end
         end
-      end.should_not raise_error
+      end.not_to raise_error
     end
 
   end
@@ -632,9 +633,9 @@ end
       schema_define do
         add_foreign_key :test_comments, :test_posts
       end
-      lambda do
+      expect do
         TestComment.create(:body => "test", :test_post_id => 1)
-      end.should raise_error() {|e| e.message.should =~ /ORA-02291.*\.#{fk_name}/i}
+      end.to raise_error() {|e| expect(e.message).to match(/ORA-02291.*\.#{fk_name}/i)}
     end
 
     context "with table_name_prefix" do
@@ -646,9 +647,9 @@ end
           add_foreign_key :test_comments, :test_posts
         end
 
-        lambda do
+        expect do
           TestComment.create(:body => "test", :test_post_id => 1)
-        end.should raise_error() {|e| e.message.should =~ /ORA-02291.*\.#{fk_name}/i}
+        end.to raise_error() {|e| expect(e.message).to match(/ORA-02291.*\.#{fk_name}/i)}
       end
     end
 
@@ -661,9 +662,9 @@ end
           add_foreign_key :test_comments, :test_posts
         end
 
-        lambda do
+        expect do
           TestComment.create(:body => "test", :test_post_id => 1)
-        end.should raise_error() {|e| e.message.should =~ /ORA-02291.*\.#{fk_name}/i}
+        end.to raise_error() {|e| expect(e.message).to match(/ORA-02291.*\.#{fk_name}/i)}
       end
     end
 
@@ -671,29 +672,31 @@ end
       schema_define do
         add_foreign_key :test_comments, :test_posts, :name => "comments_posts_fk"
       end
-      lambda do
+      expect do
         TestComment.create(:body => "test", :test_post_id => 1)
-      end.should raise_error() {|e| e.message.should =~ /ORA-02291.*\.COMMENTS_POSTS_FK/}
+      end.to raise_error() {|e| expect(e.message).to match(/ORA-02291.*\.COMMENTS_POSTS_FK/)}
     end
 
     it "should add foreign key with long name which is shortened" do
       schema_define do
         add_foreign_key :test_comments, :test_posts, :name => "test_comments_test_post_id_foreign_key"
       end
-      lambda do
+      expect do
         TestComment.create(:body => "test", :test_post_id => 1)
-      end.should raise_error() {|e| e.message.should =~
-        /ORA-02291.*\.C#{Digest::SHA1.hexdigest("test_comments_test_post_id_foreign_key")[0,29].upcase}/}
+      end.to raise_error() {|e| expect(e.message).to match(
+        /ORA-02291.*\.C#{Digest::SHA1.hexdigest("test_comments_test_post_id_foreign_key")[0,29].upcase}/
+      )}
     end
 
     it "should add foreign key with very long name which is shortened" do
       schema_define do
         add_foreign_key :test_comments, :test_posts, :name => "long_prefix_test_comments_test_post_id_foreign_key"
       end
-      lambda do
+      expect do
         TestComment.create(:body => "test", :test_post_id => 1)
-      end.should raise_error() {|e| e.message.should =~
-        /ORA-02291.*\.C#{Digest::SHA1.hexdigest("long_prefix_test_comments_test_post_id_foreign_key")[0,29].upcase}/}
+      end.to raise_error() {|e| expect(e.message).to match(
+        /ORA-02291.*\.C#{Digest::SHA1.hexdigest("long_prefix_test_comments_test_post_id_foreign_key")[0,29].upcase}/
+      )}
     end
 
     it "should add foreign key with column" do
@@ -702,9 +705,9 @@ end
       schema_define do
         add_foreign_key :test_comments, :test_posts, :column => "post_id"
       end
-      lambda do
+      expect do
         TestComment.create(:body => "test", :post_id => 1)
-      end.should raise_error() {|e| e.message.should =~ /ORA-02291.*\.#{fk_name}/i}
+      end.to raise_error() {|e| expect(e.message).to match(/ORA-02291.*\.#{fk_name}/i)}
     end
 
     it "should add foreign key with delete dependency" do
@@ -714,7 +717,7 @@ end
       p = TestPost.create(:title => "test")
       c = TestComment.create(:body => "test", :test_post => p)
       TestPost.delete(p.id)
-      TestComment.find_by_id(c.id).should be_nil
+      expect(TestComment.find_by_id(c.id)).to be_nil
     end
 
     it "should add foreign key with nullify dependency" do
@@ -724,11 +727,11 @@ end
       p = TestPost.create(:title => "test")
       c = TestComment.create(:body => "test", :test_post => p)
       TestPost.delete(p.id)
-      TestComment.find_by_id(c.id).test_post_id.should be_nil
+      expect(TestComment.find_by_id(c.id).test_post_id).to be_nil
     end
 
     it "should add a composite foreign key" do
-      pending "Composite foreign keys are not supported in this version"
+      skip "Composite foreign keys are not supported in this version"
       schema_define do
         add_column :test_posts, :baz_id, :integer
         add_column :test_posts, :fooz_id, :integer
@@ -744,14 +747,15 @@ end
         add_foreign_key :test_comments, :test_posts, :columns => ["baz_id", "fooz_id"]
       end
 
-      lambda do
+      expect do
         TestComment.create(:body => "test", :fooz_id => 1, :baz_id => 1)
-      end.should raise_error() {|e| e.message.should =~
-        /ORA-02291.*\.TES_COM_BAZ_ID_FOO_ID_FK/}
+      end.to raise_error() {|e| expect(e.message).to match(
+        /ORA-02291.*\.TES_COM_BAZ_ID_FOO_ID_FK/
+      )}
     end
 
     it "should add a composite foreign key with name" do
-      pending "Composite foreign keys are not supported in this version"
+      skip "Composite foreign keys are not supported in this version"
       schema_define do
         add_column :test_posts, :baz_id, :integer
         add_column :test_posts, :fooz_id, :integer
@@ -767,9 +771,9 @@ end
         add_foreign_key :test_comments, :test_posts, :columns => ["baz_id", "fooz_id"], :name => 'comments_posts_baz_fooz_fk'
       end
 
-      lambda do
+      expect do
         TestComment.create(:body => "test", :baz_id => 1, :fooz_id => 1)
-      end.should raise_error() {|e| e.message.should =~ /ORA-02291.*\.COMMENTS_POSTS_BAZ_FOOZ_FK/}
+      end.to raise_error() {|e| expect(e.message).to match(/ORA-02291.*\.COMMENTS_POSTS_BAZ_FOOZ_FK/)}
     end
 
     it "should remove foreign key by table name" do
@@ -777,9 +781,9 @@ end
         add_foreign_key :test_comments, :test_posts
         remove_foreign_key :test_comments, :test_posts
       end
-      lambda do
+      expect do
         TestComment.create(:body => "test", :test_post_id => 1)
-      end.should_not raise_error
+      end.not_to raise_error
     end
 
     it "should remove foreign key by constraint name" do
@@ -787,9 +791,9 @@ end
         add_foreign_key :test_comments, :test_posts, :name => "comments_posts_fk"
         remove_foreign_key :test_comments, :name => "comments_posts_fk"
       end
-      lambda do
+      expect do
         TestComment.create(:body => "test", :test_post_id => 1)
-      end.should_not raise_error
+      end.not_to raise_error
     end
 
     it "should remove foreign key by column name" do
@@ -797,9 +801,9 @@ end
         add_foreign_key :test_comments, :test_posts
         remove_foreign_key :test_comments, :column => "test_post_id"
       end
-      lambda do
+      expect do
         TestComment.create(:body => "test", :test_post_id => 1)
-      end.should_not raise_error
+      end.not_to raise_error
     end
 
   end
@@ -818,8 +822,8 @@ end
           t.binary :test_blob
         end
       end
-      TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_CLOB'").should == DATABASE_NON_DEFAULT_TABLESPACE
-      TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_BLOB'").should_not == DATABASE_NON_DEFAULT_TABLESPACE
+      expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_CLOB'")).to eq(DATABASE_NON_DEFAULT_TABLESPACE)
+      expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_BLOB'")).not_to eq(DATABASE_NON_DEFAULT_TABLESPACE)
     end
 
     it 'should use default tablespace for blobs' do
@@ -831,8 +835,8 @@ end
           t.binary :test_blob
         end
       end
-      TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_BLOB'").should == DATABASE_NON_DEFAULT_TABLESPACE
-      TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_CLOB'").should_not == DATABASE_NON_DEFAULT_TABLESPACE
+      expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_BLOB'")).to eq(DATABASE_NON_DEFAULT_TABLESPACE)
+      expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_CLOB'")).not_to eq(DATABASE_NON_DEFAULT_TABLESPACE)
     end
 
     after do
@@ -876,9 +880,9 @@ end
           t.foreign_key :test_posts
         end
       end
-      lambda do
+      expect do
         TestComment.create(:body => "test", :test_post_id => 1)
-      end.should raise_error() {|e| e.message.should =~ /ORA-02291/}
+      end.to raise_error() {|e| expect(e.message).to match(/ORA-02291/)}
     end
 
     it "should add foreign key in create_table references" do
@@ -888,9 +892,9 @@ end
           t.references :test_post, :foreign_key => true
         end
       end
-      lambda do
+      expect do
         TestComment.create(:body => "test", :test_post_id => 1)
-      end.should raise_error() {|e| e.message.should =~ /ORA-02291/}
+      end.to raise_error() {|e| expect(e.message).to match(/ORA-02291/)}
     end
 
     it "should add foreign key in change_table" do
@@ -903,9 +907,9 @@ end
           t.foreign_key :test_posts
         end
       end
-      lambda do
+      expect do
         TestComment.create(:body => "test", :test_post_id => 1)
-      end.should raise_error() {|e| e.message.should =~ /ORA-02291/}
+      end.to raise_error() {|e| expect(e.message).to match(/ORA-02291/)}
     end
 
     it "should add foreign key in change_table references" do
@@ -917,9 +921,9 @@ end
           t.references :test_post, :foreign_key => true
         end
       end
-      lambda do
+      expect do
         TestComment.create(:body => "test", :test_post_id => 1)
-      end.should raise_error() {|e| e.message.should =~ /ORA-02291/}
+      end.to raise_error() {|e| expect(e.message).to match(/ORA-02291/)}
     end
 
     it "should remove foreign key by table name" do
@@ -935,9 +939,9 @@ end
           t.remove_foreign_key :test_posts
         end
       end
-      lambda do
+      expect do
         TestComment.create(:body => "test", :test_post_id => 1)
-      end.should_not raise_error
+      end.not_to raise_error
     end
 
   end
@@ -967,18 +971,18 @@ end
     end
 
     it "should disable all foreign keys" do
-      lambda do
+      expect do
         @conn.execute "INSERT INTO test_comments (id, body, test_post_id) VALUES (1, 'test', 1)"
-      end.should raise_error
+      end.to raise_error
       @conn.disable_referential_integrity do
-        lambda do
+        expect do
           @conn.execute "INSERT INTO test_comments (id, body, test_post_id) VALUES (2, 'test', 2)"
           @conn.execute "INSERT INTO test_posts (id, title) VALUES (2, 'test')"
-        end.should_not raise_error
+        end.not_to raise_error
       end
-      lambda do
+      expect do
         @conn.execute "INSERT INTO test_comments (id, body, test_post_id) VALUES (3, 'test', 3)"
-      end.should raise_error
+      end.to raise_error
     end
 
   end
@@ -1027,9 +1031,9 @@ end
         add_synonym :synonym_to_posts, "#{schema_name}.test_posts", :force => true
         add_synonym :synonym_to_posts_seq, "#{schema_name}.test_posts_seq", :force => true
       end
-      lambda do
+      expect do
         TestPost.create(:title => "test")
-      end.should_not raise_error
+      end.not_to raise_error
     end
 
     it "should create synonym to table over database link" do
@@ -1038,9 +1042,9 @@ end
         add_synonym :synonym_to_posts, "test_posts@#{db_link}", :force => true
         add_synonym :synonym_to_posts_seq, "test_posts_seq@#{db_link}", :force => true
       end
-      lambda do
+      expect do
         TestPost.create(:title => "test")
-      end.should_not raise_error
+      end.not_to raise_error
     end
 
   end
@@ -1068,7 +1072,7 @@ end
         end
       end
       class ::TestPost < ActiveRecord::Base; end
-      TestPost.columns_hash['title'].null.should be_false
+      expect(TestPost.columns_hash['title'].null).to be_falsey
     end
 
     after(:each) do
@@ -1082,7 +1086,7 @@ end
         change_column :test_posts, :title, :string, :null => true
       end
       TestPost.reset_column_information
-      TestPost.columns_hash['title'].null.should be_true
+      expect(TestPost.columns_hash['title'].null).to be_truthy
     end
 
     it "should add column" do
@@ -1090,7 +1094,7 @@ end
         add_column :test_posts, :body, :string
       end
       TestPost.reset_column_information
-      TestPost.columns_hash['body'].should_not be_nil
+      expect(TestPost.columns_hash['body']).not_to be_nil
     end
 
     it "should add lob column with non_default tablespace" do
@@ -1098,7 +1102,7 @@ end
       schema_define do
         add_column :test_posts, :body, :text
       end
-      TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'BODY'").should == DATABASE_NON_DEFAULT_TABLESPACE
+      expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'BODY'")).to eq(DATABASE_NON_DEFAULT_TABLESPACE)
     end
 
     it "should add blob column with non_default tablespace" do
@@ -1106,7 +1110,7 @@ end
       schema_define do
         add_column :test_posts, :attachment, :binary
       end
-      TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'ATTACHMENT'").should == DATABASE_NON_DEFAULT_TABLESPACE
+      expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'ATTACHMENT'")).to eq(DATABASE_NON_DEFAULT_TABLESPACE)
     end
 
     it "should rename column" do
@@ -1114,8 +1118,8 @@ end
         rename_column :test_posts, :title, :subject
       end
       TestPost.reset_column_information
-      TestPost.columns_hash['subject'].should_not be_nil
-      TestPost.columns_hash['title'].should be_nil
+      expect(TestPost.columns_hash['subject']).not_to be_nil
+      expect(TestPost.columns_hash['title']).to be_nil
     end
 
     it "should remove column" do
@@ -1123,7 +1127,7 @@ end
         remove_column :test_posts, :title
       end
       TestPost.reset_column_information
-      TestPost.columns_hash['title'].should be_nil
+      expect(TestPost.columns_hash['title']).to be_nil
     end
 
     it "should remove column when using change_table" do
@@ -1133,7 +1137,7 @@ end
         end
       end
       TestPost.reset_column_information
-      TestPost.columns_hash['title'].should be_nil
+      expect(TestPost.columns_hash['title']).to be_nil
     end
 
     it "should remove multiple columns when using change_table" do
@@ -1143,8 +1147,8 @@ end
         end
       end
       TestPost.reset_column_information
-      TestPost.columns_hash['title'].should be_nil
-      TestPost.columns_hash['content'].should be_nil
+      expect(TestPost.columns_hash['title']).to be_nil
+      expect(TestPost.columns_hash['content']).to be_nil
     end
 
     it "should ignore type and options parameter and remove column" do
@@ -1152,13 +1156,13 @@ end
         remove_column :test_posts, :title, :string, {}
       end
       TestPost.reset_column_information
-      TestPost.columns_hash['title'].should be_nil
+      expect(TestPost.columns_hash['title']).to be_nil
     end
   end
 
   describe 'virtual columns in create_table' do
     before(:each) do
-      pending "Not supported in this database version" unless @oracle11g_or_higher
+      skip "Not supported in this database version" unless @oracle11g_or_higher
     end
 
     it 'should create virtual column with old syntax' do
@@ -1174,16 +1178,16 @@ end
 
       TestFraction.reset_column_information
       tf = TestFraction.columns.detect { |c| c.virtual? }
-      tf.should_not be nil
-      tf.name.should == "field2"
-      tf.virtual?.should be true
-      lambda do
+      expect(tf).not_to be nil
+      expect(tf.name).to eq("field2")
+      expect(tf.virtual?).to be true
+      expect do
         tf = TestFraction.new(:field1=>10)
-        tf.field2.should be nil # not whatever is in DATA_DEFAULT column
+        expect(tf.field2).to be nil # not whatever is in DATA_DEFAULT column
         tf.save!
         tf.reload
-      end.should_not raise_error
-      tf.field2.to_i.should == 11
+      end.not_to raise_error
+      expect(tf.field2.to_i).to eq(11)
 
       schema_define do
         drop_table :test_fractions
@@ -1191,20 +1195,20 @@ end
     end
 
     it 'should raise error if column expression is not provided' do
-      lambda {
+      expect {
         schema_define do
           create_table :test_fractions do |t|
             t.integer :field1
             t.virtual :field2
           end
         end
-      }.should raise_error
+      }.to raise_error
     end
   end
 
   describe 'virtual columns' do
     before(:each) do
-      pending "Not supported in this database version" unless @oracle11g_or_higher
+      skip "Not supported in this database version" unless @oracle11g_or_higher
       expr = "( numerator/NULLIF(denominator,0) )*100"
       schema_define do
         create_table :test_fractions, :force => true do |t|
@@ -1229,16 +1233,16 @@ end
 
     it 'should include virtual columns and not try to update them' do
       tf = TestFraction.columns.detect { |c| c.virtual? }
-      tf.should_not be nil
-      tf.name.should == "percent"
-      tf.virtual?.should be true
-      lambda do
+      expect(tf).not_to be nil
+      expect(tf.name).to eq("percent")
+      expect(tf.virtual?).to be true
+      expect do
         tf = TestFraction.new(:numerator=>20, :denominator=>100)
-        tf.percent.should be nil # not whatever is in DATA_DEFAULT column
+        expect(tf.percent).to be nil # not whatever is in DATA_DEFAULT column
         tf.save!
         tf.reload
-      end.should_not raise_error
-      tf.percent.to_i.should == 20
+      end.not_to raise_error
+      expect(tf.percent.to_i).to eq(20)
     end
 
     it 'should add virtual column' do
@@ -1247,15 +1251,15 @@ end
       end
       TestFraction.reset_column_information
       tf = TestFraction.columns.detect { |c| c.name == 'rem' }
-      tf.should_not be nil
-      tf.virtual?.should be true
-      lambda do
+      expect(tf).not_to be nil
+      expect(tf.virtual?).to be true
+      expect do
         tf = TestFraction.new(:numerator=>7, :denominator=>5)
-        tf.rem.should be nil
+        expect(tf.rem).to be nil
         tf.save!
         tf.reload
-      end.should_not raise_error
-      tf.rem.to_i.should == 2
+      end.not_to raise_error
+      expect(tf.rem.to_i).to eq(2)
     end
 
     it 'should add virtual column with explicit type' do
@@ -1264,17 +1268,17 @@ end
       end
       TestFraction.reset_column_information
       tf = TestFraction.columns.detect { |c| c.name == 'expression' }
-      tf.should_not be nil
-      tf.virtual?.should be true
-      tf.type.should be :string
-      tf.limit.should be 100
-      lambda do
+      expect(tf).not_to be nil
+      expect(tf.virtual?).to be true
+      expect(tf.type).to be :string
+      expect(tf.limit).to be 100
+      expect do
         tf = TestFraction.new(:numerator=>7, :denominator=>5)
-        tf.expression.should be nil
+        expect(tf.expression).to be nil
         tf.save!
         tf.reload
-      end.should_not raise_error
-      tf.expression.should == '7/5'
+      end.not_to raise_error
+      expect(tf.expression).to eq('7/5')
     end
 
     it 'should change virtual column definition' do
@@ -1284,18 +1288,18 @@ end
       end
       TestFraction.reset_column_information
       tf = TestFraction.columns.detect { |c| c.name == 'percent' }
-      tf.should_not be nil
-      tf.virtual?.should be true
-      tf.type.should be :decimal
-      tf.precision.should be 15
-      tf.scale.should be 2
-      lambda do
+      expect(tf).not_to be nil
+      expect(tf.virtual?).to be true
+      expect(tf.type).to be :decimal
+      expect(tf.precision).to be 15
+      expect(tf.scale).to be 2
+      expect do
         tf = TestFraction.new(:numerator=>11, :denominator=>17)
-        tf.percent.should be nil
+        expect(tf.percent).to be nil
         tf.save!
         tf.reload
-      end.should_not raise_error
-      tf.percent.should == '64.71'.to_d
+      end.not_to raise_error
+      expect(tf.percent).to eq('64.71'.to_d)
     end
 
     it 'should change virtual column type' do
@@ -1304,18 +1308,18 @@ end
       end
       TestFraction.reset_column_information
       tf = TestFraction.columns.detect { |c| c.name == 'percent' }
-      tf.should_not be nil
-      tf.virtual?.should be true
-      tf.type.should be :decimal
-      tf.precision.should be 12
-      tf.scale.should be 5
-      lambda do
+      expect(tf).not_to be nil
+      expect(tf.virtual?).to be true
+      expect(tf.type).to be :decimal
+      expect(tf.precision).to be 12
+      expect(tf.scale).to be 5
+      expect do
         tf = TestFraction.new(:numerator=>11, :denominator=>17)
-        tf.percent.should be nil
+        expect(tf.percent).to be nil
         tf.save!
         tf.reload
-      end.should_not raise_error
-      tf.percent.should == '64.70588'.to_d
+      end.not_to raise_error
+      expect(tf.percent).to eq('64.70588'.to_d)
     end
   end
 
@@ -1345,7 +1349,7 @@ end
           t.string :title, :null => false
         end
       end
-      @would_execute_sql.should =~ /CREATE +TABLE .* \(.*\) NOLOGGING/
+      expect(@would_execute_sql).to match(/CREATE +TABLE .* \(.*\) NOLOGGING/)
     end
 
     it "should support the :tablespace option to create_table" do
@@ -1354,7 +1358,7 @@ end
           t.string :title, :null => false
         end
       end
-      @would_execute_sql.should =~ /CREATE +TABLE .* \(.*\) TABLESPACE bogus/
+      expect(@would_execute_sql).to match(/CREATE +TABLE .* \(.*\) TABLESPACE bogus/)
     end
 
     describe "creating a table with a tablespace defaults set" do
@@ -1367,7 +1371,7 @@ end
         @conn.create_table :tablespace_tests do |t|
           t.string :foo
         end
-        @would_execute_sql.should =~ /CREATE +TABLE .* \(.*\) TABLESPACE #{DATABASE_NON_DEFAULT_TABLESPACE}/
+        expect(@would_execute_sql).to match(/CREATE +TABLE .* \(.*\) TABLESPACE #{DATABASE_NON_DEFAULT_TABLESPACE}/)
       end
     end
 
@@ -1380,7 +1384,7 @@ end
         @conn.create_table :tablespace_tests, :id=>false, :organization=>'INDEX INITRANS 4 COMPRESS 1', :tablespace=>'bogus' do |t|
           t.integer :id
         end
-        @would_execute_sql.should =~ /CREATE +TABLE .*\(.*\)\s+ORGANIZATION INDEX INITRANS 4 COMPRESS 1 TABLESPACE bogus/
+        expect(@would_execute_sql).to match(/CREATE +TABLE .*\(.*\)\s+ORGANIZATION INDEX INITRANS 4 COMPRESS 1 TABLESPACE bogus/)
       end
     end
 
@@ -1388,14 +1392,14 @@ end
       schema_define do
         add_index :keyboards, :name, :options=>'NOLOGGING'
       end
-      @would_execute_sql.should =~ /CREATE +INDEX .* ON .* \(.*\) NOLOGGING/
+      expect(@would_execute_sql).to match(/CREATE +INDEX .* ON .* \(.*\) NOLOGGING/)
     end
 
     it "should support the :tablespace option to add_index" do
       schema_define do
         add_index :keyboards, :name, :tablespace=>'bogus'
       end
-      @would_execute_sql.should =~ /CREATE +INDEX .* ON .* \(.*\) TABLESPACE bogus/
+      expect(@would_execute_sql).to match(/CREATE +INDEX .* ON .* \(.*\) TABLESPACE bogus/)
     end
 
     it "should use default_tablespaces in add_index" do
@@ -1404,14 +1408,14 @@ end
         add_index :keyboards, :name
       end
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces.delete(:index)
-      @would_execute_sql.should =~ /CREATE +INDEX .* ON .* \(.*\) TABLESPACE #{DATABASE_NON_DEFAULT_TABLESPACE}/
+      expect(@would_execute_sql).to match(/CREATE +INDEX .* ON .* \(.*\) TABLESPACE #{DATABASE_NON_DEFAULT_TABLESPACE}/)
     end
 
     it "should create unique function index but not create unique constraints" do
       schema_define do
         add_index :keyboards, 'lower(name)', unique: true, name: :index_keyboards_on_lower_name
       end
-      @would_execute_sql.should_not =~ /ALTER +TABLE .* ADD CONSTRAINT .* UNIQUE \(.*\(.*\)\)/
+      expect(@would_execute_sql).not_to match(/ALTER +TABLE .* ADD CONSTRAINT .* UNIQUE \(.*\(.*\)\)/)
     end
 
     describe "#initialize_schema_migrations_table" do
@@ -1436,7 +1440,7 @@ end
         it "should not truncate the index name" do
           add_schema_migrations_index
 
-          @would_execute_sql.should include('CREATE UNIQUE INDEX "UNIQUE_SCHEMA_MIGRATIONS" ON "SCHEMA_MIGRATIONS" ("VERSION")')
+          expect(@would_execute_sql).to include('CREATE UNIQUE INDEX "UNIQUE_SCHEMA_MIGRATIONS" ON "SCHEMA_MIGRATIONS" ("VERSION")')
         end
       end
 
@@ -1446,7 +1450,7 @@ end
         it "should truncate the 'unique_schema_migrations' portion of the index name to fit the prefix within the limit" do
           add_schema_migrations_index
 
-          @would_execute_sql.should include('CREATE UNIQUE INDEX "TOOLONG_UNIQUE_SCHEMA_MIGRATIO" ON "TOOLONG_SCHEMA_MIGRATIONS" ("VERSION")')
+          expect(@would_execute_sql).to include('CREATE UNIQUE INDEX "TOOLONG_UNIQUE_SCHEMA_MIGRATIO" ON "TOOLONG_SCHEMA_MIGRATIONS" ("VERSION")')
         end
       end
 
@@ -1456,7 +1460,7 @@ end
         it "should truncate the 'unique_schema_migrations' portion of the index name to fit the suffix within the limit" do
           add_schema_migrations_index
 
-          @would_execute_sql.should include('CREATE UNIQUE INDEX "UNIQUE_SCHEMA_MIGRATIO_TOOLONG" ON "SCHEMA_MIGRATIONS_TOOLONG" ("VERSION")')
+          expect(@would_execute_sql).to include('CREATE UNIQUE INDEX "UNIQUE_SCHEMA_MIGRATIO_TOOLONG" ON "SCHEMA_MIGRATIONS_TOOLONG" ("VERSION")')
         end
       end
 
@@ -1469,7 +1473,7 @@ end
         it "should truncate the 'unique_schema_migrations' portion of the index name to fit the suffix within the limit" do
           add_schema_migrations_index
 
-          @would_execute_sql.should include('CREATE UNIQUE INDEX "BEGIN_UNIQUE_SCHEMA_MIGRAT_END" ON "BEGIN_SCHEMA_MIGRATIONS_END" ("VERSION")')
+          expect(@would_execute_sql).to include('CREATE UNIQUE INDEX "BEGIN_UNIQUE_SCHEMA_MIGRAT_END" ON "BEGIN_SCHEMA_MIGRATIONS_END" ("VERSION")')
         end
       end
     end

--- a/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
@@ -43,7 +43,7 @@ describe "OracleEnhancedAdapter structure dump" do
   
     it "should dump single primary key" do
       dump = ActiveRecord::Base.connection.structure_dump
-      dump.should =~ /CONSTRAINT (.+) PRIMARY KEY \(ID\)\n/
+      expect(dump).to match(/CONSTRAINT (.+) PRIMARY KEY \(ID\)\n/)
     end
   
     it "should dump composite primary keys" do
@@ -58,7 +58,7 @@ describe "OracleEnhancedAdapter structure dump" do
         add CONSTRAINT pk_id_title PRIMARY KEY (id, title)
       SQL
       dump = ActiveRecord::Base.connection.structure_dump
-      dump.should =~ /CONSTRAINT (.+) PRIMARY KEY \(ID,TITLE\)\n/
+      expect(dump).to match(/CONSTRAINT (.+) PRIMARY KEY \(ID,TITLE\)\n/)
     end
   
     it "should dump foreign keys" do
@@ -67,8 +67,8 @@ describe "OracleEnhancedAdapter structure dump" do
         ADD CONSTRAINT fk_test_post_foo FOREIGN KEY (foo_id) REFERENCES foos(id)
       SQL
       dump = ActiveRecord::Base.connection.structure_dump_fk_constraints
-      dump.split('\n').length.should == 1
-      dump.should =~ /ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_FOO\"? FOREIGN KEY \(\"?FOO_ID\"?\) REFERENCES \"?FOOS\"?\(\"?ID\"?\)/i
+      expect(dump.split('\n').length).to eq(1)
+      expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_FOO\"? FOREIGN KEY \(\"?FOO_ID\"?\) REFERENCES \"?FOOS\"?\(\"?ID\"?\)/i)
     end
     
     it "should dump foreign keys when reference column name is not 'id'" do
@@ -87,12 +87,12 @@ describe "OracleEnhancedAdapter structure dump" do
       SQL
       
       dump = ActiveRecord::Base.connection.structure_dump_fk_constraints
-      dump.split('\n').length.should == 1
-      dump.should =~ /ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_BAZ\"? FOREIGN KEY \(\"?BAZ_ID\"?\) REFERENCES \"?FOOS\"?\(\"?BAZ_ID\"?\)/i
+      expect(dump.split('\n').length).to eq(1)
+      expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_BAZ\"? FOREIGN KEY \(\"?BAZ_ID\"?\) REFERENCES \"?FOOS\"?\(\"?BAZ_ID\"?\)/i)
     end
     
     it "should dump composite foreign keys" do
-      pending "Composite foreign keys are not supported in this version"
+      skip "Composite foreign keys are not supported in this version"
       @conn.add_column :foos, :fooz_id, :integer
       @conn.add_column :foos, :baz_id, :integer
       
@@ -110,14 +110,14 @@ describe "OracleEnhancedAdapter structure dump" do
       SQL
       
       dump = ActiveRecord::Base.connection.structure_dump_fk_constraints
-      dump.split('\n').length.should == 1
-      dump.should =~ /ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_FOOZ_BAZ\"? FOREIGN KEY \(\"?BAZ_ID\"?\,\"?FOOZ_ID\"?\) REFERENCES \"?FOOS\"?\(\"?BAZ_ID\"?\,\"?FOOZ_ID\"?\)/i
+      expect(dump.split('\n').length).to eq(1)
+      expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_FOOZ_BAZ\"? FOREIGN KEY \(\"?BAZ_ID\"?\,\"?FOOZ_ID\"?\) REFERENCES \"?FOOS\"?\(\"?BAZ_ID\"?\,\"?FOOZ_ID\"?\)/i)
     end
   
     it "should not error when no foreign keys are present" do
       dump = ActiveRecord::Base.connection.structure_dump_fk_constraints
-      dump.split('\n').length.should == 0
-      dump.should == ''
+      expect(dump.split('\n').length).to eq(0)
+      expect(dump).to eq('')
     end
   
     it "should dump triggers" do
@@ -131,7 +131,7 @@ describe "OracleEnhancedAdapter structure dump" do
         END;
       SQL
       dump = ActiveRecord::Base.connection.structure_dump_db_stored_code.gsub(/\n|\s+/,' ')
-      dump.should =~ /CREATE OR REPLACE TRIGGER TEST_POST_TRIGGER/
+      expect(dump).to match(/CREATE OR REPLACE TRIGGER TEST_POST_TRIGGER/)
     end
   
     it "should dump types" do
@@ -139,18 +139,18 @@ describe "OracleEnhancedAdapter structure dump" do
         create or replace TYPE TEST_TYPE AS TABLE OF VARCHAR2(10);
       SQL
       dump = ActiveRecord::Base.connection.structure_dump_db_stored_code.gsub(/\n|\s+/,' ')
-      dump.should =~ /CREATE OR REPLACE TYPE TEST_TYPE/
+      expect(dump).to match(/CREATE OR REPLACE TYPE TEST_TYPE/)
     end
 
     it "should dump views" do
       @conn.execute "create or replace VIEW test_posts_view_z as select * from test_posts"
       @conn.execute "create or replace VIEW test_posts_view_a as select * from test_posts_view_z"
       dump = ActiveRecord::Base.connection.structure_dump_db_stored_code.gsub(/\n|\s+/,' ')
-      dump.should =~ /CREATE OR REPLACE FORCE VIEW TEST_POSTS_VIEW_A.*CREATE OR REPLACE FORCE VIEW TEST_POSTS_VIEW_Z/
+      expect(dump).to match(/CREATE OR REPLACE FORCE VIEW TEST_POSTS_VIEW_A.*CREATE OR REPLACE FORCE VIEW TEST_POSTS_VIEW_Z/)
     end
   
     it "should dump virtual columns" do
-      pending "Not supported in this database version" unless @oracle11g_or_higher
+      skip "Not supported in this database version" unless @oracle11g_or_higher
       @conn.execute <<-SQL
         CREATE TABLE bars (
           id          NUMBER(38,0) NOT NULL,
@@ -159,7 +159,7 @@ describe "OracleEnhancedAdapter structure dump" do
         )
       SQL
       dump = ActiveRecord::Base.connection.structure_dump
-      dump.should =~ /\"?ID_PLUS\"? NUMBER GENERATED ALWAYS AS \(ID\+2\) VIRTUAL/
+      expect(dump).to match(/\"?ID_PLUS\"? NUMBER GENERATED ALWAYS AS \(ID\+2\) VIRTUAL/)
     end
 
     it "should dump RAW virtual columns" do
@@ -171,7 +171,7 @@ describe "OracleEnhancedAdapter structure dump" do
         )
       SQL
       dump = ActiveRecord::Base.connection.structure_dump
-      dump.should =~ /CREATE TABLE \"BARS\" \(\n\"ID\" NUMBER\(38,0\) NOT NULL,\n \"SUPER\" RAW\(255\) GENERATED ALWAYS AS \(HEXTORAW\(TO_CHAR\(ID\)\)\) VIRTUAL/
+      expect(dump).to match(/CREATE TABLE \"BARS\" \(\n\"ID\" NUMBER\(38,0\) NOT NULL,\n \"SUPER\" RAW\(255\) GENERATED ALWAYS AS \(HEXTORAW\(TO_CHAR\(ID\)\)\) VIRTUAL/)
     end
 
     it "should dump unique keys" do
@@ -180,10 +180,10 @@ describe "OracleEnhancedAdapter structure dump" do
           add CONSTRAINT uk_foo_foo_id UNIQUE (foo, foo_id)
       SQL
       dump = ActiveRecord::Base.connection.structure_dump_unique_keys("test_posts")
-      dump.should == ["ALTER TABLE TEST_POSTS ADD CONSTRAINT UK_FOO_FOO_ID UNIQUE (FOO,FOO_ID)"]
+      expect(dump).to eq(["ALTER TABLE TEST_POSTS ADD CONSTRAINT UK_FOO_FOO_ID UNIQUE (FOO,FOO_ID)"])
     
       dump = ActiveRecord::Base.connection.structure_dump
-      dump.should =~ /CONSTRAINT UK_FOO_FOO_ID UNIQUE \(FOO,FOO_ID\)/
+      expect(dump).to match(/CONSTRAINT UK_FOO_FOO_ID UNIQUE \(FOO,FOO_ID\)/)
     end
   
     it "should dump indexes" do
@@ -196,9 +196,9 @@ describe "OracleEnhancedAdapter structure dump" do
       SQL
       
       dump = ActiveRecord::Base.connection.structure_dump
-      dump.should =~ /CREATE UNIQUE INDEX "?IX_TEST_POSTS_FOO_ID"? ON "?TEST_POSTS"? \("?FOO_ID"?\)/i
-      dump.should =~ /CREATE  INDEX "?IX_TEST_POSTS_FOO\"? ON "?TEST_POSTS"? \("?FOO"?\)/i
-      dump.should_not =~ /CREATE UNIQUE INDEX "?UK_TEST_POSTS_/i
+      expect(dump).to match(/CREATE UNIQUE INDEX "?IX_TEST_POSTS_FOO_ID"? ON "?TEST_POSTS"? \("?FOO_ID"?\)/i)
+      expect(dump).to match(/CREATE  INDEX "?IX_TEST_POSTS_FOO\"? ON "?TEST_POSTS"? \("?FOO"?\)/i)
+      expect(dump).not_to match(/CREATE UNIQUE INDEX "?UK_TEST_POSTS_/i)
     end
 
     it "should dump multi-value and function value indexes" do
@@ -209,8 +209,8 @@ describe "OracleEnhancedAdapter structure dump" do
       SQL
 
       dump = ActiveRecord::Base.connection.structure_dump
-      dump.should =~ /CREATE  INDEX "?IX_TEST_POSTS_FOO_FOO_ID\"? ON "?TEST_POSTS"? \("?FOO"?, "?FOO_ID"?\)/i
-      dump.should =~ /CREATE  INDEX "?IX_TEST_POSTS_FUNCTION\"? ON "?TEST_POSTS"? \(TO_CHAR\(LENGTH\("?FOO"?\)\)\|\|"?FOO"?\)/i
+      expect(dump).to match(/CREATE  INDEX "?IX_TEST_POSTS_FOO_FOO_ID\"? ON "?TEST_POSTS"? \("?FOO"?, "?FOO_ID"?\)/i)
+      expect(dump).to match(/CREATE  INDEX "?IX_TEST_POSTS_FUNCTION\"? ON "?TEST_POSTS"? \(TO_CHAR\(LENGTH\("?FOO"?\)\)\|\|"?FOO"?\)/i)
     end
 
     it "should dump RAW columns" do
@@ -222,7 +222,7 @@ describe "OracleEnhancedAdapter structure dump" do
         )
       SQL
       dump = ActiveRecord::Base.connection.structure_dump
-      dump.should =~ /CREATE TABLE \"BARS\" \(\n\"ID\" NUMBER\(38,0\) NOT NULL,\n \"SUPER\" RAW\(255\)/
+      expect(dump).to match(/CREATE TABLE \"BARS\" \(\n\"ID\" NUMBER\(38,0\) NOT NULL,\n \"SUPER\" RAW\(255\)/)
     end
 
   end
@@ -235,7 +235,7 @@ describe "OracleEnhancedAdapter structure dump" do
         t.integer :post_id
       end
       dump = ActiveRecord::Base.connection.structure_dump
-      dump.should =~ /CREATE GLOBAL TEMPORARY TABLE "?TEST_COMMENTS"?/i
+      expect(dump).to match(/CREATE GLOBAL TEMPORARY TABLE "?TEST_COMMENTS"?/i)
     end
   end
 
@@ -254,7 +254,7 @@ describe "OracleEnhancedAdapter structure dump" do
 
     it "should return the character size of nvarchar fields" do
       if /.*unq_nvarchar nvarchar2\((\d+)\).*/ =~ @conn.structure_dump
-         "#$1".should == "255"
+         expect("#$1").to eq("255")
       end
     end
   end
@@ -270,8 +270,8 @@ describe "OracleEnhancedAdapter structure dump" do
     end
     it "should dump drop sql for just temp tables" do
       dump = @conn.temp_table_drop
-      dump.should =~ /DROP TABLE "TEMP_TBL"/
-      dump.should_not =~ /DROP TABLE "?NOT_TEMP_TBL"?/i
+      expect(dump).to match(/DROP TABLE "TEMP_TBL"/)
+      expect(dump).not_to match(/DROP TABLE "?NOT_TEMP_TBL"?/i)
     end
     after(:each) do
       @conn.drop_table :temp_tbl 
@@ -351,21 +351,21 @@ describe "OracleEnhancedAdapter structure dump" do
     end
     it "should contain correct sql" do
       drop = @conn.full_drop
-      drop.should =~ /DROP TABLE "FULL_DROP_TEST" CASCADE CONSTRAINTS/
-      drop.should =~ /DROP SEQUENCE "FULL_DROP_TEST_SEQ"/
-      drop.should =~ /DROP VIEW "FULL_DROP_TEST_VIEW"/
-      drop.should_not =~ /DROP TABLE "?FULL_DROP_TEST_MVIEW"?/i
-      drop.should =~ /DROP MATERIALIZED VIEW "FULL_DROP_TEST_MVIEW"/
-      drop.should =~ /DROP PACKAGE "FULL_DROP_TEST_PACKAGE"/
-      drop.should =~ /DROP FUNCTION "FULL_DROP_TEST_FUNCTION"/
-      drop.should =~ /DROP PROCEDURE "FULL_DROP_TEST_PROCEDURE"/
-      drop.should =~ /DROP SYNONYM "FULL_DROP_TEST_SYNONYM"/
-      drop.should =~ /DROP TYPE "FULL_DROP_TEST_TYPE"/
+      expect(drop).to match(/DROP TABLE "FULL_DROP_TEST" CASCADE CONSTRAINTS/)
+      expect(drop).to match(/DROP SEQUENCE "FULL_DROP_TEST_SEQ"/)
+      expect(drop).to match(/DROP VIEW "FULL_DROP_TEST_VIEW"/)
+      expect(drop).not_to match(/DROP TABLE "?FULL_DROP_TEST_MVIEW"?/i)
+      expect(drop).to match(/DROP MATERIALIZED VIEW "FULL_DROP_TEST_MVIEW"/)
+      expect(drop).to match(/DROP PACKAGE "FULL_DROP_TEST_PACKAGE"/)
+      expect(drop).to match(/DROP FUNCTION "FULL_DROP_TEST_FUNCTION"/)
+      expect(drop).to match(/DROP PROCEDURE "FULL_DROP_TEST_PROCEDURE"/)
+      expect(drop).to match(/DROP SYNONYM "FULL_DROP_TEST_SYNONYM"/)
+      expect(drop).to match(/DROP TYPE "FULL_DROP_TEST_TYPE"/)
     end
     it "should not drop tables when preserve_tables is true" do
       drop = @conn.full_drop(true)
-      drop.should =~ /DROP TABLE "FULL_DROP_TEST_TEMP"/
-      drop.should_not =~ /DROP TABLE "?FULL_DROP_TEST"? CASCADE CONSTRAINTS/i
+      expect(drop).to match(/DROP TABLE "FULL_DROP_TEST_TEMP"/)
+      expect(drop).not_to match(/DROP TABLE "?FULL_DROP_TEST"? CASCADE CONSTRAINTS/i)
     end
   end
 end


### PR DESCRIPTION
This pull request updates RSpec version from 2 to 3. Thanks to https://github.com/yujinakayama/transpec only 3 specs need update manually.

* How to use transpec

```ruby
$ transpec
Copying the project for dynamic analysis...
Running dynamic analysis with command "bundle exec rspec"...
==> Loading config from ENV or use default
==> Running specs with MRI version 2.2.3
==> Selected Rails version 4.0-master
==> Effective ActiveRecord version 4.2.4
........................................................................................................................................................................................................................`raise_error` was called with non-proc object true
....F...........................DEPRECATION WARNING: `:dependent` option will be deprecated. Please use `:on_delete` option. (called from add_foreign_key at /tmp/d20150904-26989-17msjv7/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:401)
.DEPRECATION WARNING: `:dependent` option will be deprecated. Please use `:on_delete` option. (called from add_foreign_key at /tmp/d20150904-26989-17msjv7/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:401)
.....*..........................................................DEPRECATION WARNING: Foreign key name test_comments_test_post_id_foreign_key is too long. It will not get shorten in later version of Oracle enhanced adapter. (called from name at /tmp/d20150904-26989-17msjv7/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb:17)
.DEPRECATION WARNING: Foreign key name long_prefix_test_comments_test_post_id_foreign_key is too long. It will not get shorten in later version of Oracle enhanced adapter. (called from name at /tmp/d20150904-26989-17msjv7/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb:17)
..DEPRECATION WARNING: `:dependent` option will be deprecated. Please use `:on_delete` option. (called from add_foreign_key at /tmp/d20150904-26989-17msjv7/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:401)
.DEPRECATION WARNING: `:dependent` option will be deprecated. Please use `:on_delete` option. (called from add_foreign_key at /tmp/d20150904-26989-17msjv7/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:401)
.**.........DEPRECATION WARNING: `foreign_key` option will be deprecated. Please use `references` option. (called from foreign_key at /tmp/d20150904-26989-17msjv7/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb:82)
..DEPRECATION WARNING: `foreign_key` option will be deprecated. Please use `references` option. (called from foreign_key at /tmp/d20150904-26989-17msjv7/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb:82)
DEPRECATION WARNING: `remove_foreign_key` option will be deprecated. Please use `remove_references` option. (called from remove_foreign_key at /tmp/d20150904-26989-17msjv7/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb:88)
.............[DEPRECATION] virtual column `:default` option is deprecated.  Please use `:as` instead.
.......................*...............

Pending:
  OracleEnhancedAdapter schema dump foreign key constraints should include composite foreign keys
    # Composite foreign keys are not supported in this version
    # ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:228
  OracleEnhancedAdapter schema definition foreign key constraints should add a composite foreign key
    # Composite foreign keys are not supported in this version
    # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:730
  OracleEnhancedAdapter schema definition foreign key constraints should add a composite foreign key with name
    # Composite foreign keys are not supported in this version
    # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:753
  OracleEnhancedAdapter structure dump structure dump should dump composite foreign keys
    # Composite foreign keys are not supported in this version
    # ./spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb:94

Failures:

  1) OracleEnhancedAdapter custom methods for create, update and destroy should rollback record when exception is raised in after_create callback
     Failure/Error: Transpec.analyze((Transpec.analyze((@employee.id), self, "spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb_6149_6161", { :should_source_location => [:object, "method(:should).source_location"], :should_example_method_defined_by_user? => [:object, "owner = method(:should).owner\nowner != RSpec::Core::ExampleGroup &&\n  owner.ancestors.include?(RSpec::Core::ExampleGroup)"] }).should), self, "spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb_6149_6168", { :expect_available? => [:context, "self.class.ancestors.any? { |a| a.name.start_with?('RSpec::') } && respond_to?(:expect)"], :"==_source_location" => [:object, "method(:==).source_location"], :"==_example_method_defined_by_user?" => [:object, "owner = method(:==).owner\nowner != RSpec::Core::ExampleGroup &&\n  owner.ancestors.include?(RSpec::Core::ExampleGroup)"] }) == nil
       expected: nil
            got: 2 (using ==)
     # /home/yahonda/.rbenv/versions/2.2.3/gemsets/rails42/gems/rspec-expectations-2.99.2/lib/rspec/expectations/fail_with.rb:32:in `fail_with'
     # /home/yahonda/.rbenv/versions/2.2.3/gemsets/rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:57:in `fail_with_message'
     # /home/yahonda/.rbenv/versions/2.2.3/gemsets/rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:98:in `__delegate_operator'
     # /home/yahonda/.rbenv/versions/2.2.3/gemsets/rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:89:in `eval_match'
     # /home/yahonda/.rbenv/versions/2.2.3/gemsets/rails42/gems/rspec-expectations-2.99.2/lib/rspec/matchers/operator_matcher.rb:38:in `block in use_custom_matcher_or_delegate'
     # ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:189:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.2.3/gemsets/rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.2.3/gemsets/rails42/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rbenv/versions/2.2.3/gemsets/rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rbenv/versions/2.2.3/gemsets/rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rbenv/versions/2.2.3/gemsets/rails42/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rbenv/versions/2.2.3/gemsets/rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.2.3/gemsets/rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rbenv/versions/2.2.3/gemsets/rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.2.3/gemsets/rails42/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rbenv/versions/2.2.3/gemsets/rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rbenv/versions/2.2.3/gemsets/rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rbenv/versions/2.2.3/gemsets/rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rbenv/versions/2.2.3/gemsets/rails42/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rbenv/versions/2.2.3/gemsets/rails42/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rbenv/versions/2.2.3/gemsets/rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rbenv/versions/2.2.3/gemsets/rails42/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Deprecation Warnings:

--------------------------------------------------------------------------------
The semantics of `RSpec::Core::Pending#pending` are changing in
RSpec 3.  In RSpec 2.x, it caused the example to be skipped. In
RSpec 3, the rest of the example will still be run but is expected
to fail, and will be marked as a failure (rather than as pending)
if the example passes.

Any passed block will no longer be executed. This feature is being
removed since it was semantically inconsistent, and the behaviour it
offered is being made available with the other ways of marking an
example pending.

To keep the same skip semantics, change `pending` to `skip`.
Otherwise, if you want the new RSpec 3 behavior, you can safely
ignore this warning and continue to upgrade to RSpec 3 without
addressing it.

Called from /tmp/d20150904-26989-17msjv7/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:229:in `block (3 levels) in <top (required)>'.

--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
The semantics of `RSpec::Core::Pending#pending` are changing in
RSpec 3.  In RSpec 2.x, it caused the example to be skipped. In
RSpec 3, the rest of the example will still be run but is expected
to fail, and will be marked as a failure (rather than as pending)
if the example passes.

Any passed block will no longer be executed. This feature is being
removed since it was semantically inconsistent, and the behaviour it
offered is being made available with the other ways of marking an
example pending.

To keep the same skip semantics, change `pending` to `skip`.
Otherwise, if you want the new RSpec 3 behavior, you can safely
ignore this warning and continue to upgrade to RSpec 3 without
addressing it.

Called from /tmp/d20150904-26989-17msjv7/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:731:in `block (3 levels) in <top (required)>'.

--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
The semantics of `RSpec::Core::Pending#pending` are changing in
RSpec 3.  In RSpec 2.x, it caused the example to be skipped. In
RSpec 3, the rest of the example will still be run but is expected
to fail, and will be marked as a failure (rather than as pending)
if the example passes.

Any passed block will no longer be executed. This feature is being
removed since it was semantically inconsistent, and the behaviour it
offered is being made available with the other ways of marking an
example pending.

To keep the same skip semantics, change `pending` to `skip`.
Otherwise, if you want the new RSpec 3 behavior, you can safely
ignore this warning and continue to upgrade to RSpec 3 without
addressing it.

Called from /tmp/d20150904-26989-17msjv7/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:754:in `block (3 levels) in <top (required)>'.

--------------------------------------------------------------------------------
Too many similar deprecation messages reported, disregarding further reports. Pass `--deprecation-out` or set `config.deprecation_stream` to a file for full output.

`be_false` is deprecated. Use `be_falsey` (for Ruby's conditional semantics) or `be false` (for exact `== false` equality) instead. Called from /tmp/d20150904-26989-17msjv7/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:368:in `block (3 levels) in <top (required)>'.
`be_false` is deprecated. Use `be_falsey` (for Ruby's conditional semantics) or `be false` (for exact `== false` equality) instead. Called from /tmp/d20150904-26989-17msjv7/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:372:in `block (3 levels) in <top (required)>'.
`be_false` is deprecated. Use `be_falsey` (for Ruby's conditional semantics) or `be false` (for exact `== false` equality) instead. Called from /tmp/d20150904-26989-17msjv7/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:376:in `block (3 levels) in <top (required)>'.
Too many uses of deprecated '`be_false`'. Pass `--deprecation-out` or set `config.deprecation_stream` to a file for full output.

`be_true` is deprecated. Use `be_truthy` (for Ruby's conditional semantics) or `be true` (for exact `== true` equality) instead. Called from /tmp/d20150904-26989-17msjv7/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:277:in `block (3 levels) in <top (required)>'.
`be_true` is deprecated. Use `be_truthy` (for Ruby's conditional semantics) or `be true` (for exact `== true` equality) instead. Called from /tmp/d20150904-26989-17msjv7/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:348:in `block (3 levels) in <top (required)>'.
`be_true` is deprecated. Use `be_truthy` (for Ruby's conditional semantics) or `be true` (for exact `== true` equality) instead. Called from /tmp/d20150904-26989-17msjv7/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:352:in `block (3 levels) in <top (required)>'.
Too many uses of deprecated '`be_true`'. Pass `--deprecation-out` or set `config.deprecation_stream` to a file for full output.

`expect { }.not_to raise_error(SpecificErrorClass, message)` is deprecated. Use `expect { }.not_to raise_error` (with no args) instead. Called from /tmp/d20150904-26989-17msjv7/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb:133:in `block (2 levels) in <top (required)>'.

stub! is deprecated. Use stub instead. Called from /tmp/d20150904-26989-17msjv7/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:344:in `block (3 levels) in <top (required)>'.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

39 deprecation warnings total

Finished in 2 minutes 44.9 seconds
383 examples, 1 failure, 4 pending

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:177 # OracleEnhancedAdapter custom methods for create, update and destroy should rollback record when exception is raised in after_create callback

Gathering the spec suite data...

Converting spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
Converting spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
Converting spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
Converting spec/active_record/connection_adapters/oracle_enhanced_cpk_spec.rb
Converting spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
Converting spec/active_record/connection_adapters/oracle_enhanced_database_tasks_spec.rb
Converting spec/active_record/connection_adapters/oracle_enhanced_dbms_output_spec.rb
Converting spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
Converting spec/active_record/connection_adapters/oracle_enhanced_emulate_oracle_adapter_spec.rb
Converting spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
Converting spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
Converting spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
Converting spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
Converting spec/spec_helper.rb

Summary:

490 conversions
  from: obj.should
    to: expect(obj).to
254 conversions
  from: == expected
    to: eq(expected)
112 conversions
  from: =~ /pattern/
    to: match(/pattern/)
68 conversions
  from: obj.should_not
    to: expect(obj).not_to
30 conversions
  from: lambda { }.should_not
    to: expect { }.not_to
29 conversions
  from: lambda { }.should
    to: expect { }.to
20 conversions
  from: be_false
    to: be_falsey
14 conversions
  from: be_true
    to: be_truthy
11 conversions
  from: pending
    to: skip
3 conversions
  from: obj.stub!(:message)
    to: allow(obj).to receive(:message)
1 conversion
  from: < expected
    to: be < expected
1 conversion
  from: obj.should_not_receive(:message)
    to: expect(obj).not_to receive(:message)

1033 conversions, 0 incompletes, 0 warnings, 0 errors

A commit message that describes the conversion summary was generated to
.git/COMMIT_EDITMSG. To use the message, type the following command for
the next commit:
    git commit -aeF .git/COMMIT_EDITMSG

Done! Now run rspec and check if everything is green.
$
```