### PR TITLE
Support `emulate_booleans_from_strings` in Rails 5

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -106,9 +106,19 @@ module ActiveRecord
           "1"
         end
 
+        def unquoted_true #:nodoc:
+          return "#{self.class.boolean_to_string(true)}" if emulate_booleans_from_strings
+          "1".freeze
+        end
+
         def quoted_false #:nodoc:
           return "'#{self.class.boolean_to_string(false)}'" if emulate_booleans_from_strings
           "0"
+        end
+
+        def unquoted_false #:nodoc:
+          return "#{self.class.boolean_to_string(false)}" if emulate_booleans_from_strings
+          "0".freeze
         end
 
         def quote_date_with_to_date(value) #:nodoc:
@@ -138,13 +148,6 @@ module ActiveRecord
 
         def _type_cast(value)
           case value
-          when true, false
-            #if emulate_booleans_from_strings || column && column.type == :string
-            if emulate_booleans_from_strings
-              self.class.boolean_to_string(value)
-            else
-              value ? 1 : 0
-            end
           when Date, Time
             if value.acts_like?(:time)
               zone_conversion_method = ActiveRecord::Base.default_timezone == :utc ? :getutc : :getlocal

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1193,7 +1193,13 @@ module ActiveRecord
           end
         end
 
-        m.register_type %r(^NUMBER\(1\))i, Type::Boolean.new if OracleEnhancedAdapter.emulate_booleans
+        if OracleEnhancedAdapter.emulate_booleans
+          if OracleEnhancedAdapter.emulate_booleans_from_strings
+            m.register_type %r(^VARCHAR2\(1\))i, Type::Boolean.new
+          else
+            m.register_type %r(^NUMBER\(1\))i, Type::Boolean.new
+          end
+        end
       end
 
       def extract_limit(sql_type) #:nodoc:

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -316,7 +316,7 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
   describe "default values in new records" do
     context "when emulate_booleans_from_strings is false" do
       before do
-        # ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = false
+        ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = false
       end
 
       it "are Y or N" do
@@ -328,7 +328,7 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
 
     context "when emulate_booleans_from_strings is true" do
       before do
-        #ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = true
+        ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = true
       end
 
       it "are True or False" do
@@ -344,14 +344,14 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
   end
 
   it "should translate boolean type to NUMBER(1) if emulate_booleans_from_strings is false" do
-    # ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = false
+    ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = false
     expect(ActiveRecord::Base.connection.type_to_sql(
       :boolean, nil, nil, nil)).to eq("NUMBER(1)")
   end
 
   describe "/ VARCHAR2 boolean values from ActiveRecord model" do
     before(:each) do
-      # ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = false
+      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = false
     end
 
     after(:each) do
@@ -373,7 +373,7 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
     end
 
     it "should return String value from VARCHAR2 boolean column if emulate_booleans_from_strings is false" do
-      # ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = false
+      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = false
       create_employee3
       %w(has_email has_phone active_flag manager_yn).each do |col|
         expect(@employee3.send(col.to_sym).class).to eq(String)
@@ -400,7 +400,7 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
     end
 
     it "should return string value from VARCHAR2 column if it is not boolean column and emulate_booleans_from_strings is true" do
-      # ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = true
+      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = true
       create_employee3
       expect(@employee3.first_name.class).to eq(String)
     end
@@ -426,7 +426,7 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
     end
 
     it "should return string value from VARCHAR2 column with boolean column name but is specified in set_string_columns" do
-      # ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = true
+      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = true
       # Test3Employee.set_string_columns :active_flag
       class ::Test3Employee < ActiveRecord::Base
         attribute :active_flag, :string


### PR DESCRIPTION
It addresses some of #942. since specs itself need changed but this setting is working by creating new application.