### PR TITLE
Support creating foreign keys in create table

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -22,6 +22,11 @@ module ActiveRecord
           create_sql = "CREATE#{' GLOBAL TEMPORARY' if o.temporary} TABLE #{quote_table_name(o.name)} "
           statements = o.columns.map { |c| accept c }
           statements << accept(o.primary_keys) if o.primary_keys
+
+          if supports_foreign_keys?
+            statements.concat(o.foreign_keys.map { |to_table, options| foreign_key_in_create(o.name, to_table, options) })
+          end
+
           create_sql << "(#{statements.join(', ')})" if statements.present?
 
           unless o.temporary

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -85,9 +85,6 @@ module ActiveRecord
           end
           td.indexes.each_pair { |c,o| add_index table_name, c, o }
 
-          td.foreign_keys.each do |other_table_name, foreign_key_options|
-            add_foreign_key(table_name, other_table_name, foreign_key_options)
-          end
         end
 
         def create_table_definition(*args)


### PR DESCRIPTION
This pull request support creating foreign keys in create table statement. Refer https://github.com/rails/rails/pull/20009

Due to Oracle implementation differences with other Rails bundled adapter supported databases, it needs separate 'create sequence' then this test still shows a failure but number of sql statement executed changed from 3 to 2.

* Without this commit. There is a separate "ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY" sql statement executed.
```ruby
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/migration/references_foreign_key_test.rb -n test_foreign_keys_can_be_created_in_one_query_when_index_is_not_added
... snip ...
# Running:

F

Finished in 0.103950s, 9.6200 runs/s, 9.6200 assertions/s.

  1) Failure:
ActiveRecord::Migration::ReferencesForeignKeyTest#test_foreign_keys_can_be_created_in_one_query_when_index_is_not_added [test/cases/migration/references_foreign_key_test.rb:37]:
3 instead of 1 queries were executed.
Queries:
CREATE TABLE "TESTINGS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY, "TESTING_PARENT_ID" NUMBER(38))
CREATE SEQUENCE "TESTINGS_SEQ" START WITH 10000
ALTER TABLE "TESTINGS" ADD CONSTRAINT "FK_RAILS_A196C353B2"
FOREIGN KEY ("TESTING_PARENT_ID")
  REFERENCES "TESTING_PARENTS" ("ID")
.
Expected: 1
  Actual: 3

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```

* With this commit. "CONSTRAINT ... FOREIGN KEY" clause included inside of the create table statement

```ruby
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/migration/references_foreign_key_test.rb -n test_foreign_keys_can_be_created_in_one_query_when_index_is_not_added
... snip ...

# Running:

F

Finished in 0.103088s, 9.7005 runs/s, 9.7005 assertions/s.

  1) Failure:
ActiveRecord::Migration::ReferencesForeignKeyTest#test_foreign_keys_can_be_created_in_one_query_when_index_is_not_added [test/cases/migration/references_foreign_key_test.rb:37]:
2 instead of 1 queries were executed.
Queries:
CREATE TABLE "TESTINGS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY, "TESTING_PARENT_ID" NUMBER(38), CONSTRAINT "FK_RAILS_A196C353B2"
FOREIGN KEY ("TESTING_PARENT_ID")
  REFERENCES "TESTING_PARENTS" ("ID")
)
CREATE SEQUENCE "TESTINGS_SEQ" START WITH 10000.
Expected: 1
  Actual: 2

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```