### PR TITLE
Enable `support_comments?` to support AR native database comment

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -455,6 +455,10 @@ module ActiveRecord
         @connection.database_version.first >= 9
       end
 
+      def supports_comments?
+        true
+      end
+
       #:stopdoc:
       DEFAULT_NLS_PARAMETERS = {
         :nls_calendar            => nil,


### PR DESCRIPTION
Since Oracle database itself does not support comment when creating table
Not implemented `supports_comments_in_create?` method, which inherits
AbstractAdapter value `false` .

Refer https://github.com/rails/rails/pull/22911 and https://github.com/rails/rails/commit/485e7f25

Note: At first this enables to run ActiveRecord tests for comments feature, it does not implement any features yet.