### PR TITLE
Handle BLOB type correctly

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -85,31 +85,12 @@ module ActiveRecord
         end
 
         def quote(value, column = nil) #:nodoc:
-          if value && column
-            case column.type
-            when :text, :binary
-              %Q{empty_#{ type_to_sql(column.type.to_sym).downcase rescue 'blob' }()}
-            # NLS_DATE_FORMAT independent TIMESTAMP support
-            when :timestamp
-              quote_timestamp_with_to_timestamp(value)
-            # NLS_DATE_FORMAT independent DATE support
-            when :date, :time, :datetime
-              quote_date_with_to_date(value)
-            when :raw
-              quote_raw(value)
-            when :string
-              # NCHAR and NVARCHAR2 literals should be quoted with N'...'.
-              # Read directly instance variable as otherwise migrations with table column default values are failing
-              # as migrations pass ColumnDefinition object to this method.
-              # Check if instance variable is defined to avoid warnings about accessing undefined instance variable.
-              column.instance_variable_defined?('@nchar') && column.instance_variable_get('@nchar') ? 'N' << super : super
-            else
-              super
-            end
-          elsif value.acts_like?(:date)
-            quote_date_with_to_date(value)
-          elsif value.acts_like?(:time)
-            value.to_i == value.to_f ? quote_date_with_to_date(value) : quote_timestamp_with_to_timestamp(value)
+          super
+        end
+
+        def _quote(value) #:nodoc:
+          if value.is_a? ActiveModel::Type::Binary::Data
+            %Q{empty_#{ type_to_sql(column.type.to_sym).downcase rescue 'blob' }()}
           else
             super
           end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -676,7 +676,6 @@ module ActiveRecord
           value = attributes[col.name]
           # changed sequence of next two lines - should check if value is nil before converting to yaml
           next if value.nil?  || (value == '')
-          value = col.cast_type.type_cast_for_database(value)
           uncached do
             sql = is_with_cpk ? "SELECT #{quote_column_name(col.name)} FROM #{quote_table_name(table_name)} WHERE #{klass.composite_where_clause(id)} FOR UPDATE" :
               "SELECT #{quote_column_name(col.name)} FROM #{quote_table_name(table_name)} WHERE #{quote_column_name(klass.primary_key)} = #{id} FOR UPDATE"


### PR DESCRIPTION
This pull request addresses this kind of ORA-01756 errors when inserting blob values.
It currently removes other type casting for timestamp. I wanted to see how Rails abstract _cast works then will update Oracle enhanced _cast method to support these types if necessary.

```ruby
$ cd activerecord
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test"  test/cases/fixtures_test.rb -n test_create_symbol_fixtures
Using oracle
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb:7: warning: method redefined; discarding old aliased_types
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb:384: warning: previous definition of aliased_types was here
Run options: -n test_create_symbol_fixtures --seed 41442

# Running:

E

Finished in 1.178226s, 0.8487 runs/s, 0.0000 assertions/s.

  1) Error:
FixturesTest#test_create_symbol_fixtures:
ActiveRecord::StatementInvalid: OCIError: ORA-01756: quoted string not properly terminated: INSERT INTO "BINARIES" ("ID", "DATA") VALUES (1, 
...

    stmt.c:82:in oci8lib_230.so
    /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.1/lib/oci8/cursor.rb:28:in `initialize'
    /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.1/lib/oci8/oci8.rb:179:in `new'
    /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.1/lib/oci8/oci8.rb:179:in `parse_internal'
    /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.1/lib/oci8/oci8.rb:172:in `parse'
    /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.1/lib/oci8/oci8.rb:279:in `exec_internal'
    /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.1/lib/oci8/oci8.rb:271:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:447:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:92:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `block in execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:527:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:521:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1167:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:330:in `insert_fixture'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:214:in `insert_fixture'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:553:in `block (5 levels) in create_fixtures'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:552:in `each'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:552:in `block (4 levels) in create_fixtures'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:551:in `each'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:551:in `block (3 levels) in create_fixtures'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:540:in `each'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:540:in `block (2 levels) in create_fixtures'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:233:in `block in transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:233:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:538:in `block in create_fixtures'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:474:in `disable_referential_integrity'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:523:in `create_fixtures'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:1015:in `load_fixtures'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:988:in `setup_fixtures'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:852:in `before_setup'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```

Refer https://github.com/rails/rails/commit/74a756a8b43e2eb5e743d32fa4f6089be2246a58https://github.com/rails/rails/commit/74a756a8b43e2eb5e743d32fa4f6089be2246a58