### PR TITLE
Address undefined method `cast_type'

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
@@ -152,7 +152,7 @@ module ActiveRecord #:nodoc:
           if partial_writes?
             # Serialized attributes should always be written in case they've been
             # changed in place.
-            update_using_custom_method(changed | (attributes.keys & self.class.columns.select {|column| column.cast_type.is_a?(Type::Serialized)}))
+            update_using_custom_method(changed | (attributes.keys & self.class.columns.select {|column| column.is_a?(Type::Serialized)}))
           else
             update_using_custom_method(attribute_names)
           end


### PR DESCRIPTION
This pull request addresses these 4 failures.
```
rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:193
rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:207
rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:226
rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:305
```

```ruby
2.3.0 [ rails5 ~/git/oracle-enhanced]$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:193
==> Loading config from ENV or use default
==> Running specs with MRI version 2.3.0
==> Effective ActiveRecord version 5.0.0.beta3
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb"=>[193]}}
F

Failures:

  1) OracleEnhancedAdapter custom methods for create, update and destroy should update record
     Failure/Error: update_using_custom_method(changed | (attributes.keys & self.class.columns.select {|column| column.cast_type.is_a?(Type::Serialized)}))

     NoMethodError:
       undefined method `cast_type' for #<ActiveRecord::ConnectionAdapters::OracleEnhancedColumn:0x00562ebb7897f0>
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:155:in `block (2 levels) in _update_record'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:155:in `select'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:155:in `block in _update_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:126:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:506:in `block (2 levels) in compile'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:455:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_update_callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:90:in `run_callbacks'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:140:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:534:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:152:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:50:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:30:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `block in save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:233:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:233:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:45:in `save!'
     # ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:202:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:236:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:236:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:478:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:435:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:478:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:616:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:478:in `run'
     # /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:435:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:478:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:233:in `run'
     # /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:581:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:577:in `map'
     # /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:577:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:543:in `run'
     # /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `map'
     # /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/configuration.rb:1680:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:118:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:117:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:93:in `run'
     # /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:78:in `run'
     # /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.0/bin/rspec:23:in `load'
     # /home/yahonda/.rbenv/versions/2.3.0/bin/rspec:23:in `<main>'

Finished in 0.52862 seconds (files took 1.8 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:193 # OracleEnhancedAdapter custom methods for create, update and destroy should update recor
```