### PR TITLE
Remove magic comment for utf-8

### DIFF
--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 Gem::Specification.new do |s|
   s.name = %q{activerecord-oracle_enhanced-adapter}
   s.version = "1.6.6"


### PR DESCRIPTION
since Rails 5 requires ruby 2.2 or higher version
whose default source file encoding is utf-8