### PR TITLE
Extract ActiveRecord::ConnectionAdapters::OracleEnhanced::Quoting

### DIFF
--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -41,6 +41,7 @@ This adapter is superset of original ActiveRecord Oracle adapter.
     "lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb",
     "lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb",
     "lib/active_record/connection_adapters/oracle_enhanced/procedures.rb",
+    "lib/active_record/connection_adapters/oracle_enhanced/quoting.rb",
     "lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb",
     "lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb",
     "lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb",

--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -38,7 +38,7 @@ module ActiveRecord
           db_link = nil
           default_owner = @owner
         end
-        real_name = OracleEnhancedAdapter.valid_table_name?(name) ? name.upcase : name
+        real_name = ActiveRecord::ConnectionAdapters::OracleEnhanced::Quoting.valid_table_name?(name) ? name.upcase : name
         if real_name.include?('.')
           table_owner, table_name = real_name.split('.')
         else

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -346,7 +346,7 @@ module ActiveRecord
             when :binary
               @raw_statement.setBlob(position, java_value)
             when :raw
-              @raw_statement.setString(position, OracleEnhancedAdapter.encode_raw(java_value))
+              @raw_statement.setString(position, ActiveRecord::ConnectionAdapters::OracleEnhanced::Quoting.encode_raw(java_value))
             when :decimal
               @raw_statement.setBigDecimal(position, java_value)
             else

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -132,7 +132,7 @@ module ActiveRecord
               ora_value.size = 0 if value == ''
               @raw_cursor.bind_param(position, ora_value)
             when :raw
-              @raw_cursor.bind_param(position, OracleEnhancedAdapter.encode_raw(value))
+              @raw_cursor.bind_param(position, ActiveRecord::ConnectionAdapters::OracleEnhanced::Quoting.encode_raw(value))
             when :decimal
               @raw_cursor.bind_param(position, BigDecimal.new(value.to_s))
             else
@@ -212,7 +212,7 @@ module ActiveRecord
       def describe(name)
         # fall back to SELECT based describe if using database link
         return super if name.to_s.include?('@')
-        quoted_name = OracleEnhancedAdapter.valid_table_name?(name) ? name : "\"#{name}\""
+        quoted_name = ActiveRecord::ConnectionAdapters::OracleEnhanced::Quoting.valid_table_name?(name) ? name : "\"#{name}\""
         @raw_connection.describe(quoted_name)
       rescue OCIException => e
         if e.code == 4043

