### PR TITLE
Introduce `data_source_exists?` to return tables and views

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -714,13 +714,41 @@ module ActiveRecord
       end
 
       def tables(name = nil) #:nodoc:
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          #tables currently returns both tables and views.
+          This behavior is deprecated and will be changed with Rails 5.1 to only return tables.
+          Use #data_sources instead.
+        MSG
+
+        if name
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            Passing arguments to #tables is deprecated without replacement.
+          MSG
+        end
+
+        data_sources
+      end
+
+
+      def data_sources
         select_values(
         "SELECT DECODE(table_name, UPPER(table_name), LOWER(table_name), table_name) FROM all_tables WHERE owner = SYS_CONTEXT('userenv', 'current_schema') AND secondary = 'N'",
-        name)
+        'SCHEMA')
+      end
+
+      def table_exists?(table_name)
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          #table_exists? currently checks both tables and views.
+          This behavior is deprecated and will be changed with Rails 5.1 to only check tables.
+          Use #data_source_exists? instead.
+        MSG
+
+        data_source_exists?(table_name)
       end
 
       # Will return true if database object exists (to be able to use also views and synonyms for ActiveRecord models)
-      def table_exists?(table_name)
+      # Needs to consider how to support synonyms in Rails 5.1
+      def data_source_exists?(table_name)
         (_owner, table_name, _db_link) = @connection.describe(table_name)
         true
       rescue


### PR DESCRIPTION
also deprecate `#table_exists?`, `#tables` and passing arguments to `#tables`

Refer https://github.com/rails/rails/pull/21601
https://github.com/rails/rails/issues/21509

This pull request addresses these 2 failures:

```ruby
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/adapter_test.rb -n test_passing_arguments_to_tables_is_deprecated
/home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.12.4/lib/bundler/rubygems_integration.rb:468: warning: method redefined; discarding old find_spec_for_exe
/home/yahonda/.rbenv/versions/2.3.1/lib/ruby/site_ruby/2.3.0/rubygems.rb:241: warning: previous definition of find_spec_for_exe was here
Using oracle
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:148: warning: assigned but unused variable - col_type
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb:7: warning: method redefined; discarding old aliased_types
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb:389: warning: previous definition of aliased_types was here
Run options: -n test_passing_arguments_to_tables_is_deprecated --seed 33907

# Running:

F

Finished in 0.075337s, 13.2737 runs/s, 13.2737 assertions/s.

  1) Failure:
ActiveRecord::AdapterTest#test_passing_arguments_to_tables_is_deprecated [test/cases/adapter_test.rb:291]:
Expected a deprecation warning within the block but received none

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
```

```ruby
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/adapter_test.rb -n test_table_exists_checking_both_tables_and_views_is_deprecated
/home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.12.4/lib/bundler/rubygems_integration.rb:468: warning: method redefined; discarding old find_spec_for_exe
/home/yahonda/.rbenv/versions/2.3.1/lib/ruby/site_ruby/2.3.0/rubygems.rb:241: warning: previous definition of find_spec_for_exe was here
Using oracle
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:148: warning: assigned but unused variable - col_type
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb:7: warning: method redefined; discarding old aliased_types
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb:389: warning: previous definition of aliased_types was here
Run options: -n test_table_exists_checking_both_tables_and_views_is_deprecated --seed 1078

# Running:

F

Finished in 0.004514s, 221.5369 runs/s, 221.5369 assertions/s.

  1) Failure:
ActiveRecord::AdapterTest#test_table_exists_checking_both_tables_and_views_is_deprecated [test/cases/adapter_test.rb:51]:
Expected a deprecation warning within the block but received none

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
```