### PR TITLE
Ignore index name in `index_exists?` when not passed a name to check for

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -193,7 +193,7 @@ module ActiveRecord
         # Remove the given index from the table.
         # Gives warning if index does not exist
         def remove_index(table_name, options = {}) #:nodoc:
-          index_name = index_name(table_name, options)
+          index_name = index_name_for_remove(table_name, options)
           unless index_name_exists?(table_name, index_name, true)
             # sometimes options can be String or Array with column names
             options = {} unless options.is_a?(Hash)
@@ -205,11 +205,6 @@ module ActiveRecord
             end
             raise ArgumentError, "Index name '#{index_name}' on table '#{table_name}' does not exist"
           end
-          remove_index!(table_name, index_name)
-        end
-
-        # clear cached indexes when removing index
-        def remove_index!(table_name, index_name) #:nodoc:
           #TODO: It should execute only when index_type == "UNIQUE"
           execute "ALTER TABLE #{quote_table_name(table_name)} DROP CONSTRAINT #{quote_column_name(index_name)}" rescue nil
           execute "DROP INDEX #{quote_column_name(index_name)}"


### PR DESCRIPTION
Refer
https://github.com/rails/rails/pull/19456
https://github.com/rails/rails/pull/24507
https://github.com/rails/rails/commit/c41ef01a

This pull request addresses one failure and one error:

```ruby
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/adapter_test.rb -n test_remove_index_when_name_and_wrong_column_name_specified
... snip 
# Running:

F

Finished in 0.041258s, 24.2379 runs/s, 24.2379 assertions/s.

  1) Failure:
ActiveRecord::AdapterTest#test_remove_index_when_name_and_wrong_column_name_specified [test/cases/adapter_test.rb:94]:
ArgumentError expected but nothing was raised.

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```

```ruby
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/migration/index_test.rb -n test_remove_named_index

... snip ...

# Running:

E

Finished in 9.570442s, 0.1045 runs/s, 0.1045 assertions/s.

  1) Error:
ActiveRecord::Migration::IndexTest#test_remove_named_index:
ArgumentError: Index name 'index_testings_on_foo' on table 'testings' does not exist
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:206:in `remove_index'
    test/cases/migration/index_test.rb:143:in `test_remove_named_index'

1 runs, 1 assertions, 0 failures, 1 errors, 0 skips
$
```

Somehow, when `bundle exec rake test_oracle` executed this commit caused these two failures. 

```ruby
 21) Failure:
ActiveRecord::AdapterTest#test_foreign_key_violations_are_translated_to_specific_exception [/home/yahonda/git/rails/activerecord/test/cases/adapter_test.rb:189]:
ActiveRecord::InvalidForeignKey expected but nothing was raised.


 22) Failure:
ActiveRecord::AdapterTest#test_foreign_key_violations_are_translated_to_specific_exception_with_validate_false [/home/yahonda/git/rails/activerecord/test/cases/adapter_test.rb:207]:
ActiveRecord::InvalidForeignKey expected but nothing was raised.
```

Which does not reproduce when executing each test as follows.

```ruby
ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/adapter_test.rb -n test_foreign_key_violations_are_translated_to_specific_exception
ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/adapter_test.rb -n test_foreign_key_violations_are_translated_to_specific_exception_with_validate_false
```