### PR TITLE
Add `ActiveRecord::ValueTooLong` exception class

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1141,9 +1141,11 @@ module ActiveRecord
       def translate_exception(exception, message) #:nodoc:
         case @connection.error_code(exception)
         when 1
-          RecordNotUnique.new(message, exception)
+          RecordNotUnique.new(message)
         when 2291
-          InvalidForeignKey.new(message, exception)
+          InvalidForeignKey.new(message)
+        when 12899
+          ValueTooLong.new(message)
         else
           super
         end


### PR DESCRIPTION
and supress `DEPRECATION WARNING: Passing #original_exception is deprecated and has no effect. Exceptions will automatically capture the original exception. `

Refer:
https://github.com/rails/rails/pull/23522
https://github.com/rails/rails/pull/18774

This pull request addresses this failure.

```ruby
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/adapter_test.rb -n test_value_limit_violations_are_translated_to_specific_exception
Using oracle
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:148: warning: assigned but unused variable - col_type
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb:7: warning: method redefined; discarding old aliased_types
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb:389: warning: previous definition of aliased_types was here
Run options: -n test_value_limit_violations_are_translated_to_specific_exception --seed 6376

# Running:

F

Finished in 0.106011s, 9.4330 runs/s, 9.4330 assertions/s.

  1) Failure:
ActiveRecord::AdapterTest#test_value_limit_violations_are_translated_to_specific_exception [test/cases/adapter_test.rb:217]:
[ActiveRecord::ValueTooLong] exception expected, not
Class: <ActiveRecord::StatementInvalid>
Message: <"OCIError: ORA-12899: value too large for column \"ARUNIT\".\"EVENTS\".\"TITLE\" (actual: 8, maximum: 5): INSERT INTO \"EVENTS\" (\"TITLE\", \"ID\") VALUES (:a1, :a2)">
---Backtrace---
stmt.c:243:in oci8lib_230.so
/home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.2/lib/oci8/cursor.rb:129:in `exec'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:168:in `exec_update'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:124:in `block in exec_insert'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:548:in `block in log'
/home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:542:in `log'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1191:in `log'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:110:in `exec_insert'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:124:in `insert'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `insert'
/home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:65:in `insert'
/home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:554:in `_create_record'
/home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:128:in `_create_record'
/home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:75:in `_create_record'
/home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:123:in `_create_record'
/home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `block in _create_record'
/home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
/home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_create_callbacks'
/home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `_create_record'
/home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:68:in `_create_record'
/home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:534:in `create_or_update'
/home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `block in create_or_update'
/home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
/home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_save_callbacks'
/home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `create_or_update'
/home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:125:in `save'
/home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:44:in `save'
/home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:22:in `save'
/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:319:in `block (2 levels) in save'
/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `block in transaction'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:319:in `block in save'
/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:334:in `rollback_active_record_state!'
/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:318:in `save'
/home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:41:in `save'
/home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:34:in `create'
test/cases/adapter_test.rb:218:in `block in test_value_limit_violations_are_translated_to_specific_exception'
---------------

1 runs, 1 assertions, 1 failures, 0 errors, 0 skip
```