### PR TITLE
Clean up IndexDefinition to prepare comment support

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -26,18 +26,13 @@ module ActiveRecord
       end
 
       class IndexDefinition < ActiveRecord::ConnectionAdapters::IndexDefinition
-        attr_accessor :table, :name, :unique, :type, :parameters, :statement_parameters, :tablespace, :columns
+        attr_accessor :parameters, :statement_parameters, :tablespace
  
-        def initialize(table, name, unique, type, parameters, statement_parameters, tablespace, columns)
-          @table = table
-          @name = name
-          @unique = unique
-          @type = type
+        def initialize(table, name, unique, columns, lengths, orders, where, type, using, parameters, statement_parameters, tablespace)
           @parameters = parameters
           @statement_parameters = statement_parameters
           @tablespace = tablespace
-          @columns = columns
-          super(table, name, unique, columns, nil, nil, nil, nil)
+          super(table, name, unique, columns, lengths, orders, where, type, using)
         end
       end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -782,10 +782,19 @@ module ActiveRecord
                   statement_parameters = $1
                 end
               end
-              all_schema_indexes << OracleEnhanced::IndexDefinition.new(row['table_name'], row['index_name'],
-                row['uniqueness'] == "UNIQUE", row['index_type'] == 'DOMAIN' ? "#{row['ityp_owner']}.#{row['ityp_name']}" : nil,
-                row['parameters'], statement_parameters,
-                row['tablespace_name'] == default_tablespace_name ? nil : row['tablespace_name'], [])
+              all_schema_indexes << OracleEnhanced::IndexDefinition.new(
+                row['table_name'],
+                row['index_name'],
+                row['uniqueness'] == "UNIQUE",
+                [],
+                nil,
+                nil,
+                nil,
+                row['index_type'] == 'DOMAIN' ? "#{row['ityp_owner']}.#{row['ityp_name']}" : nil,
+                nil,
+                row['parameters'],
+                statement_parameters,
+                row['tablespace_name'] == default_tablespace_name ? nil : row['tablespace_name'])
               current_index = row['index_name']
             end
 


### PR DESCRIPTION
Removed duplicate instance variables called in super `ActiveRecord::ConnectionAdapters::IndexDefinition` and change the order to follow super class initialize method.