### PR TITLE
Support explain for jruby

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -68,11 +68,7 @@ module ActiveRecord
         def explain(arel, binds = [])
           sql = "EXPLAIN PLAN FOR #{to_sql(arel, binds)}"
           return if sql =~ /FROM all_/
-          if ORACLE_ENHANCED_CONNECTION == :jdbc
-            exec_query(sql, 'EXPLAIN', binds)
-          else
-            exec_query(sql, 'EXPLAIN')
-          end
+          exec_query(sql, 'EXPLAIN')
           select_values("SELECT * FROM TABLE(DBMS_XPLAN.DISPLAY)", 'EXPLAIN').join("\n")
         end
 


### PR DESCRIPTION
This pull request addresses this failure when tested with `jruby-9.1.2.0` .

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:684 # OracleEnhancedAdapter explain should explain query with binds
==> Loading config from ENV or use default
==> Running specs with JRuby version 9.1.2.0
==> Effective ActiveRecord version 5.0.0
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb"=>[684]}}
F

Failures:

  1) OracleEnhancedAdapter explain should explain query with binds
     Failure/Error: Unable to find oracle.jdbc.driver.OraclePreparedStatement.setLongInternal(oracle/jdbc/driver/OraclePreparedStatement.java to read failed line
     
     ActiveRecord::StatementInvalid:
       Java::JavaSql::SQLException: Invalid column index: EXPLAIN PLAN FOR SELECT "TEST_POSTS".* FROM "TEST_POSTS" WHERE "TEST_POSTS"."ID" = 0
     # oracle.jdbc.driver.OraclePreparedStatement.setLongInternal(oracle/jdbc/driver/OraclePreparedStatement.java:6248)
     # oracle.jdbc.driver.OraclePreparedStatement.setLong(oracle/jdbc/driver/OraclePreparedStatement.java:6235)
     # oracle.jdbc.driver.OraclePreparedStatementWrapper.setLong(oracle/jdbc/driver/OraclePreparedStatementWrapper.java:217)
     # java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)
     # org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:423)
     # org.jruby.javasupport.JavaMethod.invokeDirect(org/jruby/javasupport/JavaMethod.java:290)
     # RUBY.bind_param(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:359)
     # RUBY.block in bind_params(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:338)
     # org.jruby.RubyArray.each(org/jruby/RubyArray.java:1593)
     # RUBY.bind_params(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:334)
     # RUBY.block in exec_query(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:34)
     # RUBY.block in log(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589)
     # RUBY.instrument(/home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21)
     # RUBY.log(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583)
     # RUBY.log(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1246)
     # RUBY.exec_query(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:22)
     # RUBY.explain(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:72)
     # RUBY.block in (root)(/home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:688)
     # org.jruby.RubyBasicObject.yieldUnder(org/jruby/RubyBasicObject.java:1707)
     # org.jruby.RubyBasicObject.instance_exec(org/jruby/RubyBasicObject.java:1684)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:252)
     # RUBY.block in with_around_and_singleton_context_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494)
     # RUBY.block in with_around_example_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471)
     # RUBY.run_around_example_hooks_for(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:609)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471)
     # RUBY.with_around_example_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451)
     # RUBY.with_around_and_singleton_context_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:249)
     # RUBY.block in run_examples(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:627)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run_examples(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:623)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:589)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113)
     # RUBY.with_suite_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/configuration.rb:1836)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:112)
     # RUBY.report(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/reporter.rb:77)
     # RUBY.run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:111)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:87)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:71)
     # RUBY.invoke(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:45)
     # RUBY.<top>(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/exe/rspec:4)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:849)
     # org.jruby.Ruby.loadFile(org/jruby/Ruby.java:2986)
     # org.jruby.RubyKernel.loadCommon(org/jruby/RubyKernel.java:970)
     # org.jruby.RubyKernel.load(org/jruby/RubyKernel.java:962)
     # home.yahonda.$_dot_rbenv.versions.jruby_minus_9_dot_1_dot_2_dot_0.bin.rspec.<top>(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/bin/rspec:22)
     # java.lang.invoke.MethodHandle.invokeWithArguments(java/lang/invoke/MethodHandle.java:627)
     # org.jruby.Ruby.runScript(org/jruby/Ruby.java:833)
     # org.jruby.Ruby.runScript(org/jruby/Ruby.java:825)
     # org.jruby.Ruby.runNormally(org/jruby/Ruby.java:760)
     # org.jruby.Ruby.runFromMain(org/jruby/Ruby.java:579)
     # org.jruby.Main.doRunFromMain(org/jruby/Main.java:425)
     # org.jruby.Main.internalRun(org/jruby/Main.java:313)
     # org.jruby.Main.run(org/jruby/Main.java:242)
     # org.jruby.Main.main(org/jruby/Main.java:204)
     # ------------------
     # --- Caused by: ---
     # Java::JavaSql::SQLException:
     #   Invalid column index
     #   oracle.jdbc.driver.OraclePreparedStatement.setLongInternal(oracle/jdbc/driver/OraclePreparedStatement.java:6248)

Finished in 2.41 seconds (files took 5.5 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:684 # OracleEnhancedAdapter explain should explain query with binds

```