### PR TITLE
Support RAW sql data type in Rails 5

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -115,18 +115,6 @@ module ActiveRecord
           "TO_DATE('#{value}','YYYY-MM-DD HH24:MI:SS')"
         end
 
-        # Encode a string or byte array as string of hex codes
-        def self.encode_raw(value)
-          # When given a string, convert to a byte array.
-          value = value.unpack('C*') if value.is_a?(String)
-          value.map { |x| "%02X" % x }.join
-        end
-
-        # quote encoded raw value
-        def quote_raw(value) #:nodoc:
-          "'#{self.class.encode_raw(value)}'"
-        end
-
         def quote_timestamp_with_to_timestamp(value) #:nodoc:
           # add up to 9 digits of fractional seconds to inserted time
           value = "#{quoted_date(value)}" if value.acts_like?(:time)

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -48,10 +48,6 @@ module ActiveRecord
           super(name, temporary, options, as, comment: comment)
         end
 
-        def raw(name, options={})
-          column(name, :raw, options)
-        end
-
         def virtual(* args)
           options = args.extract_options!
           column_names = args

--- a/lib/active_record/oracle_enhanced/type/raw.rb
+++ b/lib/active_record/oracle_enhanced/type/raw.rb
@@ -8,6 +8,17 @@ module ActiveRecord
         def type
           :raw
         end
+
+        def serialize(value)
+          # Encode a string or byte array as string of hex codes
+          if value.nil?
+            super
+          else
+            value = value.unpack('C*')
+            value.map { |x| "%02X" % x }.join
+          end
+        end
+
       end
     end
   end


### PR DESCRIPTION
This pull request addresses these failures.

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1327
==> Loading config from ENV or use default
==> Running specs with MRI version 2.3.1
==> Effective ActiveRecord version 5.0.0.rc2
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[1327]}}
FF.FFFF

