### PR TITLE
Use `lookup_cast_type_from_column` to get the expected type

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -27,17 +27,11 @@ describe "OracleEnhancedAdapter date type detection based on column names" do
       CREATE SEQUENCE test_employees_seq  MINVALUE 1
         INCREMENT BY 1 START WITH 10040 CACHE 20 NOORDER NOCYCLE
     SQL
-    class ::TestEmployee < ActiveRecord::Base
-      self.primary_key = "employee_id"
-    end
   end
 
   after(:all) do
     @conn.execute "DROP TABLE test_employees"
     @conn.execute "DROP SEQUENCE test_employees_seq"
-    Object.send(:remove_const, "TestEmployee")
-    @conn.clear_types_for_columns
-    ActiveRecord::Base.clear_cache! if ActiveRecord::Base.respond_to?(:"clear_cache!")
   end
 
   it "should set DATE column type as datetime if emulate_dates_by_column_name is false" do
@@ -70,22 +64,23 @@ describe "OracleEnhancedAdapter date type detection based on column names" do
 
   it "should return Time value from DATE column if emulate_dates_by_column_name is false" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = false
-    column = TestEmployee.columns.detect{|c| c.name == "hire_date"}
-    expect(TestEmployee.type_for_attribute(column).cast(Time.now).class).to eq(Time)
+    columns = @conn.columns('test_employees')
+    column = columns.detect{|c| c.name == "hire_date"}
+    expect(column.type_cast_from_database(Time.now).class).to eq(Time)
   end
 
   it "should return Date value from DATE column if column name contains 'date' and emulate_dates_by_column_name is true" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = true
     columns = @conn.columns('test_employees')
-    column = TestEmployee.columns.detect{|c| c.name == "hire_date"}
-    expect(TestEmployee.type_for_attribute(column).cast(Time.now).class).to eq(Date)
+    column = columns.detect{|c| c.name == "hire_date"}
+    expect(column.type_cast_from_database(Time.now).class).to eq(Date)
   end
 
   it "should typecast DateTime value to Date value from DATE column if column name contains 'date' and emulate_dates_by_column_name is true" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = true
     columns = @conn.columns('test_employees')
-    column = TestEmployee.columns.detect{|c| c.name == "hire_date"}
-    expect(TestEmployee.type_for_attribute(column).cast(DateTime.new(1900,1,1)).class).to eq(Date)
+    column = columns.detect{|c| c.name == "hire_date"}
+    expect(column.type_cast_from_database(DateTime.new(1900,1,1)).class).to eq(Date)
   end
 
   describe "/ DATE values from ActiveRecord model" do
@@ -221,16 +216,11 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
       CREATE SEQUENCE test2_employees_seq  MINVALUE 1
         INCREMENT BY 1 START WITH 10040 CACHE 20 NOORDER NOCYCLE
     SQL
-    class ::Test2Employee < ActiveRecord::Base
-    end
   end
   
   after(:all) do
     @conn.execute "DROP TABLE test2_employees"
     @conn.execute "DROP SEQUENCE test2_employees_seq"
-    Object.send(:remove_const, "Test2Employee")
-    @conn.clear_types_for_columns
-    ActiveRecord::Base.clear_cache! if ActiveRecord::Base.respond_to?(:"clear_cache!")
   end
 
   it "should set NUMBER column type as decimal if emulate_integers_by_column_name is false" do
@@ -259,15 +249,15 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
   it "should return BigDecimal value from NUMBER column if emulate_integers_by_column_name is false" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = false
     columns = @conn.columns('test2_employees')
-    column = Test2Employee.columns.detect{|c| c.name == "job_id"}
-    expect(Test2Employee.type_for_attribute(column).cast(1.0).class).to eq(BigDecimal)
+    column = columns.detect{|c| c.name == "job_id"}
+    expect(column.type_cast_from_database(1.0).class).to eq(BigDecimal)
   end
 
   it "should return Fixnum value from NUMBER column if column name contains 'id' and emulate_integers_by_column_name is true" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = true
     columns = @conn.columns('test2_employees')
     column = columns.detect{|c| c.name == "job_id"}
