### PR TITLE
OracleEnhancedColumn.new needs sql_type_metadata including sql_type

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
@@ -251,7 +251,8 @@ describe "OracleEnhancedConnection" do
 
     it "should execute prepared statement with decimal bind parameter " do
       cursor = @conn.prepare("INSERT INTO test_employees VALUES(:1)")
-      column = ActiveRecord::ConnectionAdapters::OracleEnhancedColumn.new('age', nil, ActiveRecord::Type::Decimal.new, 'NUMBER(10,2)')
+      type_metadata = ActiveRecord::ConnectionAdapters::SqlTypeMetadata.new(sql_type: "NUMBER", type: :decimal, limit: 10, precision: nil, scale: 2)
+      column = ActiveRecord::ConnectionAdapters::OracleEnhancedColumn.new('age', nil, type_metadata, false, "test_employees", false, false, nil)
       expect(column.type).to eq(:decimal)
       cursor.bind_param(1, "1.5", column)
       cursor.exec


### PR DESCRIPTION
This pull request addresses the following failure.

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb:252
==> Loading config from ENV or use default
==> Running specs with MRI version 2.3.1
==> Effective ActiveRecord version 5.0.0.rc1
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb"=>[252]}}
F

Failures:

  1) OracleEnhancedConnection SQL with bind parameters when NLS_NUMERIC_CHARACTERS is set to ', ' should execute prepared statement with decimal bind parameter
     Failure/Error: @object_type = sql_type_metadata.sql_type.include? '.'

     NoMethodError:
       undefined method `sql_type' for #<ActiveModel::Type::Decimal:0x0056245d23d868>
     # ./lib/active_record/connection_adapters/oracle_enhanced/column.rb:22:in `initialize'
     # ./spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb:254:in `new'
     # ./spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb:254:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:236:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:236:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:478:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:435:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:478:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:616:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:478:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:435:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:478:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:233:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:581:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:577:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:577:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:543:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:544:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:544:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:544:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/configuration.rb:1680:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:118:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:117:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:93:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:78:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:23:in `load'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:23:in `<main>'

Finished in 0.0809 seconds (files took 0.92262 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb:252 # OracleEnhancedConnection SQL with bind parameters when NLS_NUMERIC_CHARACTERS is set to ', ' should execute prepared statement with decimal bind parameter

$
```
