### PR TITLE
Ignore JDBC Drivers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tmp
 sqlnet.log
 Gemfile.lock
 /spec/spec_config.yaml
+ojdbc*.jar


### PR DESCRIPTION
This pull request adds Oracle JDBC drivers to .gitignore since they should not be included to the repository.

If Oracle JDBC driver is copied, it appears as untracked files.
```
$ git status
On branch ignore_jdbc_drivers
Untracked files:
  (use "git add <file>..." to include in what will be committed)

        lib/ojdbc7.jar

nothing added to commit but untracked files present (use "git add" to track)
$
```
This commit will avoid this entry.