### PR TITLE
Remove required_rubygems_version

### DIFF
--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -69,7 +69,6 @@ This adapter is superset of original ActiveRecord Oracle adapter.
   ]
   s.homepage = %q{http://github.com/rsim/oracle-enhanced}
   s.require_paths = [%q{lib}]
-  s.rubygems_version = %q{1.8.6}
   s.summary = %q{Oracle enhanced adapter for ActiveRecord}
   s.test_files = [
     "spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb",


### PR DESCRIPTION
http://guides.rubygems.org/specification-reference/#rubygems_version
```
RUBYGEMS_VERSION

The version of RubyGems used to create this gem.

Do not set this, it is set automatically when the gem is packaged.
```