### PR TITLE
Add note to readme about adapter name when using DATABASE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,14 @@ development:
   password: secret
 ```
 
+
+If you choose to specify your database connection via the `DATABASE_URL`
+environment variable, note that the adapter name uses a dash instead of an underscore:
+
+```bash
+DATABASE_URL=oracle-enhanced://localhost/XE
+```
+
 If you deploy JRuby on Rails application in Java application server that supports JNDI connections then you can specify JNDI connection as well:
 
 ```yml


### PR DESCRIPTION
@yahonda I anticipate this will come up more and more. Would you consider adding a note about it in the README?