### PR TITLE
Rails :time as Oracle TIMESTAMP to support subsecond precision

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -489,7 +489,7 @@ module ActiveRecord
         # changed to native TIMESTAMP type
         # :timestamp   => { :name => "DATE" },
         :timestamp   => { :name => "TIMESTAMP" },
-        :time        => { :name => "DATE" },
+        :time        => { :name => "TIMESTAMP" },
         :date        => { :name => "DATE" },
         :binary      => { :name => "BLOB" },
         :boolean     => { :name => "NUMBER", :limit => 1 },


### PR DESCRIPTION
refer https://github.com/rails/rails/pull/18914 and https://github.com/rsim/oracle-enhanced/pull/739

This pull request supports TIME with precision and fixes these errors.

```ruby
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/time_precision_test.rb
Using oracle
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb:7: warning: method redefined; discarding old aliased_types
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb:384: warning: previous definition of aliased_types was here
Run options: --seed 53044

# Running:

EE.EE

Finished in 0.044924s, 111.2997 runs/s, 22.2599 assertions/s.

  1) Error:
TimePrecisionTest#test_formatting_time_according_to_precision:
ActiveRecord::StatementInvalid: OCIError: ORA-00907: missing right parenthesis: CREATE TABLE "FOOS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY, "START" DATE(0), "FINISH" DATE(4))
    stmt.c:243:in oci8lib_230.so
    /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.1/lib/oci8/cursor.rb:129:in `exec'
    /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.1/lib/oci8/oci8.rb:280:in `exec_internal'
    /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.1/lib/oci8/oci8.rb:271:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:457:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:92:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `block in execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:527:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:521:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1169:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `execute'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:81:in `create_table'
    test/cases/time_precision_test.rb:47:in `test_formatting_time_according_to_precision'


  2) Error:
TimePrecisionTest#test_passing_precision_to_time_does_not_set_limit:
ActiveRecord::StatementInvalid: OCIError: ORA-00907: missing right parenthesis: CREATE TABLE "FOOS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY, "START" DATE(3), "FINISH" DATE(6))
    stmt.c:243:in oci8lib_230.so
    /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.1/lib/oci8/cursor.rb:129:in `exec'
    /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.1/lib/oci8/oci8.rb:280:in `exec_internal'
    /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.1/lib/oci8/oci8.rb:271:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:457:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:92:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `block in execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:527:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:521:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1169:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `execute'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:81:in `create_table'
    test/cases/time_precision_test.rb:29:in `test_passing_precision_to_time_does_not_set_limit'


  3) Error:
TimePrecisionTest#test_schema_dump_includes_time_precision:
ActiveRecord::StatementInvalid: OCIError: ORA-00907: missing right parenthesis: CREATE TABLE "FOOS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY, "START" DATE(4), "FINISH" DATE(6))
    stmt.c:243:in oci8lib_230.so
    /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.1/lib/oci8/cursor.rb:129:in `exec'
    /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.1/lib/oci8/oci8.rb:280:in `exec_internal'
    /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.1/lib/oci8/oci8.rb:271:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:457:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:92:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `block in execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:527:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:521:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1169:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `execute'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:81:in `create_table'
    test/cases/time_precision_test.rb:62:in `test_schema_dump_includes_time_precision'


  4) Error:
TimePrecisionTest#test_time_data_type_with_precision:
ActiveRecord::StatementInvalid: OCIError: ORA-01735: invalid ALTER TABLE option: ALTER TABLE "FOOS" ADD "START" DATE(3)
    stmt.c:243:in oci8lib_230.so
    /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.1/lib/oci8/cursor.rb:129:in `exec'
    /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.1/lib/oci8/oci8.rb:280:in `exec_internal'
    /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.1/lib/oci8/oci8.rb:271:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:457:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:92:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `block in execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:527:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:521:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1169:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `execute'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:288:in `add_column'
    test/cases/time_precision_test.rb:22:in `test_time_data_type_with_precision'

5 runs, 1 assertions, 0 failures, 4 errors, 0 skips
$
```

Still it needs fixed this failure since it is currently mapped to `datetime`, not `time`.

```ruby
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/time_precision_test.rb
Using oracle
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb:7: warning: method redefined; discarding old aliased_types
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb:384: warning: previous definition of aliased_types was here
Run options: --seed 29105

# Running:

.F...

Finished in 36.883637s, 0.1356 runs/s, 0.3525 assertions/s.

  1) Failure:
TimePrecisionTest#test_schema_dump_includes_time_precision [test/cases/time_precision_test.rb:67]:
Expected /t\.time\s+"start",\s+precision: 4$/ to match "# encoding: UTF-8\n# This file is auto-generated from the current state of the database. Instead\n# of editing this file, please use the migrations feature of Active Record to\n# incrementally modify your database, and then regenerate this schema definition.\n#\n# Note that this schema.rb definition is the authoritative source for your\n# database schema. If you need to create the application database on another\n# system, you should be using db:schema:load, not running all the migrations\n# from scratch. The latter is a flawed and unsustainable approach (the more migrations\n# you'll amass, the slower it'll run and the greater likelihood for issues).\n#\n# It's strongly recommended that you check this file into your version control system.\n\nActiveRecord::Schema.define(version: 0) do\n\n  create_table \"foos\", force: :cascade do |t|\n    t.datetime \"start\",  precision: 4\n    t.datetime \"finish\", precision: 6\n  end\n\nend\n".

5 runs, 13 assertions, 1 failures, 0 errors, 0 skips
$
```

