### PR TITLE
Supress WARNINGs using `raise_error` without specific errors

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
@@ -269,7 +269,11 @@ describe "OracleEnhancedConnection" do
       # @conn.auto_retry = false
       ActiveRecord::Base.connection.auto_retry = false
       kill_current_session
-      expect { @conn.exec("SELECT * FROM dual") }.to raise_error
+      if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
+        expect { @conn.exec("SELECT * FROM dual") }.to raise_error(NativeException)
+      else
+        expect { @conn.exec("SELECT * FROM dual") }.to raise_error(OCIError)
+      end
     end
 
     it "should reconnect and execute SQL select if connection is lost and auto retry is enabled" do
@@ -283,7 +287,11 @@ describe "OracleEnhancedConnection" do
       # @conn.auto_retry = false
       ActiveRecord::Base.connection.auto_retry = false
       kill_current_session
-      expect { @conn.select("SELECT * FROM dual") }.to raise_error
+      if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
+        expect { @conn.select("SELECT * FROM dual") }.to raise_error(NativeException)
+      else
+        expect { @conn.select("SELECT * FROM dual") }.to raise_error(OCIError)
+      end
     end
 
   end


### PR DESCRIPTION
This pull request suppress these warnings.

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb:268
==> Loading config from ENV or use default
==> Running specs with MRI version 2.2.3
==> Effective ActiveRecord version 5.0.0.alpha
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb"=>[268]}}
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Instead consider providing a specific error class or message. This message can be supressed by setting: `RSpec::Expectations.configuration.warn_about_potential_false_positives = false`. Called from /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb:272:in `block (3 levels) in <top (required)>'.
.

Finished in 0.1365 seconds (files took 0.96658 seconds to load)
1 example, 0 failures

$
```



```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb:282
==> Loading config from ENV or use default
==> Running specs with MRI version 2.2.3
==> Effective ActiveRecord version 5.0.0.alpha
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb"=>[282]}}
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Instead consider providing a specific error class or message. This message can be supressed by setting: `RSpec::Expectations.configuration.warn_about_potential_false_positives = false`. Called from /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb:286:in `block (3 levels) in <top (required)>'.
.

Finished in 0.12478 seconds (files took 0.91539 seconds to load)
1 example, 0 failures

$
```
