### PR TITLE
Support Oracle national character set NCHAR, NVARCHAR2

### DIFF
--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -44,6 +44,7 @@ This adapter is superset of original ActiveRecord Oracle adapter.
     "lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb",
     "lib/active_record/connection_adapters/oracle_enhanced/version.rb",
     "lib/active_record/oracle_enhanced/type/integer.rb",
+    "lib/active_record/oracle_enhanced/type/national_character_string.rb",
     "lib/active_record/oracle_enhanced/type/raw.rb",
     "lib/active_record/oracle_enhanced/type/string.rb",
     "lib/activerecord-oracle_enhanced-adapter.rb",

--- a/lib/active_record/connection_adapters/oracle_enhanced/column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column.rb
@@ -18,7 +18,6 @@ module ActiveRecord
         # Is column NCHAR or NVARCHAR2 (will need to use N'...' value quoting for these data types)?
         # Define only when needed as adapter "quote" method will check at first if instance variable is defined.
         if sql_type_metadata
-          @nchar = true if sql_type_metadata.type == :string && sql_type_metadata.sql_type[0,1] == 'N'
           @object_type = sql_type_metadata.sql_type.include? '.'
         end
         # TODO: Need to investigate when `sql_type` becomes nil

--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -89,7 +89,10 @@ module ActiveRecord
         end
 
         def _quote(value) #:nodoc:
-          if value.is_a? ActiveModel::Type::Binary::Data
+          case value
+          when ActiveRecord::OracleEnhanced::Type::NationalCharacterString::Data then
+             "N" << "'#{quote_string(value.to_s)}'"
+          when ActiveModel::Type::Binary::Data then
             %Q{empty_#{ type_to_sql(column.type.to_sym).downcase rescue 'blob' }()}
           else
             super
@@ -154,6 +157,8 @@ module ActiveRecord
             ora_value = bind_type.new(@connection.raw_oci_connection, lob_value)
             ora_value.size = 0 if value == ''
 						ora_value
+          when ActiveRecord::OracleEnhanced::Type::NationalCharacterString::Data
+            value.to_s
           else
             super
           end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1164,6 +1164,8 @@ module ActiveRecord
         register_class_with_limit m, %r(raw)i,            ActiveRecord::OracleEnhanced::Type::Raw
         register_class_with_limit m, %r(char)i,           ActiveRecord::OracleEnhanced::Type::String
 
+        m.register_type  'NCHAR', ActiveRecord::OracleEnhanced::Type::NationalCharacterString.new
+        m.alias_type %r(NVARCHAR2)i,    'NCHAR'
 
         m.register_type(%r(NUMBER)i) do |sql_type|
           scale = extract_scale(sql_type)
@@ -1309,3 +1311,6 @@ require 'active_record/oracle_enhanced/type/integer'
 
 # Add OracleEnhanced::Type::String
 require 'active_record/oracle_enhanced/type/string'
+
+# Add OracleEnhanced::Type::NationalCharacterString
+require 'active_record/oracle_enhanced/type/national_character_string'

--- a/lib/active_record/oracle_enhanced/type/national_character_string.rb
+++ b/lib/active_record/oracle_enhanced/type/national_character_string.rb
@@ -1,0 +1,25 @@
+require 'active_model/type/string'
+
+module ActiveRecord
+  module OracleEnhanced
+    module Type
+      class NationalCharacterString < ActiveRecord::OracleEnhanced::Type::String # :nodoc:
+
+        def serialize(value)
+          return unless value
+          Data.new(super)
+        end
+
+        class Data # :nodoc:
+          def initialize(value)
+            @value = value
+          end
+
+          def to_s
+            @value
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -1481,7 +1481,7 @@ describe "OracleEnhancedAdapter quoting of NCHAR and NVARCHAR2 columns" do
     ActiveRecord::Base.clear_cache! if ActiveRecord::Base.respond_to?(:"clear_cache!")
   end
 
-  it "should set nchar instance variable" do
+  xit "should set nchar instance variable" do
     columns = @conn.columns('test_items')
     %w(nchar_column nvarchar2_column char_column varchar2_column).each do |col|
       column = columns.detect{|c| c.name == col}
@@ -1494,7 +1494,7 @@ describe "OracleEnhancedAdapter quoting of NCHAR and NVARCHAR2 columns" do
     columns = @conn.columns('test_items')
     %w(nchar_column nvarchar2_column char_column varchar2_column).each do |col|
       column = columns.detect{|c| c.name == col}
-      expect(@conn.quote('abc', column)).to eq(column.nchar ? "N'abc'" : "'abc'")
+      expect(@conn.quote('abc', column)).to eq(column.sql_type[0,1] == 'N' ? "N'abc'" : "'abc'")
       expect(@conn.quote(nil, column)).to eq('NULL')
     end
   end


### PR DESCRIPTION
This pull request addresses this failure:

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1493
==> Loading config from ENV or use default
==> Running specs with MRI version 2.3.1
==> Effective ActiveRecord version 5.0.0
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[1493]}}
DEPRECATION WARNING: Passing a column to `quote` has been deprecated. It is only used for type casting, which should be handled elsewhere. See https://github.com/rails/arel/commit/6160bfbda1d1781c3b08a33ec4955f170e95be11 for more information. (called from quote at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:88)
F

Failures:

  1) OracleEnhancedAdapter quoting of NCHAR and NVARCHAR2 columns should quote with N prefix
     Failure/Error: expect(@conn.quote('abc', column)).to eq(column.nchar ? "N'abc'" : "'abc'")
     
       expected: "N'abc'"
            got: "'abc'"
     
       (compared using ==)
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-support-3.5.0/lib/rspec/support.rb:87:in `block in <module:Support>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-support-3.5.0/lib/rspec/support.rb:96:in `notify_failure'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/fail_with.rb:27:in `fail_with'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:38:in `handle_failure'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/expectation_target.rb:65:in `to'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1497:in `block (3 levels) in <top (required)>'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1495:in `each'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1495:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.0/lib/rspec/core/example.rb:252:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.0/lib/rspec/core/example.rb:252:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.0/lib/rspec/core/example.rb:494:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.0/lib/rspec/core/example.rb:451:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.0/lib/rspec/core/hooks.rb:471:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.0/lib/rspec/core/hooks.rb:609:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.0/lib/rspec/core/hooks.rb:471:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.0/lib/rspec/core/example.rb:451:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.0/lib/rspec/core/example.rb:494:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.0/lib/rspec/core/example.rb:249:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.0/lib/rspec/core/example_group.rb:613:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.0/lib/rspec/core/example_group.rb:609:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.0/lib/rspec/core/example_group.rb:609:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.0/lib/rspec/core/example_group.rb:575:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.0/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.0/lib/rspec/core/runner.rb:113:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.0/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.0/lib/rspec/core/configuration.rb:1837:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.0/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.0/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.0/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.0/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.0/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.0/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.0/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:22:in `load'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:22:in `<main>'

Finished in 0.32473 seconds (files took 2.61 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1493 # OracleEnhancedAdapter quoting of NCHAR and NVARCHAR2 columns should quote with N prefix

$
```

Also skipped a spec to test @nchar instance variable which is not necessary anymore since sql_type_metadata recognizes national character set without it.