### PR TITLE
Clean up database objects after unit tests executed

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -423,6 +423,7 @@ describe "OracleEnhancedAdapter schema definition" do
         drop_table :new_test_employees rescue nil
         drop_table :test_employees_no_pkey rescue nil
         drop_table :new_test_employees_no_pkey rescue nil
+        drop_table :aaaaaaaaaaaaaaaaaaaaaaaaaaa rescue nil
       end
     end
 


### PR DESCRIPTION
This pull request cleans up database objects after Oracle enhanced adapter unit tests executed.

```sql

SQL>  select object_name,object_type from user_objects;

OBJECT_NAME                    OBJECT_TYPE
------------------------------ -----------------------
AAAAAAAAAAAAAAAAAAAAAAAAAAA    TABLE
AAAAAAAAAAAAAAAAAAAAAAAAAA_SEQ SEQUENCE
SYS_C001451650                 INDEX

SQL>  select table_name,index_name from user_indexes
  2  ;

TABLE_NAME                     INDEX_NAME
------------------------------ ------------------------------
AAAAAAAAAAAAAAAAAAAAAAAAAAA    SYS_C001451650

SQL>
```

`drop_table` method removes related sequence. Index will be dropped by drop table sql statement itself.