### PR TITLE
Oracle TIMESTAMP sql type is associated with Rails `DateTime` type

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1166,7 +1166,6 @@ module ActiveRecord
       def initialize_type_map(m)
         super
         # oracle
-        register_class_with_limit m, %r(date)i,           Type::DateTime
         register_class_with_limit m, %r(raw)i,            ActiveRecord::OracleEnhanced::Type::Raw
 
 


### PR DESCRIPTION
to support fractional seconds and have better compatibility with Rails
by using Abstract Adapter implementations.

```
        register_class_with_precision m, %r(datetime)i,  Type::DateTime
        m.alias_type %r(timestamp)i, 'datetime'
```

Before this commit Oracle DATE sql type is associated with Rails DateTime
which does not supports fractional seconds.

* ActiveRecord unit test status:

* Fixed 3 failures

```
 22) Failure:
BasicsTest#test_preserving_date_objects [/home/yahonda/git/rails/activerecord/test/cases/base_test.rb:161]:
The last_read attribute should be of the Date class.
Expected 2004-04-15 00:00:00 UTC to be a kind of Date, not Time.


 25) Failure:
ActiveRecord::ConnectionAdapters::TypeLookupTest#test_date_types [/home/yahonda/git/rails/activerecord/test/cases/connection_adapters/type_lookup_test.rb:40]:
Expected: :date
  Actual: :datetime


 64) Failure:
AttributeMethodsTest#test_write_time_to_date_attributes [/home/yahonda/git/rails/activerecord/test/cases/attribute_methods_test.rb:561]:
--- expected
+++ actual
@@ -1 +1 @@
-Fri, 01 Jan 2010
+Fri, 01 Jan 2010 02:00:00 PST -08:00
```

* Caused one failure.

```ruby
 42) Failure:
ActiveRecord::Migration::ColumnAttributesTest#test_native_types [/home/yahonda/git/rails/activerecord/test/cases/migration/column_attributes_test.rb:163]:
Expected: Time
  Actual: Date
```

Actually this is because this commit addresses incompatibility with Rails. Will open a pull request to rails to remove OracleAdapter specific condition.

```
if current_adapter?(:OracleAdapter)
  # Oracle doesn't differentiate between date/time
  assert_equal Time, bob.favorite_day.class
else
  assert_equal Date, bob.favorite_day.class
end
```

* Oracle enhanced adapter unit test status:

Addressed 11 failures:

```ruby
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:44 # OracleEnhancedAdapter date type detection based on column names should set DATE column type as date if column name contains '_date_' and emulate_dates_by_column_name is true
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:120 # OracleEnhancedAdapter date type detection based on column names / DATE values from ActiveRecord model should return Date value from DATE column if column name contains 'date' and emulate_dates_by_column_name is true
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:126 # OracleEnhancedAdapter date type detection based on column names / DATE values from ActiveRecord model should return Date value from DATE column with old date value if column name contains 'date' and emulate_dates_by_column_name is true
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:138 # OracleEnhancedAdapter date type detection based on column names / DATE values from ActiveRecord model should return Date value from DATE column if emulate_dates_by_column_name is false but column is defined as date
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:147 # OracleEnhancedAdapter date type detection based on column names / DATE values from ActiveRecord model should return Date value from DATE column with old date value if emulate_dates_by_column_name is false but column is defined as date
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:713 # OracleEnhancedAdapter date and timestamp with different NLS date formats should return Date value from DATE column if column name contains 'date' and emulate_dates_by_column_name is true
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:795 # OracleEnhancedAdapter assign string to :date and :datetime columns should assign ISO string to date column
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:806 # OracleEnhancedAdapter assign string to :date and :datetime columns should assign NLS string to date column
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:818 # OracleEnhancedAdapter assign string to :date and :datetime columns should assign ISO time string to date column
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:829 # OracleEnhancedAdapter assign string to :date and :datetime columns should assign NLS time string to date column
rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:162 # OracleEnhancedAdapter custom methods for create, update and destroy should create record
```
14 regressions, need follow up.

```ruby
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:37 # OracleEnhancedAdapter date type detection based on column names should set DATE column type as datetime if emulate_dates_by_column_name is false
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:51 # OracleEnhancedAdapter date type detection based on column names should set DATE column type as datetime if column name does not contain '_date_' and emulate_dates_by_column_name is true
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:58 # OracleEnhancedAdapter date type detection based on column names should set DATE column type as datetime if column name contains 'date' as part of other word and emulate_dates_by_column_name is true
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:114 # OracleEnhancedAdapter date type detection based on column names / DATE values from ActiveRecord model should return Time value from DATE column if emulate_dates_by_column_name is false
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:132 # OracleEnhancedAdapter date type detection based on column names / DATE values from ActiveRecord model should return Time value from DATE column if column name does not contain 'date' and emulate_dates_by_column_name is true
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:166 # OracleEnhancedAdapter date type detection based on column names / DATE values from ActiveRecord model should return Time value from DATE column if emulate_dates_by_column_name is true but column is defined as datetime
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:181 # OracleEnhancedAdapter date type detection based on column names / DATE values from ActiveRecord model should guess Date or Time value if emulate_dates is true
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:706 # OracleEnhancedAdapter date and timestamp with different NLS date formats should return Time value from DATE column if emulate_dates_by_column_name is false
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:720 # OracleEnhancedAdapter date and timestamp with different NLS date formats should return Time value from DATE column if column name does not contain 'date' and emulate_dates_by_column_name is true
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:842 # OracleEnhancedAdapter assign string to :date and :datetime columns should assign ISO time string to datetime column
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:853 # OracleEnhancedAdapter assign string to :date and :datetime columns should assign NLS time string to datetime column
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:865 # OracleEnhancedAdapter assign string to :date and :datetime columns should assign NLS time string with time zone to datetime column
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:877 # OracleEnhancedAdapter assign string to :date and :datetime columns should assign ISO date string to datetime column
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:888 # OracleEnhancedAdapter assign string to :date and :datetime columns should assign NLS date string to datetime column
```




