### PR TITLE
join_to_update argument changed to take 3rd argument

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1078,7 +1078,7 @@ module ActiveRecord
 
       # construct additional wrapper subquery if select.offset is used to avoid generation of invalid subquery
       # ... IN ( SELECT * FROM ( SELECT raw_sql_.*, rownum raw_rnum_ FROM ( ... ) raw_sql_ ) WHERE raw_rnum_ > ... )
-      def join_to_update(update, select) #:nodoc:
+      def join_to_update(update, select, key) #:nodoc:
         if select.offset
           subsubselect = select.clone
           subsubselect.projections = [update.key]


### PR DESCRIPTION
Refer https://github.com/rails/rails/pull/22620

This pull request addresses this kind of errors.

```ruby
$ cd activerecord
$ bundle exec rake test_oracle
... snip ...
  4) Error:
RelationTest#test_update_all_with_scope:
ArgumentError: wrong number of arguments (given 3, expected 2)
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1081:in `join_to_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:384:in `update_all'
    /home/yahonda/git/rails/activerecord/test/cases/relations_test.rb:1112:in `test_update_all_with_scope'
```