### PR TITLE
Remove version check to see if ::Rails::Railtie exists

### DIFF
--- a/lib/activerecord-oracle_enhanced-adapter.rb
+++ b/lib/activerecord-oracle_enhanced-adapter.rb
@@ -1,25 +1,20 @@
-# define railtie which will be executed in Rails 3
-if defined?(::Rails::Railtie)
+module ActiveRecord
+  module ConnectionAdapters
+    class OracleEnhancedRailtie < ::Rails::Railtie
+      rake_tasks do
+        load 'active_record/connection_adapters/oracle_enhanced/database_tasks.rb'
+      end
 
-  module ActiveRecord
-    module ConnectionAdapters
-      class OracleEnhancedRailtie < ::Rails::Railtie
-        rake_tasks do
-          load 'active_record/connection_adapters/oracle_enhanced/database_tasks.rb'
-        end
+      ActiveSupport.on_load(:active_record) do
+        require 'active_record/connection_adapters/oracle_enhanced_adapter'
 
-        ActiveSupport.on_load(:active_record) do
-          require 'active_record/connection_adapters/oracle_enhanced_adapter'
-
-          # Cache column descriptions between requests in test and production environments
-          if Rails.env.test? || Rails.env.production?
-            ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.cache_columns = true
-          end
-
+        # Cache column descriptions between requests in test and production environments
+        if Rails.env.test? || Rails.env.production?
+          ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.cache_columns = true
         end
 
       end
+
     end
   end
-
 end


### PR DESCRIPTION
This logic was used to check if Rails 3 or lower version.