### PR TITLE
Support ActiveRecord native comment feature

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column.rb
@@ -4,7 +4,8 @@ module ActiveRecord
 
       attr_reader :table_name, :nchar, :virtual_column_data_default, :returning_id #:nodoc:
 
-      def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, virtual=false, returning_id=false) #:nodoc:
+      def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, virtual = false, returning_id = nil, comment = nil) #:nodoc:
+
         @virtual = virtual
         @virtual_column_data_default = default.inspect if virtual
         @returning_id = returning_id
@@ -13,8 +14,7 @@ module ActiveRecord
         else
           default_value = self.class.extract_value_from_default(default)
         end
-        super(name, default_value, sql_type_metadata, null)
-        @table_name = table_name
+        super(name, default_value, sql_type_metadata, null, table_name, comment: comment)
         # Is column NCHAR or NVARCHAR2 (will need to use N'...' value quoting for these data types)?
         # Define only when needed as adapter "quote" method will check at first if instance variable is defined.
         if sql_type_metadata
@@ -66,9 +66,10 @@ module ActiveRecord
 
       # Get column comment from schema definition.
       # Will work only if using default ActiveRecord connection.
-      def comment
-        ActiveRecord::Base.connection.column_comment(@table_name, name)
-      end
+#      def comment
+#        #TODO: may be deprecated due to conflict with variable
+#        ActiveRecord::Base.connection.column_comment(@table_name, name)
+#      end
       
       private
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -361,9 +361,10 @@ describe "OracleEnhancedAdapter schema definition" do
       [:first_name, :last_name].each do |attr|
         expect(@conn.column_comment("test_employees", attr.to_s)).to eq(column_comments[attr])
       end
-      [:first_name, :last_name].each do |attr|
-        expect(TestEmployee.columns_hash[attr.to_s].comment).to eq(column_comments[attr])
-      end
+# may drop support this syntax
+#      [:first_name, :last_name].each do |attr|
+#        expect(TestEmployee.columns_hash[attr.to_s].comment).to eq(column_comments[attr])
+#      end
     end
 
     it "should create table with table and columns comment and custom table name prefix" do
@@ -378,9 +379,10 @@ describe "OracleEnhancedAdapter schema definition" do
       [:first_name, :last_name].each do |attr|
         expect(@conn.column_comment(TestEmployee.table_name, attr.to_s)).to eq(column_comments[attr])
       end
-      [:first_name, :last_name].each do |attr|
-        expect(TestEmployee.columns_hash[attr.to_s].comment).to eq(column_comments[attr])
-      end
+# may drop support this syntax
+#      [:first_name, :last_name].each do |attr|
+#        expect(TestEmployee.columns_hash[attr.to_s].comment).to eq(column_comments[attr])
+#      end
     end
 
   end


### PR DESCRIPTION
This pull request supports ActiveRecord native comment feature.

It addresses regressions introduced by #820.

```ruby
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:490 # OracleEnhancedAdapter schema dump table comments should dump table comments
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:530 # OracleEnhancedAdapter schema dump table comments should dump table comments
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:347 # OracleEnhancedAdapter schema definition table and column comments should create table with table comment
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:369 # OracleEnhancedAdapter schema definition table and column comments should create table with table and columns comment and custom table name prefix
```
Except for `TestEmployee.columns_hash[attr.to_s].comment` syntax is de-supported due to conflicts with ActiveRecord native comment features.

Still there are 5 errors / failures to support ActiveRecord native comment feature. Unfortunately this pull request introduces the following regression.

```ruby
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/comment_test.rb -n test_blank_columns_created_in_block
... snip ...

  1) Failure:
CommentTest#test_blank_columns_created_in_block [test/cases/comment_test.rb:53]:
Expected " " to be nil.

1 runs, 2 assertions, 1 failures, 0 errors, 0 skips]$
```