### PR TITLE
[WIP] use JDBC implicit statement cache instead of AR StatementPool

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -2,6 +2,7 @@ module ActiveRecord
   module ConnectionAdapters
     # interface independent methods
     class OracleEnhancedConnection #:nodoc:
+      DEFAULT_STATEMENT_LIMIT = 250
 
       def self.create(config)
         case ORACLE_ENHANCED_CONNECTION

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -359,41 +359,10 @@ module ActiveRecord
       cattr_accessor :string_to_time_format
       self.string_to_time_format = nil
 
-      class StatementPool
-        include Enumerable
-
-        def initialize(connection, max = 300)
-          @connection = connection
-          @max        = max
-          @cache      = {}
-        end
-
-        def each(&block); @cache.each(&block); end
-        def key?(key);    @cache.key?(key); end
-        def [](key);      @cache[key]; end
-        def length;       @cache.length; end
-        def delete(key);  @cache.delete(key); end
-
-        def []=(sql, key)
-          while @max <= @cache.size
-            @cache.shift.last.close
-          end
-          @cache[sql] = key
-        end
-
-        def clear
-          @cache.values.each do |cursor|
-            cursor.close
-          end
-          @cache.clear
-        end
-      end
-
       def initialize(connection, logger, config) #:nodoc:
         super(connection, logger)
         @quoted_column_names, @quoted_table_names = {}, {}
         @config = config
-        @statements = StatementPool.new(connection, config.fetch(:statement_limit) { 250 })
         @enable_dbms_output = false
         @visitor = Arel::Visitors::Oracle.new self
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -561,10 +561,10 @@ describe "OracleEnhancedAdapter" do
   describe "eager loading" do
     before(:all) do
       schema_define do
-        create_table :test_posts do |t|
+        create_table :test_posts, force: true do |t|
           t.string      :title
         end
-        create_table :test_comments do |t|
+        create_table :test_comments, force: true do |t|
           t.integer     :test_post_id
           t.string      :description
         end
@@ -608,11 +608,11 @@ describe "OracleEnhancedAdapter" do
       @conn = ActiveRecord::Base.connection
       schema_define do
         drop_table :test_posts rescue nil
-        create_table :test_posts
+        create_table :test_posts, force: true
       end
       class ::TestPost < ActiveRecord::Base
       end
-      @statements = @conn.instance_variable_get(:@statements)
+      @raw_connection = @conn.instance_variable_get(:@connection)
     end
 
     before(:each) do
@@ -636,7 +636,7 @@ describe "OracleEnhancedAdapter" do
         4.times do |i|
           @conn.exec_query("SELECT * FROM test_posts WHERE #{i}=#{i} AND id = #{sub}", "SQL", binds)
         end
-      }.should change(@statements, :length).by(+3)
+      }.should change(@raw_connection, :cache_size).by(+3)
     end
 
     it "should cache UPDATE statements with bind variables" do
@@ -645,14 +645,14 @@ describe "OracleEnhancedAdapter" do
         sub = @conn.substitute_at(pk, 0).to_sql
         binds = [[pk, 1]]
         @conn.exec_update("UPDATE test_posts SET id = #{sub}", "SQL", binds)
-      }.should change(@statements, :length).by(+1)
+      }.should change(@raw_connection, :cache_size).by(+1)
     end
 
     it "should not cache UPDATE statements without bind variables" do
       lambda {
         binds = []
         @conn.exec_update("UPDATE test_posts SET id = 1", "SQL", binds)
-      }.should_not change(@statements, :length)
+      }.should_not change(@raw_connection, :cache_size)
     end
   end
 
@@ -661,7 +661,7 @@ describe "OracleEnhancedAdapter" do
       @conn = ActiveRecord::Base.connection
       schema_define do
         drop_table :test_posts rescue nil
-        create_table :test_posts
+        create_table :test_posts, force: true
       end
       class ::TestPost < ActiveRecord::Base
       end


### PR DESCRIPTION
Context: we've noticed a few issues with the statement caching implementation in our JRuby apps:
* `statement_limit: 0` doesn't work, raises NoMethodErrors trying to delete from an empty hash.  You can specify `statement_limit: 1` to effectively disable statement caching, but statements stay open longer than they really should and you also have unnecessary hash operations going on.
* We wanted to disable statement caching in the first place because we would get Protocol Violation errors from our RAC because of cached PreparedStatements. This can happen if you change a table and then use a cached `SELECT *` PreparedStatement [1], which is not unusual for ActiveRecord.
* ojdbc has a built-in statement cache that is intended to be enabled, has lots of documentation, etc.  [2].

The Oracle cache seems to recover from errors more easily; the above problem causes Protocol Violation errors from when we run a migration until we restart Rails, which is pretty bad. The implicit cache doesn't completely solve the problem, but this PR also moves the caching part into `with_retry`, so we could clear the cache and retry if needed.

So what I'm proposing here is to:
* Make oracle's implicit cache the default for JRuby.
* Make the cache implementation swappable so users could implement their own cursor (for e.g. explicit caching or some other strategy).

There are still a few failing tests since ojdbc doesn't expose the same information as StatementPool, will fix those is there are no other blockers here. Thoughts?

[1] We thought this was a bug, but Oracle has a support doc ID (1361340) if you can access their support site. We see it in our RAC but can't reproduce it in an XE VM.
[2] "Oracle JDBC drivers are designed with the supposition that implicit caching is enabled" - http://www.oracle.com/technetwork/articles/vasiliev-oracle-jdbc-090470.html