### PR TITLE
Bump activerecord version to 5.0.0.beta1

### DIFF
--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -88,8 +88,8 @@ This adapter is superset of original ActiveRecord Oracle adapter.
   ]
   s.add_dependency(%q<jeweler>, ["~> 2.0"])
   s.add_dependency(%q<rspec>, ["~> 3.3"])
-  s.add_dependency(%q<activerecord>, ["= 5.0.0.alpha"])
-  s.add_dependency(%q<arel>, [">= 0"])
+  s.add_dependency(%q<activerecord>, ["= 5.0.0.beta1"])
+  s.add_dependency(%q<arel>, ["~> 7.0"])
   s.add_dependency(%q<ruby-plsql>, [">= 0.5.0"])
   s.add_dependency(%q<ruby-oci8>, [">= 2.1.8"])
 end


### PR DESCRIPTION
Rails 5.0.0.beta1 is out. http://weblog.rubyonrails.org/2015/12/18/Rails-5-0-beta1/ 