### PR TITLE
Rename `insert_sql` to `exec_insert`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -83,7 +83,7 @@ module ActiveRecord
         end
 
         # Executes an INSERT statement and returns the new record's ID
-        def insert_sql(sql, name = nil, pk = nil, id_value = nil, sequence_name = nil) #:nodoc:
+        def exec_insert(sql, name = nil, pk = nil, id_value = nil, sequence_name = nil) #:nodoc:
           # if primary key value is already prefetched from sequence
           # or if there is no primary key
           if id_value || pk.nil?
@@ -96,7 +96,6 @@ module ActiveRecord
             @connection.exec_with_returning(sql_with_returning)
           end
         end
-        protected :insert_sql
 
         # Will add RETURNING clause in case of trigger generated primary keys
         def sql_for_insert(sql, pk, id_value, sequence_name, binds)


### PR DESCRIPTION
Refer https://github.com/rails/rails/pull/23086

This pull request addresses some part of this error.

* Without this commit

```ruby
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/database_statements_test.rb -n test_insert_update_delete_sql_is_deprecated
... Snip ...
# Running:

E

Finished in 0.003506s, 285.2287 runs/s, 0.0000 assertions/s.

  1) Error:
DatabaseStatementsTest#test_insert_update_delete_sql_is_deprecated:
NoMethodError: protected method `insert_sql' called for #<ActiveRecord::ConnectionAdapters::OracleAdapter:0x00562ad52a5c00>
Did you mean?  insert
    test/cases/database_statements_test.rb:17:in `block in test_insert_update_delete_sql_is_deprecated'
    /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.0.rc2/lib/active_support/testing/deprecation.rb:29:in `collect_deprecations'
    /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.0.rc2/lib/active_support/testing/deprecation.rb:7:in `assert_deprecated'
    test/cases/database_statements_test.rb:17:in `test_insert_update_delete_sql_is_deprecated'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```

* With this commit

```ruby
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/database_statements_test.rb -n test_insert_update_delete_sql_is_deprecated
... snip ...
# Running:

E

Finished in 0.013030s, 76.7441 runs/s, 0.0000 assertions/s.

  1) Error:
DatabaseStatementsTest#test_insert_update_delete_sql_is_deprecated:
ActiveRecord::StatementInvalid: OCIError: ORA-01400: cannot insert NULL into ("ARUNIT"."ACCOUNTS"."ID"): INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)
    stmt.c:243:in oci8lib_230.so
    /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.2/lib/oci8/cursor.rb:129:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:168:in `exec_update'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:123:in `block in exec_insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:566:in `block in log'
    /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.0.rc2/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:560:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1260:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:109:in `exec_insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:124:in `insert'
    /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.0.rc2/lib/active_support/deprecation/method_wrappers.rb:61:in `block (3 levels) in deprecate_methods'
    test/cases/database_statements_test.rb:17:in `block in test_insert_update_delete_sql_is_deprecated'
    /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.0.rc2/lib/active_support/testing/deprecation.rb:29:in `collect_deprecations'
    /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.0.rc2/lib/active_support/testing/deprecation.rb:7:in `assert_deprecated'
    test/cases/database_statements_test.rb:17:in `test_insert_update_delete_sql_is_deprecated'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```

Because Oracle enhanced adapter needs to insert `id` column value explicitly, then changing ActiveRecord unit test like this will address this error:

```ruby
diff --git a/activerecord/test/cases/database_statements_test.rb b/activerecord/test/cases/database_statements_test.rb
index 3169408..edc079b 100644
--- a/activerecord/test/cases/database_statements_test.rb
+++ b/activerecord/test/cases/database_statements_test.rb
@@ -14,7 +14,7 @@ def test_create_should_return_the_inserted_id
   end
 
   def test_insert_update_delete_sql_is_deprecated
-    assert_deprecated { @connection.insert_sql("INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)") }
+    assert_deprecated { @connection.insert_sql("INSERT INTO accounts (id, firm_id,credit_limit) VALUES (10000,42,5000)") }
     assert_deprecated { @connection.update_sql("UPDATE accounts SET credit_limit = 6000 WHERE firm_id = 42") }
     assert_deprecated { @connection.delete_sql("DELETE FROM accounts WHERE firm_id = 42") }
   End
```$
