### PR TITLE
Migrate from OracleEnhancedSchemaStatementExt to OracleEnhanced::SchemaStatementsExt

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements_ext.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements_ext.rb
@@ -1,65 +1,61 @@
-require 'digest/sha1'
-
 module ActiveRecord
   module ConnectionAdapters
-    module OracleEnhancedSchemaStatementsExt
-      # Create primary key trigger (so that you can skip primary key value in INSERT statement).
-      # By default trigger name will be "table_name_pkt", you can override the name with 
-      # :trigger_name option (but it is not recommended to override it as then this trigger will
-      # not be detected by ActiveRecord model and it will still do prefetching of sequence value).
-      #
-      #   add_primary_key_trigger :users
-      #
-      # You can also create primary key trigger using +create_table+ with :primary_key_trigger
-      # option:
-      #
-      #   create_table :users, :primary_key_trigger => true do |t|
-      #     # ...
-      #   end
-      #
-      def add_primary_key_trigger(table_name, options={})
-        # call the same private method that is used for create_table :primary_key_trigger => true
-        create_primary_key_trigger(table_name, options)
-      end
-
-      # Add synonym to existing table or view or sequence. Can be used to create local synonym to
-      # remote table in other schema or in other database
-      # Examples:
-      #
-      #   add_synonym :posts, "blog.posts"
-      #   add_synonym :posts_seq, "blog.posts_seq"
-      #   add_synonym :employees, "hr.employees@dblink", :force => true
-      #
-      def add_synonym(name, table_name, options = {})
-        sql = "CREATE"
-        if options[:force] == true
-          sql << " OR REPLACE"
+    module OracleEnhanced
+      module SchemaStatementsExt
+        # Create primary key trigger (so that you can skip primary key value in INSERT statement).
+        # By default trigger name will be "table_name_pkt", you can override the name with
+        # :trigger_name option (but it is not recommended to override it as then this trigger will
+        # not be detected by ActiveRecord model and it will still do prefetching of sequence value).
+        #
+        #   add_primary_key_trigger :users
+        #
+        # You can also create primary key trigger using +create_table+ with :primary_key_trigger
+        # option:
+        #
+        #   create_table :users, :primary_key_trigger => true do |t|
+        #     # ...
+        #   end
+        #
+        def add_primary_key_trigger(table_name, options={})
+          # call the same private method that is used for create_table :primary_key_trigger => true
+          create_primary_key_trigger(table_name, options)
         end
-        sql << " SYNONYM #{quote_table_name(name)} FOR #{quote_table_name(table_name)}"
-        execute sql
-      end
 
-      # Remove existing synonym to table or view or sequence
-      # Example:
-      #
-      #   remove_synonym :posts, "blog.posts"
-      #
-      def remove_synonym(name)
-        execute "DROP SYNONYM #{quote_table_name(name)}"
-      end
-
-      # get synonyms for schema dump
-      def synonyms #:nodoc:
-        select_all("SELECT synonym_name, table_owner, table_name, db_link FROM all_synonyms where owner = SYS_CONTEXT('userenv', 'session_user')").collect do |row|
-          OracleEnhanced::SynonymDefinition.new(oracle_downcase(row['synonym_name']),
-            oracle_downcase(row['table_owner']), oracle_downcase(row['table_name']), oracle_downcase(row['db_link']))
+        # Add synonym to existing table or view or sequence. Can be used to create local synonym to
+        # remote table in other schema or in other database
+        # Examples:
+        #
+        #   add_synonym :posts, "blog.posts"
+        #   add_synonym :posts_seq, "blog.posts_seq"
+        #   add_synonym :employees, "hr.employees@dblink", :force => true
+        #
+        def add_synonym(name, table_name, options = {})
+          sql = "CREATE"
+          if options[:force] == true
+            sql << " OR REPLACE"
+          end
+          sql << " SYNONYM #{quote_table_name(name)} FOR #{quote_table_name(table_name)}"
+          execute sql
         end
-      end
 
+        # Remove existing synonym to table or view or sequence
+        # Example:
+        #
+        #   remove_synonym :posts, "blog.posts"
+        #
+        def remove_synonym(name)
+          execute "DROP SYNONYM #{quote_table_name(name)}"
+        end
+
+        # get synonyms for schema dump
+        def synonyms #:nodoc:
+          select_all("SELECT synonym_name, table_owner, table_name, db_link FROM all_synonyms where owner = SYS_CONTEXT('userenv', 'session_user')").collect do |row|
+            OracleEnhanced::SynonymDefinition.new(oracle_downcase(row['synonym_name']),
+              oracle_downcase(row['table_owner']), oracle_downcase(row['table_name']), oracle_downcase(row['db_link']))
+          end
+        end
+
+      end
     end
   end
-end
-
-ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.class_eval do
-  include ActiveRecord::ConnectionAdapters::OracleEnhancedSchemaStatementsExt
 end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -32,6 +32,7 @@ require 'active_record/connection_adapters/abstract_adapter'
 require 'active_record/connection_adapters/oracle_enhanced/connection'
 require 'active_record/connection_adapters/oracle_enhanced/database_statements'
 require 'active_record/connection_adapters/oracle_enhanced/schema_statements'
+require 'active_record/connection_adapters/oracle_enhanced/schema_statements_ext'
 require 'active_record/connection_adapters/oracle_enhanced/column_dumper'
 require 'active_record/connection_adapters/oracle_enhanced/context_index'
 require 'active_record/connection_adapters/oracle_enhanced/column'
@@ -224,6 +225,7 @@ module ActiveRecord
       # TODO: Use relative
       include ActiveRecord::ConnectionAdapters::OracleEnhanced::DatabaseStatements
       include ActiveRecord::ConnectionAdapters::OracleEnhanced::SchemaStatements
+      include ActiveRecord::ConnectionAdapters::OracleEnhanced::SchemaStatementsExt
       include ActiveRecord::ConnectionAdapters::OracleEnhanced::ColumnDumper
       include ActiveRecord::ConnectionAdapters::OracleEnhanced::ContextIndex
       include ActiveRecord::ConnectionAdapters::OracleEnhanced::Quoting


### PR DESCRIPTION
Migrate from ActiveRecord::ConnectionAdapters::OracleEnhancedSchemaStatementExt
to ActiveRecord::ConnectionAdapters::OracleEnhanced::SchemaStatementsExt

Also removed 'digest/sha1' had been used for generating foreign key name