### PR TITLE
Do not enable constraints in disable_referential_integrity

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -472,9 +472,6 @@ module ActiveRecord
             end
             yield
           ensure
-            old_constraints.each do |constraint|
-              execute "ALTER TABLE #{constraint["table_name"]} ENABLE CONSTRAINT #{constraint["constraint_name"]}"
-            end
           end
         end
 


### PR DESCRIPTION
Why exactly are we trying to enable constraints in a method named disable_referential_integrity? 
We ran into some issues with transactional fixtures in a rails project, will come up with exact steps to reproduce