-    expect(Test2Employee.type_for_attribute(column).cast(1.0).class).to eq(Fixnum)
+    expect(column.type_cast_from_database(1.0).class).to eq(Fixnum)
   end
 
   describe "/ NUMBER values from ActiveRecord model" do
@@ -453,8 +443,8 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = false
     columns = @conn.columns('test3_employees')
     %w(has_email has_phone active_flag manager_yn).each do |col|
-      column = Test3Employee.columns.detect{|c| c.name == col}
-      expect(Test3Employee.type_for_attribute(column).cast("Y").class).to eq(String)
+      column = columns.detect{|c| c.name == col}
+      expect(column.type_cast_from_database("Y").class).to eq(String)
     end
   end
 
@@ -462,9 +452,9 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = true
     columns = @conn.columns('test3_employees')
     %w(has_email has_phone active_flag manager_yn).each do |col|
-      column = Test3Employee.columns.detect{|c| c.name == col}
-      expect(Test3Employee.type_for_attribute(column).cast("Y").class).to eq(TrueClass)
-      expect(Test3Employee.type_for_attribute(column).cast("N").class).to eq(FalseClass)
+      column = columns.detect{|c| c.name == col}
+      expect(column.type_cast_from_database("Y").class).to eq(TrueClass)
+      expect(column.type_cast_from_database("N").class).to eq(FalseClass)
     end
   end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -66,21 +66,21 @@ describe "OracleEnhancedAdapter date type detection based on column names" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = false
     columns = @conn.columns('test_employees')
     column = columns.detect{|c| c.name == "hire_date"}
-    expect(column.type_cast_from_database(Time.now).class).to eq(Time)
+    expect(@conn.lookup_cast_type_from_column(column).cast(Time.now).class).to eq(Time)
   end
 
   it "should return Date value from DATE column if column name contains 'date' and emulate_dates_by_column_name is true" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = true
     columns = @conn.columns('test_employees')
     column = columns.detect{|c| c.name == "hire_date"}
-    expect(column.type_cast_from_database(Time.now).class).to eq(Date)
+    expect(@conn.lookup_cast_type_from_column(column).cast(Time.now).class).to eq(Date)
   end
 
   it "should typecast DateTime value to Date value from DATE column if column name contains 'date' and emulate_dates_by_column_name is true" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = true
     columns = @conn.columns('test_employees')
     column = columns.detect{|c| c.name == "hire_date"}
-    expect(column.type_cast_from_database(DateTime.new(1900,1,1)).class).to eq(Date)
+    expect(@conn.lookup_cast_type_from_column(column).cast(DateTime.new(1900,1,1)).class).to eq(Date)
   end
 
   describe "/ DATE values from ActiveRecord model" do
@@ -250,14 +250,14 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = false
     columns = @conn.columns('test2_employees')
     column = columns.detect{|c| c.name == "job_id"}
-    expect(column.type_cast_from_database(1.0).class).to eq(BigDecimal)
+    expect(@conn.lookup_cast_type_from_column(column).cast(1.0).class).to eq(BigDecimal)
   end
 
   it "should return Fixnum value from NUMBER column if column name contains 'id' and emulate_integers_by_column_name is true" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = true
     columns = @conn.columns('test2_employees')
     column = columns.detect{|c| c.name == "job_id"}
-    expect(column.type_cast_from_database(1.0).class).to eq(Fixnum)
+    expect(@conn.lookup_cast_type_from_column(column).cast(1.0).class).to eq(Fixnum)
   end
 
   describe "/ NUMBER values from ActiveRecord model" do
@@ -444,7 +444,7 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
     columns = @conn.columns('test3_employees')
     %w(has_email has_phone active_flag manager_yn).each do |col|
       column = columns.detect{|c| c.name == col}
