### PR TITLE
Remove "warning: (...) interpreted as grouped expression"

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -123,7 +123,7 @@ module ActiveRecord
             if without_prepared_statement?(binds)
               cursor = @connection.prepare(sql)
             else
-              unless @statements.key? (sql)
+              unless @statements.key?(sql)
                 @statements[sql] = @connection.prepare(sql)
               end
 
@@ -229,7 +229,7 @@ module ActiveRecord
         # Returns default sequence name for table.
         # Will take all or first 26 characters of table name and append _seq suffix
         def default_sequence_name(table_name, primary_key = nil)
-          table_name.to_s.gsub (/(^|\.)([\w$-]{1,#{sequence_name_length-4}})([\w$-]*)$/), '\1\2_seq'
+          table_name.to_s.gsub((/(^|\.)([\w$-]{1,#{sequence_name_length-4}})([\w$-]*)$/), '\1\2_seq')
         end
 
         # Inserts the given fixture into the table. Overridden to properly handle lobs.

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -808,8 +808,8 @@ module ActiveRecord
             select NVL(max(#{quote_column_name(primary_key)}),0) + 1 from #{quote_table_name(table_name)}
           ", new_start_value)
 
-          execute ("DROP SEQUENCE #{quote_table_name(sequence_name)}")
-          execute ("CREATE SEQUENCE #{quote_table_name(sequence_name)} START WITH #{new_start_value}")
+          execute "DROP SEQUENCE #{quote_table_name(sequence_name)}"
+          execute "CREATE SEQUENCE #{quote_table_name(sequence_name)} START WITH #{new_start_value}"
         end
       end
 


### PR DESCRIPTION
This pull request addresses "warning: (...) interpreted as grouped expression" reported when tested with jruby.

```
$ ruby -v
jruby 9.0.4.0 (2.2.2) 2015-11-12 b9fb7aa Java HotSpot(TM) 64-Bit Server VM 25.71-b15 on 1.8.0_71-b15 +jit [linux-amd64]
```

```ruby
Using oracle
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:811: warning: (...) interpreted as grouped expression
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:812: warning: (...) interpreted as grouped expression
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:126: warning: (...) interpreted as grouped expression
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:232: warning: (...) interpreted as grouped expression
```