### PR TITLE
Move `ruby_to_java_value` logic to `_type_cast`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_quoting.rb
@@ -5,11 +5,16 @@ module ActiveRecord
         def _type_cast(value)
           case value
           when ActiveModel::Type::Binary::Data
-            #TODO: may need BLOB specific handling
-            value
+            blob = Java::OracleSql::BLOB.createTemporary(@connection.raw_connection, false, Java::OracleSql::BLOB::DURATION_SESSION)
+            blob.setBytes(1, value.to_s.to_java_bytes)
+            blob
           when ActiveRecord::OracleEnhanced::Type::Text::Data
             #TODO: may need CLOB specific handling
             value.to_s
+          when Date, DateTime
+            Java::oracle.sql.DATE.new(value.strftime("%Y-%m-%d %H:%M:%S"))
+          when Time
+            Java::java.sql.Timestamp.new(value.year-1900, value.month-1, value.day, value.hour, value.min, value.sec, value.usec * 1000)
           else
             super
           end


### PR DESCRIPTION
This pull request addresses these 7 failures:

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1213
uri:classloader:/jruby/kernel/jruby/process_manager.rb:28: warning: executable? does not in this environment and will return a dummy value
uri:classloader:/jruby/kernel/jruby/process_manager.rb:28: warning: executable? does not in this environment and will return a dummy value
uri:classloader:/jruby/kernel/jruby/process_manager.rb:28: warning: executable? does not in this environment and will return a dummy value
uri:classloader:/jruby/kernel/jruby/process_manager.rb:28: warning: executable? does not in this environment and will return a dummy value
uri:classloader:/jruby/kernel/jruby/process_manager.rb:28: warning: executable? does not in this environment and will return a dummy value
uri:classloader:/jruby/kernel/jruby/process_manager.rb:28: warning: executable? does not in this environment and will return a dummy value
==> Loading config from ENV or use default
==> Running specs with JRuby version 9.1.2.0
==> Effective ActiveRecord version 5.0.0
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb"=>[1213]}}
FFFFFFF

