### PR TITLE
Change bind parameters order to come offset first then limit next

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1109,6 +1109,24 @@ module ActiveRecord
         !native_database_types[type].nil?
       end
 
+      def combine_bind_parameters(
+        from_clause: [],
+        join_clause: [],
+        where_clause: [],
+        having_clause: [],
+        limit: nil,
+        offset: nil
+      ) # :nodoc:
+        result = from_clause + join_clause + where_clause + having_clause
+        if offset
+          result << offset
+        end
+        if limit
+          result << limit
+        end
+        result
+      end
+
       protected
 
       def initialize_type_map(m)


### PR DESCRIPTION
to support `OFFSET ... FETCH FIRST n ROWS ONLY` syntax

Refer https://github.com/rails/rails/commit/96f3f3d8267167d5d4c5697f2299756cfa7e37d4
https://github.com/rails/rails/issues/24775

It addresses 1 failure in Oracle enhanced adapter unit tests:
```ruby

2.3.1 [ rails5 ~/git/oracle-enhanced]$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:741
==> Loading config from ENV or use default
==> Running specs with MRI version 2.3.1
==> Effective ActiveRecord version 5.0.0.beta4
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb"=>[741]}}
F

Failures:

  1) OracleEnhancedAdapter using offset and limit should return the records starting from offset n with offset(n)
     Failure/Error: expect(@employee.order(:sort_order).offset(0).first.first_name).to eq("Peter")

     NoMethodError:
       undefined method `first_name' for nil:NilClass
     # ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:743:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:236:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:236:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:478:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:435:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:478:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:616:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:478:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:435:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:478:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:233:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:581:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:577:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:577:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:543:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:544:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:544:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:544:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/configuration.rb:1680:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:118:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:117:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:93:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:78:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:23:in `load'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:23:in `<main>'

Finished in 0.26655 seconds (files took 0.95114 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:741 # OracleEnhancedAdapter using offset and limit should return the records starting from offset n with offset(n)
```

It also addresses these 22 failures in ActiveRecord unit tests:

```ruby
  2) Failure:
RelationTest#test_connection_adapters_can_reorder_binds [/home/yahonda/git/rails/activerecord/test/cases/relations_test.rb:2008]:
Expected: 2
  Actual: 1


  3) Failure:
RelationTest#test_finding_with_order_limit_and_offset [/home/yahonda/git/rails/activerecord/test/cases/relations_test.rb:372]:
Expected: 2
  Actual: 1

 15) Failure:
EagerAssociationTest#test_count_eager_with_has_many_and_limit_and_high_offset [/home/yahonda/git/rails/activerecord/test/cases/associations/eager_test.rb:604]:
Expected: 0
  Actual: 3


 16) Failure:
EagerAssociationTest#test_eager_association_loading_with_belongs_to_and_limit_and_offset [/home/yahonda/git/rails/activerecord/test/cases/associations/eager_test.rb:367]:
Expected: 3
  Actual: 2


 17) Failure:
EagerAssociationTest#test_eager_association_loading_with_belongs_to_and_limit_and_offset_and_conditions [/home/yahonda/git/rails/activerecord/test/cases/associations/eager_test.rb:373]:
Expected: 3
  Actual: 1


 18) Failure:
EagerAssociationTest#test_eager_association_loading_with_belongs_to_and_limit_and_offset_and_conditions_array [/home/yahonda/git/rails/activerecord/test/cases/associations/eager_test.rb:379]:
Expected: 3
  Actual: 1


 19) Failure:
EagerAssociationTest#test_eager_with_has_many_and_limit_and_high_offset [/home/yahonda/git/rails/activerecord/test/cases/associations/eager_test.rb:582]:
Expected: 0
  Actual: 3


 21) Failure:
