### PR TITLE
Add documentation on setting read, write and connect timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,10 @@ or you can even use Oracle specific TNS connection description:
 ```yml
 development:
   adapter: oracle_enhanced
-  database: "(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1521)))(CONNECT_DATA=(SERVICE_NAME=xe)))"
+  database: "(DESCRIPTION=
+    (ADDRESS_LIST=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1521)))
+    (CONNECT_DATA=(SERVICE_NAME=xe))
+  )"
   username: user
   password: secret
 ```


### PR DESCRIPTION
These changes are only documentation, and describe how to enable read, write and connect timeouts using `TNSNAMES` options. Also adds a tentative description on how to deal with *stuck* applications due to timeouts not being set on underlying sockets.

Originally in #730, applies to #419