### PR TITLE
Do not cache prepared statements that are unlikely to have cache hits

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -16,7 +16,7 @@ module ActiveRecord
           reload_type_map
         end
 
-        def exec_query(sql, name = 'SQL', binds = [])
+        def exec_query(sql, name = 'SQL', binds = [], prepare: false)
           type_casted_binds = binds.map { |col, val|
             [col, type_cast(val, col)]
           }

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -402,6 +402,7 @@ module ActiveRecord
 
         if self.class.type_cast_config_to_boolean(config.fetch(:prepared_statements) { true })
           @prepared_statements = true
+          @visitor.extend(DetermineIfPreparableVisitor)
         else
           @prepared_statements = false
         end


### PR DESCRIPTION
Refer https://github.com/rails/rails/commit/cbcdecd2
https://github.com/rails/rails/issues/21992

This pull request addresses the following error.

```ruby
]$ ARCONN=oracle ruby -Itest test/cases/log_subscriber_test.rb -n test_basic_query_doesnt_log_when_level_is_not_debug
Using oracle
Run options: -n test_basic_query_doesnt_log_when_level_is_not_debug --seed 61000

# Running:

E

Finished in 0.240198s, 4.1632 runs/s, 0.0000 assertions/s.

  1) Error:
LogSubscriberTest#test_basic_query_doesnt_log_when_level_is_not_debug:
NoMethodError: undefined method `preparable' for #<Arel::Visitors::Oracle12:0x0055a67e7b4560>
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:36:in `select_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:70:in `select_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/querying.rb:39:in `find_by_sql'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:692:in `exec_queries'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:573:in `load'
    test/cases/log_subscriber_test.rb:193:in `test_basic_query_doesnt_log_when_level_is_not_debug'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```