### PR TITLE
deprecate `quote_date_with_to_date` and `quote_timestamp_with_to_timestamp`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -117,8 +117,8 @@ module ActiveRecord
 
         def quote_timestamp_with_to_timestamp(value) #:nodoc:
           # add up to 9 digits of fractional seconds to inserted time
-          value = "#{quoted_date(value)}" if value.acts_like?(:time)
-          "TO_TIMESTAMP('#{value}','YYYY-MM-DD HH24:MI:SS.FF6')"
+          value = "#{quoted_date(value)}:#{("%.6f"%value.to_f).split('.')[1]}" if value.acts_like?(:time)
+          "TO_TIMESTAMP('#{value}','YYYY-MM-DD HH24:MI:SS:FF6')"
         end
 
         # Cast a +value+ to a type that the database understands.

--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -89,11 +89,8 @@ module ActiveRecord
         end
 
         def _quote(value) #:nodoc:
-          case value
-          when ActiveModel::Type::Binary::Data then
+          if value.is_a? ActiveModel::Type::Binary::Data
             %Q{empty_#{ type_to_sql(column.type.to_sym).downcase rescue 'blob' }()}
-          when Date then
-            quote_date_with_to_date(value)
           else
             super
           end

--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -107,12 +107,20 @@ module ActiveRecord
         end
 
         def quote_date_with_to_date(value) #:nodoc:
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            `quote_date_with_to_date` will be deprecated in future version of Oracle enhanced adapter.
+            Also this method should not be called directly. Let Abstract adapter `_quote` method handle it.
+          MSG
           # should support that composite_primary_keys gem will pass date as string
           value = quoted_date(value) if value.acts_like?(:date) || value.acts_like?(:time)
           "TO_DATE('#{value}','YYYY-MM-DD HH24:MI:SS')"
         end
 
         def quote_timestamp_with_to_timestamp(value) #:nodoc:
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            `quote_timestamp_with_to_timestamp` will be deprecated in future version of Oracle enhanced adapter.
+            Also this method should not be called directly. Let Abstract adapter `_quote` method handle it.
+          MSG
           # add up to 9 digits of fractional seconds to inserted time
           value = "#{quoted_date(value)}:#{("%.6f"%value.to_f).split('.')[1]}" if value.acts_like?(:time)
           "TO_TIMESTAMP('#{value}','YYYY-MM-DD HH24:MI:SS:FF6')"

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -778,16 +778,16 @@ describe "OracleEnhancedAdapter date and timestamp with different NLS date forma
     expect(@employee.created_at_ts).to eq(@now)
   end
 
-  it "should quote Date values with TO_DATE" do
+  xit "should quote Date values with TO_DATE" do
     expect(@conn.quote(@today)).to eq("TO_DATE('#{@today.year}-#{"%02d" % @today.month}-#{"%02d" % @today.day}','YYYY-MM-DD HH24:MI:SS')")
   end
 
-  it "should quote Time values with TO_DATE" do
+  xit "should quote Time values with TO_DATE" do
     expect(@conn.quote(@now)).to eq("TO_DATE('#{@now.year}-#{"%02d" % @now.month}-#{"%02d" % @now.day} "+
                                 "#{"%02d" % @now.hour}:#{"%02d" % @now.min}:#{"%02d" % @now.sec}','YYYY-MM-DD HH24:MI:SS')")
   end
 
-  it "should quote Time values with TO_TIMESTAMP" do
+  xit "should quote Time values with TO_TIMESTAMP" do
     @ts = @now + 0.1
     expect(@conn.quote(@ts)).to eq("TO_TIMESTAMP('#{@ts.year}-#{"%02d" % @ts.month}-#{"%02d" % @ts.day} "+
                                 "#{"%02d" % @ts.hour}:#{"%02d" % @ts.min}:#{"%02d" % @ts.sec}:100000','YYYY-MM-DD HH24:MI:SS:FF6')")


### PR DESCRIPTION
This pull request reverts #799 and #808. 

Also deprecate `quote_date_with_to_date` and `quote_timestamp_with_to_timestamp` methods. Since these two methods are not called from [`_quote`](https://github.com/rails/rails/blob/5-0-stable/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb#L163-L179)

