### PR TITLE
Use Abstract adapter sql_for_insert

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -98,15 +98,9 @@ module ActiveRecord
         end
         protected :insert_sql
 
-        # New method in ActiveRecord 3.1
         # Will add RETURNING clause in case of trigger generated primary keys
         def sql_for_insert(sql, pk, id_value, sequence_name, binds)
-          unless id_value || pk.nil? || (defined?(CompositePrimaryKeys) && pk.kind_of?(CompositePrimaryKeys::CompositeKeys))
-            sql = "#{sql} RETURNING #{quote_column_name(pk)} INTO :returning_id"
-            returning_id_col = new_column("returning_id", nil, fetch_type_metadata("number"), true, "dual", true, true)
-            (binds = binds.dup) << [returning_id_col, nil]
-          end
-          [sql, binds]
+          super
         end
 
         # New method in ActiveRecord 3.1


### PR DESCRIPTION
This pull request addresses this kind of errors when `ActiveRecord::ConnectionAdapters::OracleEnhancedColumn` does not have `value_for_database` method.

It uses Abstract adapter's method modified in https://github.com/rails/rails/pull/23067, it may cause some regressions to Oracle enhanced adapter, then just call super instead of removing it.

```ruby
$ cd activerecord
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test"  test/cases/associations/has_many_associations_test.rb

... snip ...
  4) Error:
HasManyAssociationsTest#test_building_the_association_with_an_array:
NoMethodError: undefined method `value_for_database' for #<Array:0x00563b4d965e40>
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:114:in `block in exec_insert'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:114:in `map'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:114:in `exec_insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:123:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:65:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:554:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:128:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:75:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:123:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `block in _create_record'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:126:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:506:in `block (2 levels) in compile'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:455:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_create_callbacks'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:68:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:534:in `create_or_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `block in create_or_update'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:126:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:506:in `block (2 levels) in compile'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:455:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_save_callbacks'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `create_or_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:125:in `save'
    /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:44:in `save'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:22:in `save'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:319:in `block (2 levels) in save'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:231:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:319:in `block in save'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:334:in `rollback_active_record_state!'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:318:in `save'
    /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:41:in `save'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/has_many_association.rb:48:in `insert_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/autosave_association.rb:400:in `block in save_collection_association'
    /home/yahonda/git/rails/activerecord/lib/active_record/autosave_association.rb:391:in `each'
    /home/yahonda/git/rails/activerecord/lib/active_record/autosave_association.rb:391:in `save_collection_association'
    /home/yahonda/git/rails/activerecord/lib/active_record/autosave_association.rb:185:in `block in add_autosave_association_callbacks'
    /home/yahonda/git/rails/activerecord/lib/active_record/autosave_association.rb:158:in `instance_eval'
    /home/yahonda/git/rails/activerecord/lib/active_record/autosave_association.rb:158:in `block in define_non_cyclic_method'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:382:in `block in make_lambda'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:207:in `block in halting_and_conditional'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:456:in `block in call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:456:in `each'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:456:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_create_callbacks'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:68:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:534:in `create_or_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `block in create_or_update'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:126:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:506:in `block (2 levels) in compile'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:455:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_save_callbacks'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `create_or_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:125:in `save'
    /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:44:in `save'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:22:in `save'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:319:in `block (2 levels) in save'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:233:in `block in transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:233:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:319:in `block in save'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:334:in `rollback_active_record_state!'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:318:in `save'
    /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:41:in `save'
    test/cases/associations/has_many_associations_test.rb:311:in `block in <class:HasManyAssociationsTest>'
```
