### PR TITLE
Add byebug for ruby platform

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,6 @@ group :development do
 
   platforms :ruby do
     gem 'ruby-oci8',    github: 'kubo/ruby-oci8'
+    gem 'byebug'
   end
 end


### PR DESCRIPTION
rails5 branch still requires a lot of debug work, `byebug` should be bundled by default.