EagerAssociationTest#test_limited_eager_with_multiple_order_columns [/home/yahonda/git/rails/activerecord/test/cases/associations/eager_test.rb:866]:
--- expected
+++ actual
@@ -1 +1 @@
-[#<SpecialPost id: 2, author_id: 1, title: "So I was thinking", body: "Like I hopefully always am", type: "SpecialPost", comments_count: 1, taggings_with_delete_all_count: 0, taggings_with_destroy_count: 0, tags_count: 1, tags_with_destroy_count: 0, tags_with_nullify_count: 0>, #<Post id: 4, author_id: 1, title: "sti comments", body: "hello", type: "Post", comments_count: 0, taggings_with_delete_all_count: 0, taggings_with_destroy_count: 0, tags_count: 0, tags_with_destroy_count: 0, tags_with_nullify_count: 0>]
+[#<Post id: 4, author_id: 1, title: "sti comments", body: "hello", type: "Post", comments_count: 0, taggings_with_delete_all_count: 0, taggings_with_destroy_count: 0, tags_count: 0, tags_with_destroy_count: 0, tags_with_nullify_count: 0>]



 22) Failure:
EagerAssociationTest#test_limited_eager_with_numeric_in_association [/home/yahonda/git/rails/activerecord/test/cases/associations/eager_test.rb:883]:
--- expected
+++ actual
@@ -1 +1 @@
-[#<Person id: 2, first_name: "David", primary_contact_id: 3, gender: "M", number1_fan_id: 1, lock_version: 0, comments: nil, followers_count: 1, friends_too_count: 1, best_friend_id: nil, best_friend_of_id: nil, insures: 0, born_at: nil, created_at: "2016-05-08 00:39:48", updated_at: "2016-05-08 00:39:48">, #<Person id: 3, first_name: "Susan", primary_contact_id: 2, gender: "F", number1_fan_id: 1, lock_version: 0, comments: nil, followers_count: 1, friends_too_count: 1, best_friend_id: nil, best_friend_of_id: nil, insures: 0, born_at: nil, created_at: "2016-05-08 00:39:48", updated_at: "2016-05-08 00:39:48">]
+[]



 23) Failure:
EagerAssociationTest#test_limited_eager_with_order [/home/yahonda/git/rails/activerecord/test/cases/associations/eager_test.rb:849]:
--- expected
+++ actual
@@ -1 +1 @@
-[#<SpecialPost id: 2, author_id: 1, title: "So I was thinking", body: "Like I hopefully always am", type: "SpecialPost", comments_count: 1, taggings_with_delete_all_count: 0, taggings_with_destroy_count: 0, tags_count: 1, tags_with_destroy_count: 0, tags_with_nullify_count: 0>, #<Post id: 4, author_id: 1, title: "sti comments", body: "hello", type: "Post", comments_count: 0, taggings_with_delete_all_count: 0, taggings_with_destroy_count: 0, tags_count: 0, tags_with_destroy_count: 0, tags_with_nullify_count: 0>]
+[#<Post id: 4, author_id: 1, title: "sti comments", body: "hello", type: "Post", comments_count: 0, taggings_with_delete_all_count: 0, taggings_with_destroy_count: 0, tags_count: 0, tags_with_destroy_count: 0, tags_with_nullify_count: 0>]


 59) Failure:
CalculationsTest#test_should_limit_calculation_with_offset [/home/yahonda/git/rails/activerecord/test/cases/calculations_test.rb:164]:
Expected: [2, 6]
  Actual: [6]


 86) Failure:
FinderTest#test_fifth [/home/yahonda/git/rails/activerecord/test/cases/finder_test.rb:468]:
Expected: "The Fifth Topic of the day"
  Actual: "The Second Topic of the day"


 87) Failure:
FinderTest#test_fifth_have_primary_key_order_by_default [/home/yahonda/git/rails/activerecord/test/cases/finder_test.rb:478]:
--- expected
+++ actual
@@ -1 +1 @@
-#<Topic id: 5, title: "The Fifth Topic of the day", author_name: "Jason", author_email_address: nil, written_on: "2013-07-13 11:11:00", bonus_time: nil, last_read: nil, content: "Omakase", important: nil, approved: 1, replies_count: 0, unique_replies_count: 0, parent_id: nil, parent_title: nil, type: nil, group: nil, created_at: "2016-05-08 00:47:39", updated_at: "2016-05-08 00:47:40">
+#<Reply id: 2, title: "The Second Topic of the day", author_name: "Mary", author_email_address: nil, written_on: "2004-07-15 14:28:00", bonus_time: nil, last_read: nil, content: "Have a nice day", important: nil, approved: 1, replies_count: 0, unique_replies_count: 0, parent_id: 1, parent_title: nil, type: "Reply", group: nil, created_at: "2016-05-08 00:47:39", updated_at: "2016-05-08 00:47:39">



 88) Failure:
