### PR TITLE
Not passing `native_database_types` to `TableDefinition`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -94,7 +94,7 @@ module ActiveRecord
         end
 
         def create_table_definition(name, temporary, options)
-          ActiveRecord::ConnectionAdapters::OracleEnhanced::TableDefinition.new native_database_types, name, temporary, options
+          ActiveRecord::ConnectionAdapters::OracleEnhanced::TableDefinition.new name, temporary, options
         end
 
         def rename_table(table_name, new_name) #:nodoc:


### PR DESCRIPTION
Refer https://github.com/rails/rails/pull/22214

This pull request addresses following error.

```ruby
$ rake test_oracle
...
Using oracle
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb:7: warning: method redefined; discarding old aliased_types
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb:383: warning: previous definition of aliased_types was here
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb:36:in `visit_TableDefinition': undefined method `[]' for nil:NilClass (NoMethodError)
        from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:14:in `accept'
        from /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:81:in `create_table'
        from /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:787:in `block in method_missing'
        from /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:756:in `block in say_with_time'
        from /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/2.2.0/benchmark.rb:288:in `measure'
        from /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:756:in `say_with_time'
        from /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:776:in `method_missing'
        from /home/yahonda/git/rails/activerecord/test/schema/schema.rb:15:in `block in <top (required)>'
        from /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:48:in `instance_eval'
        from /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:48:in `define'
        from /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:44:in `define'
        from /home/yahonda/git/rails/activerecord/test/schema/schema.rb:1:in `<top (required)>'
        from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:296:in `load'
        from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:296:in `block in load'
        from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:268:in `load_dependency'
        from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:296:in `load'
        from /home/yahonda/git/rails/activerecord/test/cases/helper.rb:162:in `load_schema'
        from /home/yahonda/git/rails/activerecord/test/cases/helper.rb:171:in `<top (required)>'
        from /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        from /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        from /home/yahonda/git/rails/activerecord/test/cases/relations_test.rb:1:in `<top (required)>'
        from /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        from /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        from /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/rake_test_loader.rb:15:in `block in <main>'
        from /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/rake_test_loader.rb:4:in `select'
        from /home/yahonda/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/rake_test_loader.rb:4:in `<main>'
rake aborted!
```