### PR TITLE
Remove select method from Oracle enhanced adapter

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -248,12 +248,6 @@ module ActiveRecord
           end
         end
 
-        private
-
-        def select(sql, name = nil, binds = [])
-          exec_query(sql, name, binds)
-        end
-
       end
     end
   end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1309,10 +1309,6 @@ module ActiveRecord
 
       private
 
-      def select(sql, name = nil, binds = [])
-        exec_query(sql, name, binds)
-      end
-
       def oracle_downcase(column_name)
         @connection.oracle_downcase(column_name)
       end


### PR DESCRIPTION
ActiveRecord::ConnectionAdapters::DatabaseStatements#select does the same thing