### PR TITLE
ActiveRecord::Calculations#count no longer accepts an options hash argument

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -278,7 +278,7 @@ describe "OracleEnhancedAdapter" do
     end
 
     it "should execute correct SQL COUNT DISTINCT statement" do
-      expect { TestEmployee.count(:employee_id, :distinct => true) }.not_to raise_error
+      expect { TestEmployee.distinct.count(:employee_id) }.not_to raise_error
     end
 
   end


### PR DESCRIPTION
My apologies for such a tiny pull request. I am new to this project, and I'm just trying to dip my toe in to make sure I have the correct protocol for contributions. Please let me know if I have done something incorrectly here.

This pull request fixes a single spec that started failing in the rails 5 branch because it used some deprecated ActiveRecord syntax. Thanks.