### PR TITLE
Deprecate `set_date_columns` and `set_datetime_columns`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -58,14 +58,20 @@ module ActiveRecord
     #
     #   set_date_columns :created_on, :updated_on
     def self.set_date_columns(*args)
-      connection.set_type_for_columns(table_name,:date,*args)
+      ActiveSupport::Deprecation.warn(<<-MSG.squish)
+        'set_date_columns` has been deprecated. Please use Rails attribute API.
+      MSG
+      # connection.set_type_for_columns(table_name,:date,*args)
     end
 
     # Specify which table columns should be typecasted to Time (or DateTime), e.g.:
     #
     #   set_datetime_columns :created_date, :updated_date
     def self.set_datetime_columns(*args)
-      connection.set_type_for_columns(table_name,:datetime,*args)
+      ActiveSupport::Deprecation.warn(<<-MSG.squish)
+        'set_datetime_columns` has been deprecated. Please use Rails attribute API.
+      MSG
+      # connection.set_type_for_columns(table_name,:datetime,*args)
     end
 
     # Specify which table columns should be typecasted to boolean values +true+ or +false+, e.g.:

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -162,7 +162,7 @@ describe "OracleEnhancedAdapter date type detection based on column names" do
       expect(@employee.hire_date.class).to eq(Date)
     end
 
-    it "should see set_date_columns values in different connection" do
+    xit "should see set_date_columns values in different connection" do
       class ::TestEmployee < ActiveRecord::Base
         set_date_columns :hire_date
       end


### PR DESCRIPTION
Follow up for #868 which has removed `set_date_columns and `set_datetime_columns` from specs