FinderTest#test_fifth_with_offset [/home/yahonda/git/rails/activerecord/test/cases/finder_test.rb:472]:
--- expected
+++ actual
@@ -1 +1 @@
-#<Topic id: 5, title: "The Fifth Topic of the day", author_name: "Jason", author_email_address: nil, written_on: "2013-07-13 11:11:00", bonus_time: nil, last_read: nil, content: "Omakase", important: nil, approved: 1, replies_count: 0, unique_replies_count: 0, parent_id: nil, parent_title: nil, type: nil, group: nil, created_at: "2016-05-08 00:47:39", updated_at: "2016-05-08 00:47:39">
+#<Reply id: 2, title: "The Second Topic of the day", author_name: "Mary", author_email_address: nil, written_on: "2004-07-15 14:28:00", bonus_time: nil, last_read: nil, content: "Have a nice day", important: nil, approved: 1, replies_count: 0, unique_replies_count: 0, parent_id: 1, parent_title: nil, type: "Reply", group: nil, created_at: "2016-05-08 00:47:39", updated_at: "2016-05-08 00:47:39">



 89) Failure:
FinderTest#test_find_last_with_offset [/home/yahonda/git/rails/activerecord/test/cases/finder_test.rb:994]:
--- expected
+++ actual
@@ -1 +1 @@
-#<Developer id: 3, name: "fixture_3", salary: 100000, firm_id: nil, mentor_id: nil, created_at: "2016-05-08 00:47:39", updated_at: "2016-05-08 00:47:39", created_on: "2016-05-08 00:47:39", updated_on: "2016-05-08 00:47:39">
+#<Developer id: 2, name: "Jamis", salary: 150000, firm_id: nil, mentor_id: nil, created_at: "2016-05-08 00:47:39", updated_at: "2016-05-08 00:47:39", created_on: "2016-05-08 00:47:39", updated_on: "2016-05-08 00:47:39">



 90) Failure:
FinderTest#test_fourth [/home/yahonda/git/rails/activerecord/test/cases/finder_test.rb:446]:
Expected: "The Fourth Topic of the day"
  Actual: "The Second Topic of the day"


 91) Failure:
FinderTest#test_fourth_have_primary_key_order_by_default [/home/yahonda/git/rails/activerecord/test/cases/finder_test.rb:456]:
--- expected
+++ actual
@@ -1 +1 @@
-#<Reply id: 4, title: "The Fourth Topic of the day", author_name: "Carl", author_email_address: nil, written_on: "2006-07-15 14:28:00", bonus_time: nil, last_read: nil, content: "Why not?", important: nil, approved: 1, replies_count: 0, unique_replies_count: 0, parent_id: 3, parent_title: nil, type: "Reply", group: nil, created_at: "2016-05-08 00:47:39", updated_at: "2016-05-08 00:47:42">
+#<Reply id: 2, title: "The Second Topic of the day", author_name: "Mary", author_email_address: nil, written_on: "2004-07-15 14:28:00", bonus_time: nil, last_read: nil, content: "Have a nice day", important: nil, approved: 1, replies_count: 0, unique_replies_count: 0, parent_id: 1, parent_title: nil, type: "Reply", group: nil, created_at: "2016-05-08 00:47:39", updated_at: "2016-05-08 00:47:39">



 92) Failure:
FinderTest#test_fourth_with_offset [/home/yahonda/git/rails/activerecord/test/cases/finder_test.rb:450]:
--- expected
+++ actual
@@ -1 +1 @@
-#<Topic id: 5, title: "The Fifth Topic of the day", author_name: "Jason", author_email_address: nil, written_on: "2013-07-13 11:11:00", bonus_time: nil, last_read: nil, content: "Omakase", important: nil, approved: 1, replies_count: 0, unique_replies_count: 0, parent_id: nil, parent_title: nil, type: nil, group: nil, created_at: "2016-05-08 00:47:39", updated_at: "2016-05-08 00:47:39">
+#<Reply id: 2, title: "The Second Topic of the day", author_name: "Mary", author_email_address: nil, written_on: "2004-07-15 14:28:00", bonus_time: nil, last_read: nil, content: "Have a nice day", important: nil, approved: 1, replies_count: 0, unique_replies_count: 0, parent_id: 1, parent_title: nil, type: "Reply", group: nil, created_at: "2016-05-08 00:47:39", updated_at: "2016-05-08 00:47:39">


 94) Failure:
