### PR TITLE
Remove insert_sql method

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -82,22 +82,6 @@ module ActiveRecord
           exec_query(sql, name, binds).rows
         end
 
-        # Executes an INSERT statement and returns the new record's ID
-        def insert_sql(sql, name = nil, pk = nil, id_value = nil, sequence_name = nil) #:nodoc:
-          # if primary key value is already prefetched from sequence
-          # or if there is no primary key
-          if id_value || pk.nil?
-            execute(sql, name)
-            return id_value
-          end
-
-          sql_with_returning = sql + @connection.returning_clause(quote_column_name(pk))
-          log(sql, name) do
-            @connection.exec_with_returning(sql_with_returning)
-          end
-        end
-        protected :insert_sql
-
         # Will add RETURNING clause in case of trigger generated primary keys
         def sql_for_insert(sql, pk, id_value, sequence_name, binds)
           super

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -83,7 +83,7 @@ module ActiveRecord
         end
 
         # Executes an INSERT statement and returns the new record's ID
-        def exec_insert(sql, name = nil, pk = nil, id_value = nil, sequence_name = nil) #:nodoc:
+        def insert_sql(sql, name = nil, pk = nil, id_value = nil, sequence_name = nil) #:nodoc:
           # if primary key value is already prefetched from sequence
           # or if there is no primary key
           if id_value || pk.nil?
@@ -96,6 +96,7 @@ module ActiveRecord
             @connection.exec_with_returning(sql_with_returning)
           end
         end
+        protected :insert_sql
 
         # Will add RETURNING clause in case of trigger generated primary keys
         def sql_for_insert(sql, pk, id_value, sequence_name, binds)


### PR DESCRIPTION
This pull request reverts #866 and remove `exec_insert` method, which is not used (at least) Rails 4.2.