### PR TITLE
Pending a test using virtual columns features introduced in 11gR1

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
@@ -163,6 +163,7 @@ describe "OracleEnhancedAdapter structure dump" do
     end
 
     it "should dump RAW virtual columns" do
+      pending "Not supported in this database version" unless @oracle11g_or_higher
       @conn.execute <<-SQL
         CREATE TABLE bars (
           id          NUMBER(38,0) NOT NULL,


### PR DESCRIPTION
This pull request addresses a following failure tested with Oracle Database 10gR2 since it uses virtual columns syntax introduced in 11gR1 http://docs.oracle.com/cd/B28359_01/server.111/b28279/chapter1.htm

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb:165
==> Loading config from ENV or use default
==> Running specs with MRI version 2.2.3
==> Selected Rails version 4.0-master
==> Effective ActiveRecord version 4.2.4
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb"=>[165]}}
F

Failures:

  1) OracleEnhancedAdapter structure dump structure dump should dump RAW virtual columns
     Failure/Error: @conn.execute <<-SQL
     ActiveRecord::StatementInvalid:
       OCIError: ORA-00907: missing right parenthesis:         CREATE TABLE bars (
                 id          NUMBER(38,0) NOT NULL,
                 super       RAW(255) GENERATED ALWAYS AS ( HEXTORAW(ID) ) VIRTUAL,
                 PRIMARY KEY (ID)
               )
     # stmt.c:243:in oci8lib_220.so
     # /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/ruby-oci8-a2e18582f826/lib/oci8/cursor.rb:129:in `exec'
     # /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/ruby-oci8-a2e18582f826/lib/oci8/oci8.rb:280:in `exec_internal'
     # /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/ruby-oci8-a2e18582f826/lib/oci8/oci8.rb:271:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:469:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:94:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `block in execute'
     # /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/rails-c9ba7666cbaf/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:472:in `block in log'
     # /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/rails-c9ba7666cbaf/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
     # /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/rails-c9ba7666cbaf/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:466:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1348:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `execute'
     # ./spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb:166:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:116:in `block in run'
     # /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:248:in `with_around_each_hooks'
     # /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/example.rb:113:in `run'
     # /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:515:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `map'
     # /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:511:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:496:in `run'
     # /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `block in run'
     # /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `map'
     # /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/example_group.rb:497:in `run'
     # /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block (2 levels) in run'
     # /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `map'
     # /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:24:in `block in run'
     # /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:58:in `report'
     # /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
     # /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
     # /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'

Finished in 0.16546 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb:165 # OracleEnhancedAdapter structure dump structure dump should dump RAW virtual columns
$
```
