### PR TITLE
Fix auto retry on cursor-initiated queries

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -108,14 +108,21 @@ module ActiveRecord
       end
 
       def prepare(sql)
-        Cursor.new(self, @raw_connection.parse(sql))
+        Cursor.new(self, sql)
       end
 
       class Cursor
-        def initialize(connection, raw_cursor)
+        def initialize(connection, sql)
           @connection = connection
-          @raw_cursor = raw_cursor
+          @sql        = sql
+
+          allocate_cursor
         end
+
+        def allocate_cursor
+          @raw_cursor = @connection.raw_connection.parse(@sql)
+        end
+        private :allocate_cursor
 
         def bind_param(position, value, column = nil)
           if column && column.object_type?

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -152,10 +152,7 @@ module ActiveRecord
         def exec
           @raw_cursor.exec
         end
-
-        def exec_update
-          @raw_cursor.exec
-        end
+        alias :exec_update :exec
 
         def get_col_names
           @raw_cursor.get_col_names

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -449,9 +449,13 @@ class OCI8EnhancedAutoRecover < DelegateClass(OCI8) #:nodoc:
     ERROR_CODES = [ 28, 1012, 3113, 3114, 3135 ] #:nodoc:
 
     def lost_connection?
-      self.respond_to?(:code) && ERROR_CODES.include?(self.code)
+      self.already_closed? ||
+        self.respond_to?(:code) && ERROR_CODES.include?(self.code)
     end
 
+    def already_closed?
+      self.message == 'OCI8 was already closed.'
+    end
   end
 
   ::OCIException.class_eval do

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -36,7 +36,7 @@ module ActiveRecord
         # ActiveRecord Oracle enhanced adapter puts OCI8EnhancedAutoRecover wrapper around OCI8
         # in this case we need to pass original OCI8 connection
         else
-          @raw_connection.instance_variable_get(:@connection)
+          @raw_connection.oci_connection
         end
       end
 
@@ -439,5 +439,8 @@ class OCI8EnhancedAutoRecover < DelegateClass(OCI8) #:nodoc:
     end
   end
 
+  def oci_connection
+    @connection
+  end
 end
 #:startdoc:

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -99,7 +99,7 @@ module ActiveRecord
       # execute sql with RETURNING ... INTO :insert_id
       # and return :insert_id value
       def exec_with_returning(sql)
-        cursor = @raw_connection.parse(sql)
+        cursor = prepare(sql)
         cursor.bind_param(':insert_id', nil, Integer)
         cursor.exec
         cursor[':insert_id']

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -41,11 +41,11 @@ module ActiveRecord
       end
 
       def auto_retry
-        @raw_connection.auto_retry if @raw_connection
+        @raw_connection.auto_retry
       end
 
       def auto_retry=(value)
-        @raw_connection.auto_retry = value if @raw_connection
+        @raw_connection.auto_retry = value
       end
 
       def logoff
@@ -376,11 +376,8 @@ class OCI8EnhancedAutoRecover < DelegateClass(OCI8) #:nodoc:
   attr_accessor :active #:nodoc:
   alias :active? :active #:nodoc:
 
-  cattr_accessor :auto_retry
-  class << self
-    alias :auto_retry? :auto_retry #:nodoc:
-  end
-  @@auto_retry = false
+  attr_accessor :auto_retry
+  alias :auto_retry? :auto_retry
 
   def initialize(config, factory) #:nodoc:
     @active = true
@@ -425,7 +422,7 @@ class OCI8EnhancedAutoRecover < DelegateClass(OCI8) #:nodoc:
   #
   # See: http://www.jiubao.org/ruby-oci8/api.en.html#label-11
   def exec(sql, *bindvars, &block) #:nodoc:
-    should_retry = self.class.auto_retry? && autocommit?
+    should_retry = self.auto_retry? && self.autocommit?
 
     begin
       @connection.exec(sql, *bindvars, &block)

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -177,8 +177,7 @@ module ActiveRecord
         def close
           @raw_cursor.close
         end
-
-      end
+      end # Cursor
 
       def select(sql, name = nil, return_column_names = false)
         cursor = @raw_connection.exec(sql)

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -706,12 +706,12 @@ module ActiveRecord
       # If SQL statement fails due to lost connection then reconnect
       # and retry SQL statement if autocommit mode is enabled.
       # By default this functionality is disabled.
-      attr_reader :auto_retry #:nodoc:
-      @auto_retry = false
+      def auto_retry
+        @connection.auto_retry
+      end
 
       def auto_retry=(value) #:nodoc:
-        @auto_retry = value
-        @connection.auto_retry = value if @connection
+        @connection.auto_retry = value
       end
 
       # return raw OCI8 or JDBC connection

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1079,7 +1079,7 @@ module ActiveRecord
           end
 
           # TODO: Consider to extract another method such as `get_cast_type`
-          case row['sql_type'] 
+          case row['sql_type']
           when /decimal|numeric|number/i
             if get_type_for_column(table_name, oracle_downcase(row['name'])) == :integer
               cast_type = ActiveRecord::OracleEnhanced::Type::Integer.new

--- a/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
@@ -296,6 +296,20 @@ describe "OracleEnhancedConnection" do
       lambda { @conn.exec("SELECT * FROM dual") }.should raise_error
     end
 
+    it "should reconnect and execute SQL statement via cursors if connection is lost and auto retry is enabled" do
+      # @conn.auto_retry = true
+      ActiveRecord::Base.connection.auto_retry = true
+      kill_current_session
+      @conn.exec_with_returning("SELECT * FROM dual").should_not be_nil
+    end
+
+    it "should not reconnect and execute SQL statement via cursors if connection is lost and auto retry is disabled" do
+      # @conn.auto_retry = false
+      ActiveRecord::Base.connection.auto_retry = false
+      kill_current_session
+      lambda { @conn.exec_with_returning("SELECT * FROM dual") }.should raise_error
+    end
+
     it "should reconnect and execute SQL select if connection is lost and auto retry is enabled" do
       # @conn.auto_retry = true
       ActiveRecord::Base.connection.auto_retry = true


### PR DESCRIPTION
The auto_retry functionality currently wraps the OCI8 connection, works only when `.exec` is used on it - but it is bypassed when cursors are used. This scenario is very common in recent ARs, because the newer `exec_with_returning` AR APIs uses Cursors.

These changes wrap the `auto_retry` logic bits in reusable methods, and add `auto_retry` support to the Cursor class.

Please note: these changes currently target only the `OCI` connection adapter.

Originally in #730
