### PR TITLE
Address RSpec WARNINGS for using the `raise_error` matcher without providing a specific error or message

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -438,7 +438,7 @@ describe "OracleEnhancedAdapter schema definition" do
     it "should raise error when new table name length is too long" do
       expect do
         @conn.rename_table("test_employees","a"*31)
-      end.to raise_error
+      end.to raise_error(ArgumentError)
     end
 
     it "should not raise error when new sequence name length is too long" do
@@ -542,19 +542,19 @@ describe "OracleEnhancedAdapter schema definition" do
     it "should raise error when current index name and new index name are identical" do
       expect do
         @conn.rename_index("test_employees","i_test_employees_first_name","i_test_employees_first_name")
-      end.to raise_error
+      end.to raise_error(ActiveRecord::StatementInvalid)
     end
 
     it "should raise error when new index name length is too long" do
       expect do
         @conn.rename_index("test_employees","i_test_employees_first_name","a"*31)
-      end.to raise_error
+      end.to raise_error(ArgumentError)
     end
 
     it "should raise error when current index name does not exist" do
       expect do
         @conn.rename_index("test_employees","nonexist_index_name","new_index_name")
-      end.to raise_error
+      end.to raise_error(ArgumentError)
     end
 
     it "should rename index name with new one" do
@@ -930,7 +930,7 @@ end
     it "should disable all foreign keys" do
       expect do
         @conn.execute "INSERT INTO test_comments (id, body, test_post_id) VALUES (1, 'test', 1)"
-      end.to raise_error
+      end.to raise_error(ActiveRecord::InvalidForeignKey)
       @conn.disable_referential_integrity do
         expect do
           @conn.execute "INSERT INTO test_comments (id, body, test_post_id) VALUES (2, 'test', 2)"
@@ -939,7 +939,7 @@ end
       end
       expect do
         @conn.execute "INSERT INTO test_comments (id, body, test_post_id) VALUES (3, 'test', 3)"
-      end.to raise_error
+      end.to raise_error(ActiveRecord::InvalidForeignKey)
     end
 
   end


### PR DESCRIPTION
This pull request suppresses these 6 RSpec warnings:

```ruby
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<ArgumentError: New table name 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' is too long; the limit is 30 characters>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:439:in `block (3 levels) in <top (required)>'.

WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<ActiveRecord::StatementInvalid: OCIError: ORA-00955: name is already used by an existing object: ALTER INDEX "I_TEST_EMPLOYEES_FIRST_NAME" rename to "I_TEST_EMPLOYEES_FIRST_NAME">. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:543:in `block (3 levels) in <top (required)>'.

WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<ArgumentError: Index name 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' on table 'test_employees' is too long; the limit is 30 characters>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:549:in `block (3 levels) in <top (required)>'.

WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<ArgumentError: Index name 'nonexist_index_name' on table 'test_employees' does not exist>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:555:in `block (3 levels) in <top (required)>'.

WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<ActiveRecord::InvalidForeignKey: OCIError: ORA-02291: integrity constraint (ORACLE_ENHANCED.FK_RAIL...ed - parent key not found: INSERT INTO test_comments (id, body, test_post_id) VALUES (1, 'test', 1)>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:931:in `block (3 levels) in <top (required)>'.

WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<ActiveRecord::InvalidForeignKey: OCIError: ORA-02291: integrity constraint (ORACLE_ENHANCED.FK_RAIL...ed - parent key not found: INSERT INTO test_comments (id, body, test_post_id) VALUES (3, 'test', 3)>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:940:in `block (3 levels) in <top (required)>'.
```