### PR TITLE
Oracle enhanced adapter 1.7 target version is Rails 5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ group :development do
   gem 'rdoc'
   gem 'rake'
 
-  gem 'activerecord',   github: 'rails/rails', branch: 'master'
+  gem 'activerecord',   github: 'rails/rails', branch: '5-0-stable'
   gem 'rack',           github: 'rack/rack', branch: 'master'
   gem 'arel',           github: 'rails/arel', branch: 'master'
 


### PR DESCRIPTION
then it should point `5-0-stable` branch