### PR TITLE
Fix schema dumper errors

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column.rb
@@ -5,7 +5,6 @@ module ActiveRecord
       attr_reader :table_name, :nchar, :virtual_column_data_default, :returning_id #:nodoc:
 
       def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, virtual=false, returning_id=false) #:nodoc:
-        @table_name = table_name
         @virtual = virtual
         @virtual_column_data_default = default.inspect if virtual
         @returning_id = returning_id
@@ -15,6 +14,7 @@ module ActiveRecord
           default_value = self.class.extract_value_from_default(default)
         end
         super(name, default_value, sql_type_metadata, null)
+        @table_name = table_name
         # Is column NCHAR or NVARCHAR2 (will need to use N'...' value quoting for these data types)?
         # Define only when needed as adapter "quote" method will check at first if instance variable is defined.
         if sql_type_metadata

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -138,9 +138,9 @@ module ActiveRecord #:nodoc:
 
             # then dump all non-primary key columns
             column_specs = columns.map do |column|
-              raise StandardError, "Unknown type '#{column.sql_type}' for column '#{column.name}'" if @types[column.type].nil?
+              raise StandardError, "Unknown type '#{column.sql_type}' for column '#{column.name}'" unless @connection.valid_type?(column.type)
               next if column.name == pk
-              @connection.column_spec(column, @types)
+              @connection.column_spec(column, @connection.native_database_types)
             end.compact
 
             # find all migration keys used in this table

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1083,6 +1083,10 @@ module ActiveRecord
         super
       end
 
+      def valid_type?(type)
+        !native_database_types[type].nil?
+      end
+
       protected
 
       def initialize_type_map(m)

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -745,4 +745,28 @@ describe "OracleEnhancedAdapter" do
       expect(@employee.order(:sort_order).offset(4).first.first_name).to eq("Natasha")
     end
   end
+
+  describe "valid_type?" do
+    before(:all) do
+      @conn = ActiveRecord::Base.connection
+      @conn.execute <<-SQL
+        CREATE TABLE test_employees (
+          first_name    VARCHAR2(20)
+       )
+      SQL
+    end
+
+    after(:all) do
+      @conn.execute "DROP TABLE test_employees"
+    end
+
+    it "returns true when passed a valid type" do
+      column = @conn.columns('test_employees').find { |col| col.name == 'first_name' }
+      expect(@conn.valid_type?(column.type)).to be true
+    end
+
+    it "returns false when passed an invalid type" do
+      expect(@conn.valid_type?(:foobar)).to be false
+    end
+  end
 end


### PR DESCRIPTION
Fixes #802 

3a8c0a9 addresses the undefined method error that was getting returned as a result of `@types` getting dropped.

c1856de addresses a bug caused by active record's column initialize method setting @table_name to nil.

With these changes, the schema_dumper_spec now passes.