### PR TITLE
log binds should not be type_casted

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -19,7 +19,7 @@ module ActiveRecord
         def exec_query(sql, name = 'SQL', binds = [], prepare: false)
           type_casted_binds = binds.map { |attr| type_cast(attr.value_for_database) }
 
-          log(sql, name, type_casted_binds) do
+          log(sql, name, binds) do
             cursor = nil
             cached = false
             if without_prepared_statement?(binds)
@@ -107,7 +107,7 @@ module ActiveRecord
         def exec_insert(sql, name, binds, pk = nil, sequence_name = nil)
           type_casted_binds = binds.map { |attr| type_cast(attr.value_for_database) }
 
-          log(sql, name, type_casted_binds) do
+          log(sql, name, binds) do
             returning_id_col = returning_id_index = nil
             if without_prepared_statement?(binds)
               cursor = @connection.prepare(sql)
@@ -136,7 +136,7 @@ module ActiveRecord
         def exec_update(sql, name, binds)
           type_casted_binds = binds.map { |attr| type_cast(attr.value_for_database) }
 
-          log(sql, name, type_casted_binds) do
+          log(sql, name, binds) do
             cached = false
             if without_prepared_statement?(binds)
               cursor = @connection.prepare(sql)


### PR DESCRIPTION
Refer https://github.com/rails/rails/commit/b06f64c3480cd389d14618540d62da4978918af0

This pull request addresses these ActiveRecord unit test failures and errors.
```ruby
31) Failure:
ActiveRecord::BindParameterTest#test_binds_are_logged [/home/yahonda/git/rails/activerecord/test/cases/bind_parameter_test.rb:50]:
--- expected
+++ actual
@@ -1 +1 @@
-[#<ActiveRecord::Relation::QueryAttribute:0xXXXXXX @name="id", @value_before_type_cast=1, @type=#<ActiveModel::Type::Value:0xXXXXXX @precision=nil, @scale=nil, @limit=nil>, @original_attribute=nil, @value=1, @value_for_database=1>]
+[1]



 32) Error:
ActiveRecord::BindParameterTest#test_find_one_uses_binds:
NoMethodError: undefined method `value' for 1:Fixnum
    /home/yahonda/git/rails/activerecord/test/cases/bind_parameter_test.rb:55:in `block (2 levels) in test_find_one_uses_binds'
    /home/yahonda/git/rails/activerecord/test/cases/bind_parameter_test.rb:55:in `any?'
    /home/yahonda/git/rails/activerecord/test/cases/bind_parameter_test.rb:55:in `block in test_find_one_uses_binds'
    /home/yahonda/git/rails/activerecord/test/cases/bind_parameter_test.rb:55:in `each'
    /home/yahonda/git/rails/activerecord/test/cases/bind_parameter_test.rb:55:in `find'
    /home/yahonda/git/rails/activerecord/test/cases/bind_parameter_test.rb:55:in `test_find_one_uses_binds'

 41) Error:
ExplainTest#test_collecting_queries_for_explain:
NoMethodError: undefined method `value' for "honda":String
    /home/yahonda/git/rails/activerecord/test/cases/explain_test.rb:31:in `test_collecting_queries_for_explain'

 42) Error:
ExplainTest#test_relation_explain:
NoMethodError: undefined method `name' for "honda":String
    /home/yahonda/git/rails/activerecord/lib/active_record/explain.rb:23:in `block (3 levels) in exec_explain'
    /home/yahonda/git/rails/activerecord/lib/active_record/explain.rb:23:in `map'
    /home/yahonda/git/rails/activerecord/lib/active_record/explain.rb:23:in `block (2 levels) in exec_explain'
    /home/yahonda/git/rails/activerecord/lib/active_record/explain.rb:20:in `tap'
    /home/yahonda/git/rails/activerecord/lib/active_record/explain.rb:20:in `block in exec_explain'
    /home/yahonda/git/rails/activerecord/lib/active_record/explain.rb:19:in `map'
    /home/yahonda/git/rails/activerecord/lib/active_record/explain.rb:19:in `exec_explain'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:251:in `explain'
    /home/yahonda/git/rails/activerecord/test/cases/explain_test.rb:18:in `test_relation_explain'

 61) Failure:
LogSubscriberTest#test_exists_query_logging [/home/yahonda/git/rails/activerecord/test/cases/log_subscriber_test.rb:175]:
Expected: 1
  Actual: 0
```

Also it addresses Oracle enhanced adapter unit test failure.

```ruby
rspec ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:678 # OracleEnhancedAdapter explain should explain query
```