### PR TITLE
Address ArgumentError: wrong number of arguments (given 1, expected 2)

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -51,13 +51,8 @@ module ActiveRecord
         def add_column_options!(sql, options)
           type = options[:type] || ((column = options[:column]) && column.type)
           type = type && type.to_sym
-          # handle case of defaults for CLOB columns, which would otherwise get "quoted" incorrectly
           if options_include_default?(options)
-            if type == :text
-              sql << " DEFAULT #{quote_default_expression(options[:default])}"
-            else
-              sql << " DEFAULT #{quote_default_expression(options[:default], options[:column])}"
-            end
+            sql << " DEFAULT #{quote_default_expression(options[:default], options[:column])}"
           end
           # must explicitly add NULL or NOT NULL to allow change_column to work on migrations
           if options[:null] == false


### PR DESCRIPTION
for `quote_default_expression`
No need to separate for :text which is mapped for CLOB sql data type.

This pull request addresses this error:

```ruby
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/migration/change_schema_test.rb -n test_create_table_with_defaults

... snip ...
# Running:

E

Finished in 0.101438s, 9.8582 runs/s, 0.0000 assertions/s.

  1) Error:
ActiveRecord::Migration::ChangeSchemaTest#test_create_table_with_defaults:
ArgumentError: wrong number of arguments (given 1, expected 2)
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:105:in `quote_default_expression'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:17:in `quote_default_expression'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb:57:in `add_column_options!'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:34:in `visit_ColumnDefinition'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb:18:in `visit_ColumnDefinition'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:14:in `accept'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb:23:in `block in visit_TableDefinition'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb:23:in `map'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb:23:in `visit_TableDefinition'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:14:in `accept'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:76:in `create_table'
    test/cases/migration/change_schema_test.rb:56:in `test_create_table_with_defaults'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```