### PR TITLE
Warn if `AR.primary_key` is called for a table with composite primary key

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1062,6 +1062,12 @@ module ActiveRecord
              AND cc.constraint_name = c.constraint_name
         SQL
 
+        warn <<-WARNING.strip_heredoc if pks.count > 1
+          WARNING: Rails does not support composite primary key.
+
+          #{table_name} has composite primary key. Composite primary key is ignored.
+        WARNING
+
         # only support single column keys
         pks.size == 1 ? [oracle_downcase(pks.first),
                          oracle_downcase(seqs.first)] : nil


### PR DESCRIPTION
Refer https://github.com/rails/rails/pull/23345

This pull request addresses this failure.

```ruby
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/primary_keys_test.rb -n test_primary_key_issues_warning

... snip ...

# Running:

F

Finished in 1.547723s, 0.6461 runs/s, 1.9383 assertions/s.

  1) Failure:
CompositePrimaryKeyTest#test_primary_key_issues_warning [test/cases/primary_keys_test.rb:268]:
Expected /WARNING: Rails does not support composite primary key\./ to match "".

1 runs, 3 assertions, 1 failures, 0 errors, 0 skips
$
```