Failures:

  1) OracleEnhancedAdapter handling of BLOB columns should create record with BLOB data
     Failure/Error: raise ArgumentError, "Don't know how to bind variable with type #{value.class}"

     ActiveRecord::StatementInvalid:
       ArgumentError: Don't know how to bind variable with type ActiveModel::Type::Binary::Data: INSERT INTO "TEST_EMPLOYEES" ("FIRST_NAME", "LAST_NAME", "BINARY_DATA", "EMPLOYEE_ID") VALUES (:a1, :a2, :a3, :a4)
     # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:391:in `bind_param'
     # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:338:in `block in bind_params'
     # org/jruby/RubyArray.java:1593:in `each'
     # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:334:in `bind_params'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:110:in `block in exec_insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
     # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1246:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:99:in `exec_insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:124:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:65:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:559:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:128:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:75:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:123:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `block in _create_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_create_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:68:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:539:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:152:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:50:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:30:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `block in save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:45:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:51:in `create!'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1250:in `block in (root)'
     # org/jruby/RubyBasicObject.java:1684:in `instance_exec'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:252:in `block in run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471:in `block in run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:609:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:249:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # org/jruby/RubyArray.java:2355:in `map'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113:in `block in run_specs'
     # org/jruby/RubyArray.java:2355:in `map'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/configuration.rb:1836:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/exe/rspec:4:in `<top>'
     # org/jruby/RubyKernel.java:962:in `load'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/bin/rspec:1:in `<top>'
     # ------------------
     # --- Caused by: ---
     # ArgumentError:
     #   Don't know how to bind variable with type ActiveModel::Type::Binary::Data
     #   ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:391:in `bind_param'

  2) OracleEnhancedAdapter handling of BLOB columns should update record with BLOB data
     Failure/Error: raise ArgumentError, "Don't know how to bind variable with type #{value.class}"

     ActiveRecord::StatementInvalid:
       ArgumentError: Don't know how to bind variable with type ActiveModel::Type::Binary::Data: UPDATE "TEST_EMPLOYEES" SET "BINARY_DATA" = :a1 WHERE "TEST_EMPLOYEES"."EMPLOYEE_ID" = :a2
     # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:391:in `bind_param'
     # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:338:in `block in bind_params'
     # org/jruby/RubyArray.java:1593:in `each'
     # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:334:in `bind_params'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:140:in `block in exec_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
     # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1246:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:129:in `exec_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:133:in `update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:89:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:550:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:79:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:119:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:306:in `block in _update_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:126:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:506:in `block in compile'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:455:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_update_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:306:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:81:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:539:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:152:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:50:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:30:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `block in save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:45:in `save!'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1267:in `block in (root)'
     # org/jruby/RubyBasicObject.java:1684:in `instance_exec'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:252:in `block in run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471:in `block in run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:609:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:249:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # org/jruby/RubyArray.java:2355:in `map'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113:in `block in run_specs'
     # org/jruby/RubyArray.java:2355:in `map'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/configuration.rb:1836:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/exe/rspec:4:in `<top>'
     # org/jruby/RubyKernel.java:962:in `load'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/bin/rspec:1:in `<top>'
     # ------------------
     # --- Caused by: ---
     # ArgumentError:
     #   Don't know how to bind variable with type ActiveModel::Type::Binary::Data
     #   ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:391:in `bind_param'

  3) OracleEnhancedAdapter handling of BLOB columns should update record with zero-length BLOB data
     Failure/Error: raise ArgumentError, "Don't know how to bind variable with type #{value.class}"

     ActiveRecord::StatementInvalid:
       ArgumentError: Don't know how to bind variable with type ActiveModel::Type::Binary::Data: UPDATE "TEST_EMPLOYEES" SET "BINARY_DATA" = :a1 WHERE "TEST_EMPLOYEES"."EMPLOYEE_ID" = :a2
     # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:391:in `bind_param'
     # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:338:in `block in bind_params'
     # org/jruby/RubyArray.java:1593:in `each'
     # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:334:in `bind_params'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:140:in `block in exec_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
     # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1246:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:129:in `exec_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:133:in `update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:89:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:550:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:79:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:119:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:306:in `block in _update_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:126:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:506:in `block in compile'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:455:in `call'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_update_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:306:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:81:in `_update_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:539:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:152:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:50:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:30:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `block in save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:45:in `save!'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1280:in `block in (root)'
     # org/jruby/RubyBasicObject.java:1684:in `instance_exec'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:252:in `block in run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471:in `block in run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:609:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:249:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # org/jruby/RubyArray.java:2355:in `map'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113:in `block in run_specs'
     # org/jruby/RubyArray.java:2355:in `map'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/configuration.rb:1836:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/exe/rspec:4:in `<top>'
     # org/jruby/RubyKernel.java:962:in `load'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/bin/rspec:1:in `<top>'
     # ------------------
     # --- Caused by: ---
     # ArgumentError:
     #   Don't know how to bind variable with type ActiveModel::Type::Binary::Data
     #   ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:391:in `bind_param'

  4) OracleEnhancedAdapter handling of BLOB columns should update record that has existing BLOB data with different BLOB data
     Failure/Error: raise ArgumentError, "Don't know how to bind variable with type #{value.class}"

     ActiveRecord::StatementInvalid:
       ArgumentError: Don't know how to bind variable with type ActiveModel::Type::Binary::Data: INSERT INTO "TEST_EMPLOYEES" ("FIRST_NAME", "LAST_NAME", "BINARY_DATA", "EMPLOYEE_ID") VALUES (:a1, :a2, :a3, :a4)
     # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:391:in `bind_param'
     # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:338:in `block in bind_params'
     # org/jruby/RubyArray.java:1593:in `each'
     # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:334:in `bind_params'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:110:in `block in exec_insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
     # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1246:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:99:in `exec_insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:124:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:65:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:559:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:128:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:75:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:123:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `block in _create_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_create_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:68:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:539:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:152:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:50:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:30:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `block in save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:45:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:51:in `create!'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1286:in `block in (root)'
     # org/jruby/RubyBasicObject.java:1684:in `instance_exec'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:252:in `block in run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471:in `block in run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:609:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:249:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # org/jruby/RubyArray.java:2355:in `map'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113:in `block in run_specs'
     # org/jruby/RubyArray.java:2355:in `map'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/configuration.rb:1836:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/exe/rspec:4:in `<top>'
     # org/jruby/RubyKernel.java:962:in `load'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/bin/rspec:1:in `<top>'
     # ------------------
     # --- Caused by: ---
     # ArgumentError:
     #   Don't know how to bind variable with type ActiveModel::Type::Binary::Data
     #   ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:391:in `bind_param'

  5) OracleEnhancedAdapter handling of BLOB columns should update record that has existing BLOB data with nil
     Failure/Error: raise ArgumentError, "Don't know how to bind variable with type #{value.class}"

     ActiveRecord::StatementInvalid:
       ArgumentError: Don't know how to bind variable with type ActiveModel::Type::Binary::Data: INSERT INTO "TEST_EMPLOYEES" ("FIRST_NAME", "LAST_NAME", "BINARY_DATA", "EMPLOYEE_ID") VALUES (:a1, :a2, :a3, :a4)
     # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:391:in `bind_param'
     # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:338:in `block in bind_params'
     # org/jruby/RubyArray.java:1593:in `each'
     # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:334:in `bind_params'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:110:in `block in exec_insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
     # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1246:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:99:in `exec_insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:124:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:65:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:559:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:128:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:75:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:123:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `block in _create_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_create_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:68:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:539:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:152:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:50:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:30:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `block in save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:45:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:51:in `create!'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1299:in `block in (root)'
     # org/jruby/RubyBasicObject.java:1684:in `instance_exec'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:252:in `block in run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471:in `block in run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:609:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:249:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # org/jruby/RubyArray.java:2355:in `map'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113:in `block in run_specs'
     # org/jruby/RubyArray.java:2355:in `map'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/configuration.rb:1836:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/exe/rspec:4:in `<top>'
     # org/jruby/RubyKernel.java:962:in `load'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/bin/rspec:1:in `<top>'
     # ------------------
     # --- Caused by: ---
     # ArgumentError:
     #   Don't know how to bind variable with type ActiveModel::Type::Binary::Data
     #   ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:391:in `bind_param'

  6) OracleEnhancedAdapter handling of BLOB columns should update record that has existing BLOB data with zero-length BLOB data
     Failure/Error: raise ArgumentError, "Don't know how to bind variable with type #{value.class}"

     ActiveRecord::StatementInvalid:
       ArgumentError: Don't know how to bind variable with type ActiveModel::Type::Binary::Data: INSERT INTO "TEST_EMPLOYEES" ("FIRST_NAME", "LAST_NAME", "BINARY_DATA", "EMPLOYEE_ID") VALUES (:a1, :a2, :a3, :a4)
     # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:391:in `bind_param'
     # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:338:in `block in bind_params'
     # org/jruby/RubyArray.java:1593:in `each'
     # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:334:in `bind_params'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:110:in `block in exec_insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
     # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1246:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:99:in `exec_insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:124:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:65:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:559:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:128:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:75:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:123:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `block in _create_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_create_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:68:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:539:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:152:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:50:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:30:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `block in save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:45:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:51:in `create!'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1312:in `block in (root)'
     # org/jruby/RubyBasicObject.java:1684:in `instance_exec'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:252:in `block in run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471:in `block in run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:609:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:249:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # org/jruby/RubyArray.java:2355:in `map'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113:in `block in run_specs'
     # org/jruby/RubyArray.java:2355:in `map'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/configuration.rb:1836:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/exe/rspec:4:in `<top>'
     # org/jruby/RubyKernel.java:962:in `load'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/bin/rspec:1:in `<top>'
     # ------------------
     # --- Caused by: ---
     # ArgumentError:
     #   Don't know how to bind variable with type ActiveModel::Type::Binary::Data
     #   ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:391:in `bind_param'

  7) OracleEnhancedAdapter handling of BLOB columns should update record that has zero-length BLOB data with non-empty BLOB data
     Failure/Error: raise ArgumentError, "Don't know how to bind variable with type #{value.class}"

     ActiveRecord::StatementInvalid:
       ArgumentError: Don't know how to bind variable with type ActiveModel::Type::Binary::Data: INSERT INTO "TEST_EMPLOYEES" ("FIRST_NAME", "LAST_NAME", "BINARY_DATA", "EMPLOYEE_ID") VALUES (:a1, :a2, :a3, :a4)
     # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:391:in `bind_param'
     # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:338:in `block in bind_params'
     # org/jruby/RubyArray.java:1593:in `each'
     # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:334:in `bind_params'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:110:in `block in exec_insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
     # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1246:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:99:in `exec_insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:124:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:65:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:559:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:128:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:75:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:123:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `block in _create_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_create_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:68:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:539:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:152:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:50:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:30:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `block in save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:45:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:51:in `create!'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1325:in `block in (root)'
     # org/jruby/RubyBasicObject.java:1684:in `instance_exec'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:252:in `block in run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471:in `block in run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:609:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:249:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # org/jruby/RubyArray.java:2355:in `map'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113:in `block in run_specs'
     # org/jruby/RubyArray.java:2355:in `map'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/configuration.rb:1836:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/exe/rspec:4:in `<top>'
     # org/jruby/RubyKernel.java:962:in `load'
     # /home/yahonda/.rbenv/versions/jruby-9.1.2.0/bin/rspec:1:in `<top>'
     # ------------------
     # --- Caused by: ---
     # ArgumentError:
     #   Don't know how to bind variable with type ActiveModel::Type::Binary::Data
     #   ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:391:in `bind_param'

