### PR TITLE
Set default value of Booleans correctly

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1075,7 +1075,7 @@ module ActiveRecord
             row['data_default'].sub!(/^'(.*)'$/m, '\1')
             row['data_default'] = nil if row['data_default'] =~ /^(null|empty_[bc]lob\(\))$/i
             # TODO: Needs better fix to fallback "N" to false
-            row['data_default'] = false if row['data_default'] == "N"
+            row['data_default'] = false if (row['data_default'] == "N" && OracleEnhancedAdapter.emulate_booleans_from_strings)
           end
 
           # TODO: Consider to extract another method such as `get_cast_type`

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -376,6 +376,43 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = false
   end
 
+  before(:each) do
+    class ::Test3Employee < ActiveRecord::Base
+    end
+  end
+
+  after(:each) do
+    Object.send(:remove_const, "Test3Employee")
+    @conn.clear_types_for_columns
+    ActiveRecord::Base.clear_cache! if ActiveRecord::Base.respond_to?(:"clear_cache!")
+  end
+
+  describe "default values in new records" do
+    context "when emulate_booleans_from_strings is false" do
+      before do
+        ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = false
+      end
+
+      it "are Y or N" do
+        subject = Test3Employee.new
+        expect(subject.has_phone).to eq('Y')
+        expect(subject.manager_yn).to eq('N')
+      end
+    end
+
+    context "when emulate_booleans_from_strings is true" do
+      before do
+        ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = true
+      end
+
+      it "are True or False" do
+        subject = Test3Employee.new
+        expect(subject.has_phone).to be_a(TrueClass)
+        expect(subject.manager_yn).to be_a(FalseClass)
+      end
+    end
+  end
+
   it "should set CHAR/VARCHAR2 column type as string if emulate_booleans_from_strings is false" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = false
     columns = @conn.columns('test3_employees')
@@ -444,12 +481,9 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
   describe "/ VARCHAR2 boolean values from ActiveRecord model" do
     before(:each) do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = false
-      class ::Test3Employee < ActiveRecord::Base
-      end
     end
 
     after(:each) do
-      Object.send(:remove_const, "Test3Employee")
       @conn.clear_types_for_columns
       ActiveRecord::Base.clear_cache! if ActiveRecord::Base.respond_to?(:"clear_cache!")
     end


### PR DESCRIPTION
Fixes #750 

This is not the prettiest fix, but it does fix the problem. And it adds tests to catch the various cases of default values and the emulate_booleans_from_strings setting.