Failures:

  1) OracleEnhancedAdapter handling of RAW columns should create record with RAW data
     Failure/Error: @raw_cursor.exec

     ActiveRecord::StatementInvalid:
       OCIError: ORA-01465: invalid hex number: INSERT INTO "TEST_EMPLOYEES" ("FIRST_NAME", "LAST_NAME", "BINARY_DATA", "EMPLOYEE_ID") VALUES (:a1, :a2, :a3, :a4)
     # stmt.c:243:in oci8lib_230.so
     # /home/yahonda/git/ruby-oci8/lib/oci8/cursor.rb:129:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:168:in `exec_update'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:123:in `block in exec_insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:566:in `block in log'
     # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:560:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1239:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:109:in `exec_insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:124:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:65:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:554:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:128:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:75:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:123:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `block in _create_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_create_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:68:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:534:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:152:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:50:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:30:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `block in save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:45:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:51:in `create!'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1364:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:236:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:236:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:478:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:435:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:478:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:616:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:478:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:435:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:478:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:233:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:581:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:577:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:577:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:543:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/configuration.rb:1680:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:118:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:117:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:93:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:78:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:23:in `load'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:23:in `<main>'
     # ------------------
     # --- Caused by: ---
     # OCIError:
     #   ORA-01465: invalid hex number
     #   stmt.c:243:in oci8lib_230.so

  2) OracleEnhancedAdapter handling of RAW columns should update record with RAW data
     Failure/Error: @raw_cursor.exec

     ActiveRecord::StatementInvalid:
       OCIError: ORA-01465: invalid hex number: UPDATE "TEST_EMPLOYEES" SET "BINARY_DATA" = :a1 WHERE "TEST_EMPLOYEES"."EMPLOYEE_ID" = :a2
     # stmt.c:243:in oci8lib_230.so
     # /home/yahonda/git/ruby-oci8/lib/oci8/cursor.rb:129:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:168:in `exec_update'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:154:in `block in exec_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:566:in `block in log'
     # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:560:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1239:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:138:in `exec_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:133:in `update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:89:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:545:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:79:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:119:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:306:in `block in _update_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:126:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:506:in `block (2 levels) in compile'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:455:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_update_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:306:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:81:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:534:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:152:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:50:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:30:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `block in save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:45:in `save!'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1381:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:236:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:236:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:478:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:435:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:478:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:616:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:478:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:435:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:478:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:233:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:581:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:577:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:577:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:543:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/configuration.rb:1680:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:118:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:117:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:93:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:78:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:23:in `load'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:23:in `<main>'
     # ------------------
     # --- Caused by: ---
     # OCIError:
     #   ORA-01465: invalid hex number
     #   stmt.c:243:in oci8lib_230.so

  3) OracleEnhancedAdapter handling of RAW columns should update record that has existing RAW data with different RAW data
     Failure/Error: @raw_cursor.exec

     ActiveRecord::StatementInvalid:
       OCIError: ORA-01465: invalid hex number: INSERT INTO "TEST_EMPLOYEES" ("FIRST_NAME", "LAST_NAME", "BINARY_DATA", "EMPLOYEE_ID") VALUES (:a1, :a2, :a3, :a4)
     # stmt.c:243:in oci8lib_230.so
     # /home/yahonda/git/ruby-oci8/lib/oci8/cursor.rb:129:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:168:in `exec_update'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:123:in `block in exec_insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:566:in `block in log'
     # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:560:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1239:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:109:in `exec_insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:124:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:65:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:554:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:128:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:75:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:123:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `block in _create_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_create_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:68:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:534:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:152:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:50:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:30:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `block in save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:45:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:51:in `create!'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1400:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:236:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:236:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:478:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:435:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:478:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:616:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:478:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:435:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:478:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:233:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:581:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:577:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:577:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:543:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/configuration.rb:1680:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:118:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:117:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:93:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:78:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:23:in `load'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:23:in `<main>'
     # ------------------
     # --- Caused by: ---
     # OCIError:
     #   ORA-01465: invalid hex number
     #   stmt.c:243:in oci8lib_230.so

  4) OracleEnhancedAdapter handling of RAW columns should update record that has existing RAW data with nil
     Failure/Error: @raw_cursor.exec

     ActiveRecord::StatementInvalid:
       OCIError: ORA-01465: invalid hex number: INSERT INTO "TEST_EMPLOYEES" ("FIRST_NAME", "LAST_NAME", "BINARY_DATA", "EMPLOYEE_ID") VALUES (:a1, :a2, :a3, :a4)
     # stmt.c:243:in oci8lib_230.so
     # /home/yahonda/git/ruby-oci8/lib/oci8/cursor.rb:129:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:168:in `exec_update'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:123:in `block in exec_insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:566:in `block in log'
     # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:560:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1239:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:109:in `exec_insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:124:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:65:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:554:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:128:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:75:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:123:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `block in _create_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_create_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:68:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:534:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:152:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:50:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:30:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `block in save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:45:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:51:in `create!'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1413:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:236:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:236:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:478:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:435:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:478:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:616:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:478:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:435:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:478:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:233:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:581:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:577:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:577:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:543:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/configuration.rb:1680:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:118:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:117:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:93:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:78:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:23:in `load'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:23:in `<main>'
     # ------------------
     # --- Caused by: ---
     # OCIError:
     #   ORA-01465: invalid hex number
     #   stmt.c:243:in oci8lib_230.so

  5) OracleEnhancedAdapter handling of RAW columns should update record that has existing RAW data with zero-length RAW data
     Failure/Error: @raw_cursor.exec

     ActiveRecord::StatementInvalid:
       OCIError: ORA-01465: invalid hex number: INSERT INTO "TEST_EMPLOYEES" ("FIRST_NAME", "LAST_NAME", "BINARY_DATA", "EMPLOYEE_ID") VALUES (:a1, :a2, :a3, :a4)
     # stmt.c:243:in oci8lib_230.so
     # /home/yahonda/git/ruby-oci8/lib/oci8/cursor.rb:129:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:168:in `exec_update'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:123:in `block in exec_insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:566:in `block in log'
     # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:560:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1239:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:109:in `exec_insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:124:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:65:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:554:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:128:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:75:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:123:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `block in _create_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_create_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:68:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:534:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:152:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:50:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:30:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `block in save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:45:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:51:in `create!'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1426:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:236:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:236:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:478:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:435:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:478:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:616:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:478:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:435:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:478:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:233:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:581:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:577:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:577:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:543:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/configuration.rb:1680:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:118:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:117:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:93:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:78:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:23:in `load'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:23:in `<main>'
     # ------------------
     # --- Caused by: ---
     # OCIError:
     #   ORA-01465: invalid hex number
     #   stmt.c:243:in oci8lib_230.so

  6) OracleEnhancedAdapter handling of RAW columns should update record that has zero-length BLOB data with non-empty RAW data
     Failure/Error: @raw_cursor.exec

     ActiveRecord::StatementInvalid:
       OCIError: ORA-01465: invalid hex number: UPDATE "TEST_EMPLOYEES" SET "BINARY_DATA" = :a1 WHERE "TEST_EMPLOYEES"."EMPLOYEE_ID" = :a2
     # stmt.c:243:in oci8lib_230.so
     # /home/yahonda/git/ruby-oci8/lib/oci8/cursor.rb:129:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:168:in `exec_update'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:154:in `block in exec_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:566:in `block in log'
     # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:560:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1239:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:138:in `exec_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:133:in `update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:89:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:545:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:79:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:119:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:306:in `block in _update_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:126:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:506:in `block (2 levels) in compile'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:455:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_update_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:306:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:81:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:534:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:152:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:50:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:30:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `block in save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:45:in `save!'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1446:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:236:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:236:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:478:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:435:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:478:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:616:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/hooks.rb:478:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:435:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:478:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example.rb:233:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:581:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:577:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:577:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:543:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:119:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/configuration.rb:1680:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:118:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:117:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:93:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:78:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:23:in `load'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:23:in `<main>'
     # ------------------
     # --- Caused by: ---
     # OCIError:
     #   ORA-01465: invalid hex number
     #   stmt.c:243:in oci8lib_230.so

Finished in 0.69742 seconds (files took 1.29 seconds to load)
7 examples, 6 failures

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1363 # OracleEnhancedAdapter handling of RAW columns should create record with RAW data
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1373 # OracleEnhancedAdapter handling of RAW columns should update record with RAW data
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1399 # OracleEnhancedAdapter handling of RAW columns should update record that has existing RAW data with different RAW data
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1412 # OracleEnhancedAdapter handling of RAW columns should update record that has existing RAW data with nil
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1425 # OracleEnhancedAdapter handling of RAW columns should update record that has existing RAW data with zero-length RAW data
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1438 # OracleEnhancedAdapter handling of RAW columns should update record that has zero-length BLOB data with non-empty RAW data

$
```
