### PR TITLE
Call `bind_returning_param` when sql has returning_id and using JRuby

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -108,12 +108,17 @@ module ActiveRecord
               cursor = @statements[sql]
 
               cursor.bind_params(type_casted_binds)
+
+              if sql =~ /:returning_id/
+                returning_id_index = 1
+                cursor.bind_returning_param(returning_id_index, Integer) if ORACLE_ENHANCED_CONNECTION == :jdbc
+              end
+
             end
 
             cursor.exec_update
 
             rows = []
-            returning_id_index = 1 if sql =~ /:returning_id/
             if returning_id_index
               returning_id = cursor.get_returning_param(returning_id_index, Integer).to_i
               rows << [returning_id]


### PR DESCRIPTION
This pull request follows up #894 which just supported returning_id only for CRuby.

It addresses these 5 failures below:

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:206
==> Loading config from ENV or use default
==> Running specs with JRuby version 9.1.2.0
==> Effective ActiveRecord version 5.0.0
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb"=>[206]}}
F

Failures:

  1) OracleEnhancedAdapter schema definition create table with primary key trigger with default primary key should return new key value using connection insert method
     Failure/Error: Unable to find oracle.jdbc.driver.OraclePreparedStatement.setupDbaBindBuffers(oracle/jdbc/driver/OraclePreparedStatement.java to read failed line

     ActiveRecord::StatementInvalid:
       Java::JavaSql::SQLException: Not all return parameters registered: INSERT INTO test_employees (first_name) VALUES ('Raimonds') RETURNING "ID" INTO :returning_id
     # oracle.jdbc.driver.OraclePreparedStatement.setupDbaBindBuffers(oracle/jdbc/driver/OraclePreparedStatement.java:3546)
     # oracle.jdbc.driver.OraclePreparedStatement.setupBindBuffers(oracle/jdbc/driver/OraclePreparedStatement.java:3046)
     # oracle.jdbc.driver.OraclePreparedStatement.processCompletedBindRow(oracle/jdbc/driver/OraclePreparedStatement.java:2670)
     # oracle.jdbc.driver.OraclePreparedStatement.executeInternal(oracle/jdbc/driver/OraclePreparedStatement.java:4790)
     # oracle.jdbc.driver.OraclePreparedStatement.executeUpdate(oracle/jdbc/driver/OraclePreparedStatement.java:4875)
     # oracle.jdbc.driver.OraclePreparedStatementWrapper.executeUpdate(oracle/jdbc/driver/OraclePreparedStatementWrapper.java:1361)
     # java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)
     # org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:438)
     # org.jruby.javasupport.JavaMethod.invokeDirect(org/jruby/javasupport/JavaMethod.java:302)
     # RUBY.exec_update(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:408)
     # RUBY.block in exec_insert(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:113)
     # RUBY.block in log(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589)
     # RUBY.instrument(/home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21)
     # RUBY.log(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583)
     # RUBY.log(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1243)
     # RUBY.exec_insert(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:99)
     # RUBY.insert(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:124)
     # RUBY.insert(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14)
     # RUBY.block in (root)(/home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:207)
     # org.jruby.RubyBasicObject.yieldUnder(org/jruby/RubyBasicObject.java:1707)
     # org.jruby.RubyBasicObject.instance_exec(org/jruby/RubyBasicObject.java:1684)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:252)
     # RUBY.block in with_around_and_singleton_context_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494)
     # RUBY.block in with_around_example_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471)
     # RUBY.run_around_example_hooks_for(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:609)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471)
     # RUBY.with_around_example_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451)
     # RUBY.with_around_and_singleton_context_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:249)
     # RUBY.block in run_examples(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:627)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run_examples(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:623)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:589)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113)
     # RUBY.with_suite_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/configuration.rb:1836)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:112)
     # RUBY.report(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/reporter.rb:77)
     # RUBY.run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:111)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:87)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:71)
     # RUBY.invoke(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:45)
     # RUBY.<top>(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/exe/rspec:4)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:849)
     # org.jruby.Ruby.loadFile(org/jruby/Ruby.java:2986)
     # org.jruby.RubyKernel.loadCommon(org/jruby/RubyKernel.java:970)
     # org.jruby.RubyKernel.load(org/jruby/RubyKernel.java:962)
     # RUBY.<top>(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/bin/rspec:1)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:868)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:873)
     # org.jruby.Ruby.runNormally(org/jruby/Ruby.java:765)
     # org.jruby.Ruby.runFromMain(org/jruby/Ruby.java:579)
     # org.jruby.Main.doRunFromMain(org/jruby/Main.java:425)
     # org.jruby.Main.internalRun(org/jruby/Main.java:313)
     # org.jruby.Main.run(org/jruby/Main.java:242)
     # org.jruby.Main.main(org/jruby/Main.java:204)
     # ------------------
     # --- Caused by: ---
     # Java::JavaSql::SQLException:
     #   Not all return parameters registered
     #   oracle.jdbc.driver.OraclePreparedStatement.setupDbaBindBuffers(oracle/jdbc/driver/OraclePreparedStatement.java:3546)

Finished in 3.16 seconds (files took 7.33 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:206 # OracleEnhancedAdapter schema definition create table with primary key trigger with default primary key should return new key value using connection insert method
```

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:216
==> Loading config from ENV or use default
==> Running specs with JRuby version 9.1.2.0
==> Effective ActiveRecord version 5.0.0
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb"=>[216]}}
F

Failures:

  1) OracleEnhancedAdapter schema definition create table with primary key trigger with default primary key should not generate NoMethodError for :returning_id:Symbol
     Failure/Error: Unable to find oracle.jdbc.driver.OraclePreparedStatement.setupDbaBindBuffers(oracle/jdbc/driver/OraclePreparedStatement.java to read failed line

     ActiveRecord::StatementInvalid:
       Java::JavaSql::SQLException: Not all return parameters registered: INSERT INTO test_employees (first_name) VALUES ('Yasuo') RETURNING "ID" INTO :returning_id
     # oracle.jdbc.driver.OraclePreparedStatement.setupDbaBindBuffers(oracle/jdbc/driver/OraclePreparedStatement.java:3546)
     # oracle.jdbc.driver.OraclePreparedStatement.setupBindBuffers(oracle/jdbc/driver/OraclePreparedStatement.java:3046)
     # oracle.jdbc.driver.OraclePreparedStatement.processCompletedBindRow(oracle/jdbc/driver/OraclePreparedStatement.java:2670)
     # oracle.jdbc.driver.OraclePreparedStatement.executeInternal(oracle/jdbc/driver/OraclePreparedStatement.java:4790)
     # oracle.jdbc.driver.OraclePreparedStatement.executeUpdate(oracle/jdbc/driver/OraclePreparedStatement.java:4875)
     # oracle.jdbc.driver.OraclePreparedStatementWrapper.executeUpdate(oracle/jdbc/driver/OraclePreparedStatementWrapper.java:1361)
     # java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)
     # org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:438)
     # org.jruby.javasupport.JavaMethod.invokeDirect(org/jruby/javasupport/JavaMethod.java:302)
     # RUBY.exec_update(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:408)
     # RUBY.block in exec_insert(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:113)
     # RUBY.block in log(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589)
     # RUBY.instrument(/home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21)
     # RUBY.log(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583)
     # RUBY.log(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1243)
     # RUBY.exec_insert(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:99)
     # RUBY.insert(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:124)
     # RUBY.insert(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14)
     # RUBY.block in (root)(/home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:219)
     # org.jruby.RubyBasicObject.yieldUnder(org/jruby/RubyBasicObject.java:1707)
     # org.jruby.RubyBasicObject.instance_exec(org/jruby/RubyBasicObject.java:1684)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:252)
     # RUBY.block in with_around_and_singleton_context_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494)
     # RUBY.block in with_around_example_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471)
     # RUBY.run_around_example_hooks_for(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:609)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471)
     # RUBY.with_around_example_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451)
     # RUBY.with_around_and_singleton_context_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:249)
     # RUBY.block in run_examples(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:627)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run_examples(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:623)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:589)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113)
     # RUBY.with_suite_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/configuration.rb:1836)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:112)
     # RUBY.report(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/reporter.rb:77)
     # RUBY.run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:111)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:87)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:71)
     # RUBY.invoke(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:45)
     # RUBY.<top>(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/exe/rspec:4)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:849)
     # org.jruby.Ruby.loadFile(org/jruby/Ruby.java:2986)
     # org.jruby.RubyKernel.loadCommon(org/jruby/RubyKernel.java:970)
     # org.jruby.RubyKernel.load(org/jruby/RubyKernel.java:962)
     # RUBY.<top>(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/bin/rspec:1)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:868)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:873)
     # org.jruby.Ruby.runNormally(org/jruby/Ruby.java:765)
     # org.jruby.Ruby.runFromMain(org/jruby/Ruby.java:579)
     # org.jruby.Main.doRunFromMain(org/jruby/Main.java:425)
     # org.jruby.Main.internalRun(org/jruby/Main.java:313)
     # org.jruby.Main.run(org/jruby/Main.java:242)
     # org.jruby.Main.main(org/jruby/Main.java:204)
     # ------------------
     # --- Caused by: ---
     # Java::JavaSql::SQLException:
     #   Not all return parameters registered
     #   oracle.jdbc.driver.OraclePreparedStatement.setupDbaBindBuffers(oracle/jdbc/driver/OraclePreparedStatement.java:3546)

Finished in 2.49 seconds (files took 7.24 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:216 # OracleEnhancedAdapter schema definition create table with primary key trigger with default primary key should not generate NoMethodError for :returning_id:Symbol
```

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:245
==> Loading config from ENV or use default
==> Running specs with JRuby version 9.1.2.0
==> Effective ActiveRecord version 5.0.0
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb"=>[245]}}
F

Failures:

  1) OracleEnhancedAdapter schema definition create table with primary key trigger with separate creation of primary key trigger should return new key value using connection insert method
     Failure/Error: Unable to find oracle.jdbc.driver.OraclePreparedStatement.setupDbaBindBuffers(oracle/jdbc/driver/OraclePreparedStatement.java to read failed line

     ActiveRecord::StatementInvalid:
       Java::JavaSql::SQLException: Not all return parameters registered: INSERT INTO test_employees (first_name) VALUES ('Raimonds') RETURNING "ID" INTO :returning_id
     # oracle.jdbc.driver.OraclePreparedStatement.setupDbaBindBuffers(oracle/jdbc/driver/OraclePreparedStatement.java:3546)
     # oracle.jdbc.driver.OraclePreparedStatement.setupBindBuffers(oracle/jdbc/driver/OraclePreparedStatement.java:3046)
     # oracle.jdbc.driver.OraclePreparedStatement.processCompletedBindRow(oracle/jdbc/driver/OraclePreparedStatement.java:2670)
     # oracle.jdbc.driver.OraclePreparedStatement.executeInternal(oracle/jdbc/driver/OraclePreparedStatement.java:4790)
     # oracle.jdbc.driver.OraclePreparedStatement.executeUpdate(oracle/jdbc/driver/OraclePreparedStatement.java:4875)
     # oracle.jdbc.driver.OraclePreparedStatementWrapper.executeUpdate(oracle/jdbc/driver/OraclePreparedStatementWrapper.java:1361)
     # java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)
     # org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:438)
     # org.jruby.javasupport.JavaMethod.invokeDirect(org/jruby/javasupport/JavaMethod.java:302)
     # RUBY.exec_update(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:408)
     # RUBY.block in exec_insert(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:113)
     # RUBY.block in log(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589)
     # RUBY.instrument(/home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21)
     # RUBY.log(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583)
     # RUBY.log(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1243)
     # RUBY.exec_insert(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:99)
     # RUBY.insert(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:124)
     # RUBY.insert(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14)
     # RUBY.block in (root)(/home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:246)
     # org.jruby.RubyBasicObject.yieldUnder(org/jruby/RubyBasicObject.java:1707)
     # org.jruby.RubyBasicObject.instance_exec(org/jruby/RubyBasicObject.java:1684)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:252)
     # RUBY.block in with_around_and_singleton_context_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494)
     # RUBY.block in with_around_example_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471)
     # RUBY.run_around_example_hooks_for(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:609)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471)
     # RUBY.with_around_example_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451)
     # RUBY.with_around_and_singleton_context_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:249)
     # RUBY.block in run_examples(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:627)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run_examples(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:623)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:589)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113)
     # RUBY.with_suite_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/configuration.rb:1836)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:112)
     # RUBY.report(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/reporter.rb:77)
     # RUBY.run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:111)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:87)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:71)
     # RUBY.invoke(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:45)
     # RUBY.<top>(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/exe/rspec:4)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:849)
     # org.jruby.Ruby.loadFile(org/jruby/Ruby.java:2986)
     # org.jruby.RubyKernel.loadCommon(org/jruby/RubyKernel.java:970)
     # org.jruby.RubyKernel.load(org/jruby/RubyKernel.java:962)
     # RUBY.<top>(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/bin/rspec:1)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:868)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:873)
     # org.jruby.Ruby.runNormally(org/jruby/Ruby.java:765)
     # org.jruby.Ruby.runFromMain(org/jruby/Ruby.java:579)
     # org.jruby.Main.doRunFromMain(org/jruby/Main.java:425)
     # org.jruby.Main.internalRun(org/jruby/Main.java:313)
     # org.jruby.Main.run(org/jruby/Main.java:242)
     # org.jruby.Main.main(org/jruby/Main.java:204)
     # ------------------
     # --- Caused by: ---
     # Java::JavaSql::SQLException:
     #   Not all return parameters registered
     #   oracle.jdbc.driver.OraclePreparedStatement.setupDbaBindBuffers(oracle/jdbc/driver/OraclePreparedStatement.java:3546)

Finished in 2.32 seconds (files took 6.77 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:245 # OracleEnhancedAdapter schema definition create table with primary key trigger with separate creation of primary key trigger should return new key value using connection insert method
```

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:278
==> Loading config from ENV or use default
==> Running specs with JRuby version 9.1.2.0
==> Effective ActiveRecord version 5.0.0
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb"=>[278]}}
F

Failures:

  1) OracleEnhancedAdapter schema definition create table with primary key trigger with non-default primary key and non-default sequence name should return new key value using connection insert method
     Failure/Error: Unable to find oracle.jdbc.driver.OraclePreparedStatement.setupDbaBindBuffers(oracle/jdbc/driver/OraclePreparedStatement.java to read failed line

     ActiveRecord::StatementInvalid:
       Java::JavaSql::SQLException: Not all return parameters registered: INSERT INTO test_employees (first_name) VALUES ('Raimonds') RETURNING "EMPLOYEE_ID" INTO :returning_id
     # oracle.jdbc.driver.OraclePreparedStatement.setupDbaBindBuffers(oracle/jdbc/driver/OraclePreparedStatement.java:3546)
     # oracle.jdbc.driver.OraclePreparedStatement.setupBindBuffers(oracle/jdbc/driver/OraclePreparedStatement.java:3046)
     # oracle.jdbc.driver.OraclePreparedStatement.processCompletedBindRow(oracle/jdbc/driver/OraclePreparedStatement.java:2670)
     # oracle.jdbc.driver.OraclePreparedStatement.executeInternal(oracle/jdbc/driver/OraclePreparedStatement.java:4790)
     # oracle.jdbc.driver.OraclePreparedStatement.executeUpdate(oracle/jdbc/driver/OraclePreparedStatement.java:4875)
     # oracle.jdbc.driver.OraclePreparedStatementWrapper.executeUpdate(oracle/jdbc/driver/OraclePreparedStatementWrapper.java:1361)
     # java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)
     # org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:438)
     # org.jruby.javasupport.JavaMethod.invokeDirect(org/jruby/javasupport/JavaMethod.java:302)
     # RUBY.exec_update(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:408)
     # RUBY.block in exec_insert(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:113)
     # RUBY.block in log(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589)
     # RUBY.instrument(/home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21)
     # RUBY.log(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583)
     # RUBY.log(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1243)
     # RUBY.exec_insert(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:99)
     # RUBY.insert(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:124)
     # RUBY.insert(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14)
     # RUBY.block in (root)(/home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:279)
     # org.jruby.RubyBasicObject.yieldUnder(org/jruby/RubyBasicObject.java:1707)
     # org.jruby.RubyBasicObject.instance_exec(org/jruby/RubyBasicObject.java:1684)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:252)
     # RUBY.block in with_around_and_singleton_context_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494)
     # RUBY.block in with_around_example_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471)
     # RUBY.run_around_example_hooks_for(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:609)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471)
     # RUBY.with_around_example_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451)
     # RUBY.with_around_and_singleton_context_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:249)
     # RUBY.block in run_examples(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:627)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run_examples(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:623)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:589)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113)
     # RUBY.with_suite_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/configuration.rb:1836)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:112)
     # RUBY.report(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/reporter.rb:77)
     # RUBY.run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:111)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:87)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:71)
     # RUBY.invoke(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:45)
     # RUBY.<top>(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/exe/rspec:4)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:849)
     # org.jruby.Ruby.loadFile(org/jruby/Ruby.java:2986)
     # org.jruby.RubyKernel.loadCommon(org/jruby/RubyKernel.java:970)
     # org.jruby.RubyKernel.load(org/jruby/RubyKernel.java:962)
     # RUBY.<top>(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/bin/rspec:1)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:868)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:873)
     # org.jruby.Ruby.runNormally(org/jruby/Ruby.java:765)
     # org.jruby.Ruby.runFromMain(org/jruby/Ruby.java:579)
     # org.jruby.Main.doRunFromMain(org/jruby/Main.java:425)
     # org.jruby.Main.internalRun(org/jruby/Main.java:313)
     # org.jruby.Main.run(org/jruby/Main.java:242)
     # org.jruby.Main.main(org/jruby/Main.java:204)
     # ------------------
     # --- Caused by: ---
     # Java::JavaSql::SQLException:
     #   Not all return parameters registered
     #   oracle.jdbc.driver.OraclePreparedStatement.setupDbaBindBuffers(oracle/jdbc/driver/OraclePreparedStatement.java:3546)

Finished in 2.73 seconds (files took 8.2 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:278 # OracleEnhancedAdapter schema definition create table with primary key trigger with non-default primary key and non-default sequence name should return new key value using connection insert method
```

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:310
==> Loading config from ENV or use default
==> Running specs with JRuby version 9.1.2.0
==> Effective ActiveRecord version 5.0.0
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb"=>[310]}}
F

Failures:

  1) OracleEnhancedAdapter schema definition create table with primary key trigger with non-default sequence name and non-default trigger name should return new key value using connection insert method
     Failure/Error: Unable to find oracle.jdbc.driver.OraclePreparedStatement.setupDbaBindBuffers(oracle/jdbc/driver/OraclePreparedStatement.java to read failed line

     ActiveRecord::StatementInvalid:
       Java::JavaSql::SQLException: Not all return parameters registered: INSERT INTO test_employees (first_name) VALUES ('Raimonds') RETURNING "ID" INTO :returning_id
     # oracle.jdbc.driver.OraclePreparedStatement.setupDbaBindBuffers(oracle/jdbc/driver/OraclePreparedStatement.java:3546)
     # oracle.jdbc.driver.OraclePreparedStatement.setupBindBuffers(oracle/jdbc/driver/OraclePreparedStatement.java:3046)
     # oracle.jdbc.driver.OraclePreparedStatement.processCompletedBindRow(oracle/jdbc/driver/OraclePreparedStatement.java:2670)
     # oracle.jdbc.driver.OraclePreparedStatement.executeInternal(oracle/jdbc/driver/OraclePreparedStatement.java:4790)
     # oracle.jdbc.driver.OraclePreparedStatement.executeUpdate(oracle/jdbc/driver/OraclePreparedStatement.java:4875)
     # oracle.jdbc.driver.OraclePreparedStatementWrapper.executeUpdate(oracle/jdbc/driver/OraclePreparedStatementWrapper.java:1361)
     # java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)
     # org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:438)
     # org.jruby.javasupport.JavaMethod.invokeDirect(org/jruby/javasupport/JavaMethod.java:302)
     # RUBY.exec_update(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:408)
     # RUBY.block in exec_insert(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:113)
     # RUBY.block in log(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589)
     # RUBY.instrument(/home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21)
     # RUBY.log(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583)
     # RUBY.log(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1243)
     # RUBY.exec_insert(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:99)
     # RUBY.insert(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:124)
     # RUBY.insert(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14)
     # RUBY.block in (root)(/home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:311)
     # org.jruby.RubyBasicObject.yieldUnder(org/jruby/RubyBasicObject.java:1707)
     # org.jruby.RubyBasicObject.instance_exec(org/jruby/RubyBasicObject.java:1684)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:252)
     # RUBY.block in with_around_and_singleton_context_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494)
     # RUBY.block in with_around_example_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471)
     # RUBY.run_around_example_hooks_for(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:609)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471)
     # RUBY.with_around_example_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451)
     # RUBY.with_around_and_singleton_context_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:249)
     # RUBY.block in run_examples(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:627)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run_examples(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:623)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:589)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113)
     # RUBY.with_suite_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/configuration.rb:1836)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:112)
     # RUBY.report(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/reporter.rb:77)
     # RUBY.run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:111)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:87)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:71)
     # RUBY.invoke(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:45)
     # RUBY.<top>(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/exe/rspec:4)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:849)
     # org.jruby.Ruby.loadFile(org/jruby/Ruby.java:2986)
     # org.jruby.RubyKernel.loadCommon(org/jruby/RubyKernel.java:970)
     # org.jruby.RubyKernel.load(org/jruby/RubyKernel.java:962)
     # RUBY.<top>(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/bin/rspec:1)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:868)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:873)
     # org.jruby.Ruby.runNormally(org/jruby/Ruby.java:765)
     # org.jruby.Ruby.runFromMain(org/jruby/Ruby.java:579)
     # org.jruby.Main.doRunFromMain(org/jruby/Main.java:425)
     # org.jruby.Main.internalRun(org/jruby/Main.java:313)
     # org.jruby.Main.run(org/jruby/Main.java:242)
     # org.jruby.Main.main(org/jruby/Main.java:204)
     # ------------------
     # --- Caused by: ---
     # Java::JavaSql::SQLException:
     #   Not all return parameters registered
     #   oracle.jdbc.driver.OraclePreparedStatement.setupDbaBindBuffers(oracle/jdbc/driver/OraclePreparedStatement.java:3546)

Finished in 2.48 seconds (files took 6.56 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:310 # OracleEnhancedAdapter schema definition create table with primary key trigger with non-default sequence name and non-default trigger name should return new key value using connection insert method

$
``` 

Without `if ORACLE_ENHANCED_CONNECTION == :jdbc` condition it would cause this failure tested with ruby 2.3.1.
```ruby
ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/associations/has_many_associations_test.rb

  2) Failure:
HasManyAssociationsTest#test_building_the_association_with_an_array [test/cases/associations/has_many_associations_test.rb:312]:
Expected: ["first", "second"]
  Actual: [nil, nil]

251 runs, 589 assertions, 1 failures, 1 errors, 0 skips
```
