### PR TITLE
Remove specs for composite primary keys, which is not supported

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
@@ -225,24 +225,6 @@ describe "OracleEnhancedAdapter schema dump" do
       expect(standard_dump(ignore_tables: [ /test_posts/i ])).to match(/add_foreign_key "test_comments"/)
     end
 
-    it "should include composite foreign keys" do
-      skip "Composite foreign keys are not supported in this version"
-      schema_define do
-        add_column :test_posts, :baz_id, :integer
-        add_column :test_posts, :fooz_id, :integer
-
-        execute <<-SQL
-          ALTER TABLE TEST_POSTS
-          ADD CONSTRAINT UK_FOOZ_BAZ UNIQUE (BAZ_ID,FOOZ_ID)
-        SQL
-
-        add_column :test_comments, :baz_id, :integer
-        add_column :test_comments, :fooz_id, :integer
-
-        add_foreign_key :test_comments, :test_posts, columns: ["baz_id", "fooz_id"], name: 'comments_posts_baz_fooz_fk'
-      end
-      expect(standard_dump).to match(/add_foreign_key "test_comments", "test_posts", columns: \["baz_id", "fooz_id"\], name: "comments_posts_baz_fooz_fk"/)
-    end
     it "should include foreign keys following all tables" do
       # if foreign keys preceed declaration of all tables
       # it can cause problems when using db:test rake tasks

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -733,52 +733,6 @@ end
       expect(TestComment.find_by_id(c.id).test_post_id).to be_nil
     end
 
-    it "should add a composite foreign key" do
-      skip "Composite foreign keys are not supported in this version"
-      schema_define do
-        add_column :test_posts, :baz_id, :integer
-        add_column :test_posts, :fooz_id, :integer
-
-        execute <<-SQL
-          ALTER TABLE TEST_POSTS
-          ADD CONSTRAINT UK_FOOZ_BAZ UNIQUE (BAZ_ID,FOOZ_ID)
-        SQL
-
-        add_column :test_comments, :baz_id, :integer
-        add_column :test_comments, :fooz_id, :integer
-
-        add_foreign_key :test_comments, :test_posts, :columns => ["baz_id", "fooz_id"]
-      end
-
-      expect do
-        TestComment.create(:body => "test", :fooz_id => 1, :baz_id => 1)
-      end.to raise_error() {|e| expect(e.message).to match(
-        /ORA-02291.*\.TES_COM_BAZ_ID_FOO_ID_FK/
-      )}
-    end
-
-    it "should add a composite foreign key with name" do
-      skip "Composite foreign keys are not supported in this version"
-      schema_define do
-        add_column :test_posts, :baz_id, :integer
-        add_column :test_posts, :fooz_id, :integer
-
-        execute <<-SQL
-          ALTER TABLE TEST_POSTS
-          ADD CONSTRAINT UK_FOOZ_BAZ UNIQUE (BAZ_ID,FOOZ_ID)
-        SQL
-
-        add_column :test_comments, :baz_id, :integer
-        add_column :test_comments, :fooz_id, :integer
-
-        add_foreign_key :test_comments, :test_posts, :columns => ["baz_id", "fooz_id"], :name => 'comments_posts_baz_fooz_fk'
-      end
-
-      expect do
-        TestComment.create(:body => "test", :baz_id => 1, :fooz_id => 1)
-      end.to raise_error() {|e| expect(e.message).to match(/ORA-02291.*\.COMMENTS_POSTS_BAZ_FOOZ_FK/)}
-    end
-
     it "should remove foreign key by table name" do
       schema_define do
         add_foreign_key :test_comments, :test_posts

--- a/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
@@ -91,29 +91,6 @@ describe "OracleEnhancedAdapter structure dump" do
       expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_BAZ\"? FOREIGN KEY \(\"?BAZ_ID\"?\) REFERENCES \"?FOOS\"?\(\"?BAZ_ID\"?\)/i)
     end
     
-    it "should dump composite foreign keys" do
-      skip "Composite foreign keys are not supported in this version"
-      @conn.add_column :foos, :fooz_id, :integer
-      @conn.add_column :foos, :baz_id, :integer
-      
-      @conn.execute <<-SQL
-        ALTER TABLE FOOS 
-        ADD CONSTRAINT UK_FOOZ_BAZ UNIQUE (BAZ_ID,FOOZ_ID)
-      SQL
-      
-      @conn.add_column :test_posts, :fooz_id, :integer
-      @conn.add_column :test_posts, :baz_id, :integer
-            
-      @conn.execute <<-SQL
-        ALTER TABLE TEST_POSTS
-        ADD CONSTRAINT fk_test_post_fooz_baz FOREIGN KEY (baz_id,fooz_id) REFERENCES foos(baz_id,fooz_id)
-      SQL
-      
-      dump = ActiveRecord::Base.connection.structure_dump_fk_constraints
-      expect(dump.split('\n').length).to eq(1)
-      expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_FOOZ_BAZ\"? FOREIGN KEY \(\"?BAZ_ID\"?\,\"?FOOZ_ID\"?\) REFERENCES \"?FOOS\"?\(\"?BAZ_ID\"?\,\"?FOOZ_ID\"?\)/i)
-    end
-  
     it "should not error when no foreign keys are present" do
       dump = ActiveRecord::Base.connection.structure_dump_fk_constraints
       expect(dump.split('\n').length).to eq(0)


### PR DESCRIPTION
This pull request removes specs for composite primary keys skipped in #632

```ruby
$ rake spec
... snip ...

  2) OracleEnhancedAdapter schema dump foreign key constraints should include composite foreign keys
     # Composite foreign keys are not supported in this version
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:228

  3) OracleEnhancedAdapter schema definition foreign key constraints should add a composite foreign key
     # Composite foreign keys are not supported in this version
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:736

  4) OracleEnhancedAdapter schema definition foreign key constraints should add a composite foreign key with name
     # Composite foreign keys are not supported in this version
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:760

  5) OracleEnhancedAdapter structure dump structure dump should dump composite foreign keys
     # Composite foreign keys are not supported in this version
     # ./spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb:94
```
