### PR TITLE
No need to set @visitor instance variable here

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -405,9 +405,9 @@ module ActiveRecord
 
       def arel_visitor # :nodoc:
         if supports_fetch_first_n_rows_and_offset?
-          @visitor = Arel::Visitors::Oracle12.new(self)
+          Arel::Visitors::Oracle12.new(self)
         else
-          @visitor = Arel::Visitors::Oracle.new(self)
+          Arel::Visitors::Oracle.new(self)
         end
       end
 


### PR DESCRIPTION
Follow up for #853 since `visitor` instance variable is set at AbstractAdapter initialize method.