-      expect(column.type_cast_from_database("Y").class).to eq(String)
+      expect(@conn.lookup_cast_type_from_column(column).cast("Y").class).to eq(String)
     end
   end
 
@@ -453,8 +453,8 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
     columns = @conn.columns('test3_employees')
     %w(has_email has_phone active_flag manager_yn).each do |col|
       column = columns.detect{|c| c.name == col}
-      expect(column.type_cast_from_database("Y").class).to eq(TrueClass)
-      expect(column.type_cast_from_database("N").class).to eq(FalseClass)
+      expect(@conn.lookup_cast_type_from_column(column).cast("Y").class).to eq(TrueClass)
+      expect(@conn.lookup_cast_type_from_column(column).cast("N").class).to eq(FalseClass)
     end
   end
 


### PR DESCRIPTION
This pull request reverts #850 and use `lookup_cast_type_from_column` to get the expected type.

* <Model>.type_for_attribute(column) is not the expected type, `ActiveModel::Type::Value`

```ruby
[82, 91] in /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
   82:     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = true
   83:     columns = @conn.columns('test_employees')
   84:     column = TestEmployee.columns.detect{|c| c.name == "hire_date"}
   85:     require 'byebug'
   86:     byebug
=> 87:     expect(TestEmployee.type_for_attribute(column).cast(Time.now).class).to eq(Date)
   88:   end
   89:
   90:   it "should typecast DateTime value to Date value from DATE column if column name contains 'date' and emulate_dates_by_column_name is true" do
   91:     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = true
(byebug) TestEmployee.type_for_attribute(column)
```

* Calling `lookup_cast_type_from_column` directly is doing wrong. Refer rails/rails@155b1b7 This spec touches some internal things, then in the long term this test needs rewrite.

This "fixes" these 3 specs and causes one regression. It may be due to incorrect spec change in #850. 

* Fixed 1 of 3

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:77
==> Loading config from ENV or use default
==> Running specs with MRI version 2.3.1
==> Effective ActiveRecord version 5.0.0.rc1
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[77]}}
F

Failures:

  1) OracleEnhancedAdapter date type detection based on column names should return Date value from DATE column if column name contains 'date' and emulate_dates_by_column_name is true
     Failure/Error: expect(TestEmployee.type_for_attribute(column).cast(Time.now).class).to eq(Date)

       expected: Date
            got: Time

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
       -Date
       +Time

     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-support-3.4.1/lib/rspec/support.rb:87:in `block in <module:Support>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-support-3.4.1/lib/rspec/support.rb:96:in `notify_failure'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.4.0/lib/rspec/expectations/fail_with.rb:27:in `fail_with'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.4.0/lib/rspec/expectations/handler.rb:38:in `handle_failure'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.4.0/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.4.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.4.0/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.4.0/lib/rspec/expectations/expectation_target.rb:54:in `to'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:81:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:236:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:236:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:478:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:435:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:478:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:616:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:478:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:435:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:478:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:233:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:581:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:577:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:577:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:543:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/configuration.rb:1680:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:118:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:117:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:93:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:78:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:23:in `load'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:23:in `<main>'

Finished in 0.20145 seconds (files took 1.04 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:77 # OracleEnhancedAdapter date type detection based on column names should return Date value from DATE column if column name contains 'date' and emulate_dates_by_column_name is true

$
```

