### PR TITLE
Use binds.size to set returning_id_index for returning_id

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -110,7 +110,8 @@ module ActiveRecord
               cursor.bind_params(type_casted_binds)
 
               if sql =~ /:returning_id/
-                returning_id_index = 1
+                # it currently expects that returning_id comes last part of binds
+                returning_id_index = binds.size
                 cursor.bind_returning_param(returning_id_index, Integer) if ORACLE_ENHANCED_CONNECTION == :jdbc
               end
 


### PR DESCRIPTION
This pull request addresses 4 failures. The error messages of CRuby and JRuby are different then it will show both output. It addresses #907 and #912 

```ruby
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:211 # OracleEnhancedAdapter schema definition create table with primary key trigger with default primary key should create new record for model
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:250 # OracleEnhancedAdapter schema definition create table with primary key trigger with separate creation of primary key trigger should create new record for model
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:283 # OracleEnhancedAdapter schema definition create table with primary key trigger with non-default primary key and non-default sequence name should create new record for model with autogenerated sequence option
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:315 # OracleEnhancedAdapter schema definition create table with primary key trigger with non-default sequence name and non-default trigger name should create new record for model with autogenerated sequence option
```

* Ruby 2.3.1 (aka CRuby)

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:211
==> Loading config from ENV or use default
==> Running specs with MRI version 2.3.1
==> Effective ActiveRecord version 5.0.0
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb"=>[211]}}
F

Failures:

  1) OracleEnhancedAdapter schema definition create table with primary key trigger with default primary key should create new record for model
     Failure/Error: expect(@conn.select_value("SELECT test_employees_seq.currval FROM dual")).to eq(e.id)

       expected: 0
            got: 10000

       (compared using ==)
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-support-3.5.0/lib/rspec/support.rb:87:in `block in <module:Support>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-support-3.5.0/lib/rspec/support.rb:96:in `notify_failure'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/fail_with.rb:27:in `fail_with'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:38:in `handle_failure'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/expectation_target.rb:65:in `to'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:213:in `block (4 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:252:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:252:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:609:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:249:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/configuration.rb:1836:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:22:in `load'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:22:in `<main>'

Finished in 0.64859 seconds (files took 1.32 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:211 # OracleEnhancedAdapter schema definition create table with primary key trigger with default primary key should create new record for model
```

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:250
==> Loading config from ENV or use default
==> Running specs with MRI version 2.3.1
==> Effective ActiveRecord version 5.0.0
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb"=>[250]}}
F

Failures:

  1) OracleEnhancedAdapter schema definition create table with primary key trigger with separate creation of primary key trigger should create new record for model
     Failure/Error: expect(@conn.select_value("SELECT test_employees_seq.currval FROM dual")).to eq(e.id)

       expected: 0
            got: 10000

       (compared using ==)
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-support-3.5.0/lib/rspec/support.rb:87:in `block in <module:Support>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-support-3.5.0/lib/rspec/support.rb:96:in `notify_failure'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/fail_with.rb:27:in `fail_with'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:38:in `handle_failure'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/expectation_target.rb:65:in `to'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:252:in `block (4 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:252:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:252:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:609:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:249:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/configuration.rb:1836:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:22:in `load'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:22:in `<main>'

Finished in 0.62572 seconds (files took 1.45 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:250 # OracleEnhancedAdapter schema definition create table with primary key trigger with separate creation of primary key trigger should create new record for model
```

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:283
==> Loading config from ENV or use default
==> Running specs with MRI version 2.3.1
==> Effective ActiveRecord version 5.0.0
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb"=>[283]}}
F

Failures:

  1) OracleEnhancedAdapter schema definition create table with primary key trigger with non-default primary key and non-default sequence name should create new record for model with autogenerated sequence option
     Failure/Error: expect(@conn.select_value("SELECT #{@sequence_name}.currval FROM dual")).to eq(e.id)

       expected: 0
            got: 10000

       (compared using ==)
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-support-3.5.0/lib/rspec/support.rb:87:in `block in <module:Support>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-support-3.5.0/lib/rspec/support.rb:96:in `notify_failure'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/fail_with.rb:27:in `fail_with'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:38:in `handle_failure'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/expectation_target.rb:65:in `to'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:285:in `block (4 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:252:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:252:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:609:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:249:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/configuration.rb:1836:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:22:in `load'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:22:in `<main>'

Finished in 0.61272 seconds (files took 1.2 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:283 # OracleEnhancedAdapter schema definition create table with primary key trigger with non-default primary key and non-default sequence name should create new record for model with autogenerated sequence option
```

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:315
==> Loading config from ENV or use default
==> Running specs with MRI version 2.3.1
==> Effective ActiveRecord version 5.0.0
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb"=>[315]}}
F

