### PR TITLE
Support for any type primary key

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -42,7 +42,18 @@ module ActiveRecord
         def create_table(table_name, comment: nil, **options)
           create_sequence = options[:id] != false
           td = create_table_definition table_name, options[:temporary], options[:options], options[:as], options[:tablespace], options[:organization], comment: comment
-          td.primary_key(options[:primary_key] || Base.get_primary_key(table_name.to_s.singularize)) unless options[:id] == false
+
+          if options[:id] != false && !options[:as]
+            pk = options.fetch(:primary_key) do
+              Base.get_primary_key table_name.to_s.singularize
+            end
+
+            if pk.is_a?(Array)
+              td.primary_keys pk
+            else
+              td.primary_key pk, options.fetch(:id, :primary_key), options
+            end
+          end
 
           # store that primary key was defined in create_table block
           unless create_sequence


### PR DESCRIPTION
Refer https://github.com/rails/rails/pull/18220
https://github.com/rails/rails/pull/21614

This pull request addresses 3 failures and 3 errors of ActiveRecord unit tests.

```ruby
  9) Error:
HasAndBelongsToManyAssociationsTest#test_join_table_composite_primary_key_should_not_warn:
ActiveRecord::StatementInvalid: OCIError: ORA-01400: cannot insert NULL into ("ARUNIT"."COUNTRIES_TREATIES"."[:country_id, :treaty_id]"): INSERT INTO "COUNTRIES_TREATIES" ("COUNTRY_ID", "TREATY_ID") VALUES (:a1, :a2)
    stmt.c:243:in oci8lib_230.so
    /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.2/lib/oci8/cursor.rb:129:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:168:in `exec_update'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:124:in `block in exec_insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:566:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:560:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1211:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:110:in `exec_insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:124:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:65:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:554:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:128:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:75:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:123:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `block in _create_record'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_create_callbacks'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:68:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:534:in `create_or_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `block in create_or_update'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:126:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:506:in `block (2 levels) in compile'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:455:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_save_callbacks'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `create_or_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:152:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:50:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:30:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `block in save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:230:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:45:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/has_many_through_association.rb:89:in `save_through_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/has_many_through_association.rb:47:in `insert_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:587:in `block (2 levels) in concat_records'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:430:in `replace_on_target'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:423:in `add_to_target'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:586:in `block in concat_records'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:584:in `each'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:584:in `concat_records'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/has_many_association.rb:129:in `concat_records'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/has_many_through_association.rb:27:in `concat_records'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:188:in `block in concat'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:203:in `block in transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `block in transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:202:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:188:in `concat'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/has_many_through_association.rb:21:in `concat'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_proxy.rb:1007:in `<<'
    /home/yahonda/git/rails/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb:158:in `block in test_join_table_composite_primary_key_should_not_warn'
    /home/yahonda/git/rails/activesupport/lib/active_support/testing/stream.rb:31:in `capture'
    /home/yahonda/git/rails/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb:157:in `test_join_table_composite_primary_key_should_not_warn'

 11) Error:
HasAndBelongsToManyAssociationsTest#test_proper_usage_of_primary_keys_and_join_table:
ActiveRecord::StatementInvalid: OCIError: ORA-01400: cannot insert NULL into ("ARUNIT"."COUNTRIES_TREATIES"."[:country_id, :treaty_id]"): INSERT INTO "COUNTRIES_TREATIES" ("COUNTRY_ID", "TREATY_ID") VALUES (:a1, :a2)
    stmt.c:243:in oci8lib_230.so
    /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.2/lib/oci8/cursor.rb:129:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:168:in `exec_update'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:124:in `block in exec_insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:566:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:560:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1211:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:110:in `exec_insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:124:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:65:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:554:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:128:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:75:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:123:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `block in _create_record'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_create_callbacks'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:68:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:534:in `create_or_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `block in create_or_update'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:126:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:506:in `block (2 levels) in compile'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:455:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_save_callbacks'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `create_or_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:152:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:50:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:30:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `block in save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:230:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:45:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/has_many_through_association.rb:89:in `save_through_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/has_many_through_association.rb:47:in `insert_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:587:in `block (2 levels) in concat_records'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:430:in `replace_on_target'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:423:in `add_to_target'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:586:in `block in concat_records'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:584:in `each'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:584:in `concat_records'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/has_many_association.rb:129:in `concat_records'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/has_many_through_association.rb:27:in `concat_records'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:188:in `block in concat'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:203:in `block in transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `block in transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:202:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:188:in `concat'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/has_many_through_association.rb:21:in `concat'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_proxy.rb:1007:in `<<'
    /home/yahonda/git/rails/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb:121:in `setup_data_for_habtm_case'
    /home/yahonda/git/rails/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb:141:in `test_proper_usage_of_primary_keys_and_join_table'


 12) Error:
