### PR TITLE
Add reversible syntax for change_column_default

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -294,7 +294,8 @@ module ActiveRecord
           fallback
         end
 
-        def change_column_default(table_name, column_name, default) #:nodoc:
+        def change_column_default(table_name, column_name, default_or_changes) #:nodoc:
+          default = extract_new_default_value(default_or_changes)
           execute "ALTER TABLE #{quote_table_name(table_name)} MODIFY #{quote_column_name(column_name)} DEFAULT #{quote(default)}"
         ensure
           clear_table_columns_cache(table_name)


### PR DESCRIPTION
Refer https://github.com/rails/rails/pull/20018

This pull request addresses these two errors.

```ruby
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/invertible_migration_test.rb -n test_migrate_revert_change_column_default
... snip ...
# Running:

E

Finished in 0.096858s, 10.3244 runs/s, 10.3244 assertions/s.

  1) Error:
ActiveRecord::InvertibleMigrationTest#test_migrate_revert_change_column_default:
TypeError: can't quote Hash
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:177:in `_quote'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:98:in `_quote'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:22:in `quote'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:88:in `quote'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:298:in `change_column_default'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:845:in `block in method_missing'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:814:in `block in say_with_time'
    /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/2.3.0/benchmark.rb:293:in `measure'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:814:in `say_with_time'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:834:in `method_missing'
    test/cases/invertible_migration_test.rb:92:in `change'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:788:in `exec_migration'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:772:in `block (2 levels) in migrate'
    /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/2.3.0/benchmark.rb:293:in `measure'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:771:in `block in migrate'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:398:in `with_connection'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:770:in `migrate'
    test/cases/invertible_migration_test.rb:269:in `test_migrate_revert_change_column_default'

1 runs, 1 assertions, 0 failures, 1 errors, 0 skips
$
```

```ruby
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/migration/columns_test.rb -n test_change_column_default_with_from_and_to
... snip ...
# Running:

E

Finished in 0.110734s, 9.0307 runs/s, 0.0000 assertions/s.

  1) Error:
ActiveRecord::Migration::ColumnsTest#test_change_column_default_with_from_and_to:
TypeError: can't quote Hash
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:177:in `_quote'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:98:in `_quote'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:22:in `quote'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:88:in `quote'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:298:in `change_column_default'
    test/cases/migration/columns_test.rb:272:in `test_change_column_default_with_from_and_to'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```