Failures:

  1) OracleEnhancedAdapter schema definition create table with primary key trigger with non-default sequence name and non-default trigger name should create new record for model with autogenerated sequence option
     Failure/Error: expect(@conn.select_value("SELECT #{@sequence_name}.currval FROM dual")).to eq(e.id)

       expected: 0
            got: 10000

       (compared using ==)
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-support-3.5.0/lib/rspec/support.rb:87:in `block in <module:Support>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-support-3.5.0/lib/rspec/support.rb:96:in `notify_failure'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/fail_with.rb:27:in `fail_with'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:38:in `handle_failure'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/expectation_target.rb:65:in `to'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:317:in `block (4 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:252:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:252:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:609:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:249:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/configuration.rb:1836:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.1/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:22:in `load'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:22:in `<main>'

Finished in 0.65321 seconds (files took 1.17 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:315 # OracleEnhancedAdapter schema definition create table with primary key trigger with non-default sequence name and non-default trigger name should create new record for model with autogenerated sequence option

$
```


* JRuby 9.1.2.0

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:211
==> Loading config from ENV or use default
==> Running specs with JRuby version 9.1.2.0
==> Effective ActiveRecord version 5.0.0
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb"=>[211]}}
F

Failures:

  1) OracleEnhancedAdapter schema definition create table with primary key trigger with default primary key should create new record for model
     Failure/Error: Unable to find oracle.jdbc.driver.OraclePreparedStatement.registerReturnParameter(oracle/jdbc/driver/OraclePreparedStatement.java to read failed line

     ActiveRecord::StatementInvalid:
       Java::JavaSql::SQLException: Invalid column index: INSERT INTO "TEST_EMPLOYEES" ("FIRST_NAME") VALUES (:a1) RETURNING "ID" INTO :returning_id
     # oracle.jdbc.driver.OraclePreparedStatement.registerReturnParameter(oracle/jdbc/driver/OraclePreparedStatement.java:12919)
     # oracle.jdbc.driver.OraclePreparedStatementWrapper.registerReturnParameter(oracle/jdbc/driver/OraclePreparedStatementWrapper.java:1477)
     # java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)
     # org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:423)
     # org.jruby.javasupport.JavaMethod.invokeDirect(org/jruby/javasupport/JavaMethod.java:290)
     # RUBY.bind_returning_param(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:398)
     # RUBY.block in exec_insert(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:114)
     # RUBY.block in log(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589)
     # RUBY.instrument(/home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21)
     # RUBY.log(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583)
     # RUBY.log(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1243)
     # RUBY.exec_insert(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:99)
     # RUBY.insert(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:124)
     # RUBY.insert(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14)
     # RUBY.insert(/home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:65)
     # RUBY._create_record(/home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:559)
     # RUBY._create_record(/home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:128)
     # RUBY._create_record(/home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:75)
     # RUBY._create_record(/home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:123)
     # RUBY.block in _create_record(/home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302)
     # RUBY.__run_callbacks__(/home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97)
     # RUBY._run_create_callbacks(/home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750)
     # RUBY._create_record(/home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302)
     # RUBY._create_record(/home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:68)
     # RUBY.create_or_update(/home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:539)
     # RUBY.block in create_or_update(/home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298)
     # RUBY.__run_callbacks__(/home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97)
     # RUBY._run_save_callbacks(/home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750)
     # RUBY.create_or_update(/home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298)
     # RUBY.save!(/home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:152)
     # RUBY.save!(/home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:50)
     # RUBY.save!(/home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:30)
     # RUBY.block in save!(/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324)
     # RUBY.block in with_transaction_returning_status(/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:395)
     # RUBY.block in transaction(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232)
     # RUBY.within_new_transaction(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189)
     # RUBY.transaction(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232)
     # RUBY.transaction(/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211)
     # RUBY.with_transaction_returning_status(/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:392)
     # RUBY.save!(/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324)
     # RUBY.save!(/home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:45)
     # RUBY.create!(/home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:51)
     # RUBY.block in (root)(/home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:212)
     # org.jruby.RubyBasicObject.yieldUnder(org/jruby/RubyBasicObject.java:1707)
     # org.jruby.RubyBasicObject.instance_exec(org/jruby/RubyBasicObject.java:1684)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:252)
     # RUBY.block in with_around_and_singleton_context_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494)
     # RUBY.block in with_around_example_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471)
     # RUBY.run_around_example_hooks_for(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:609)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471)
     # RUBY.with_around_example_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451)
     # RUBY.with_around_and_singleton_context_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:249)
     # RUBY.block in run_examples(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:627)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run_examples(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:623)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:589)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113)
     # RUBY.with_suite_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/configuration.rb:1836)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:112)
     # RUBY.report(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/reporter.rb:77)
     # RUBY.run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:111)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:87)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:71)
     # RUBY.invoke(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:45)
     # RUBY.<top>(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/exe/rspec:4)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:849)
     # org.jruby.Ruby.loadFile(org/jruby/Ruby.java:2986)
     # org.jruby.RubyKernel.loadCommon(org/jruby/RubyKernel.java:970)
     # org.jruby.RubyKernel.load(org/jruby/RubyKernel.java:962)
     # RUBY.<top>(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/bin/rspec:1)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:868)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:873)
     # org.jruby.Ruby.runNormally(org/jruby/Ruby.java:765)
     # org.jruby.Ruby.runFromMain(org/jruby/Ruby.java:579)
     # org.jruby.Main.doRunFromMain(org/jruby/Main.java:425)
     # org.jruby.Main.internalRun(org/jruby/Main.java:313)
     # org.jruby.Main.run(org/jruby/Main.java:242)
     # org.jruby.Main.main(org/jruby/Main.java:204)
     # ------------------
     # --- Caused by: ---
     # Java::JavaSql::SQLException:
     #   Invalid column index
     #   oracle.jdbc.driver.OraclePreparedStatement.registerReturnParameter(oracle/jdbc/driver/OraclePreparedStatement.java:12919)

Finished in 6.83 seconds (files took 7.33 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:211 # OracleEnhancedAdapter schema definition create table with primary key trigger with default primary key should create new record for model
```

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:250
==> Loading config from ENV or use default
==> Running specs with JRuby version 9.1.2.0
==> Effective ActiveRecord version 5.0.0
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb"=>[250]}}
F

Failures:

  1) OracleEnhancedAdapter schema definition create table with primary key trigger with separate creation of primary key trigger should create new record for model
     Failure/Error: Unable to find oracle.jdbc.driver.OraclePreparedStatement.registerReturnParameter(oracle/jdbc/driver/OraclePreparedStatement.java to read failed line

     ActiveRecord::StatementInvalid:
       Java::JavaSql::SQLException: Invalid column index: INSERT INTO "TEST_EMPLOYEES" ("FIRST_NAME") VALUES (:a1) RETURNING "ID" INTO :returning_id
     # oracle.jdbc.driver.OraclePreparedStatement.registerReturnParameter(oracle/jdbc/driver/OraclePreparedStatement.java:12919)
     # oracle.jdbc.driver.OraclePreparedStatementWrapper.registerReturnParameter(oracle/jdbc/driver/OraclePreparedStatementWrapper.java:1477)
     # java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)
     # org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:423)
     # org.jruby.javasupport.JavaMethod.invokeDirect(org/jruby/javasupport/JavaMethod.java:290)
     # RUBY.bind_returning_param(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:398)
     # RUBY.block in exec_insert(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:114)
     # RUBY.block in log(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589)
     # RUBY.instrument(/home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21)
     # RUBY.log(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583)
     # RUBY.log(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1243)
     # RUBY.exec_insert(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:99)
     # RUBY.insert(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:124)
     # RUBY.insert(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14)
     # RUBY.insert(/home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:65)
     # RUBY._create_record(/home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:559)
     # RUBY._create_record(/home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:128)
     # RUBY._create_record(/home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:75)
     # RUBY._create_record(/home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:123)
     # RUBY.block in _create_record(/home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302)
     # RUBY.__run_callbacks__(/home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97)
     # RUBY._run_create_callbacks(/home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750)
     # RUBY._create_record(/home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302)
     # RUBY._create_record(/home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:68)
     # RUBY.create_or_update(/home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:539)
     # RUBY.block in create_or_update(/home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298)
     # RUBY.__run_callbacks__(/home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97)
     # RUBY._run_save_callbacks(/home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750)
     # RUBY.create_or_update(/home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298)
     # RUBY.save!(/home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:152)
     # RUBY.save!(/home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:50)
     # RUBY.save!(/home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:30)
     # RUBY.block in save!(/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324)
     # RUBY.block in with_transaction_returning_status(/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:395)
     # RUBY.block in transaction(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232)
     # RUBY.within_new_transaction(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189)
     # RUBY.transaction(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232)
     # RUBY.transaction(/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211)
     # RUBY.with_transaction_returning_status(/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:392)
     # RUBY.save!(/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324)
     # RUBY.save!(/home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:45)
     # RUBY.create!(/home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:51)
     # RUBY.block in (root)(/home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:251)
     # org.jruby.RubyBasicObject.yieldUnder(org/jruby/RubyBasicObject.java:1707)
     # org.jruby.RubyBasicObject.instance_exec(org/jruby/RubyBasicObject.java:1684)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:252)
     # RUBY.block in with_around_and_singleton_context_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494)
     # RUBY.block in with_around_example_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471)
     # RUBY.run_around_example_hooks_for(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:609)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471)
     # RUBY.with_around_example_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451)
     # RUBY.with_around_and_singleton_context_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:249)
     # RUBY.block in run_examples(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:627)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run_examples(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:623)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:589)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113)
     # RUBY.with_suite_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/configuration.rb:1836)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:112)
     # RUBY.report(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/reporter.rb:77)
     # RUBY.run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:111)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:87)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:71)
     # RUBY.invoke(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:45)
     # RUBY.<top>(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/exe/rspec:4)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:849)
     # org.jruby.Ruby.loadFile(org/jruby/Ruby.java:2986)
     # org.jruby.RubyKernel.loadCommon(org/jruby/RubyKernel.java:970)
     # org.jruby.RubyKernel.load(org/jruby/RubyKernel.java:962)
     # RUBY.<top>(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/bin/rspec:1)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:868)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:873)
     # org.jruby.Ruby.runNormally(org/jruby/Ruby.java:765)
     # org.jruby.Ruby.runFromMain(org/jruby/Ruby.java:579)
     # org.jruby.Main.doRunFromMain(org/jruby/Main.java:425)
     # org.jruby.Main.internalRun(org/jruby/Main.java:313)
     # org.jruby.Main.run(org/jruby/Main.java:242)
     # org.jruby.Main.main(org/jruby/Main.java:204)
     # ------------------
     # --- Caused by: ---
     # Java::JavaSql::SQLException:
     #   Invalid column index
     #   oracle.jdbc.driver.OraclePreparedStatement.registerReturnParameter(oracle/jdbc/driver/OraclePreparedStatement.java:12919)

Finished in 3.38 seconds (files took 6.94 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:250 # OracleEnhancedAdapter schema definition create table with primary key trigger with separate creation of primary key trigger should create new record for model
```

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:283
==> Loading config from ENV or use default
==> Running specs with JRuby version 9.1.2.0
==> Effective ActiveRecord version 5.0.0
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb"=>[283]}}
F

Failures:

  1) OracleEnhancedAdapter schema definition create table with primary key trigger with non-default primary key and non-default sequence name should create new record for model with autogenerated sequence option
     Failure/Error: Unable to find oracle.jdbc.driver.OraclePreparedStatement.registerReturnParameter(oracle/jdbc/driver/OraclePreparedStatement.java to read failed line

     ActiveRecord::StatementInvalid:
       Java::JavaSql::SQLException: Invalid column index: INSERT INTO "TEST_EMPLOYEES" ("FIRST_NAME") VALUES (:a1) RETURNING "EMPLOYEE_ID" INTO :returning_id
     # oracle.jdbc.driver.OraclePreparedStatement.registerReturnParameter(oracle/jdbc/driver/OraclePreparedStatement.java:12919)
     # oracle.jdbc.driver.OraclePreparedStatementWrapper.registerReturnParameter(oracle/jdbc/driver/OraclePreparedStatementWrapper.java:1477)
     # java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)
     # org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:423)
     # org.jruby.javasupport.JavaMethod.invokeDirect(org/jruby/javasupport/JavaMethod.java:290)
     # RUBY.bind_returning_param(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:398)
     # RUBY.block in exec_insert(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:114)
     # RUBY.block in log(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589)
     # RUBY.instrument(/home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21)
     # RUBY.log(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583)
     # RUBY.log(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1243)
     # RUBY.exec_insert(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:99)
     # RUBY.insert(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:124)
     # RUBY.insert(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14)
     # RUBY.insert(/home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:65)
     # RUBY._create_record(/home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:559)
     # RUBY._create_record(/home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:128)
     # RUBY._create_record(/home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:75)
     # RUBY._create_record(/home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:123)
     # RUBY.block in _create_record(/home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302)
     # RUBY.__run_callbacks__(/home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97)
     # RUBY._run_create_callbacks(/home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750)
     # RUBY._create_record(/home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302)
     # RUBY._create_record(/home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:68)
     # RUBY.create_or_update(/home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:539)
     # RUBY.block in create_or_update(/home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298)
     # RUBY.__run_callbacks__(/home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97)
     # RUBY._run_save_callbacks(/home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750)
     # RUBY.create_or_update(/home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298)
     # RUBY.save!(/home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:152)
     # RUBY.save!(/home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:50)
     # RUBY.save!(/home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:30)
     # RUBY.block in save!(/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324)
     # RUBY.block in with_transaction_returning_status(/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:395)
     # RUBY.block in transaction(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232)
     # RUBY.within_new_transaction(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189)
     # RUBY.transaction(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232)
     # RUBY.transaction(/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211)
     # RUBY.with_transaction_returning_status(/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:392)
     # RUBY.save!(/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324)
     # RUBY.save!(/home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:45)
     # RUBY.create!(/home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:51)
     # RUBY.block in (root)(/home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:284)
     # org.jruby.RubyBasicObject.yieldUnder(org/jruby/RubyBasicObject.java:1707)
     # org.jruby.RubyBasicObject.instance_exec(org/jruby/RubyBasicObject.java:1684)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:252)
     # RUBY.block in with_around_and_singleton_context_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494)
     # RUBY.block in with_around_example_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471)
     # RUBY.run_around_example_hooks_for(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:609)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471)
     # RUBY.with_around_example_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451)
     # RUBY.with_around_and_singleton_context_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:249)
     # RUBY.block in run_examples(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:627)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run_examples(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:623)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:589)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113)
     # RUBY.with_suite_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/configuration.rb:1836)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:112)
     # RUBY.report(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/reporter.rb:77)
     # RUBY.run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:111)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:87)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:71)
     # RUBY.invoke(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:45)
     # RUBY.<top>(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/exe/rspec:4)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:849)
     # org.jruby.Ruby.loadFile(org/jruby/Ruby.java:2986)
     # org.jruby.RubyKernel.loadCommon(org/jruby/RubyKernel.java:970)
     # org.jruby.RubyKernel.load(org/jruby/RubyKernel.java:962)
     # RUBY.<top>(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/bin/rspec:1)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:868)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:873)
     # org.jruby.Ruby.runNormally(org/jruby/Ruby.java:765)
     # org.jruby.Ruby.runFromMain(org/jruby/Ruby.java:579)
     # org.jruby.Main.doRunFromMain(org/jruby/Main.java:425)
     # org.jruby.Main.internalRun(org/jruby/Main.java:313)
     # org.jruby.Main.run(org/jruby/Main.java:242)
     # org.jruby.Main.main(org/jruby/Main.java:204)
     # ------------------
     # --- Caused by: ---
     # Java::JavaSql::SQLException:
     #   Invalid column index
     #   oracle.jdbc.driver.OraclePreparedStatement.registerReturnParameter(oracle/jdbc/driver/OraclePreparedStatement.java:12919)

Finished in 3.2 seconds (files took 7.26 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:283 # OracleEnhancedAdapter schema definition create table with primary key trigger with non-default primary key and non-default sequence name should create new record for model with autogenerated sequence option
```

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:315
==> Loading config from ENV or use default
==> Running specs with JRuby version 9.1.2.0
==> Effective ActiveRecord version 5.0.0
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb"=>[315]}}
F

Failures:

  1) OracleEnhancedAdapter schema definition create table with primary key trigger with non-default sequence name and non-default trigger name should create new record for model with autogenerated sequence option
     Failure/Error: Unable to find oracle.jdbc.driver.OraclePreparedStatement.registerReturnParameter(oracle/jdbc/driver/OraclePreparedStatement.java to read failed line

     ActiveRecord::StatementInvalid:
       Java::JavaSql::SQLException: Invalid column index: INSERT INTO "TEST_EMPLOYEES" ("FIRST_NAME", "ID") VALUES (:a1, :a2) RETURNING "ID" INTO :returning_id
     # oracle.jdbc.driver.OraclePreparedStatement.registerReturnParameter(oracle/jdbc/driver/OraclePreparedStatement.java:12919)
     # oracle.jdbc.driver.OraclePreparedStatementWrapper.registerReturnParameter(oracle/jdbc/driver/OraclePreparedStatementWrapper.java:1477)
     # java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)
     # org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:423)
     # org.jruby.javasupport.JavaMethod.invokeDirect(org/jruby/javasupport/JavaMethod.java:290)
     # RUBY.bind_returning_param(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:398)
     # RUBY.block in exec_insert(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:114)
     # RUBY.block in log(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589)
     # RUBY.instrument(/home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21)
     # RUBY.log(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583)
     # RUBY.log(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1243)
     # RUBY.exec_insert(/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:99)
     # RUBY.insert(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:124)
     # RUBY.insert(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14)
     # RUBY.insert(/home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:65)
     # RUBY._create_record(/home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:559)
     # RUBY._create_record(/home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:128)
     # RUBY._create_record(/home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:75)
     # RUBY._create_record(/home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:123)
     # RUBY.block in _create_record(/home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302)
     # RUBY.__run_callbacks__(/home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97)
     # RUBY._run_create_callbacks(/home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750)
     # RUBY._create_record(/home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302)
     # RUBY._create_record(/home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:68)
     # RUBY.create_or_update(/home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:539)
     # RUBY.block in create_or_update(/home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298)
     # RUBY.__run_callbacks__(/home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97)
     # RUBY._run_save_callbacks(/home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750)
     # RUBY.create_or_update(/home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298)
     # RUBY.save!(/home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:152)
     # RUBY.save!(/home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:50)
     # RUBY.save!(/home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:30)
     # RUBY.block in save!(/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324)
     # RUBY.block in with_transaction_returning_status(/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:395)
     # RUBY.block in transaction(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232)
     # RUBY.within_new_transaction(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189)
     # RUBY.transaction(/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232)
     # RUBY.transaction(/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211)
     # RUBY.with_transaction_returning_status(/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:392)
     # RUBY.save!(/home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324)
     # RUBY.save!(/home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:45)
     # RUBY.create!(/home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:51)
     # RUBY.block in (root)(/home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:316)
     # org.jruby.RubyBasicObject.yieldUnder(org/jruby/RubyBasicObject.java:1707)
     # org.jruby.RubyBasicObject.instance_exec(org/jruby/RubyBasicObject.java:1684)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:252)
     # RUBY.block in with_around_and_singleton_context_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494)
     # RUBY.block in with_around_example_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471)
     # RUBY.run_around_example_hooks_for(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:609)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/hooks.rb:471)
     # RUBY.with_around_example_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:451)
     # RUBY.with_around_and_singleton_context_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:494)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example.rb:249)
     # RUBY.block in run_examples(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:627)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run_examples(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:623)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:589)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # RUBY.block in run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/example_group.rb:590)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:113)
     # RUBY.with_suite_hooks(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/configuration.rb:1836)
     # RUBY.block in run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:112)
     # RUBY.report(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/reporter.rb:77)
     # RUBY.run_specs(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:111)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:87)
     # RUBY.run(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:71)
     # RUBY.invoke(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/lib/rspec/core/runner.rb:45)
     # RUBY.<top>(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/lib/ruby/gems/shared/gems/rspec-core-3.5.1/exe/rspec:4)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:849)
     # org.jruby.Ruby.loadFile(org/jruby/Ruby.java:2986)
     # org.jruby.RubyKernel.loadCommon(org/jruby/RubyKernel.java:970)
     # org.jruby.RubyKernel.load(org/jruby/RubyKernel.java:962)
     # RUBY.<top>(/home/yahonda/.rbenv/versions/jruby-9.1.2.0/bin/rspec:1)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:868)
     # org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:873)
     # org.jruby.Ruby.runNormally(org/jruby/Ruby.java:765)
     # org.jruby.Ruby.runFromMain(org/jruby/Ruby.java:579)
     # org.jruby.Main.doRunFromMain(org/jruby/Main.java:425)
     # org.jruby.Main.internalRun(org/jruby/Main.java:313)
     # org.jruby.Main.run(org/jruby/Main.java:242)
     # org.jruby.Main.main(org/jruby/Main.java:204)
     # ------------------
     # --- Caused by: ---
     # Java::JavaSql::SQLException:
     #   Invalid column index
     #   oracle.jdbc.driver.OraclePreparedStatement.registerReturnParameter(oracle/jdbc/driver/OraclePreparedStatement.java:12919)

Finished in 3.27 seconds (files took 7.07 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:315 # OracleEnhancedAdapter schema definition create table with primary key trigger with non-default sequence name and non-default trigger name should create new record for model with autogenerated sequence option

$
```
