### PR TITLE
perserve time zone of records on database

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -273,7 +273,11 @@ module ActiveRecord
           if OracleEnhancedAdapter.emulate_dates && date_without_time?(value)
             value.to_date
           else
-            create_time_with_default_timezone(value)
+            if Rails.configuration.respond_to?(:oracle_enhanced_preserve_time_zone) && Rails.configuration.oracle_enhanced_preserve_time_zone
+              value
+            else
+              create_time_with_default_timezone(value)
+            end
           end
         else
           value


### PR DESCRIPTION
I need save and get many time zones of my records in my database, but by default I must be a choice between timezone local or utc, with this simple modification I can work with each time zone recovered of database
to use, just put in application.rb
````ruby
    config.oracle_enhanced_preserve_time_zone = false
````