### PR TITLE
Use all_* dictionary replacing user_* ones

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements_ext.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements_ext.rb
@@ -50,7 +50,7 @@ module ActiveRecord
 
       # get synonyms for schema dump
       def synonyms #:nodoc:
-        select_all("SELECT synonym_name, table_owner, table_name, db_link FROM user_synonyms").collect do |row|
+        select_all("SELECT synonym_name, table_owner, table_name, db_link FROM all_synonyms where owner = SYS_CONTEXT('userenv', 'session_user')").collect do |row|
           OracleEnhanced::SynonymDefinition.new(oracle_downcase(row['synonym_name']),
             oracle_downcase(row['table_owner']), oracle_downcase(row['table_name']), oracle_downcase(row['db_link']))
         end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -863,7 +863,7 @@ module ActiveRecord
 
       # Default tablespace name of current user
       def default_tablespace
-        select_value("SELECT LOWER(default_tablespace) FROM user_users WHERE username = SYS_CONTEXT('userenv', 'session_user')")
+        select_value("SELECT LOWER(default_tablespace) FROM user_users")
       end
 
       def tables(name = nil) #:nodoc:

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1253,7 +1253,7 @@ module ActiveRecord
       end
 
       def temporary_table?(table_name) #:nodoc:
-        select_value("SELECT temporary FROM user_tables WHERE table_name = '#{table_name.upcase}'") == 'Y'
+        select_value("SELECT temporary FROM all_tables WHERE table_name = '#{table_name.upcase}' and owner = SYS_CONTEXT('userenv', 'session_user')") == 'Y'
       end
 
       # construct additional wrapper subquery if select.offset is used to avoid generation of invalid subquery


### PR DESCRIPTION
This pull request uses all_* dictionary replacing user_* ones to keep consistency.

As an exception, `all_users` view does not have `default_tablespace` column then it cannot be changed from `user_users` to `all_users`. Also `user_users` always return one row based on the current database user session, then where clause removed.