### PR TITLE
Use keyword arguments for new table options

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -28,12 +28,13 @@ module ActiveRecord
             @lob_tablespaces.each do |lob_column, tablespace|
               create_sql << " LOB (#{quote_column_name(lob_column)}) STORE AS (TABLESPACE #{tablespace}) \n"
             end if defined?(@lob_tablespaces)
-            create_sql << " ORGANIZATION #{o.options[:organization]}" if o.options[:organization]
-            if (tablespace = o.options[:tablespace] || default_tablespace_for(:table))
+            create_sql << " ORGANIZATION #{o.organization}" if o.organization
+            if (tablespace = o.tablespace || default_tablespace_for(:table))
               create_sql << " TABLESPACE #{tablespace}"
             end
           end
-          create_sql << " #{o.options[:options]}"
+          add_table_options!(create_sql, table_options(o))
+          create_sql << "#{o.options}"
           create_sql
         end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -46,6 +46,12 @@ module ActiveRecord
       end
 
       class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
+        attr_accessor :tablespace, :organization
+        def initialize(name, temporary = false, options = nil, as = nil, tablespace = nil, organization = nil, comment: nil)
+          @tablespace = tablespace
+          @organization = organization
+          super(name, temporary, options, as, comment: comment)
+        end
 
         def raw(name, options={})
           column(name, :raw, options)

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -39,12 +39,10 @@ module ActiveRecord
         #     t.string      :last_name, :comment => “Surname”
         #   end
 
-        def create_table(table_name, options = {})
+        def create_table(table_name, comment: nil, **options)
           create_sequence = options[:id] != false
           column_comments = {}
-          temporary = options.delete(:temporary)
-          additional_options = options
-          td = create_table_definition table_name, temporary, additional_options
+          td = create_table_definition table_name, options[:temporary], options[:options], options[:as], options[:tablespace], options[:organization], comment: comment
           td.primary_key(options[:primary_key] || Base.get_primary_key(table_name.to_s.singularize)) unless options[:id] == false
 
           # store that primary key was defined in create_table block
@@ -93,8 +91,8 @@ module ActiveRecord
           end
         end
 
-        def create_table_definition(name, temporary, options)
-          ActiveRecord::ConnectionAdapters::OracleEnhanced::TableDefinition.new name, temporary, options
+        def create_table_definition(*args)
+          ActiveRecord::ConnectionAdapters::OracleEnhanced::TableDefinition.new(*args)
         end
 
         def rename_table(table_name, new_name) #:nodoc:
@@ -173,7 +171,7 @@ module ActiveRecord
           column_names = Array(column_name)
           index_name   = index_name(table_name, column: column_names)
 
-          options.assert_valid_keys(:unique, :order, :name, :where, :length, :internal, :tablespace, :options, :using)
+          options.assert_valid_keys(:unique, :order, :name, :where, :length, :internal, :tablespace, :options, :using, :comment)
 
           index_type = options[:unique] ? "UNIQUE" : ""
           index_name = options[:name].to_s if options.key?(:name)


### PR DESCRIPTION
refer https://github.com/rails/rails/commit/485e7f25f29ca1ca23bb214b802cf68840dabbb6
https://github.com/rails/rails/commit/485e7f25f29ca1ca23bb214b802cf68840dabbb6

This pull request addresses this error.
```ruby
$ bundle exec rake test_oracle
... snip ...
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb:212:in `initialize': unknown keyword: force (ArgumentError)
        from /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:97:in `new'
        from /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:97:in `create_table_definition'
        from /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:47:in `create_table'
        from /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:851:in `block in method_missing'
        from /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:820:in `block in say_with_time'
        from /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/2.3.0/benchmark.rb:293:in `measure'
        from /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:820:in `say_with_time'
        from /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:840:in `method_missing'
        from /home/yahonda/git/rails/activerecord/test/schema/schema.rb:9:in `block in <top (required)>'
        from /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:48:in `instance_eval'
        from /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:48:in `define'
        from /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:44:in `define'
        from /home/yahonda/git/rails/activerecord/test/schema/schema.rb:1:in `<top (required)>'
        from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:287:in `load'
        from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:287:in `block in load'
        from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:259:in `load_dependency'
        from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:287:in `load'
        from /home/yahonda/git/rails/activerecord/test/cases/helper.rb:160:in `load_schema'
        from /home/yahonda/git/rails/activerecord/test/cases/helper.rb:169:in `<top (required)>'
        from /home/yahonda/git/rails/activerecord/test/cases/relations_test.rb:1:in `require'
        from /home/yahonda/git/rails/activerecord/test/cases/relations_test.rb:1:in `<top (required)>'
        from /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rake-11.1.1/lib/rake/rake_test_loader.rb:15:in `require'
        from /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rake-11.1.1/lib/rake/rake_test_loader.rb:15:in `block in <main>'
        from /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rake-11.1.1/lib/rake/rake_test_loader.rb:4:in `select'
        from /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rake-11.1.1/lib/rake/rake_test_loader.rb:4:in `<main>'
rake aborted!
```

Since Rails supports keyword arguments for new table options about comments.
This commit itself does not support comment features of ActiveRecord or Oracle enhanced adapter yet. Then these tests become fail.

```ruby
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:490 # OracleEnhancedAdapter schema dump table comments should dump table comments
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:530 # OracleEnhancedAdapter schema dump table comments should dump table comments
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:347 # OracleEnhancedAdapter schema definition table and column comments should create table with table comment
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:369 # OracleEnhancedAdapter schema definition table and column comments should create table with table and columns comment and custom table na
```