### PR TITLE
Address ORA-01830 errors

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -145,8 +145,8 @@ module ActiveRecord
 
         def quote_timestamp_with_to_timestamp(value) #:nodoc:
           # add up to 9 digits of fractional seconds to inserted time
-          value = "#{quoted_date(value)}:#{("%.6f"%value.to_f).split('.')[1]}" if value.acts_like?(:time)
-          "TO_TIMESTAMP('#{value}','YYYY-MM-DD HH24:MI:SS:FF6')"
+          value = "#{quoted_date(value)}" if value.acts_like?(:time)
+          "TO_TIMESTAMP('#{value}','YYYY-MM-DD HH24:MI:SS.FF6')"
         end
 
         # Cast a +value+ to a type that the database understands.


### PR DESCRIPTION
This pull request addresses ORA-01830 errors since somehow `quoted_date(value)` now includes fractional seconds. It would cause some regression since Oracle enhanced adapter needs to use : . Which will be fixed later.

```ruby

$ cd activerecord
$ bundle exec rake test_oracle
...

  2) Error:
RelationTest#test_first_or_create_with_invalid_array:
ActiveRecord::StatementInvalid: OCIError: ORA-01830: date format picture ends before converting entire input string: INSERT INTO "TOPICS" ("ID", "TITLE", "AUTHOR_NAME", "AUTHOR_EMAIL_ADDRESS", "WRITTEN_ON", "LAST_READ", "BONUS_TIME", "CONTENT", "APPROVED", "REPLIES_COUNT", "CREATED_AT", "UPDATED_AT") VALUES (1, 'The First Topic', 'David', 'david@loudthinking.com', TO_TIMESTAMP('2003-07-16 14:28:11.223300:223300','YYYY-MM-DD HH24:MI:SS:FF6'), TO_DATE('2004-04-15','YYYY-MM-DD HH24:MI:SS'), TO_DATE('2005-01-30 14:28:00','YYYY-MM-DD HH24:MI:SS'), '--- Have a nice day
...
', 0, 1, TO_TIMESTAMP('2016-04-08 12:47:46.637798:637799','YYYY-MM-DD HH24:MI:SS:FF6'), TO_TIMESTAMP('2016-04-08 12:47:46.637798:637799','YYYY-MM-DD HH24:MI:SS:FF6'))
    stmt.c:243:in oci8lib_230.so
    /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.1/lib/oci8/cursor.rb:129:in `exec'
    /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.1/lib/oci8/oci8.rb:280:in `exec_internal'
    /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.1/lib/oci8/oci8.rb:271:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:447:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:92:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `block in execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:527:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:521:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1176:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:330:in `insert_fixture'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:220:in `insert_fixture'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:553:in `block (5 levels) in create_fixtures'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:552:in `each'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:552:in `block (4 levels) in create_fixtures'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:551:in `each'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:551:in `block (3 levels) in create_fixtures'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:540:in `each'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:540:in `block (2 levels) in create_fixtures'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:233:in `block in transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:233:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:538:in `block in create_fixtures'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:474:in `disable_referential_integrity'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:523:in `create_fixtures'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:1015:in `load_fixtures'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:977:in `setup_fixtures'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:852:in `before_setup'
```