* Fixed 2 of 3
```ruby
2.3.1 [ rails5 ~/git/oracle-enhanced]$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:84
==> Loading config from ENV or use default
==> Running specs with MRI version 2.3.1

==> Effective ActiveRecord version 5.0.0.rc1
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[84]}}
F

Failures:

  1) OracleEnhancedAdapter date type detection based on column names should typecast DateTime value to Date value from DATE column if column name contains 'date' and emulate_dates_by_column_name is true
     Failure/Error: expect(TestEmployee.type_for_attribute(column).cast(DateTime.new(1900,1,1)).class).to eq(Date)

       expected: Date
            got: DateTime

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
       -Date
       +DateTime

     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-support-3.4.1/lib/rspec/support.rb:87:in `block in <module:Support>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-support-3.4.1/lib/rspec/support.rb:96:in `notify_failure'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.4.0/lib/rspec/expectations/fail_with.rb:27:in `fail_with'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.4.0/lib/rspec/expectations/handler.rb:38:in `handle_failure'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.4.0/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.4.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.4.0/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.4.0/lib/rspec/expectations/expectation_target.rb:54:in `to'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:88:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:236:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:236:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:478:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:435:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:478:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:616:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:478:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:435:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:478:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:233:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:581:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:577:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:577:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:543:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/configuration.rb:1680:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:118:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:117:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:93:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:78:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:23:in `load'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:23:in `<main>'

Finished in 0.1554 seconds (files took 1.06 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:84 # OracleEnhancedAdapter date type detection based on column names should typecast DateTime value to Date value from DATE column if column name contains 'date' and emulate_dates_by_column_name is true

$
```

* Fixed 3 of 3
```ruby
2.3.1 [ rails5 ~/git/oracle-enhanced]$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:259
==> Loading config from ENV or use default
==> Running specs with MRI version 2.3.1
==> Effective ActiveRecord version 5.0.0.rc1
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[259]}}
F

Failures:

  1) OracleEnhancedAdapter integer type detection based on column names should return BigDecimal value from NUMBER column if emulate_integers_by_column_name is false
     Failure/Error: expect(Test2Employee.type_for_attribute(column).cast(1.0).class).to eq(BigDecimal)

       expected: BigDecimal
            got: Float

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
       -BigDecimal
       +Float

     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-support-3.4.1/lib/rspec/support.rb:87:in `block in <module:Support>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-support-3.4.1/lib/rspec/support.rb:96:in `notify_failure'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.4.0/lib/rspec/expectations/fail_with.rb:27:in `fail_with'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.4.0/lib/rspec/expectations/handler.rb:38:in `handle_failure'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.4.0/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.4.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.4.0/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.4.0/lib/rspec/expectations/expectation_target.rb:54:in `to'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:263:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:236:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:236:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:478:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:435:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:478:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:616:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:478:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:435:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:478:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:233:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:581:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:577:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:577:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:543:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/configuration.rb:1680:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:118:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:117:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:93:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:78:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:23:in `load'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:23:in `<main>'

Finished in 0.19153 seconds (files took 0.99054 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:259 # OracleEnhancedAdapter integer type detection based on column names should return BigDecimal value from NUMBER column if emulate_integers_by_column_name is false

$
```

* Regression

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:65
==> Loading config from ENV or use default
==> Running specs with MRI version 2.3.1
==> Effective ActiveRecord version 5.0.0.rc1
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[65]}}
F

Failures:

  1) OracleEnhancedAdapter date type detection based on column names should return Time value from DATE column if emulate_dates_by_column_name is false
     Failure/Error: expect(@conn.lookup_cast_type_from_column(column).cast(Time.now).class).to eq(Time)

       expected: Time
            got: Date

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
       -Time
       +Date

     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-support-3.4.1/lib/rspec/support.rb:87:in `block in <module:Support>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-support-3.4.1/lib/rspec/support.rb:96:in `notify_failure'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.4.0/lib/rspec/expectations/fail_with.rb:27:in `fail_with'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.4.0/lib/rspec/expectations/handler.rb:38:in `handle_failure'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.4.0/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.4.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.4.0/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.4.0/lib/rspec/expectations/expectation_target.rb:54:in `to'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:69:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:236:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:236:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:478:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:435:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:478:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:616:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:478:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:435:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:478:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:233:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:581:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:577:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:577:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:543:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/configuration.rb:1680:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:118:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:117:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:93:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:78:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:23:in `load'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:23:in `<main>'

Finished in 0.17009 seconds (files took 1.06 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:65 # OracleEnhancedAdapter date type detection based on column names should return Time value from DATE column if emulate_dates_by_column_name is false

$
```
