### PR TITLE
Address ORA-00904 when context index CONTAINS has `table_name.column_name`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/context_index.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/context_index.rb
@@ -332,7 +332,7 @@ module ActiveRecord
           # Add context index condition.
           def contains(column, query, options ={})
             score_label = options[:label].to_i || 1
-            where("CONTAINS(#{connection.quote_column_name(column)}, ?, #{score_label}) > 0", query).
+            where("CONTAINS(#{connection.quote_table_name(column)}, ?, #{score_label}) > 0", query).
               order("SCORE(#{score_label}) DESC")
           end
         end

--- a/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
@@ -169,6 +169,14 @@ describe "OracleEnhancedAdapter context index" do
       end
       @conn.remove_context_index :posts, :title
     end
+
+    it "should use index when contains has schema_name.table_name syntax" do
+      @conn.add_context_index :posts, :title
+      @title_words.each do |word|
+        Post.contains('posts.title', word).to_a.should == [@post2, @post1]
+      end
+      @conn.remove_context_index :posts, :title
+    end
   end
 
   describe "on multiple tables" do


### PR DESCRIPTION
This pull request addresses #667 when CONTAINS have `table_name.column_name` style syntax. It should also address #463.