### PR TITLE
Use Abstract adapter join_to_update

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1079,18 +1079,9 @@ module ActiveRecord
       # construct additional wrapper subquery if select.offset is used to avoid generation of invalid subquery
       # ... IN ( SELECT * FROM ( SELECT raw_sql_.*, rownum raw_rnum_ FROM ( ... ) raw_sql_ ) WHERE raw_rnum_ > ... )
       def join_to_update(update, select, key) #:nodoc:
-        if select.offset
-          subsubselect = select.clone
-          subsubselect.projections = [update.key]
-
-          subselect = Arel::SelectManager.new(select.engine)
-          subselect.project Arel.sql(quote_column_name update.key.name)
-          subselect.from subsubselect.as('alias_join_to_update')
-
-          update.where update.key.in(subselect)
-        else
-          super
-        end
+        #TODO: Need to validate if we can remove join_to_update from Oracle enhanced adapter after testing
+        # older version of Oracle 11gR2
+        super
       end
 
       protected


### PR DESCRIPTION
This pull request addresses these errors. 

Reason why it just calls super instead of removing this method itself is Oracle enhanced adapter may need to implement its own method for older version of Oracle 11gR2 or lower.

This test has been addressed when tested with Oracle database 12c, which has its own Arel visitor called Oracle12.

```ruby
$ cd activerecord
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test"  test/cases/relations_test.rb

... snip ...

  3) Error:
RelationTest#test_update_all_with_joins_and_offset_and_order:
NoMethodError: undefined method `name' for nil:NilClass
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1087:in `join_to_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:384:in `update_all'
    test/cases/relations_test.rb:1611:in `test_update_all_with_joins_and_offset_and_order'

... snip ...
  6) Error:
RelationTest#test_update_all_with_joins_and_offset:
NoMethodError: undefined method `name' for nil:NilClass
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1087:in `join_to_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:384:in `update_all'
    test/cases/relations_test.rb:1603:in `test_update_all_with_joins_and_offset'

```