--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -1,0 +1,179 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module OracleEnhanced
+      module Quoting
+        # QUOTING ==================================================
+        #
+        # see: abstract/quoting.rb
+
+        def quote_column_name(name) #:nodoc:
+          name = name.to_s
+          @quoted_column_names[name] ||= begin
+            # if only valid lowercase column characters in name
+            if name =~ /\A[a-z][a-z_0-9\$#]*\Z/
+              "\"#{name.upcase}\""
+            else
+              # remove double quotes which cannot be used inside quoted identifier
+              "\"#{name.gsub('"', '')}\""
+            end
+          end
+        end
+
+        # This method is used in add_index to identify either column name (which is quoted)
+        # or function based index (in which case function expression is not quoted)
+        def quote_column_name_or_expression(name) #:nodoc:
+          name = name.to_s
+          case name
+          # if only valid lowercase column characters in name
+          when /^[a-z][a-z_0-9\$#]*$/
+            "\"#{name.upcase}\""
+          when /^[a-z][a-z_0-9\$#\-]*$/i
+            "\"#{name}\""
+          # if other characters present then assume that it is expression
+          # which should not be quoted
+          else
+            name
+          end
+        end
+
+        # Used only for quoting database links as the naming rules for links
+        # differ from the rules for column names. Specifically, link names may
+        # include periods.
+        def quote_database_link(name)
+          case name
+          when NONQUOTED_DATABASE_LINK
+            %Q("#{name.upcase}")
+          else
+            name
+          end
+        end
+
+        # Names must be from 1 to 30 bytes long with these exceptions:
+        # * Names of databases are limited to 8 bytes.
+        # * Names of database links can be as long as 128 bytes.
+        #
+        # Nonquoted identifiers cannot be Oracle Database reserved words
+        #
+        # Nonquoted identifiers must begin with an alphabetic character from
+        # your database character set
+        #
+        # Nonquoted identifiers can contain only alphanumeric characters from
+        # your database character set and the underscore (_), dollar sign ($),
+        # and pound sign (#). Database links can also contain periods (.) and
+        # "at" signs (@). Oracle strongly discourages you from using $ and # in
+        # nonquoted identifiers.
+        NONQUOTED_OBJECT_NAME   = /[A-Za-z][A-z0-9$#]{0,29}/
+        NONQUOTED_DATABASE_LINK = /[A-Za-z][A-z0-9$#\.@]{0,127}/
+        VALID_TABLE_NAME = /\A(?:#{NONQUOTED_OBJECT_NAME}\.)?#{NONQUOTED_OBJECT_NAME}(?:@#{NONQUOTED_DATABASE_LINK})?\Z/
+
+        # unescaped table name should start with letter and
+        # contain letters, digits, _, $ or #
+        # can be prefixed with schema name
+        # CamelCase table names should be quoted
+        def self.valid_table_name?(name) #:nodoc:
+          name = name.to_s
+          name =~ VALID_TABLE_NAME && !(name =~ /[A-Z]/ && name =~ /[a-z]/) ? true : false
+        end
+
+        def quote_table_name(name) #:nodoc:
+          name, link = name.to_s.split('@')
+          @quoted_table_names[name] ||= [name.split('.').map{|n| quote_column_name(n)}.join('.'), quote_database_link(link)].compact.join('@')
+        end
+
+        def quote_string(s) #:nodoc:
+          s.gsub(/'/, "''")
+        end
+
+        def quote(value, column = nil) #:nodoc:
+          if value && column
+            case column.type
+            when :text, :binary
+              %Q{empty_#{ type_to_sql(column.type.to_sym).downcase rescue 'blob' }()}
+            # NLS_DATE_FORMAT independent TIMESTAMP support
+            when :timestamp
+              quote_timestamp_with_to_timestamp(value)
+            # NLS_DATE_FORMAT independent DATE support
+            when :date, :time, :datetime
+              quote_date_with_to_date(value)
+            when :raw
+              quote_raw(value)
+            when :string
+              # NCHAR and NVARCHAR2 literals should be quoted with N'...'.
+              # Read directly instance variable as otherwise migrations with table column default values are failing
+              # as migrations pass ColumnDefinition object to this method.
+              # Check if instance variable is defined to avoid warnings about accessing undefined instance variable.
+              column.instance_variable_defined?('@nchar') && column.instance_variable_get('@nchar') ? 'N' << super : super
+            else
+              super
+            end
+          elsif value.acts_like?(:date)
+            quote_date_with_to_date(value)
+          elsif value.acts_like?(:time)
+            value.to_i == value.to_f ? quote_date_with_to_date(value) : quote_timestamp_with_to_timestamp(value)
+          else
+            super
+          end
+        end
+
+        def quoted_true #:nodoc:
+          return "'#{self.class.boolean_to_string(true)}'" if emulate_booleans_from_strings
+          "1"
+        end
+
+        def quoted_false #:nodoc:
+          return "'#{self.class.boolean_to_string(false)}'" if emulate_booleans_from_strings
+          "0"
+        end
+
+        def quote_date_with_to_date(value) #:nodoc:
+          # should support that composite_primary_keys gem will pass date as string
+          value = quoted_date(value) if value.acts_like?(:date) || value.acts_like?(:time)
+          "TO_DATE('#{value}','YYYY-MM-DD HH24:MI:SS')"
+        end
+
+        # Encode a string or byte array as string of hex codes
+        def self.encode_raw(value)
+          # When given a string, convert to a byte array.
+          value = value.unpack('C*') if value.is_a?(String)
+          value.map { |x| "%02X" % x }.join
+        end
+
+        # quote encoded raw value
+        def quote_raw(value) #:nodoc:
+          "'#{self.class.encode_raw(value)}'"
+        end
+
+        def quote_timestamp_with_to_timestamp(value) #:nodoc:
+          # add up to 9 digits of fractional seconds to inserted time
+          value = "#{quoted_date(value)}:#{("%.6f"%value.to_f).split('.')[1]}" if value.acts_like?(:time)
+          "TO_TIMESTAMP('#{value}','YYYY-MM-DD HH24:MI:SS:FF6')"
+        end
+
+        # Cast a +value+ to a type that the database understands.
+        def type_cast(value, column)
+          if column && column.cast_type.is_a?(Type::Serialized)
+            super
+          else
+            case value
+            when true, false
+              if emulate_booleans_from_strings || column && column.type == :string
+                self.class.boolean_to_string(value)
+              else
+                value ? 1 : 0
+              end
+            when Date, Time
+              if value.acts_like?(:time)
+                zone_conversion_method = ActiveRecord::Base.default_timezone == :utc ? :getutc : :getlocal
+                value.respond_to?(zone_conversion_method) ? value.send(zone_conversion_method) : value
+              else
+                value
+              end
+            else
+              super
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -34,8 +34,8 @@ require 'active_record/connection_adapters/oracle_enhanced/database_statements'
 require 'active_record/connection_adapters/oracle_enhanced/schema_statements'
 require 'active_record/connection_adapters/oracle_enhanced/column_dumper'
 require 'active_record/connection_adapters/oracle_enhanced/context_index'
-
 require 'active_record/connection_adapters/oracle_enhanced/column'
+require 'active_record/connection_adapters/oracle_enhanced/quoting'
 
 require 'digest/sha1'
 
@@ -226,6 +226,7 @@ module ActiveRecord
       include ActiveRecord::ConnectionAdapters::OracleEnhanced::SchemaStatements
       include ActiveRecord::ConnectionAdapters::OracleEnhanced::ColumnDumper
       include ActiveRecord::ConnectionAdapters::OracleEnhanced::ContextIndex
+      include ActiveRecord::ConnectionAdapters::OracleEnhanced::Quoting
 
       def schema_creation
         OracleEnhanced::SchemaCreation.new self
@@ -546,178 +547,6 @@ module ActiveRecord
         1000
       end
       alias ids_in_list_limit in_clause_length
-
-      # QUOTING ==================================================
-      #
-      # see: abstract/quoting.rb
-
-      def quote_column_name(name) #:nodoc:
-        name = name.to_s
-        @quoted_column_names[name] ||= begin
-          # if only valid lowercase column characters in name
-          if name =~ /\A[a-z][a-z_0-9\$#]*\Z/
-            "\"#{name.upcase}\""
-          else
-            # remove double quotes which cannot be used inside quoted identifier
-            "\"#{name.gsub('"', '')}\""
-          end
-        end
-      end
-
-      # This method is used in add_index to identify either column name (which is quoted)
-      # or function based index (in which case function expression is not quoted)
-      def quote_column_name_or_expression(name) #:nodoc:
-        name = name.to_s
-        case name
-        # if only valid lowercase column characters in name
-        when /^[a-z][a-z_0-9\$#]*$/
-          "\"#{name.upcase}\""
-        when /^[a-z][a-z_0-9\$#\-]*$/i
-          "\"#{name}\""
-        # if other characters present then assume that it is expression
-        # which should not be quoted
-        else
-          name
-        end
-      end
-
-      # Used only for quoting database links as the naming rules for links
-      # differ from the rules for column names. Specifically, link names may
-      # include periods.
-      def quote_database_link(name)
-        case name
-        when NONQUOTED_DATABASE_LINK
-          %Q("#{name.upcase}")
-        else
-          name
-        end
-      end
-
-      # Names must be from 1 to 30 bytes long with these exceptions:
-      # * Names of databases are limited to 8 bytes.
-      # * Names of database links can be as long as 128 bytes.
-      #
-      # Nonquoted identifiers cannot be Oracle Database reserved words
-      #
-      # Nonquoted identifiers must begin with an alphabetic character from
-      # your database character set
-      #
-      # Nonquoted identifiers can contain only alphanumeric characters from
-      # your database character set and the underscore (_), dollar sign ($),
-      # and pound sign (#). Database links can also contain periods (.) and
-      # "at" signs (@). Oracle strongly discourages you from using $ and # in
-      # nonquoted identifiers.
-      NONQUOTED_OBJECT_NAME   = /[A-Za-z][A-z0-9$#]{0,29}/
-      NONQUOTED_DATABASE_LINK = /[A-Za-z][A-z0-9$#\.@]{0,127}/
-      VALID_TABLE_NAME = /\A(?:#{NONQUOTED_OBJECT_NAME}\.)?#{NONQUOTED_OBJECT_NAME}(?:@#{NONQUOTED_DATABASE_LINK})?\Z/
-
-      # unescaped table name should start with letter and
-      # contain letters, digits, _, $ or #
-      # can be prefixed with schema name
-      # CamelCase table names should be quoted
-      def self.valid_table_name?(name) #:nodoc:
-        name = name.to_s
-        name =~ VALID_TABLE_NAME && !(name =~ /[A-Z]/ && name =~ /[a-z]/) ? true : false
-      end
-
-      def quote_table_name(name) #:nodoc:
-        name, link = name.to_s.split('@')
-        @quoted_table_names[name] ||= [name.split('.').map{|n| quote_column_name(n)}.join('.'), quote_database_link(link)].compact.join('@')
-      end
-
-      def quote_string(s) #:nodoc:
-        s.gsub(/'/, "''")
-      end
-
-      def quote(value, column = nil) #:nodoc:
-        if value && column
-          case column.type
-          when :text, :binary
-            %Q{empty_#{ type_to_sql(column.type.to_sym).downcase rescue 'blob' }()}
-          # NLS_DATE_FORMAT independent TIMESTAMP support
-          when :timestamp
-            quote_timestamp_with_to_timestamp(value)
-          # NLS_DATE_FORMAT independent DATE support
-          when :date, :time, :datetime
-            quote_date_with_to_date(value)
-          when :raw
-            quote_raw(value)
-          when :string
-            # NCHAR and NVARCHAR2 literals should be quoted with N'...'.
-            # Read directly instance variable as otherwise migrations with table column default values are failing
-            # as migrations pass ColumnDefinition object to this method.
-            # Check if instance variable is defined to avoid warnings about accessing undefined instance variable.
-            column.instance_variable_defined?('@nchar') && column.instance_variable_get('@nchar') ? 'N' << super : super
-          else
-            super
-          end
-        elsif value.acts_like?(:date)
-          quote_date_with_to_date(value)
-        elsif value.acts_like?(:time)
-          value.to_i == value.to_f ? quote_date_with_to_date(value) : quote_timestamp_with_to_timestamp(value)
-        else
-          super
-        end
-      end
-
-      def quoted_true #:nodoc:
-        return "'#{self.class.boolean_to_string(true)}'" if emulate_booleans_from_strings
-        "1"
-      end
-
-      def quoted_false #:nodoc:
-        return "'#{self.class.boolean_to_string(false)}'" if emulate_booleans_from_strings
-        "0"
-      end
-
-      def quote_date_with_to_date(value) #:nodoc:
-        # should support that composite_primary_keys gem will pass date as string
-        value = quoted_date(value) if value.acts_like?(:date) || value.acts_like?(:time)
-        "TO_DATE('#{value}','YYYY-MM-DD HH24:MI:SS')"
-      end
-
-      # Encode a string or byte array as string of hex codes
-      def self.encode_raw(value)
-        # When given a string, convert to a byte array.
-        value = value.unpack('C*') if value.is_a?(String)
-        value.map { |x| "%02X" % x }.join
-      end
-
-      # quote encoded raw value
-      def quote_raw(value) #:nodoc:
-        "'#{self.class.encode_raw(value)}'"
-      end
-
-      def quote_timestamp_with_to_timestamp(value) #:nodoc:
-        # add up to 9 digits of fractional seconds to inserted time
-        value = "#{quoted_date(value)}:#{("%.6f"%value.to_f).split('.')[1]}" if value.acts_like?(:time)
-        "TO_TIMESTAMP('#{value}','YYYY-MM-DD HH24:MI:SS:FF6')"
-      end
-
-      # Cast a +value+ to a type that the database understands.
-      def type_cast(value, column)
-        if column && column.cast_type.is_a?(Type::Serialized)
-          super
-        else
-          case value
-          when true, false
-            if emulate_booleans_from_strings || column && column.type == :string
-              self.class.boolean_to_string(value)
-            else
-              value ? 1 : 0
-            end
-          when Date, Time
-            if value.acts_like?(:time)
-              zone_conversion_method = ActiveRecord::Base.default_timezone == :utc ? :getutc : :getlocal
-              value.respond_to?(zone_conversion_method) ? value.send(zone_conversion_method) : value
-            else
-              value
-            end
-          else
-            super
-          end
-        end
-      end
 
       # CONNECTION MANAGEMENT ====================================
       #

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -341,7 +341,7 @@ describe "OracleEnhancedAdapter" do
 
   describe "valid table names" do
     before(:all) do
-      @adapter = ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter
+      @adapter = ActiveRecord::ConnectionAdapters::OracleEnhanced::Quoting
     end
 
     it "should be valid with letters and digits" do


### PR DESCRIPTION
Since Rails 5 requires a lot of changes for type casting, this pull request extracts quoting related method into  ActiveRecord::ConnectionAdapters::OracleEnhanced::Quoting