### PR TITLE
Replace `table_exists?` with `data_source_exists?`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -16,7 +16,7 @@ module ActiveRecord #:nodoc:
 
         def tables(stream)
           # do not include materialized views in schema dump - they should be created separately after schema creation
-          sorted_tables = (@connection.tables - @connection.materialized_views).sort
+          sorted_tables = (@connection.data_sources - @connection.materialized_views).sort
           sorted_tables.each do |tbl|
             # add table prefix or suffix for schema_migrations
             next if ignored? tbl

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -69,7 +69,7 @@ module ActiveRecord
           yield td if block_given?
           create_sequence = create_sequence || td.create_sequence
 
-          if options[:force] && table_exists?(table_name)
+          if options[:force] && data_source_exists?(table_name)
             drop_table(table_name, options)
           end
 
@@ -124,7 +124,7 @@ module ActiveRecord
         def initialize_schema_migrations_table
           sm_table = ActiveRecord::Migrator.schema_migrations_table_name
 
-          unless table_exists?(sm_table)
+          unless data_source_exists?(sm_table)
             index_name = "#{Base.table_name_prefix}unique_schema_migrations#{Base.table_name_suffix}"
             if index_name.length > index_name_length
               truncate_to    = index_name_length - index_name.to_s.length - 1
@@ -140,7 +140,7 @@ module ActiveRecord
             # Backwards-compatibility: if we find schema_info, assume we've
             # migrated up to that point:
             si_table = Base.table_name_prefix + 'schema_info' + Base.table_name_suffix
-            if table_exists?(si_table)
+            if data_source_exists?(si_table)
               ActiveSupport::Deprecation.warn "Usage of the schema table `#{si_table}` is deprecated. Please switch to using `schema_migrations` table"
 
               old_version = select_value("SELECT version FROM #{quote_table_name(si_table)}").to_i

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -640,7 +640,7 @@ module ActiveRecord
       end
 
       def reset_pk_sequence!(table_name, primary_key = nil, sequence_name = nil) #:nodoc:
-        return nil unless table_exists?(table_name)
+        return nil unless data_source_exists?(table_name)
         unless primary_key and sequence_name
         # *Note*: Only primary key is implemented - sequence will be nil.
           primary_key, sequence_name = pk_and_sequence_for(table_name)


### PR DESCRIPTION
This pull request follows up #841 to avoid this deprecation warning.

```ruby
DEPRECATION WARNING: #table_exists? currently checks both tables and views. This behavior is deprecated and will be changed with Rails 5.1 to only check tables. Use #data_source_exists? instead. (called from table_exists? at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:740)
```