Finished in 3.8 seconds (files took 6.77 seconds to load)
7 examples, 7 failures

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1249 # OracleEnhancedAdapter handling of BLOB columns should create record with BLOB data
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1259 # OracleEnhancedAdapter handling of BLOB columns should update record with BLOB data
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1272 # OracleEnhancedAdapter handling of BLOB columns should update record with zero-length BLOB data
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1285 # OracleEnhancedAdapter handling of BLOB columns should update record that has existing BLOB data with different BLOB data
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1298 # OracleEnhancedAdapter handling of BLOB columns should update record that has existing BLOB data with nil
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1311 # OracleEnhancedAdapter handling of BLOB columns should update record that has existing BLOB data with zero-length BLOB data
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1324 # OracleEnhancedAdapter handling of BLOB columns should update record that has zero-length BLOB data with non-empty BLOB data
```

It causes this regression, which needs investigated later.

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb:252
uri:classloader:/jruby/kernel/jruby/process_manager.rb:28: warning: executable? does not in this environment and will return a dummy value
uri:classloader:/jruby/kernel/jruby/process_manager.rb:28: warning: executable? does not in this environment and will return a dummy value
uri:classloader:/jruby/kernel/jruby/process_manager.rb:28: warning: executable? does not in this environment and will return a dummy value
uri:classloader:/jruby/kernel/jruby/process_manager.rb:28: warning: executable? does not in this environment and will return a dummy value
uri:classloader:/jruby/kernel/jruby/process_manager.rb:28: warning: executable? does not in this environment and will return a dummy value
uri:classloader:/jruby/kernel/jruby/process_manager.rb:28: warning: executable? does not in this environment and will return a dummy value
==> Loading config from ENV or use default
==> Running specs with JRuby version 9.1.2.0
==> Effective ActiveRecord version 5.0.0
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb"=>[252]}}
DEPRECATION WARNING: ******************************************************* Passing a column to `bind_param` will be deprecated. `type_casted_binds` should be already type casted so that `bind_param` should not need to know column. ******************************************************* (called from bind_param at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:346)
F

Failures:

  1) OracleEnhancedConnection SQL with bind parameters when NLS_NUMERIC_CHARACTERS is set to ', ' should execute prepared statement with decimal bind parameter
     Failure/Error: Unable to find oracle.jdbc.driver.T4CTTIoer.processError(oracle/jdbc/driver/T4CTTIoer.java to read failed line

     Java::JavaSql::SQLSyntaxErrorException:
       ORA-01722: invalid number
     # oracle.jdbc.driver.T4CTTIoer.processError(oracle/jdbc/driver/T4CTTIoer.java:450)
     # oracle.jdbc.driver.T4CTTIoer.processError(oracle/jdbc/driver/T4CTTIoer.java:399)
     # oracle.jdbc.driver.T4C8Oall.processError(oracle/jdbc/driver/T4C8Oall.java:1059)
     # oracle.jdbc.driver.T4CTTIfun.receive(oracle/jdbc/driver/T4CTTIfun.java:522)
     # oracle.jdbc.driver.T4CTTIfun.doRPC(oracle/jdbc/driver/T4CTTIfun.java:257)
     # oracle.jdbc.driver.T4C8Oall.doOALL(oracle/jdbc/driver/T4C8Oall.java:587)
     # oracle.jdbc.driver.T4CPreparedStatement.doOall8(oracle/jdbc/driver/T4CPreparedStatement.java:225)
     # oracle.jdbc.driver.T4CPreparedStatement.doOall8(oracle/jdbc/driver/T4CPreparedStatement.java:53)
     # oracle.jdbc.driver.T4CPreparedStatement.executeForRows(oracle/jdbc/driver/T4CPreparedStatement.java:943)
     # oracle.jdbc.driver.OracleStatement.doExecuteWithTimeout(oracle/jdbc/driver/OracleStatement.java:1150)
     # oracle.jdbc.driver.OraclePreparedStatement.executeInternal(oracle/jdbc/driver/OraclePreparedStatement.java:4798)
     # oracle.jdbc.driver.OraclePreparedStatement.executeQuery(oracle/jdbc/driver/OraclePreparedStatement.java:4845)
     # oracle.jdbc.driver.OraclePreparedStatementWrapper.executeQuery(oracle/jdbc/driver/OraclePreparedStatementWrapper.java:1501)
     # java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)
     # org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:438)
     # org.jruby.javasupport.JavaMethod.invokeDirect(org/jruby/javasupport/JavaMethod.java:302)
     # RUBY.exec(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:403)
     # RUBY.block in (root)(/home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb:258)
     # org.jruby.RubyBasicObject.yieldUnder(org/jruby/RubyBasicObject.java:1707)
     # org.jruby.RubyBasicObject.instance_exec(org/jruby/RubyBasicObject.java:1684)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:252)
     # RUBY.block in with_around_and_singleton_context_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494)
     # RUBY.block in with_around_example_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471)
     # RUBY.run_around_example_hooks_for(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:609)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471)
     # RUBY.with_around_example_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451)
     # RUBY.with_around_and_singleton_context_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:249)
     # RUBY.block in run_examples(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:627)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run_examples(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:623)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:589)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113)
     # RUBY.with_suite_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/configuration.rb:1836)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:112)
     # RUBY.report(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/reporter.rb:77)
     # RUBY.run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:111)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:87)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:71)
     # RUBY.invoke(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:45)
     # RUBY.<top>(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/exe/rspec:4)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:849)
     # org.jruby.Ruby.loadFile(org/jruby/Ruby.java:2986)
     # org.jruby.RubyKernel.loadCommon(org/jruby/RubyKernel.java:970)
     # org.jruby.RubyKernel.load(org/jruby/RubyKernel.java:962)
     # RUBY.<top>(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/bin/rspec:1)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:868)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:873)
     # org.jruby.Ruby.runNormally(org/jruby/Ruby.java:765)
     # org.jruby.Ruby.runFromMain(org/jruby/Ruby.java:579)
     # org.jruby.Main.doRunFromMain(org/jruby/Main.java:425)
     # org.jruby.Main.internalRun(org/jruby/Main.java:313)
     # org.jruby.Main.run(org/jruby/Main.java:242)
     # org.jruby.Main.main(org/jruby/Main.java:204)

Finished in 0.948 seconds (files took 6.24 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb:252 # OracleEnhancedConnection SQL with bind parameters when NLS_NUMERIC_CHARACTERS is set to ', ' should execute prepared statement with decimal bind parameter

$
```
