### PR TITLE
Rails :datetime as Oracle TIMESTAMP to support subsecond precision

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -445,6 +445,12 @@ module ActiveRecord
         end
       end
 
+      def supports_datetime_with_precision?
+        #TODO: Needs to consider to return false to keep old behaviour
+        #to map :datetime as DATE
+        @connection.database_version.first >= 9
+      end
+
       #:stopdoc:
       DEFAULT_NLS_PARAMETERS = {
         :nls_calendar            => nil,
@@ -474,7 +480,8 @@ module ActiveRecord
         :integer     => { :name => "NUMBER", :limit => 38 },
         :float       => { :name => "BINARY_FLOAT" },
         :decimal     => { :name => "DECIMAL" },
-        :datetime    => { :name => "DATE" },
+        #TODO: Needs to consider to support :datetime as DATE 
+        :datetime    => { :name => "TIMESTAMP" },
         # changed to native TIMESTAMP type
         # :timestamp   => { :name => "DATE" },
         :timestamp   => { :name => "TIMESTAMP" },


### PR DESCRIPTION
This pull request handles Rails :datetime as Oracle TIMESTAMP to support subsecond precision,
which has been mapped to Oracle DATE.

It also addresses the following error.
```
$ rake test_oracle
...
 OCIError: ORA-00907: missing right parenthesis: CREATE TABLE "DEVELOPERS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY, "NAME" VARCHAR2(255), "FIRST_NAME" VARCHAR2(255), "SALARY" NUMBER(38) DEFAULT 70000, "FIRM_ID" NUMBER(38), "MENTOR_ID" NUMBER(38), "CREATED_AT" DATE(6), "UPDATED_AT" DATE(6), "CREATED_ON" DATE(6), "UPDATED_ON" DATE(6))  (ActiveRecord::StatementInvalid)
...rake aborted!
```

* Rails 5 will support subsecond precision https://github.com/rails/rails/pull/18914
* Oracle Timestamp data type has been introduced in 9.0.1 aka 9iR1
* Modify Oracle `date` to `timestamp` is straightforward 
```sql
SQL> create table date2timestamp (id number(38) not null primary key,
  2  updated_at date);

Table created.

SQL> desc date2timestamp
 Name                                      Null?    Type
 ----------------------------------------- -------- ----------------------------
 ID                                        NOT NULL NUMBER(38)
 UPDATED_AT                                         DATE

SQL> insert into date2timestamp values (1, sysdate);

1 row created.

SQL> select * from date2timestamp;

        ID UPDATED_AT
---------- ------------------
         1 13-NOV-15

SQL> alter table date2timestamp modify UPDATED_AT timestamp(6);

Table altered.

SQL>  desc date2timestamp
 Name                                      Null?    Type
 ----------------------------------------- -------- ----------------------------
 ID                                        NOT NULL NUMBER(38)
 UPDATED_AT                                         TIMESTAMP(6)

SQL> select * from date2timestamp;

        ID
----------
UPDATED_AT
---------------------------------------------------------------------------
         1
13-NOV-15 01.25.25.000000 PM


SQL>
```