### PR TITLE
Register `NUMBER(1)` sql_type to `Type::Boolean`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1169,6 +1169,7 @@ module ActiveRecord
         register_class_with_limit m, %r(date)i,           Type::DateTime
         register_class_with_limit m, %r(raw)i,            ActiveRecord::OracleEnhanced::Type::Raw
 
+
         m.register_type(%r(NUMBER)i) do |sql_type|
           scale = extract_scale(sql_type)
           precision = extract_precision(sql_type)
@@ -1179,6 +1180,8 @@ module ActiveRecord
             Type::Decimal.new(precision: precision, scale: scale)
           end
         end
+
+        m.register_type %r(^NUMBER\(1\))i, Type::Boolean.new if OracleEnhancedAdapter.emulate_booleans
       end
 
       def extract_limit(sql_type) #:nodoc:


### PR DESCRIPTION
 if OracleEnhancedAdapter.emulate_booleans


This pull request addresses these 15 failures of ActiveRecord unit tests.
```ruby
  4) Failure:
HasManyAssociationsTest#test_build_and_create_from_association_should_respect_passed_attributes_over_default_scope [/home/yahonda/git/rails/activerecord/test/cases/associations/has_many_associations_test.rb:221]:
Expected: false
  Actual: 0


  5) Failure:
HasManyThroughAssociationsTest#test_create_with_conditions_hash_on_through_association [/home/yahonda/git/rails/activerecord/test/cases/associations/has_many_through_associations_test.rb:1019]:
Expected: true
  Actual: 1

 17) Failure:
SchemaDumperTest#test_schema_dump_should_use_false_as_default [/home/yahonda/git/rails/activerecord/test/cases/schema_dumper_test.rb:222]:
Expected /t\.boolean\s+"has_fun",.+default: false/ to match "# encoding: UTF-8\n# This file is auto-generated from the current state of the database. Instead\n# of editing this file, please use the migrations feature of Active Record to\n# incrementally modify your database, and then regenerate this schema definition.\n#\n# Note that this schema.rb definition is the authoritative source for your\n# database schema. If you need to create the application database on another\n# system, you should be using db:schema:load, not running all the migrations\n# from scratch. The latter is a flawed and unsustainable approach (the more migrations\n# you'll amass, the slower it'll run and the greater likelihood for issues).\n#\n# It's strongly recommended that you check this file into your version control system.\n\nActiveRecord::Schema.define(version: 0) do\n\n  create_table \"CamelCase\", force: :cascade do |t|\n    t.string \"name\"\n  end\n\n  create_table \"accounts\", force: :cascade do |t|\n    t.integer \"firm_id\",      precision: 38\n    t.string  \"firm_name\"\n    t.integer \"credit_limit\", precision: 38\n  end\n\n  create_table \"admin_accounts\", force: :cascade do |t|\n    t.string \"name\"\n  end\n\n  create_table \"admin_users\", force: :cascade do |t|\n    t.string  \"name\"\n    t.string  \"settings\",        limit: 1024\n    t.string  \"preferences\",     limit: 1024,                default: \"\"\n    t.string  \"json_data\",       limit: 1024\n    t.string  \"json_data_empty\", limit: 1024,                default: \"\"\n    t.text    \"params\"\n    t.integer \"account_id\",                   precision: 38\n  end\n\n  add_index \"admin_users\", [\"account_id\"], name: \"i_admin_users_account_id\"\n\n  create_table \"aircraft\", force: :cascade do |t|\n    t.string  \"name\"\n    t.integer \"wheels_count\", precision: 38, default: 0, null: false\n  end\n\n  create_table \"articles\", force: :cascade do |t|\n  end\n\n  create_table \"articles_magazines\", force: :cascade do |t|\n    t.integer \"article_id\",  precision: 38\n    t.integer \"magazine_id\", precision: 38\n  end\n\n  add_index \"articles_magazines\", [\"article_id\"], name: \"i_art_mag_art_id\"\n  add_index \"articles_magazines\", [\"magazine_id\"], name: \"i_art_mag_mag_id\"\n\n  create_table \"articles_tags\", force: :cascade do |t|\n    t.integer \"article_id\", precision: 38\n    t.integer \"tag_id\",     precision: 38\n  end\n\n  add_index \"articles_tags\", [\"article_id\"], name: \"i_articles_tags_article_id\"\n  add_index \"articles_tags\", [\"tag_id\"], name: \"index_articles_tags_on_tag_id\"\n\n  create_table \"audit_logs\", force: :cascade do |t|\n    t.string  \"message\",                                 null: false\n    t.integer \"developer_id\",             precision: 38, null: false\n    t.integer \"unvalidated_developer_id\", precision: 38\n  end\n\n  create_table \"author_addresses\", force: :cascade do |t|\n  end\n\n  create_table \"author_favorites\", force: :cascade do |t|\n    t.integer \"author_id\",          precision: 38\n    t.integer \"favorite_author_id\", precision: 38\n  end\n\n  create_table \"authors\", force: :cascade do |t|\n    t.string  \"name\",                                   null: false\n    t.integer \"author_address_id\",       precision: 38\n    t.integer \"author_address_extra_id\", precision: 38\n    t.string  \"organization_id\"\n    t.string  \"owned_essay_id\"\n  end\n\n  create_table \"auto_id_tests\", primary_key: \"auto_id\", force: :cascade do |t|\n    t.integer \"value\", precision: 38\n  end\n\n  create_table \"binaries\", force: :cascade do |t|\n    t.string \"name\"\n    t.binary \"data\"\n    t.binary \"short_data\"\n  end\n\n  create_table \"birds\", force: :cascade do |t|\n    t.string  \"name\"\n    t.string  \"color\"\n    t.integer \"pirate_id\", precision: 38\n  end\n\n  create_table \"books\", force: :cascade do |t|\n    t.integer \"author_id\",              precision: 38\n    t.string  \"format\"\n    t.string  \"name\"\n    t.integer \"status\",                 precision: 38, default: 0\n    t.integer \"read_status\",            precision: 38, default: 0\n    t.integer \"nullable_status\",        precision: 38\n    t.integer \"language\",               precision: 38, default: 0\n    t.integer \"author_visibility\",      precision: 38, default: 0\n    t.integer \"illustrator_visibility\", precision: 38, default: 0\n    t.integer \"font_size\",              precision: 38, default: 0\n    t.string  \"cover\",                                 default: \"hard\"\n  end\n\n  create_table \"booleans\", force: :cascade do |t|\n    t.integer \"value\",   limit: 1, precision: 1\n    t.integer \"has_fun\", limit: 1, precision: 1, default: 0, null: false\n  end\n\n  create_table \"bulbs\", force: :cascade do |t|\n    t.integer \"car_id\",                   precision: 38\n    t.string  \"name\"\n    t.integer \"frickinawesome\", limit: 1, precision: 1,  default: 0\n    t.string  \"color\"\n  end\n\n  create_table \"cake_designers\", force: :cascade do |t|\n  end\n\n  create_table \"carriers\", force: :cascade do |t|\n  end\n\n  create_table \"cars\", force: :cascade do |t|\n    t.string   \"name\"\n    t.integer  \"engines_count\", precision: 38\n    t.integer  \"wheels_count\",  precision: 38\n    t.integer  \"lock_version\",  precision: 38, default: 0, null: false\n    t.datetime \"created_at\",    precision: 6,              null: false\n    t.datetime \"updated_at\",    precision: 6,              null: false\n  end\n\n  create_table \"categories\", force: :cascade do |t|\n    t.string  \"name\",                                 null: false\n    t.string  \"type\"\n    t.integer \"categorizations_count\", precision: 38\n  end\n\n  create_table \"categories_posts\", id: false, force: :cascade do |t|\n    t.integer \"category_id\", precision: 38, null: false\n    t.integer \"post_id\",     precision: 38, null: false\n  end\n\n  create_table \"categorizations\", force: :cascade do |t|\n    t.integer \"category_id\",                   precision: 38\n    t.string  \"named_category_name\"\n    t.integer \"post_id\",                       precision: 38\n    t.integer \"author_id\",                     precision: 38\n    t.integer \"special\",             limit: 1, precision: 1\n  end\n\n  create_table \"chefs\", force: :cascade do |t|\n    t.integer \"employable_id\",        precision: 38\n    t.string  \"employable_type\"\n    t.integer \"department_id\",        precision: 38\n    t.string  \"employable_list_type\"\n    t.integer \"employable_list_id\",   precision: 38\n  end\n\n  create_table \"circles\", force: :cascade do |t|\n  end\n\n  create_table \"citations\", force: :cascade do |t|\n    t.integer \"book1_id\", precision: 38\n    t.integer \"book2_id\", precision: 38\n  end\n\n  create_table \"clubs\", force: :cascade do |t|\n    t.string  \"name\"\n    t.integer \"category_id\", precision: 38\n  end\n\n  create_table \"cold_jokes\", force: :cascade do |t|\n    t.string \"cold_name\"\n  end\n\n  create_table \"collections\", force: :cascade do |t|\n    t.string \"name\"\n  end\n\n  create_table \"colnametests\", force: :cascade do |t|\n    t.integer \"references\", precision: 38, null: false\n  end\n\n  create_table \"columns\", force: :cascade do |t|\n    t.integer \"record_id\", precision: 38\n  end\n\n  add_index \"columns\", [\"record_id\"], name: \"index_columns_on_record_id\"\n\n  create_table \"comments\", force: :cascade do |t|\n    t.integer \"post_id\",                     precision: 38,             null: false\n    t.string  \"body\",           limit: 4000,                            null: false\n    t.string  \"type\"\n    t.integer \"tags_count\",                  precision: 38, default: 0\n    t.integer \"children_count\",              precision: 38, default: 0\n    t.integer \"parent_id\",                   precision: 38\n    t.string  \"author_type\"\n    t.integer \"author_id\",                   precision: 38\n    t.string  \"resource_id\"\n    t.string  \"resource_type\"\n    t.integer \"developer_id\",                precision: 38\n  end\n\n  add_index \"comments\", [\"author_type\", \"author_id\"], name: \"i_com_aut_typ_aut_id\"\n\n  create_table \"companies\", force: :cascade do |t|\n    t.string  \"type\"\n    t.integer \"firm_id\",     precision: 38\n    t.string  \"firm_name\"\n    t.string  \"name\"\n    t.integer \"client_of\",   precision: 38\n    t.integer \"rating\",      precision: 38, default: 1\n    t.integer \"account_id\",  precision: 38\n    t.string  \"description\",                default: \"\"\n  end\n\n  add_index \"companies\", [\"firm_id\", \"type\", \"rating\"], name: \"company_index\"\n  add_index \"companies\", [\"firm_id\", \"type\"], name: \"company_partial_index\"\n  add_index \"companies\", [\"name\"], name: \"company_name_index\"\n\n  create_table \"computers\", force: :cascade do |t|\n    t.string  \"system\"\n    t.integer \"developer\",        precision: 38, null: false\n    t.integer \"extendedWarranty\", precision: 38, null: false\n  end\n\n  create_table \"computers_developers\", id: false, force: :cascade do |t|\n    t.integer \"computer_id\",  precision: 38\n    t.integer \"developer_id\", precision: 38\n  end\n\n  add_index \"computers_developers\", [\"computer_id\"], name: \"i_com_dev_com_id\"\n  add_index \"computers_developers\", [\"developer_id\"], name: \"i_com_dev_dev_id\"\n\n  create_table \"content\", force: :cascade do |t|\n    t.string \"title\"\n  end\n\n  create_table \"content_positions\", force: :cascade do |t|\n    t.integer \"content_id\", precision: 38\n  end\n\n  create_table \"contracts\", force: :cascade do |t|\n    t.integer \"developer_id\", precision: 38\n    t.integer \"company_id\",   precision: 38\n  end\n\n  create_table \"countries\", id: false, force: :cascade do |t|\n    t.string \"country_id\"\n    t.string \"name\"\n  end\n\n  create_table \"countries_treaties\", id: false, force: :cascade do |t|\n    t.string \"country_id\", null: false\n    t.string \"treaty_id\",  null: false\n  end\n\n  create_table \"customer_carriers\", force: :cascade do |t|\n    t.integer \"customer_id\", precision: 38\n    t.integer \"carrier_id\",  precision: 38\n  end\n\n  add_index \"customer_carriers\", [\"carrier_id\"], name: \"i_customer_carriers_carrier_id\"\n  add_index \"customer_carriers\", [\"customer_id\"], name: \"i_cus_car_cus_id\"\n\n  create_table \"customers\", force: :cascade do |t|\n    t.string  \"name\"\n    t.integer \"balance\",         precision: 38, default: 0\n    t.string  \"address_street\"\n    t.string  \"address_city\"\n    t.string  \"address_country\"\n    t.string  \"gps_location\"\n  end\n\n  create_table \"dashboards\", id: false, force: :cascade do |t|\n    t.string \"dashboard_id\"\n    t.string \"name\"\n  end\n\n  create_table \"defaults\", id: false, force: :cascade do |t|\n    t.integer  \"id\",                                precision: 38,                                 null: false\n    t.datetime \"modified_date\"\n    t.datetime \"modified_date_function\"\n    t.datetime \"fixed_date\",                                       default: '2004-01-01 00:00:00'\n    t.datetime \"modified_time\"\n    t.datetime \"modified_time_function\"\n    t.datetime \"fixed_time\",                                       default: '2004-01-01 00:00:00'\n    t.string   \"char1\",                  limit: 1,                 default: \"Y\"\n    t.string   \"char2\",                  limit: 50,                default: \"a varchar field\"\n    t.text     \"char3\",                                            default: \"a text field\"\n  end\n\n  create_table \"departments\", force: :cascade do |t|\n    t.integer \"hotel_id\", precision: 38\n  end\n\n  create_table \"developers\", force: :cascade do |t|\n    t.string   \"name\"\n    t.string   \"first_name\"\n    t.integer  \"salary\",     precision: 38, default: 70000\n    t.integer  \"firm_id\",    precision: 38\n    t.integer  \"mentor_id\",  precision: 38\n    t.datetime \"created_at\", precision: 6\n    t.datetime \"updated_at\", precision: 6\n    t.datetime \"created_on\", precision: 6\n    t.datetime \"updated_on\", precision: 6\n  end\n\n  create_table \"developers_projects\", id: false, force: :cascade do |t|\n    t.integer  \"developer_id\", precision: 38,             null: false\n    t.integer  \"project_id\",   precision: 38,             null: false\n    t.datetime \"joined_on\"\n    t.integer  \"access_level\", precision: 38, default: 1\n  end\n\n  create_table \"dog_lovers\", force: :cascade do |t|\n    t.integer \"trained_dogs_count\", precision: 38, default: 0\n    t.integer \"bred_dogs_count\",    precision: 38, default: 0\n    t.integer \"dogs_count\",         precision: 38, default: 0\n  end\n\n  create_table \"dogs\", force: :cascade do |t|\n    t.integer \"trainer_id\",   precision: 38\n    t.integer \"breeder_id\",   precision: 38\n    t.integer \"dog_lover_id\", precision: 38\n    t.string  \"alias\"\n  end\n\n  create_table \"doubloons\", force: :cascade do |t|\n    t.integer \"pirate_id\", precision: 38\n    t.integer \"weight\",    precision: 38\n  end\n\n  create_table \"drink_designers\", force: :cascade do |t|\n  end\n\n  create_table \"edges\", id: false, force: :cascade do |t|\n    t.integer \"source_id\", precision: 38, null: false\n    t.integer \"sink_id\",   precision: 38, null: false\n  end\n\n  add_index \"edges\", [\"source_id\", \"sink_id\"], name: \"unique_edge_index\", unique: true\n\n  create_table \"electrons\", force: :cascade do |t|\n    t.integer \"molecule_id\", precision: 38\n    t.string  \"name\"\n  end\n\n  create_table \"engines\", force: :cascade do |t|\n    t.integer \"car_id\", precision: 38\n  end\n\n  create_table \"entrants\", force: :cascade do |t|\n    t.string  \"name\",                     null: false\n    t.integer \"course_id\", precision: 38, null: false\n  end\n\n  create_table \"essays\", force: :cascade do |t|\n    t.string \"name\"\n    t.string \"writer_id\"\n    t.string \"writer_type\"\n    t.string \"category_id\"\n    t.string \"author_id\"\n  end\n\n  create_table \"events\", force: :cascade do |t|\n    t.string \"title\", limit: 5\n  end\n\n  create_table \"eyes\", force: :cascade do |t|\n  end\n\n  create_table \"faces\", force: :cascade do |t|\n    t.string  \"description\"\n    t.integer \"man_id\",                        precision: 38\n    t.integer \"polymorphic_man_id\",            precision: 38\n    t.string  \"polymorphic_man_type\"\n    t.integer \"poly_man_without_inverse_id\",   precision: 38\n    t.string  \"poly_man_without_inverse_type\"\n    t.integer \"horrible_polymorphic_man_id\",   precision: 38\n    t.string  \"horrible_polymorphic_man_type\"\n  end\n\n  create_table \"fk_test_has_fk\", force: :cascade do |t|\n    t.integer \"fk_id\", precision: 38, null: false\n  end\n\n  create_table \"fk_test_has_pk\", primary_key: \"pk_id\", force: :cascade do |t|\n  end\n\n  create_table \"friendships\", force: :cascade do |t|\n    t.integer \"friend_id\",   precision: 38\n    t.integer \"follower_id\", precision: 38\n  end\n\n  create_table \"funny_jokes\", force: :cascade do |t|\n    t.string \"name\"\n  end\n\n  create_table \"goofy_string_id\", id: false, force: :cascade do |t|\n    t.string \"id\",   null: false\n    t.string \"info\"\n  end\n\n  create_table \"guids\", force: :cascade do |t|\n    t.string \"key\"\n  end\n\n  create_table \"guitars\", force: :cascade do |t|\n    t.string \"color\"\n  end\n\n  create_table \"having\", force: :cascade do |t|\n    t.string \"where\"\n  end\n\n  create_table \"hotels\", force: :cascade do |t|\n  end\n\n  create_table \"images\", force: :cascade do |t|\n    t.integer \"imageable_identifier\", precision: 38\n    t.string  \"imageable_class\"\n  end\n\n  create_table \"inept_wizards\", force: :cascade do |t|\n    t.string \"name\", null: false\n    t.string \"city\", null: false\n    t.string \"type\"\n  end\n\n  create_table \"integer_limits\", force: :cascade do |t|\n    t.integer \"c_int_without_limit\",           precision: 38\n    t.integer \"c_int_1\",             limit: 1, precision: 1\n    t.integer \"c_int_2\",             limit: 2, precision: 2\n    t.integer \"c_int_3\",             limit: 3, precision: 3\n    t.integer \"c_int_4\",             limit: 4, precision: 4\n    t.integer \"c_int_5\",             limit: 5, precision: 5\n    t.integer \"c_int_6\",             limit: 6, precision: 6\n    t.integer \"c_int_7\",             limit: 7, precision: 7\n    t.integer \"c_int_8\",             limit: 8, precision: 8\n  end\n\n  create_table \"interests\", force: :cascade do |t|\n    t.string  \"topic\"\n    t.integer \"man_id\",               precision: 38\n    t.integer \"polymorphic_man_id\",   precision: 38\n    t.string  \"polymorphic_man_type\"\n    t.integer \"zine_id\",              precision: 38\n  end\n\n  create_table \"invoices\", force: :cascade do |t|\n    t.integer  \"balance\",    precision: 38\n    t.datetime \"updated_at\", precision: 6\n  end\n\n  create_table \"iris\", force: :cascade do |t|\n    t.integer \"eye_id\", precision: 38\n    t.string  \"color\"\n  end\n\n  add_index \"iris\", [\"eye_id\"], name: \"index_iris_on_eye_id\"\n\n  create_table \"items\", force: :cascade do |t|\n    t.string \"name\"\n  end\n\n  create_table \"jobs\", force: :cascade do |t|\n    t.integer \"ideal_reference_id\", precision: 38\n  end\n\n  create_table \"keyboards\", primary_key: \"key_number\", force: :cascade do |t|\n    t.string \"name\"\n  end\n\n  create_table \"legacy_things\", force: :cascade do |t|\n    t.integer \"tps_report_number\", precision: 38\n    t.integer \"version\",           precision: 38, default: 0, null: false\n  end\n\n  create_table \"lessons\", force: :cascade do |t|\n    t.string \"name\"\n  end\n\n  create_table \"lessons_students\", id: false, force: :cascade do |t|\n    t.integer \"lesson_id\",  precision: 38\n    t.integer \"student_id\", precision: 38\n  end\n\n  add_index \"lessons_students\", [\"lesson_id\"], name: \"i_lessons_students_lesson_id\"\n  add_index \"lessons_students\", [\"student_id\"], name: \"i_lessons_students_student_id\"\n\n  create_table \"line_items\", force: :cascade do |t|\n    t.integer \"invoice_id\", precision: 38\n    t.integer \"amount\",     precision: 38\n  end\n\n  create_table \"lint_models\", force: :cascade do |t|\n  end\n\n  create_table \"lions\", force: :cascade do |t|\n    t.integer \"gender\",                  precision: 38\n    t.integer \"is_vegetarian\", limit: 1, precision: 1,  default: 0\n  end\n\n  create_table \"liquid\", force: :cascade do |t|\n    t.string \"name\"\n  end\n\n  create_table \"lock_without_defaults\", force: :cascade do |t|\n    t.integer \"lock_version\", precision: 38\n  end\n\n  create_table \"lock_without_defaults_cust\", force: :cascade do |t|\n    t.integer \"custom_lock_version\", precision: 38\n  end\n\n  create_table \"magazines\", force: :cascade do |t|\n  end\n\n  create_table \"mateys\", id: false, force: :cascade do |t|\n    t.integer \"pirate_id\", precision: 38\n    t.integer \"target_id\", precision: 38\n    t.integer \"weight\",    precision: 38\n  end\n\n  create_table \"member_details\", force: :cascade do |t|\n    t.integer \"member_id\",       precision: 38\n    t.integer \"organization_id\", precision: 38\n    t.string  \"extra_data\"\n  end\n\n  create_table \"member_friends\", id: false, force: :cascade do |t|\n    t.integer \"member_id\", precision: 38\n    t.integer \"friend_id\", precision: 38\n  end\n\n  create_table \"member_types\", force: :cascade do |t|\n    t.string \"name\"\n  end\n\n  create_table \"members\", force: :cascade do |t|\n    t.string  \"name\"\n    t.integer \"member_type_id\", precision: 38\n  end\n\n  create_table \"memberships\", force: :cascade do |t|\n    t.datetime \"joined_on\",           precision: 6\n    t.integer  \"club_id\",             precision: 38\n    t.integer  \"member_id\",           precision: 38\n    t.integer  \"favourite\", limit: 1, precision: 1,  default: 0\n    t.string   \"type\"\n  end\n\n  create_table \"men\", force: :cascade do |t|\n    t.string \"name\"\n  end\n\n  create_table \"mentors\", force: :cascade do |t|\n    t.string \"name\"\n  end\n\n  create_table \"minimalistics\", force: :cascade do |t|\n  end\n\n  create_table \"minivans\", id: false, force: :cascade do |t|\n    t.string \"minivan_id\"\n    t.string \"name\"\n    t.string \"speedometer_id\"\n    t.string \"color\"\n  end\n\n  create_table \"mixed_case_monkeys\", primary_key: \"monkeyID\", force: :cascade do |t|\n    t.integer \"fleaCount\", precision: 38\n  end\n\n  create_table \"mixins\", force: :cascade do |t|\n    t.integer  \"parent_id\",  precision: 38\n    t.integer  \"pos\",        precision: 38\n    t.datetime \"created_at\", precision: 6\n    t.datetime \"updated_at\", precision: 6\n    t.integer  \"lft\",        precision: 38\n    t.integer  \"rgt\",        precision: 38\n    t.integer  \"root_id\",    precision: 38\n    t.string   \"type\"\n  end\n\n  create_table \"molecules\", force: :cascade do |t|\n    t.integer \"liquid_id\", precision: 38\n    t.string  \"name\"\n  end\n\n  create_table \"movies\", primary_key: \"movieid\", force: :cascade do |t|\n    t.string \"name\"\n  end\n\n  create_table \"nodes\", force: :cascade do |t|\n    t.integer  \"tree_id\",    precision: 38\n    t.integer  \"parent_id\",  precision: 38\n    t.string   \"name\"\n    t.datetime \"updated_at\", precision: 6\n  end\n\n  create_table \"non_poly_ones\", force: :cascade do |t|\n  end\n\n  create_table \"non_poly_twos\", force: :cascade do |t|\n  end\n\n  create_table \"notifications\", force: :cascade do |t|\n    t.string \"message\"\n  end\n\n  create_table \"numeric_data\", force: :cascade do |t|\n    t.decimal \"bank_balance\",                           precision: 10, scale: 2\n    t.decimal \"big_bank_balance\",                       precision: 15, scale: 2\n    t.integer \"world_population\",            limit: 10, precision: 10\n    t.integer \"my_house_population\",         limit: 2,  precision: 2\n    t.decimal \"decimal_number_with_default\",            precision: 3,  scale: 2, default: \"2.78\"\n    t.float   \"temperature\"\n    t.integer \"atoms_in_universe\",                      precision: 38\n  end\n\n  create_table \"orders\", force: :cascade do |t|\n    t.string  \"name\"\n    t.integer \"billing_customer_id\",  precision: 38\n    t.integer \"shipping_customer_id\", precision: 38\n  end\n\n  create_table \"organizations\", force: :cascade do |t|\n    t.string \"name\"\n  end\n\n  create_table \"overloaded_types\", force: :cascade do |t|\n    t.float  \"overloaded_float\",             default: 500.0\n    t.float  \"unoverloaded_float\"\n    t.string \"overloaded_string_with_limit\"\n    t.string \"string_with_default\",          default: \"the original default\"\n  end\n\n  create_table \"owners\", primary_key: \"owner_id\", force: :cascade do |t|\n    t.string   \"name\"\n    t.datetime \"updated_at\", precision: 6\n    t.datetime \"happy_at\",   precision: 6\n    t.string   \"essay_id\"\n  end\n\n  create_table \"paint_colors\", force: :cascade do |t|\n    t.integer \"non_poly_one_id\", precision: 38\n  end\n\n  create_table \"paint_textures\", force: :cascade do |t|\n    t.integer \"non_poly_two_id\", precision: 38\n  end\n\n  create_table \"parrots\", force: :cascade do |t|\n    t.string   \"name\"\n    t.string   \"color\"\n    t.string   \"parrot_sti_class\"\n    t.integer  \"killer_id\",        precision: 38\n    t.datetime \"created_at\",       precision: 0\n    t.datetime \"created_on\",       precision: 0\n    t.datetime \"updated_at\",       precision: 0\n    t.datetime \"updated_on\",       precision: 0\n  end\n\n  create_table \"parrots_pirates\", id: false, force: :cascade do |t|\n    t.integer \"parrot_id\", precision: 38\n    t.integer \"pirate_id\", precision: 38\n  end\n\n  create_table \"parrots_treasures\", id: false, force: :cascade do |t|\n    t.integer \"parrot_id\",   precision: 38\n    t.integer \"treasure_id\", precision: 38\n  end\n\n  create_table \"people\", force: :cascade do |t|\n    t.string   \"first_name\",                                              null: false\n    t.integer  \"primary_contact_id\",           precision: 38\n    t.string   \"gender\",             limit: 1\n    t.integer  \"number1_fan_id\",               precision: 38\n    t.integer  \"lock_version\",                 precision: 38, default: 0, null: false\n    t.string   \"comments\"\n    t.integer  \"followers_count\",              precision: 38, default: 0\n    t.integer  \"friends_too_count\",            precision: 38, default: 0\n    t.integer  \"best_friend_id\",               precision: 38\n    t.integer  \"best_friend_of_id\",            precision: 38\n    t.integer  \"insures\",                      precision: 38, default: 0, null: false\n    t.datetime \"born_at\",                      precision: 6\n    t.datetime \"created_at\",                   precision: 6,              null: false\n    t.datetime \"updated_at\",                   precision: 6,              null: false\n  end\n\n  add_index \"people\", [\"best_friend_id\"], name: \"index_people_on_best_friend_id\"\n  add_index \"people\", [\"best_friend_of_id\"], name: \"i_people_best_friend_of_id\"\n  add_index \"people\", [\"number1_fan_id\"], name: \"index_people_on_number1_fan_id\"\n  add_index \"people\", [\"primary_contact_id\"], name: \"i_people_primary_contact_id\"\n\n  create_table \"peoples_treasures\", id: false, force: :cascade do |t|\n    t.integer \"rich_person_id\", precision: 38\n    t.integer \"treasure_id\",    precision: 38\n  end\n\n  create_table \"personal_legacy_things\", force: :cascade do |t|\n    t.integer \"tps_report_number\", precision: 38\n    t.integer \"person_id\",         precision: 38\n    t.integer \"version\",           precision: 38, default: 0, null: false\n  end\n\n  create_table \"pets\", primary_key: \"pet_id\", force: :cascade do |t|\n    t.string   \"name\"\n    t.integer  \"owner_id\",   precision: 38\n    t.integer  \"integer\",    precision: 38\n    t.datetime \"created_at\", precision: 6,  null: false\n    t.datetime \"updated_at\", precision: 6,  null: false\n  end\n\n  create_table \"pets_treasures\", force: :cascade do |t|\n    t.integer \"treasure_id\",   precision: 38\n    t.integer \"pet_id\",        precision: 38\n    t.string  \"rainbow_color\"\n  end\n\n  create_table \"pirates\", force: :cascade do |t|\n    t.string   \"catchphrase\"\n    t.integer  \"parrot_id\",               precision: 38\n    t.integer  \"non_validated_parrot_id\", precision: 38\n    t.datetime \"created_on\",              precision: 6\n    t.datetime \"updated_on\",              precision: 6\n  end\n\n  create_table \"posts\", force: :cascade do |t|\n    t.integer \"author_id\",                                   precision: 38\n    t.string  \"title\",                                                                  null: false\n    t.string  \"body\",                           limit: 4000,                            null: false\n    t.string  \"type\"\n    t.integer \"comments_count\",                              precision: 38, default: 0\n    t.integer \"taggings_with_delete_all_count\",              precision: 38, default: 0\n    t.integer \"taggings_with_destroy_count\",                 precision: 38, default: 0\n    t.integer \"tags_count\",                                  precision: 38, default: 0\n    t.integer \"tags_with_destroy_count\",                     precision: 38, default: 0\n    t.integer \"tags_with_nullify_count\",                     precision: 38, default: 0\n  end\n\n  create_table \"price_estimates\", force: :cascade do |t|\n    t.string  \"estimate_of_type\"\n    t.integer \"estimate_of_id\",   precision: 38\n    t.integer \"price\",            precision: 38\n  end\n\n  create_table \"prisoners\", force: :cascade do |t|\n    t.integer \"ship_id\", precision: 38\n  end\n\n  add_index \"prisoners\", [\"ship_id\"], name: \"index_prisoners_on_ship_id\"\n\n  create_table \"product_types\", force: :cascade do |t|\n    t.string \"name\"\n  end\n\n  create_table \"products\", force: :cascade do |t|\n    t.integer \"collection_id\", precision: 38\n    t.integer \"type_id\",       precision: 38\n    t.string  \"name\"\n  end\n\n  add_index \"products\", [\"collection_id\"], name: \"i_products_collection_id\"\n  add_index \"products\", [\"type_id\"], name: \"index_products_on_type_id\"\n\n  create_table \"projects\", force: :cascade do |t|\n    t.string  \"name\"\n    t.string  \"type\"\n    t.integer \"firm_id\",   precision: 38\n    t.integer \"mentor_id\", precision: 38\n  end\n\n  create_table \"randomly_named_table1\", force: :cascade do |t|\n    t.string  \"some_attribute\"\n    t.integer \"another_attribute\", precision: 38\n  end\n\n  create_table \"randomly_named_table2\", force: :cascade do |t|\n    t.string  \"some_attribute\"\n    t.integer \"another_attribute\", precision: 38\n  end\n\n  create_table \"randomly_named_table3\", force: :cascade do |t|\n    t.string  \"some_attribute\"\n    t.integer \"another_attribute\", precision: 38\n  end\n\n  create_table \"ratings\", force: :cascade do |t|\n    t.integer \"comment_id\", precision: 38\n    t.integer \"value\",      precision: 38\n  end\n\n  create_table \"readers\", force: :cascade do |t|\n    t.integer \"post_id\",                 precision: 38,             null: false\n    t.integer \"person_id\",               precision: 38,             null: false\n    t.integer \"skimmer\",       limit: 1, precision: 1,  default: 0\n    t.integer \"first_post_id\",           precision: 38\n  end\n\n  create_table \"recipes\", force: :cascade do |t|\n    t.integer \"chef_id\",  precision: 38\n    t.integer \"hotel_id\", precision: 38\n  end\n\n  create_table \"records\", force: :cascade do |t|\n  end\n\n  create_table \"references\", force: :cascade do |t|\n    t.integer \"person_id\",              precision: 38\n    t.integer \"job_id\",                 precision: 38\n    t.integer \"favourite\",    limit: 1, precision: 1\n    t.integer \"lock_version\",           precision: 38, default: 0\n  end\n\n  create_table \"serialized_posts\", force: :cascade do |t|\n    t.integer \"author_id\", precision: 38\n    t.string  \"title\",                    null: false\n  end\n\n  create_table \"shape_expressions\", force: :cascade do |t|\n    t.string  \"paint_type\"\n    t.integer \"paint_id\",   precision: 38\n    t.string  \"shape_type\"\n    t.integer \"shape_id\",   precision: 38\n  end\n\n  create_table \"ship_parts\", force: :cascade do |t|\n    t.string   \"name\"\n    t.integer  \"ship_id\",    precision: 38\n    t.datetime \"updated_at\", precision: 6\n  end\n\n  create_table \"ships\", force: :cascade do |t|\n    t.string   \"name\"\n    t.integer  \"pirate_id\",             precision: 38\n    t.integer  \"developer_id\",          precision: 38\n    t.integer  \"update_only_pirate_id\", precision: 38\n    t.integer  \"treasures_count\",       precision: 38, default: 0\n    t.datetime \"created_at\",            precision: 6\n    t.datetime \"created_on\",            precision: 6\n    t.datetime \"updated_at\",            precision: 6\n    t.datetime \"updated_on\",            precision: 6\n  end\n\n  add_index \"ships\", [\"developer_id\"], name: \"index_ships_on_developer_id\"\n\n  create_table \"shop_accounts\", force: :cascade do |t|\n    t.integer \"customer_id\",         precision: 38\n    t.integer \"customer_carrier_id\", precision: 38\n  end\n\n  add_index \"shop_accounts\", [\"customer_carrier_id\"], name: \"i_sho_acc_cus_car_id\"\n  add_index \"shop_accounts\", [\"customer_id\"], name: \"i_shop_accounts_customer_id\"\n\n  create_table \"speedometers\", id: false, force: :cascade do |t|\n    t.string \"speedometer_id\"\n    t.string \"name\"\n    t.string \"dashboard_id\"\n  end\n\n  create_table \"sponsors\", force: :cascade do |t|\n    t.integer \"club_id\",          precision: 38\n    t.integer \"sponsorable_id\",   precision: 38\n    t.string  \"sponsorable_type\"\n  end\n\n  create_table \"squares\", force: :cascade do |t|\n  end\n\n  create_table \"string_key_objects\", id: false, force: :cascade do |t|\n    t.string  \"id\"\n    t.string  \"name\"\n    t.integer \"lock_version\", precision: 38, default: 0, null: false\n  end\n\n  create_table \"students\", force: :cascade do |t|\n    t.string  \"name\"\n    t.integer \"active\",     limit: 1, precision: 1\n    t.integer \"college_id\",           precision: 38\n  end\n\n  create_table \"subscribers\", id: false, force: :cascade do |t|\n    t.string  \"nick\",                                   null: false\n    t.string  \"name\"\n    t.integer \"books_count\", precision: 38, default: 0, null: false\n  end\n\n  add_index \"subscribers\", [\"nick\"], name: \"index_subscribers_on_nick\", unique: true\n\n  create_table \"subscriptions\", force: :cascade do |t|\n    t.string  \"subscriber_id\"\n    t.integer \"book_id\",       precision: 38\n  end\n\n  create_table \"taggings\", force: :cascade do |t|\n    t.integer \"tag_id\",        precision: 38\n    t.integer \"super_tag_id\",  precision: 38\n    t.string  \"taggable_type\"\n    t.integer \"taggable_id\",   precision: 38\n    t.string  \"comment\"\n  end\n\n  create_table \"tags\", force: :cascade do |t|\n    t.string  \"name\"\n    t.integer \"taggings_count\", precision: 38, default: 0\n  end\n\n  create_table \"tasks\", force: :cascade do |t|\n    t.datetime \"starting\", precision: 6\n    t.datetime \"ending\",   precision: 6\n  end\n\n  create_table \"test_oracle_defaults\", force: :cascade do |t|\n    t.string  \"test_char\",   limit: 1,                 default: \"X\",     null: false\n    t.string  \"test_string\", limit: 20,                default: \"hello\", null: false\n    t.integer \"test_int\",               precision: 38, default: 3,       null: false\n  end\n\n  create_table \"test_with_keyword_column_name\", force: :cascade do |t|\n    t.string \"desc\"\n  end\n\n  create_table \"topics\", force: :cascade do |t|\n    t.string   \"title\",                limit: 250\n    t.string   \"author_name\"\n    t.string   \"author_email_address\"\n    t.datetime \"written_on\",                        precision: 6\n    t.datetime \"bonus_time\",                        precision: 6\n    t.datetime \"last_read\"\n    t.string   \"content\",              limit: 4000\n    t.string   \"important\",            limit: 4000\n    t.integer  \"approved\",             limit: 1,    precision: 1,  default: 1\n    t.integer  \"replies_count\",                     precision: 38, default: 0\n    t.integer  \"unique_replies_count\",              precision: 38, default: 0\n    t.integer  \"parent_id\",                         precision: 38\n    t.string   \"parent_title\"\n    t.string   \"type\"\n    t.string   \"group\"\n    t.datetime \"created_at\",                        precision: 6\n    t.datetime \"updated_at\",                        precision: 6\n  end\n\n  create_table \"toys\", primary_key: \"toy_id\", force: :cascade do |t|\n    t.string   \"name\"\n    t.integer  \"pet_id\",     precision: 38\n    t.integer  \"integer\",    precision: 38\n    t.datetime \"created_at\", precision: 6,  null: false\n    t.datetime \"updated_at\", precision: 6,  null: false\n  end\n\n  create_table \"traffic_lights\", force: :cascade do |t|\n    t.string   \"location\"\n    t.string   \"state\"\n    t.text     \"long_state\",               null: false\n    t.datetime \"created_at\", precision: 6\n    t.datetime \"updated_at\", precision: 6\n  end\n\n  create_table \"treasures\", force: :cascade do |t|\n    t.string  \"name\"\n    t.string  \"type\"\n    t.integer \"looter_id\",   precision: 38\n    t.string  \"looter_type\"\n    t.integer \"ship_id\",     precision: 38\n  end\n\n  add_index \"treasures\", [\"ship_id\"], name: \"index_treasures_on_ship_id\"\n\n  create_table \"treaties\", id: false, force: :cascade do |t|\n    t.string \"treaty_id\"\n    t.string \"name\"\n  end\n\n  create_table \"trees\", force: :cascade do |t|\n    t.string   \"name\"\n    t.datetime \"updated_at\", precision: 6\n  end\n\n  create_table \"triangles\", force: :cascade do |t|\n  end\n\n  create_table \"tuning_pegs\", force: :cascade do |t|\n    t.integer \"guitar_id\", precision: 38\n    t.float   \"pitch\"\n  end\n\n  create_table \"tyres\", force: :cascade do |t|\n    t.integer \"car_id\", precision: 38\n  end\n\n  create_table \"users\", force: :cascade do |t|\n    t.string \"token\"\n    t.string \"auth_token\"\n  end\n\n  create_table \"variants\", force: :cascade do |t|\n    t.integer \"product_id\", precision: 38\n    t.string  \"name\"\n  end\n\n  add_index \"variants\", [\"product_id\"], name: \"index_variants_on_product_id\"\n\n  create_table \"vegetables\", force: :cascade do |t|\n    t.string  \"name\"\n    t.integer \"seller_id\",   precision: 38\n    t.string  \"custom_type\"\n  end\n\n  create_table \"vertices\", force: :cascade do |t|\n    t.string \"label\"\n  end\n\n  create_table \"warehouse-things\", force: :cascade do |t|\n    t.integer \"value\", precision: 38\n  end\n\n  create_table \"weirds\", force: :cascade do |t|\n    t.string \"a$b\"\n    t.string \"なまえ\"\n    t.string \"from\"\n  end\n\n  create_table \"wheels\", force: :cascade do |t|\n    t.string  \"wheelable_type\"\n    t.integer \"wheelable_id\",   precision: 38\n  end\n\n  add_index \"wheels\", [\"wheelable_type\", \"wheelable_id\"], name: \"i_whe_whe_typ_whe_id\"\n\n  create_table \"zines\", force: :cascade do |t|\n    t.string \"title\"\n  end\n\n  add_foreign_key \"authors\", \"author_addresses\"\n  add_foreign_key \"fk_test_has_fk\", \"fk_test_has_pk\", column: \"fk_id\", primary_key: \"pk_id\", name: \"fk_name\"\n  add_foreign_key \"lessons_students\", \"students\"\nend\n".


 22) Failure:
BasicsTest#test_create_after_initialize_with_array_param [/home/yahonda/git/rails/activerecord/test/cases/base_test.rb:316]:
Failed assertion, no message given.


 23) Failure:
BasicsTest#test_create_after_initialize_with_block [/home/yahonda/git/rails/activerecord/test/cases/base_test.rb:308]:
Expected: true
  Actual: 1


 24) Failure:
BasicsTest#test_create_after_initialize_without_block [/home/yahonda/git/rails/activerecord/test/cases/base_test.rb:302]:
Expected: true
  Actual: 1

 32) Failure:
TransactionTest#test_rolling_back_in_a_callback_rollbacks_before_save [/home/yahonda/git/rails/activerecord/test/cases/transactions_test.rb:160]:
Failed assertion, no message given.

 34) Failure:
CalculationsTest#test_distinct_is_honored_when_used_with_count_operation_after_group [/home/yahonda/git/rails/activerecord/test/cases/calculations_test.rb:563]:
Expected: nil
  Actual: 4

 36) Failure:
CalculationsTest#test_pluck_replaces_select_clause [/home/yahonda/git/rails/activerecord/test/cases/calculations_test.rb:687]:
--- expected
+++ actual
@@ -1 +1 @@
-[false, true, true, true, true]
+[0, 1, 1, 1, 1]

 47) Failure:
ActiveRecord::Migration::ColumnsTest#test_change_column [/home/yahonda/git/rails/activerecord/test/cases/migration/columns_test.rb:199]:
Failed assertion, no message given.

 62) Failure:
CoreTest#test_inspect_instance [/home/yahonda/git/rails/activerecord/test/cases/core_test.rb:20]:
--- expected
+++ actual
@@ -1 +1 @@
-"#<Topic id: 1, title: \"The First Topic\", author_name: \"David\", author_email_address: \"david@loudthinking.com\", written_on: \"2003-07-16 14:28:11\", bonus_time: \"2005-01-30 14:28:00\", last_read: \"2004-04-15 00:00:00\", content: \"Have a nice day\", important: nil, approved: false, replies_count: 1, unique_replies_count: 0, parent_id: nil, parent_title: nil, type: nil, group: nil, created_at: \"2016-05-24 17:34:38\", updated_at: \"2016-05-24 17:34:38\">"
+"#<Topic id: 1, title: \"The First Topic\", author_name: \"David\", author_email_address: \"david@loudthinking.com\", written_on: \"2003-07-16 14:28:11\", bonus_time: \"2005-01-30 14:28:00\", last_read: \"2004-04-15 00:00:00\", content: \"Have a nice day\", important: nil, approved: 0, replies_count: 1, unique_replies_count: 0, parent_id: nil, parent_title: nil, type: nil, group: nil, created_at: \"2016-05-24 17:34:38\", updated_at: \"2016-05-24 17:34:38\">"


 63) Failure:
CoreTest#test_pretty_print_new [/home/yahonda/git/rails/activerecord/test/cases/core_test.rb:62]:
Failed assertion, no message given.

 72) Failure:
AttributeMethodsTest#test_query_attribute_boolean [/home/yahonda/git/rails/activerecord/test/cases/attribute_methods_test.rb:413]:
Expected: true
  Actual: false


 73) Failure:
AttributeMethodsTest#test_read_attribute_when_true [/home/yahonda/git/rails/activerecord/test/cases/attribute_methods_test.rb:333]:
approved should be true


 74) Failure:
AttributeMethodsTest#test_read_write_boolean_attribute [/home/yahonda/git/rails/activerecord/test/cases/attribute_methods_test.rb:345]:
approved should be true
```

Also it addresses this failure in Oracle enhanced adapter unit test.
```ruby
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:318 # OracleEnhancedAdapter integer type detection based on column names / NUMBER values from ActiveRecord model should return Boolean value from NUMBER(1) column if emulate booleans is used
```

However, it also causes "regressions" for these 2 unit tests. Will address them later.
```
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:324 # OracleEnhancedAdapter integer type detection based on column names / NUMBER values from ActiveRecord model should return Fixnum value from NUMBER(1) column if emulate booleans is not used
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:330 # OracleEnhancedAdapter integer type detection based on column names / NUMBER values from ActiveRecord model should return Fixnum value from NUMBER(1) column if column specified in set_integer_columns
```
