### PR TITLE
Update waning message for composite primary keys

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1070,7 +1070,7 @@ module ActiveRecord
         SQL
 
         warn <<-WARNING.strip_heredoc if pks.count > 1
-          WARNING: Rails does not support composite primary key.
+          WARNING: Active Record does not support composite primary key.
 
           #{table_name} has composite primary key. Composite primary key is ignored.
         WARNING


### PR DESCRIPTION
refer https://github.com/rails/rails/pull/25578

This pull request addresses this failure:

```ruby
$ cd activerecord
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/primary_keys_test.rb -n test_primary_key_issues_warning
... snip ...
# Running:

F

Finished in 0.125439s, 7.9720 runs/s, 23.9161 assertions/s.

  1) Failure:
CompositePrimaryKeyTest#test_primary_key_issues_warning [test/cases/primary_keys_test.rb:274]:
Expected /WARNING: Active Record does not support composite primary key\./ to match "WARNING: Rails does not support composite primary key.\n\nbarcodes has composite primary key. Composite primary key is ignored.\n".

1 runs, 3 assertions, 1 failures, 0 errors, 0 skips
$
```
