### PR TITLE
Remove ActiveRecord::ConnectionAdapters::TableDefinition#aliased_types

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -1,14 +1,5 @@
 module ActiveRecord
   module ConnectionAdapters
-    #TODO: Overriding `aliased_types` cause another database adapter behavior changes
-    #It should be addressed by supporting `create_table_definition`
-    class TableDefinition
-      private
-      def aliased_types(name, fallback)
-        fallback
-      end
-    end
-
     module OracleEnhanced
 
       class ForeignKeyDefinition < ActiveRecord::ConnectionAdapters::ForeignKeyDefinition


### PR DESCRIPTION
It is kind of reverting https://github.com/rsim/oracle-enhanced/commit/c1722f0001a894d2f9899038e999ab41acebbe3b done in #575

Since Oracle enhanced adapter 1.7 does not have its own :timestamp datatype implementation by #815
this overriding code is not necessary anymore.

It eliminates these warnings.

```ruby
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb:7: warning: method redefined; discarding old aliased_types
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb:390: warning: previous definition of aliased_types was here
```