### PR TITLE
Clean up specs and test documentation

### DIFF
--- a/RUNNING_TESTS.md
+++ b/RUNNING_TESTS.md
@@ -16,7 +16,9 @@ to increase process limit and then restart the database (this will be necessary 
 Ruby versions
 -------------
 
-It is recommended to use [RVM](http://rvm.beginrescueend.com) to run tests with different Ruby implementations. oracle_enhanced is mainly tested with MRI 1.8.7 (all Rails versions) and 1.9.2 (Rails 3) and JRuby 1.6.
+oracle_enhanced is tested with MRI 2.1.x and 2.2.x, and JRuby 1.7.x and 9.0.x.x.  
+
+It is recommended to use [RVM](http://rvm.beginrescueend.com) to run tests with different Ruby implementations.
 
 Running tests
 -------------
@@ -29,19 +31,19 @@ Running tests
         SQL> CREATE USER oracle_enhanced_schema IDENTIFIED BY oracle_enhanced_schema;
         SQL> GRANT unlimited tablespace, create session, create table, create sequence, create procedure, create trigger, create view, create materialized view, create database link, create synonym, create type, ctxapp TO oracle_enhanced_schema;
 
-* If you use RVM then switch to corresponding Ruby (1.8.7, 1.9.2 or JRuby) and it is recommended to create isolated gemset for test purposes (e.g. rvm create gemset oracle_enhanced)
+* If you use RVM then switch to corresponding Ruby. It is recommended to create isolated gemsets for test purposes (e.g. rvm create gemset oracle_enhanced)
 
 * Install bundler with
 
         gem install bundler
 
-* Set RAILS_GEM_VERSION to Rails version that you would like to use in oracle_enhanced tests, e.g.
-
-        export RAILS_GEM_VERSION=3.0.3
-
 * Install necessary gems with
 
         bundle install
+        
+* Configure database credentials in one of two ways:
+    * copy spec/spec_config.yaml.template to spec/config.yaml and modify as needed
+    * set required environment variables (see DATABASE_NAME in spec_helper.rb)
 
 * Run tests with
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -171,7 +171,7 @@ describe "OracleEnhancedAdapter" do
       end
 
       it 'should identify virtual columns as such' do
-        pending "Not supported in this database version" unless @oracle11g_or_higher
+        skip "Not supported in this database version" unless @oracle11g_or_higher
         te = TestEmployee.connection.columns('test_employees').detect(&:virtual?)
         te.name.should == 'full_name'
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -274,7 +274,7 @@ describe "OracleEnhancedAdapter" do
     end
 
     it "should tell ActiveRecord that count distinct is supported" do
-      ActiveRecord::Base.connection.supports_count_distinct?.should be_true
+      ActiveRecord::Base.connection.supports_count_distinct?.should be true
     end
 
     it "should execute correct SQL COUNT DISTINCT statement" do
@@ -345,56 +345,56 @@ describe "OracleEnhancedAdapter" do
     end
 
     it "should be valid with letters and digits" do
-      @adapter.valid_table_name?("abc_123").should be_true
+      @adapter.valid_table_name?("abc_123").should be true
     end
 
     it "should be valid with schema name" do
-      @adapter.valid_table_name?("abc_123.def_456").should be_true
+      @adapter.valid_table_name?("abc_123.def_456").should be true
     end
 
     it "should be valid with $ in name" do
-      @adapter.valid_table_name?("sys.v$session").should be_true
+      @adapter.valid_table_name?("sys.v$session").should be true
     end
 
     it "should be valid with upcase schema name" do
-      @adapter.valid_table_name?("ABC_123.DEF_456").should be_true
+      @adapter.valid_table_name?("ABC_123.DEF_456").should be true
     end
 
     it "should be valid with irregular schema name and database links" do
-      @adapter.valid_table_name?('abc$#_123.abc$#_123@abc$#@._123').should be_true
+      @adapter.valid_table_name?('abc$#_123.abc$#_123@abc$#@._123').should be true
     end
 
     it "should not be valid with two dots in name" do
-      @adapter.valid_table_name?("abc_123.def_456.ghi_789").should be_false
+      @adapter.valid_table_name?("abc_123.def_456.ghi_789").should be false
     end
 
     it "should not be valid with invalid characters" do
-      @adapter.valid_table_name?("warehouse-things").should be_false
+      @adapter.valid_table_name?("warehouse-things").should be false
     end
 
     it "should not be valid with for camel-case" do
-      @adapter.valid_table_name?("Abc").should be_false
-      @adapter.valid_table_name?("aBc").should be_false
-      @adapter.valid_table_name?("abC").should be_false
+      @adapter.valid_table_name?("Abc").should be false
+      @adapter.valid_table_name?("aBc").should be false
+      @adapter.valid_table_name?("abC").should be false
     end
     
     it "should not be valid for names > 30 characters" do
-      @adapter.valid_table_name?("a" * 31).should be_false
+      @adapter.valid_table_name?("a" * 31).should be false
     end
     
     it "should not be valid for schema names > 30 characters" do
-      @adapter.valid_table_name?(("a" * 31) + ".validname").should be_false
+      @adapter.valid_table_name?(("a" * 31) + ".validname").should be false
     end
     
     it "should not be valid for database links > 128 characters" do
-      @adapter.valid_table_name?("name@" + "a" * 129).should be_false
+      @adapter.valid_table_name?("name@" + "a" * 129).should be false
     end
     
     it "should not be valid for names that do not begin with alphabetic characters" do
-      @adapter.valid_table_name?("1abc").should be_false
-      @adapter.valid_table_name?("_abc").should be_false
-      @adapter.valid_table_name?("abc.1xyz").should be_false
-      @adapter.valid_table_name?("abc._xyz").should be_false
+      @adapter.valid_table_name?("1abc").should be false
+      @adapter.valid_table_name?("_abc").should be false
+      @adapter.valid_table_name?("abc.1xyz").should be false
+      @adapter.valid_table_name?("abc._xyz").should be false
     end
   end
 
@@ -554,7 +554,7 @@ describe "OracleEnhancedAdapter" do
       @conn.create_table :foos, :temporary => true, :id => false do |t|
         t.integer :id
       end
-      @conn.temporary_table?("foos").should be_true
+      @conn.temporary_table?("foos").should be true
     end
   end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -600,7 +600,7 @@ describe "OracleEnhancedAdapter" do
       posts.size.should == @ids.size
     end
 
-  end if ENV['RAILS_GEM_VERSION'] >= '3.1'
+  end
 
   describe "with statement pool" do
     before(:all) do
@@ -654,7 +654,7 @@ describe "OracleEnhancedAdapter" do
         @conn.exec_update("UPDATE test_posts SET id = 1", "SQL", binds)
       }.should_not change(@statements, :length)
     end
-  end if ENV['RAILS_GEM_VERSION'] >= '3.1'
+  end
 
   describe "explain" do
     before(:all) do
@@ -688,7 +688,7 @@ describe "OracleEnhancedAdapter" do
       explain.should include("Cost")
       explain.should include("INDEX UNIQUE SCAN")
     end
-  end if ENV['RAILS_GEM_VERSION'] >= '3.2'
+  end
 
   describe "using offset and limit" do
     before(:all) do

--- a/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
@@ -149,7 +149,7 @@ describe "OracleEnhancedConnection" do
           import 'org.apache.commons.dbcp.PoolableConnectionFactory'
           import 'org.apache.commons.dbcp.DriverManagerConnectionFactory'
         rescue NameError => e
-          return pending e.message
+          return skip e.message
         end
 
         class InitialContextMock
@@ -170,7 +170,7 @@ describe "OracleEnhancedConnection" do
           end
         end
 
-        javax.naming.InitialContext.stub!(:new).and_return(InitialContextMock.new)
+        javax.naming.InitialContext.stub(:new).and_return(InitialContextMock.new)
 
         params = {}
         params[:jndi] = 'java:comp/env/jdbc/test'
@@ -185,7 +185,7 @@ describe "OracleEnhancedConnection" do
       params[:url] = "jdbc:oracle:thin:@#{DATABASE_HOST && "//#{DATABASE_HOST}#{DATABASE_PORT && ":#{DATABASE_PORT}"}/"}#{DATABASE_NAME}"
       params[:host] = nil
       params[:database] = nil
-      java.sql.DriverManager.stub!(:getConnection).and_raise('no suitable driver found')
+      java.sql.DriverManager.stub(:getConnection).and_raise('no suitable driver found')
       @conn = ActiveRecord::ConnectionAdapters::OracleEnhancedConnection.create(params)
       @conn.should be_active
     end

--- a/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
@@ -16,7 +16,7 @@ describe "OracleEnhancedConnection" do
     end
 
     it "should ping active connection" do
-      @conn.ping.should be_true
+      @conn.ping.should be true
     end
 
     it "should not ping inactive connection" do

--- a/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
@@ -103,7 +103,7 @@ describe "OracleEnhancedAdapter context index" do
 
     it "should not include text index secondary tables in user tables list" do
       @conn.add_context_index :posts, :title
-      @conn.tables.any?{|t| t =~ /^dr\$/i}.should be_false
+      @conn.tables.any?{|t| t =~ /^dr\$/i}.should be false
       @conn.remove_context_index :posts, :title
     end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_cpk_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_cpk_spec.rb
@@ -52,7 +52,7 @@ describe "OracleEnhancedAdapter composite_primary_keys support" do
     end
 
     it "should tell ActiveRecord that count distinct is not supported" do
-      ActiveRecord::Base.connection.supports_count_distinct?.should be_false
+      ActiveRecord::Base.connection.supports_count_distinct?.should be false
     end
 
     it "should execute correct SQL COUNT DISTINCT statement on table with composite primary keys" do

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -474,8 +474,8 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
   it "should get default value from VARCHAR2 boolean column if emulate_booleans_from_strings is true" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = true
     columns = @conn.columns('test3_employees')
-    columns.detect{|c| c.name == 'has_phone'}.default.should be_true
-    columns.detect{|c| c.name == 'manager_yn'}.default.should be_false
+    columns.detect{|c| c.name == 'has_phone'}.default.should eq 'Y'
+    columns.detect{|c| c.name == 'manager_yn'}.default.should be false
   end
 
   describe "/ VARCHAR2 boolean values from ActiveRecord model" do

--- a/spec/active_record/connection_adapters/oracle_enhanced_database_tasks_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_database_tasks_spec.rb
@@ -42,14 +42,14 @@ describe "Oracle Enhanced adapter database tasks" do
     describe "drop" do
       before { ActiveRecord::Tasks::DatabaseTasks.drop(config) }
       it "drops all tables" do
-        ActiveRecord::Base.connection.table_exists?(:test_posts).should be_false
+        ActiveRecord::Base.connection.table_exists?(:test_posts).should be false
       end
     end
 
     describe "purge" do
       before { ActiveRecord::Tasks::DatabaseTasks.purge(config) }
       it "drops all tables" do
-        ActiveRecord::Base.connection.table_exists?(:test_posts).should be_false
+        ActiveRecord::Base.connection.table_exists?(:test_posts).should be false
         ActiveRecord::Base.connection.select_value("SELECT COUNT(*) FROM RECYCLEBIN").should == 0
       end
     end
@@ -77,7 +77,7 @@ describe "Oracle Enhanced adapter database tasks" do
           ActiveRecord::Tasks::DatabaseTasks.structure_load(config, temp_file)
         end
         it "loads the database structure from a file" do
-          ActiveRecord::Base.connection.table_exists?(:test_posts).should be_true
+          ActiveRecord::Base.connection.table_exists?(:test_posts).should be true
         end
       end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
@@ -130,7 +130,7 @@ if ActiveRecord::Base.method_defined?(:changed?)
       class << oci_conn
          def write_lob(lob, value, is_binary = false); raise "don't do this'"; end
       end
-      @employee.save!.should_not raise_exception(RuntimeError, "don't do this'")
+      expect { @employee.save! }.to_not raise_error
       class << oci_conn
         remove_method :write_lob
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
@@ -110,7 +110,7 @@ if ActiveRecord::Base.method_defined?(:changed?)
     it "should not mark integer as changed when reassigning it" do
       @employee = TestEmployee.new
       @employee.job_id = 0
-      @employee.save!.should be_true
+      @employee.save.should be true
       
       @employee.should_not be_changed
 
@@ -122,7 +122,7 @@ if ActiveRecord::Base.method_defined?(:changed?)
       @employee = TestEmployee.create!(
           :comments => "initial"
       )
-      @employee.save!.should be_true
+      @employee.save.should be true
       @employee.reload
       @employee.comments.should == 'initial'
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_emulate_oracle_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_emulate_oracle_adapter_spec.rb
@@ -12,7 +12,7 @@ describe "OracleEnhancedAdapter emulate OracleAdapter" do
   it "should be an OracleAdapter" do
     @conn = ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(:emulate_oracle_adapter => true))
     ActiveRecord::Base.connection.should_not be_nil
-    ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::OracleAdapter).should be_true
+    ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::OracleAdapter).should be true
   end
 
   after(:all) do

