### PR TITLE
Remove type_cast from Column

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column.rb
@@ -24,12 +24,6 @@ module ActiveRecord
         # TODO: Need to investigate when `sql_type` becomes nil
       end
 
-      def type_cast(value) #:nodoc:
-        return OracleEnhancedColumn::string_to_raw(value) if type == :raw
-        return guess_date_or_time(value) if type == :datetime && OracleEnhancedAdapter.emulate_dates
-        super
-      end
-
       def virtual?
         @virtual
       end


### PR DESCRIPTION
it had been removed from Rails before Rails 4.2.

Refer these commits:
https://github.com/rails/rails/commit/748f070895dc0d76a02a45e1be5c50ea67a79e85
https://github.com/rails/rails/commit/e781aa31fc52a7c696115302ef4d4e02bfd1533b