### PR TITLE
Remove FALSE_VALUES

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column.rb
@@ -4,8 +4,6 @@ module ActiveRecord
 
       attr_reader :table_name, :nchar, :virtual_column_data_default, :returning_id #:nodoc:
 
-      FALSE_VALUES << 'N'
-
       def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, virtual=false, returning_id=false) #:nodoc:
         @table_name = table_name
         @virtual = virtual


### PR DESCRIPTION
This pull request addresses following NameError.

```ruby
$ rake spec
==> Loading config from ENV or use default
==> Running specs with MRI version 2.3.0
rake aborted!
NameError: uninitialized constant ActiveRecord::ConnectionAdapters::OracleEnhancedColumn::FALSE_VALUES
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/column.rb:7:in `<class:OracleEnhancedColumn>'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/column.rb:3:in `<module:ConnectionAdapters>'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/column.rb:2:in `<module:ActiveRecord>'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/column.rb:1:in `<top (required)>'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:39:in `<top (required)>'
/home/yahonda/git/oracle-enhanced/spec/spec_helper.rb:37:in `require'
/home/yahonda/git/oracle-enhanced/spec/spec_helper.rb:37:in `<top (required)>'
/home/yahonda/git/oracle-enhanced/Rakefile:39:in `require'
/home/yahonda/git/oracle-enhanced/Rakefile:39:in `block in <top (required)>'
Tasks: TOP => spec => clear
(See full trace by running task with --trace)
```