### PR TITLE
Include table/column comments in schema and structure dumps

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/column_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column_dumper.rb
@@ -48,6 +48,7 @@ module ActiveRecord #:nodoc:
           spec[:null]      = 'false' if !column.null
           spec[:as]        = column.virtual_column_data_default if column.virtual?
           spec[:default]   = schema_default(column) if column.has_default? && !column.virtual?
+          spec[:comment]   = column.comment.inspect unless column.comment.nil?
           spec.delete(:default) if spec[:default].nil?
           spec
         end
@@ -57,7 +58,7 @@ module ActiveRecord #:nodoc:
           # return original method if not using 'OracleEnhanced'
           return migration_keys_without_oracle_enhanced unless oracle_enhanced_adapter?
 
-          [:name, :limit, :precision, :scale, :default, :null, :as, :virtual_type]
+          [:name, :limit, :precision, :scale, :default, :null, :as, :virtual_type, :comment]
         end
       end
     end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -125,12 +125,17 @@ module ActiveRecord #:nodoc:
           elsif @connection.respond_to?(:primary_key)
             pk = @connection.primary_key(table)
           end
-          
+
           tbl.print "  create_table #{table.inspect}"
-          
+
           # addition to make temporary option work
           tbl.print ", temporary: true" if @connection.temporary_table?(table)
-          
+
+          table_comments = @connection.table_comment(table)
+          unless table_comments.nil?
+            tbl.print ", comment: #{table_comments.inspect}"
+          end
+
           if columns.detect { |c| c.name == pk }
             if pk != 'id'
               tbl.print %Q(, primary_key: "#{pk}")

--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -34,6 +34,8 @@ module ActiveRecord #:nodoc:
           structure << ddl
           structure << structure_dump_indexes(table_name)
           structure << structure_dump_unique_keys(table_name)
+          structure << structure_dump_table_comments(table_name)
+          structure << structure_dump_column_comments(table_name)
         end
 
         join_with_statement_token(structure) << structure_dump_fk_constraints
@@ -132,6 +134,31 @@ module ActiveRecord #:nodoc:
           end
         end.flatten.compact
         join_with_statement_token(fks)
+      end
+
+      def structure_dump_table_comments(table_name)
+        comments = []
+        comment = table_comment(table_name)
+
+        unless comment.nil?
+          comments << "COMMENT ON TABLE #{quote_table_name(table_name)} IS '#{quote_string(comment)}'"
+        end
+
+        join_with_statement_token(comments)
+      end
+
+      def structure_dump_column_comments(table_name)
+        comments = []
+        columns = select_values("SELECT column_name FROM user_tab_columns WHERE table_name = '#{table_name}' ORDER BY column_id")
+
+        columns.each do |column|
+          comment = column_comment(table_name, column)
+          unless comment.nil?
+            comments << "COMMENT ON COLUMN #{quote_table_name(table_name)}.#{quote_column_name(column)} IS '#{quote_string(comment)}'"
+          end
+        end
+
+        join_with_statement_token(comments)
       end
 
       def foreign_key_definition(to_table, options = {}) #:nodoc:

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
@@ -474,4 +474,44 @@ describe "OracleEnhancedAdapter schema dump" do
       standard_dump.should =~ /t\.float "hourly_rate"$/
     end
   end
+
+  describe "table comments" do
+    before(:each) do
+      schema_define do
+        create_table :test_table_comments, :comment => "this is a \"table comment\"!", force: true do |t|
+          t.string :blah
+        end
+      end
+    end
+
+    after(:each) do
+      schema_define do
+        drop_table :test_table_comments
+      end
+    end
+
+    it "should dump table comments" do
+      standard_dump.should =~ /comment: "this is a \\"table comment\\"!"/
+    end
+  end
+
+  describe "column comments" do
+    before(:each) do
+      schema_define do
+        create_table :test_column_comments, force: true do |t|
+          t.string :blah, :comment => "this is a \"column comment\"!"
+        end
+      end
+    end
+
+    after(:each) do
+      schema_define do
+        drop_table :test_column_comments
+      end
+    end
+
+    it "should dump column comments" do
+      standard_dump.should =~ /comment: "this is a \\"column comment\\"!"/
+    end
+  end
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
@@ -226,6 +226,20 @@ describe "OracleEnhancedAdapter structure dump" do
       dump.should =~ /CREATE TABLE \"BARS\" \(\n\"ID\" NUMBER\(38,0\) NOT NULL,\n \"SUPER\" RAW\(255\)/
     end
 
+    it "should dump table comments" do
+      comment_sql = %Q(COMMENT ON TABLE "TEST_POSTS" IS 'Test posts with ''some'' "quotes"')
+      @conn.execute comment_sql
+      dump = ActiveRecord::Base.connection.structure_dump
+      dump.should =~ /#{comment_sql}/
+    end
+
+    it "should dump column comments" do
+      comment_sql = %Q(COMMENT ON COLUMN "TEST_POSTS"."TITLE" IS 'The title of the post with ''some'' "quotes"')
+      @conn.execute comment_sql
+      dump = ActiveRecord::Base.connection.structure_dump
+      dump.should =~ /#{comment_sql}/
+    end
+
   end
   describe "temporary tables" do
     after(:all) do


### PR DESCRIPTION
This PR addresses #259. I don't personally use comments, but it makes sense that if they're accepted in migrations that they should also appear in the dumps. Thoughts?