FinderTest#test_second_with_offset [/home/yahonda/git/rails/activerecord/test/cases/finder_test.rb:406]:
--- expected
+++ actual
@@ -1 +1 @@
-#<Topic id: 5, title: "The Fifth Topic of the day", author_name: "Jason", author_email_address: nil, written_on: "2013-07-13 11:11:00", bonus_time: nil, last_read: nil, content: "Omakase", important: nil, approved: 1, replies_count: 0, unique_replies_count: 0, parent_id: nil, parent_title: nil, type: nil, group: nil, created_at: "2016-05-08 00:47:39", updated_at: "2016-05-08 00:47:39">
+#<Reply id: 2, title: "The Second Topic of the day", author_name: "Mary", author_email_address: nil, written_on: "2004-07-15 14:28:00", bonus_time: nil, last_read: nil, content: "Have a nice day", important: nil, approved: 1, replies_count: 0, unique_replies_count: 0, parent_id: 1, parent_title: nil, type: "Reply", group: nil, created_at: "2016-05-08 00:47:39", updated_at: "2016-05-08 00:47:39">

 96) Failure:
FinderTest#test_third [/home/yahonda/git/rails/activerecord/test/cases/finder_test.rb:424]:
Expected: "The Third Topic of the day"
  Actual: "The Second Topic of the day"


 97) Failure:
FinderTest#test_third_have_primary_key_order_by_default [/home/yahonda/git/rails/activerecord/test/cases/finder_test.rb:434]:
--- expected
+++ actual
@@ -1 +1 @@
-#<Topic id: 3, title: "The Third Topic of the day", author_name: "Carl", author_email_address: nil, written_on: "2012-08-12 20:24:22", bonus_time: nil, last_read: nil, content: "I'm a troll", important: nil, approved: 1, replies_count: 1, unique_replies_count: 0, parent_id: nil, parent_title: nil, type: nil, group: nil, created_at: "2016-05-08 00:47:39", updated_at: "2016-05-08 00:47:43">
+#<Reply id: 2, title: "The Second Topic of the day", author_name: "Mary", author_email_address: nil, written_on: "2004-07-15 14:28:00", bonus_time: nil, last_read: nil, content: "Have a nice day", important: nil, approved: 1, replies_count: 0, unique_replies_count: 0, parent_id: 1, parent_title: nil, type: "Reply", group: nil, created_at: "2016-05-08 00:47:39", updated_at: "2016-05-08 00:47:39">



 98) Failure:
FinderTest#test_third_with_offset [/home/yahonda/git/rails/activerecord/test/cases/finder_test.rb:428]:
--- expected
+++ actual
@@ -1 +1 @@
-#<Topic id: 5, title: "The Fifth Topic of the day", author_name: "Jason", author_email_address: nil, written_on: "2013-07-13 11:11:00", bonus_time: nil, last_read: nil, content: "Omakase", important: nil, approved: 1, replies_count: 0, unique_replies_count: 0, parent_id: nil, parent_title: nil, type: nil, group: nil, created_at: "2016-05-08 00:47:39", updated_at: "2016-05-08 00:47:39">
+#<Reply id: 2, title: "The Second Topic of the day", author_name: "Mary", author_email_address: nil, written_on: "2004-07-15 14:28:00", bonus_time: nil, last_read: nil, content: "Have a nice day", important: nil, approved: 1, replies_count: 0, unique_replies_count: 0, parent_id: 1, parent_title: nil, type: "Reply", group: nil, created_at: "2016-05-08 00:47:39", updated_at: "2016-05-08 00:47:39">

```

There are 2 "regressions" with this change: we need to address them later.

```ruby

 28) Failure:
ActiveRecord::AdapterTest#test_foreign_key_violations_are_translated_to_specific_exception [/home/yahonda/git/rails/activerecord/test/cases/adapter_test.rb:189]:
ActiveRecord::InvalidForeignKey expected but nothing was raised.


 29) Failure:
ActiveRecord::AdapterTest#test_foreign_key_violations_are_translated_to_specific_exception_with_validate_false [/home/yahonda/git/rails/activerecord/test/cases/adapter_test.rb:207]:
ActiveRecord::InvalidForeignKey expected but nothing was raised.

```
