### PR TITLE
Added :stoplist argument to add_context_index

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/context_index.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/context_index.rb
@@ -24,6 +24,7 @@ module ActiveRecord
         # * <tt>:lexer</tt> - Lexer options (e.g. <tt>:type => 'BASIC_LEXER', :base_letter => true</tt>).
         # * <tt>:wordlist</tt> - Wordlist options (e.g. <tt>:type => 'BASIC_WORDLIST', :prefix_index => true</tt>).
         # * <tt>:transactional</tt> - When +true+, the CONTAINS operator will process inserted and updated rows.
+        # * <tt>:stoplist</tt> - Name of stoplist to use
         #
         # ===== Examples
         #
@@ -72,6 +73,9 @@ module ActiveRecord
         # ====== Creating transactional index (will reindex changed rows when querying)
         #  add_context_index :posts, :title, :transactional => true
         #
+        # ====== Creating index using stoplist
+        #  add_context_index :posts, :title, :stoplist => 'CTXSYS.MY_STOPLIST'
+
         def add_context_index(table_name, column_name, options = {})
           self.all_schema_indexes = nil
           column_names = Array(column_name)
@@ -117,6 +121,10 @@ module ActiveRecord
             create_wordlist_preference(wordlist_name, wordlist_type, wordlist_options)
             parameters << "WORDLIST #{wordlist_name}"
           end
+          if options[:stoplist]
+            parameters << "STOPLIST #{options[:stoplist]}"
+          end
+
           if options[:transactional]
             parameters << "TRANSACTIONAL"
           end


### PR DESCRIPTION
Adds a simple :stoplist argument to the add_context_index command.  The stoplist should have already been created elsewhere, this is just a way to reference the stoplist when creating the index.
