### PR TITLE
Deprecate `set_type_for_columns`, `set_type_for_columns` and `clear_types_for_columns`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -892,20 +892,22 @@ module ActiveRecord
 
       # set explicit type for specified table columns
       def set_type_for_columns(table_name, column_type, *args) #:nodoc:
-        @@table_column_type ||= {}
-        @@table_column_type[table_name] ||= {}
-        args.each do |col|
-          @@table_column_type[table_name][col.to_s.downcase] = column_type
-        end
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          `set_type_for_columns` has been deprecated. Please use Rails attribute API.
+        MSG
       end
 
       def get_type_for_column(table_name, column_name) #:nodoc:
-        @@table_column_type && @@table_column_type[table_name] && @@table_column_type[table_name][column_name.to_s.downcase]
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          `get_type_for_columns` has been deprecated. Please use Rails attribute API.
+        MSG
       end
 
       # used just in tests to clear column data type definitions
       def clear_types_for_columns #:nodoc:
-        @@table_column_type = nil
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          `clear_types_for_columns` has been deprecated. Please use Rails attribute API.
+        MSG
       end
 
       # check if table has primary key trigger with _pkt suffix

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -58,7 +58,6 @@ describe "OracleEnhancedAdapter date type detection based on column names" do
     after(:each) do
       # @employee.destroy if @employee
       Object.send(:remove_const, "TestEmployee")
-      @conn.clear_types_for_columns
       ActiveRecord::Base.clear_cache! if ActiveRecord::Base.respond_to?(:"clear_cache!")
     end
 
@@ -186,7 +185,6 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
     
     after(:each) do
       Object.send(:remove_const, "Test2Employee")
-      @conn.clear_types_for_columns
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans = true
       ActiveRecord::Base.clear_cache! if ActiveRecord::Base.respond_to?(:"clear_cache!")
     end
@@ -312,7 +310,6 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
 
   after(:each) do
     Object.send(:remove_const, "Test3Employee")
-    @conn.clear_types_for_columns
     ActiveRecord::Base.clear_cache! if ActiveRecord::Base.respond_to?(:"clear_cache!")
   end
 
@@ -358,7 +355,6 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
     end
 
     after(:each) do
-      @conn.clear_types_for_columns
       ActiveRecord::Base.clear_cache! if ActiveRecord::Base.respond_to?(:"clear_cache!")
     end
 


### PR DESCRIPTION
These methods should not be executed since setting specific attributes for columns.
They have been replaced by Rails attribute API for attributes, not for columns.