### PR TITLE
Quoting booleans should return a frozen string

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -103,7 +103,7 @@ module ActiveRecord
 
         def quoted_true #:nodoc:
           return "'#{self.class.boolean_to_string(true)}'" if emulate_booleans_from_strings
-          "1"
+          "1".freeze
         end
 
         def unquoted_true #:nodoc:
@@ -113,7 +113,7 @@ module ActiveRecord
 
         def quoted_false #:nodoc:
           return "'#{self.class.boolean_to_string(false)}'" if emulate_booleans_from_strings
-          "0"
+          "0".freeze
         end
 
         def unquoted_false #:nodoc:


### PR DESCRIPTION
refer rails/rails#25408

This pull request addresses a following failure.

```ruby
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/quoting_test.rb -n test_quote_returns_frozen_string
... snip ...
Using oracle
Run options: -n test_quote_returns_frozen_string --seed 8961

# Running:

F

Finished in 0.003497s, 285.9946 runs/s, 285.9946 assertions/s.

  1) Failure:
ActiveRecord::ConnectionAdapters::QuoteBooleanTest#test_quote_returns_frozen_string [test/cases/quoting_test.rb:159]:
Expected "1" to be frozen?.

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```

* Environment
```
* Rails master branch
* Oracle enhanced adapter `rails51` branch
* Oracle Database 12c Enterprise Edition Release 12.1.0.2.0 - 64bit Production
* ruby 2.4.0dev (2016-08-04 trunk 55812) [x86_64-linux]
```