### PR TITLE
preserve the timezone of records on database

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -261,6 +261,8 @@ module ActiveRecord
         when Time, DateTime
           if OracleEnhancedAdapter.emulate_dates && date_without_time?(value)
             value.to_date
+          elsif OracleEnhancedAdapter.preserve_time_zone
+            value
           else
             create_time_with_default_timezone(value)
           end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -231,6 +231,16 @@ module ActiveRecord
       def schema_creation
         OracleEnhanced::SchemaCreation.new self
       end
+      
+      # :singleton-method:
+      # Perserve time zone of records on database
+      # By default, the OracleEnhancedAdapter will convert the timezone of records to UTC or to yours local timezone.       
+      # If you wish to preserver timezone of records on database you can add the following line to your initializer file:
+      #
+      #   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.preserve_time_zone = true
+      #
+      cattr_accessor :preserve_time_zone
+      self.preserve_time_zone = false
 
       ##
       # :singleton-method:


### PR DESCRIPTION
I need save and get many time zones of my records in my database, but by default I must be a choice between timezone local or utc, with this simple modification I can work with each time zone recovered of database
to use, just run this

````ruby
ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.preserve_time_zone = true
````