### PR TITLE
Remove warnings for + when tested with JRuby 9.1.2

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -72,7 +72,7 @@ describe "OracleEnhancedAdapter schema definition" do
 
     it "should return sequence name without truncating too much" do
       seq_name_length = ActiveRecord::Base.connection.sequence_name_length
-      tname = "#{DATABASE_USER}" + "." +"a"*(seq_name_length - DATABASE_USER.length) + "z"*(DATABASE_USER).length
+      tname = "#{DATABASE_USER}" + "." + "a"*(seq_name_length - DATABASE_USER.length) + "z"*(DATABASE_USER).length
       expect(ActiveRecord::Base.connection.default_sequence_name(tname)).to match (/z_seq$/)
     end
   end


### PR DESCRIPTION
```ruby
  warning: `+' after local variable or literal is interpreted as binary operator
  warning: even though it seems like unary operator
```