### PR TITLE
Handle ActiveModel::Type::Binary::Data type cast in _type_cast

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -146,13 +146,6 @@ module ActiveRecord
             @raw_cursor.bind_param(position, nil, String)
           else
             case col_type = column && column.type
-            when :text, :binary
-              # ruby-oci8 cannot create CLOB/BLOB from ''
-              lob_value = value == '' ? ' ' : value
-              bind_type = col_type == :text ? OCI8::CLOB : OCI8::BLOB
-              ora_value = bind_type.new(@connection.raw_oci_connection, lob_value)
-              ora_value.size = 0 if value == ''
-              @raw_cursor.bind_param(position, ora_value)
             when :raw
               @raw_cursor.bind_param(position, ActiveRecord::ConnectionAdapters::OracleEnhanced::Quoting.encode_raw(value))
             when :decimal


### PR DESCRIPTION
because Rails 5 will not give column to bind_param method it should be type casted here.

This pull request addreses these 7 failures in Oracle enhanced adapter unit tests and 4 errors in ActiveRecord unit tests.

```ruby
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1188 # OracleEnhancedAdapter handling of BLOB columns should create record with BLOB data
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1198 # OracleEnhancedAdapter handling of BLOB columns should update record with BLOB data
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1211 # OracleEnhancedAdapter handling of BLOB columns should update record with zero-length BLOB data
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1224 # OracleEnhancedAdapter handling of BLOB columns should update record that has existing BLOB data with different BLOB data
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1237 # OracleEnhancedAdapter handling of BLOB columns should update record that has existing BLOB data with nil
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1250 # OracleEnhancedAdapter handling of BLOB columns should update record that has existing BLOB data with zero-length BLOB data
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1263 # OracleEnhancedAdapter handling of BLOB columns should update record that has zero-length BLOB data with non-empty BLOB data
```

```ruby

  23) Error:
 BinaryTest#test_load_save:
 ActiveRecord::StatementInvalid: Encoding::UndefinedConversionError: "\xFF" from ASCII-8BIT to UTF-8: INSERT INTO "BINARIES" ("DATA", "ID") VALUES (:a1, :a2)

  24) Error:
 BinaryTest#test_mixed_encoding:
 ActiveRecord::StatementInvalid: Encoding::UndefinedConversionError: "\x80" from ASCII-8BIT to UTF-8: INSERT INTO "BINARIES" ("NAME", "DATA", "ID") VALUES (:a1, :a2, :a3)

  37) Error:
 DirtyTest#test_in_place_mutation_for_binary:
 ActiveRecord::StatementInvalid: OCIError: ORA-01465: invalid hex number: INSERT INTO "BINARIES" ("DATA", "ID") VALUES (:a1, :a2)
     stmt.c:243:in oci8lib_230.so

  44) Error:
 LogSubscriberTest#test_binary_data_is_not_logged:
 ActiveRecord::StatementInvalid: OCIError: ORA-01465: invalid hex number: INSERT INTO "BINARIES" ("DATA", "ID") VALUES (:a1, :a2)
     stmt.c:243:in oci8lib_230.so

```