### PR TITLE
add_dependency with ruby-oci8 only if it runs cruby, not jruby

### DIFF
--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -89,7 +89,7 @@ This adapter is superset of original ActiveRecord Oracle adapter.
   s.add_dependency(%q<activerecord>, ["~> 5.0.0"])
   s.add_dependency(%q<arel>, ["~> 7.0"])
   s.add_dependency(%q<ruby-plsql>, [">= 0.5.0"])
-  s.add_dependency(%q<ruby-oci8>, [">= 2.2.0"])
+  s.add_dependency(%q<ruby-oci8>, [">= 2.2.0"]) if !defined?(RUBY_ENGINE) || RUBY_ENGINE == 'ruby'
   s.license = 'MIT'
 end
 


### PR DESCRIPTION
This pull request adddresses this build errror when `bundle` executed using jruby

```ruby
$ ruby -v
jruby 9.1.2.0 (2.3.0) 2016-05-26 7357c8f Java HotSpot(TM) 64-Bit Server VM 25.92-b14 on 1.8.0_92-b14 +jit [linux-x86_64]
$ cd activerecord
$ bundle
...
Installing ruby-oci8 2.2.2 with native extensions

Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/ruby-oci8-2.2.2/ext/oci8
/home/yahonda/.rbenv/versions/jruby-9.1.2.0/bin/jruby -r ./siteconf20160715-24905-1we1ee5.rb extconf.rb
NotImplementedError: C extensions are not supported
    <top> at /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/stdlib/mkmf.rb:1
  require at org/jruby/RubyKernel.java:944
   (root) at /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:1
    <top> at /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:55

extconf failed, exit code 1

Gem files will remain installed in /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/ruby-oci8-2.2.2 for inspection.
Results logged to /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/extensions/universal-java-1.8/2.3.0/ruby-oci8-2.2.2/gem_make.out
```