### PR TITLE
Set required_ruby_version  = '>= 2.2.2'

### DIFF
--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -3,6 +3,7 @@ Gem::Specification.new do |s|
   s.version = "1.7.0.beta1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
+  s.required_ruby_version     = '>= 2.2.2'
   s.license = 'MIT'
   s.authors = [%q{Raimonds Simanovskis}]
   s.date = %q{2016-07-18}


### PR DESCRIPTION
to meet the same ruby version as Rails 5.0.0 does.