### PR TITLE
Remove unused col_type to avoid warnings

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -142,14 +142,14 @@ module ActiveRecord
 
           if column && column.object_type?
             @raw_cursor.bind_param(position, value, :named_type, column.sql_type)
-          elsif value.nil?
-            @raw_cursor.bind_param(position, nil, String)
           else
-            case col_type = column && column.type
-            when :raw
+            case value
+            when ActiveRecord::OracleEnhanced::Type::Raw
               @raw_cursor.bind_param(position, ActiveRecord::ConnectionAdapters::OracleEnhanced::Quoting.encode_raw(value))
-            when :decimal
+            when ActiveModel::Type::Decimal
               @raw_cursor.bind_param(position, BigDecimal.new(value.to_s))
+            when NilClass
+              @raw_cursor.bind_param(position, nil, String)
             else
               @raw_cursor.bind_param(position, value)
             end


### PR DESCRIPTION
This pull request removes this warning by folllowing `OracleEnhancedJDBCConnection` style for `bind_param` method implementation.

```ruby
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:148: warning: assigned but unused variable - col_type
```