HasAndBelongsToManyAssociationsTest#test_should_property_quote_string_primary_keys:
ActiveRecord::StatementInvalid: OCIError: ORA-01400: cannot insert NULL into ("ARUNIT"."COUNTRIES_TREATIES"."[:country_id, :treaty_id]"): INSERT INTO "COUNTRIES_TREATIES" ("COUNTRY_ID", "TREATY_ID") VALUES (:a1, :a2)
    stmt.c:243:in oci8lib_230.so
    /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.2/lib/oci8/cursor.rb:129:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:168:in `exec_update'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:124:in `block in exec_insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:566:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:560:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1211:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:110:in `exec_insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:124:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:65:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:554:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:128:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:75:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:123:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `block in _create_record'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_create_callbacks'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:68:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:534:in `create_or_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `block in create_or_update'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:126:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:506:in `block (2 levels) in compile'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:455:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_save_callbacks'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `create_or_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:152:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:50:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:30:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `block in save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:230:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:45:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/has_many_through_association.rb:89:in `save_through_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/has_many_through_association.rb:47:in `insert_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:587:in `block (2 levels) in concat_records'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:430:in `replace_on_target'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:423:in `add_to_target'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:586:in `block in concat_records'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:584:in `each'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:584:in `concat_records'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/has_many_association.rb:129:in `concat_records'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/has_many_through_association.rb:27:in `concat_records'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:188:in `block in concat'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:203:in `block in transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `block in transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:202:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:188:in `concat'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/has_many_through_association.rb:21:in `concat'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_proxy.rb:1007:in `<<'
    /home/yahonda/git/rails/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb:121:in `setup_data_for_habtm_case'
    /home/yahonda/git/rails/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb:131:in `test_should_property_quote_string_primary_keys'


 28) Failure:
ActiveRecord::AdapterTest#test_foreign_key_violations_are_translated_to_specific_exception [/home/yahonda/git/rails/activerecord/test/cases/adapter_test.rb:189]:
ActiveRecord::InvalidForeignKey expected but nothing was raised.


 29) Failure:
ActiveRecord::AdapterTest#test_foreign_key_violations_are_translated_to_specific_exception_with_validate_false [/home/yahonda/git/rails/activerecord/test/cases/adapter_test.rb:207]:
ActiveRecord::InvalidForeignKey expected but nothing was raised.


 51) Failure:
PrimaryKeyAnyTypeTest#test_any_type_primary_key [/home/yahonda/git/rails/activerecord/test/cases/primary_keys_test.rb:233]:
Expected: :string
  Actual: :integer
```

Also it changes the reason of failure from
```ruby
 55) Failure:
CompositePrimaryKeyTest#test_primary_key_issues_warning [/home/yahonda/git/rails/activerecord/test/cases/primary_keys_test.rb:266]:
Expected "[region, code]" to be nil.
```

to 

```ruby
 49) Failure:
CompositePrimaryKeyTest#test_primary_key_issues_warning [/home/yahonda/git/rails/activerecord/test/cases/primary_keys_test.rb:268]:
Expected /WARNING: Rails does not support composite primary key\./ to match "".
```