--- a/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
@@ -186,7 +186,7 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
     lambda {
       @employee.save
     }.should raise_error("Make the transaction rollback")
-    @employee.id.should == nil
+    @employee.new_record?.should be true
     TestEmployee.count.should == employees_count
   end
 
@@ -360,7 +360,7 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
       :last_name => "Last",
       :hire_date => @today
     )
-    @employee.save.should be_false
+    @employee.save.should be false
     @employee.errors[:first_name].should_not be_blank
   end
 
@@ -371,7 +371,7 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
       :hire_date => @today
     )
     @employee.first_name = nil
-    @employee.save.should be_false
+    @employee.save.should be false
     @employee.errors[:first_name].should_not be_blank
   end
   

--- a/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
@@ -263,7 +263,6 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
   end
 
   it "should delete record and set destroyed flag" do
-    return pending("Not in this ActiveRecord version (requires >= 2.3.5)") unless TestEmployee.method_defined?(:destroyed?)
     @employee = TestEmployee.create(
       :first_name => "First",
       :last_name => "Last",

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
@@ -226,7 +226,7 @@ describe "OracleEnhancedAdapter schema dump" do
     end
 
     it "should include composite foreign keys" do
-      pending "Composite foreign keys are not supported in this version"
+      skip "Composite foreign keys are not supported in this version"
       schema_define do
         add_column :test_posts, :baz_id, :integer
         add_column :test_posts, :fooz_id, :integer
@@ -341,7 +341,7 @@ describe "OracleEnhancedAdapter schema dump" do
 
     it "should specify non-default tablespace in add index" do
       tablespace_name = @conn.default_tablespace
-      @conn.stub!(:default_tablespace).and_return('dummy')
+      @conn.stub(:default_tablespace).and_return('dummy')
       create_test_posts_table
       standard_dump.should =~ /add_index "test_posts", \["title"\], name: "index_test_posts_on_title", tablespace: "#{tablespace_name}"$/
     end
@@ -369,21 +369,18 @@ describe "OracleEnhancedAdapter schema dump" do
 
   describe 'virtual columns' do
     before(:all) do
-      if @oracle11g_or_higher
-        schema_define do
-          create_table :test_names, :force => true do |t|
-            t.string  :first_name
-            t.string  :last_name
-            t.virtual :full_name,        :as => "first_name || ', ' || last_name"
-            t.virtual :short_name,       :as => "COALESCE(first_name, last_name)", :type => :string, :limit => 300
-            t.virtual :abbrev_name,      :as => "SUBSTR(first_name,1,50) || ' ' || SUBSTR(last_name,1,1) || '.'", :type => "VARCHAR(100)"
-            t.virtual :name_ratio, :as=>'(LENGTH(first_name)*10/LENGTH(last_name)*10)'
-            t.column  :full_name_length, :virtual, :as => "length(first_name || ', ' || last_name)", :type => :integer
-            t.virtual :field_with_leading_space, :as => "' ' || first_name || ' '", :limit => 300, :type => :string
-          end
+      skip "Not supported in this database version" unless @oracle11g_or_higher
+      schema_define do
+        create_table :test_names, :force => true do |t|
+          t.string :first_name
+          t.string :last_name
+          t.virtual :full_name,       :as => "first_name || ', ' || last_name"
+          t.virtual :short_name,      :as => "COALESCE(first_name, last_name)", :type => :string, :limit => 300
+          t.virtual :abbrev_name,     :as => "SUBSTR(first_name,1,50) || ' ' || SUBSTR(last_name,1,1) || '.'", :type => "VARCHAR(100)"
+          t.virtual :name_ratio,      :as => '(LENGTH(first_name)*10/LENGTH(last_name)*10)'
+          t.column :full_name_length, :virtual, :as => "length(first_name || ', ' || last_name)", :type => :integer
+          t.virtual :field_with_leading_space, :as => "' ' || first_name || ' '", :limit => 300, :type => :string
         end
-      else
-        pending "Not supported in this database version"
       end
     end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -1069,7 +1069,7 @@ end
         end
       end
       class ::TestPost < ActiveRecord::Base; end
-      TestPost.columns_hash['title'].null.should be_false
+      TestPost.columns_hash['title'].null.should be false
     end
 
     after(:each) do
@@ -1083,7 +1083,7 @@ end
         change_column :test_posts, :title, :string, :null => true
       end
       TestPost.reset_column_information
-      TestPost.columns_hash['title'].null.should be_true
+      TestPost.columns_hash['title'].null.should be true
     end
 
     it "should add column" do

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -729,7 +729,7 @@ end
     end
 
     it "should add a composite foreign key" do
-      pending "Composite foreign keys are not supported in this version"
+      skip "Composite foreign keys are not supported in this version"
       schema_define do
         add_column :test_posts, :baz_id, :integer
         add_column :test_posts, :fooz_id, :integer
@@ -752,7 +752,7 @@ end
     end
 
     it "should add a composite foreign key with name" do
-      pending "Composite foreign keys are not supported in this version"
+      skip "Composite foreign keys are not supported in this version"
       schema_define do
         add_column :test_posts, :baz_id, :integer
         add_column :test_posts, :fooz_id, :integer
@@ -1159,7 +1159,7 @@ end
 
   describe 'virtual columns in create_table' do
     before(:each) do
-      pending "Not supported in this database version" unless @oracle11g_or_higher
+      skip "Not supported in this database version" unless @oracle11g_or_higher
     end
 
     it 'should create virtual column with old syntax' do
@@ -1205,7 +1205,7 @@ end
 
   describe 'virtual columns' do
     before(:each) do
-      pending "Not supported in this database version" unless @oracle11g_or_higher
+      skip "Not supported in this database version" unless @oracle11g_or_higher
       expr = "( numerator/NULLIF(denominator,0) )*100"
       schema_define do
         create_table :test_fractions, :force => true do |t|

--- a/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
@@ -92,7 +92,7 @@ describe "OracleEnhancedAdapter structure dump" do
     end
     
     it "should dump composite foreign keys" do
-      pending "Composite foreign keys are not supported in this version"
+      skip "Composite foreign keys are not supported in this version"
       @conn.add_column :foos, :fooz_id, :integer
       @conn.add_column :foos, :baz_id, :integer
       
@@ -150,7 +150,7 @@ describe "OracleEnhancedAdapter structure dump" do
     end
   
     it "should dump virtual columns" do
-      pending "Not supported in this database version" unless @oracle11g_or_higher
+      skip "Not supported in this database version" unless @oracle11g_or_higher
       @conn.execute <<-SQL
         CREATE TABLE bars (
           id          NUMBER(38,0) NOT NULL,
@@ -163,7 +163,7 @@ describe "OracleEnhancedAdapter structure dump" do
     end
 
     it "should dump RAW virtual columns" do
-      pending "Not supported in this database version" unless @oracle11g_or_higher
+      skip "Not supported in this database version" unless @oracle11g_or_higher
       @conn.execute <<-SQL
         CREATE TABLE bars (
           id          NUMBER(38,0) NOT NULL,

--- a/spec/spec_config.yaml.template
+++ b/spec/spec_config.yaml.template
@@ -1,5 +1,5 @@
-rails:
-  gem_version: '4.0-master'
+# copy this file to spec/config.yaml and set appropriate values
+# you can also use environment variables, see spec_helper.rb
 database:
   name:         'orcl'
   host:         '127.0.0.1'
@@ -7,4 +7,5 @@ database:
   user:         'oracle_enhanced'
   password:     'oracle_enhanced'
   sys_password: 'admin'
+  non_default_tablespace: 'SYSTEM'
 timezone: 'Europe/Riga'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,10 +22,7 @@ elsif RUBY_ENGINE == 'jruby'
   puts "==> Running specs with JRuby version #{JRUBY_VERSION}"
 end
 
-ENV['RAILS_GEM_VERSION'] ||= config["rails"]["gem_version"] || '4.0-master'
 NO_COMPOSITE_PRIMARY_KEYS = true
-
-puts "==> Selected Rails version #{ENV['RAILS_GEM_VERSION']}"
 
 require 'active_record'
 
@@ -166,7 +163,7 @@ SYSTEM_CONNECTION_PARAMS = {
   :password => DATABASE_SYS_PASSWORD
 }
 
-DATABASE_NON_DEFAULT_TABLESPACE = ENV['DATABASE_NON_DEFAULT_TABLESPACE'] || "SYSTEM"
+DATABASE_NON_DEFAULT_TABLESPACE = config["database"]["non_default_tablespace"] || ENV['DATABASE_NON_DEFAULT_TABLESPACE'] || "SYSTEM"
 
 # set default time zone in TZ environment variable
 # which will be used to set session time zone


### PR DESCRIPTION
The specs had deprecation warnings and dead code in a few places, so I resolved them. It looks like RAILS_GEM_VERSION isn't needed anymore, so I removed that and updated RUNNING_TESTS to remove that and include info on YAML config.

One question I have is which Ruby versions 1.6.x officially supports. RUNNING_TESTS.md was way out of date and I needed to edit it anyway. so I took a guess but might be wrong, e.g. MRI 1.9.3 compatibility might still be good to test, but probably not 1.8.7 :smile: 

WDYT?