### PR TITLE
Pass `type_casted_binds` to log subscriber

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -19,7 +19,7 @@ module ActiveRecord
         def exec_query(sql, name = 'SQL', binds = [], prepare: false)
           type_casted_binds = binds.map { |attr| type_cast(attr.value_for_database) }
 
-          log(sql, name, binds) do
+          log(sql, name, binds, type_casted_binds) do
             cursor = nil
             cached = false
             if without_prepared_statement?(binds)
@@ -96,7 +96,7 @@ module ActiveRecord
         def exec_insert(sql, name, binds, pk = nil, sequence_name = nil)
           type_casted_binds = binds.map { |attr| type_cast(attr.value_for_database) }
 
-          log(sql, name, binds) do
+          log(sql, name, binds, type_casted_binds) do
             returning_id_col = returning_id_index = nil
             if without_prepared_statement?(binds)
               cursor = @connection.prepare(sql)
@@ -132,7 +132,7 @@ module ActiveRecord
         def exec_update(sql, name, binds)
           type_casted_binds = binds.map { |attr| type_cast(attr.value_for_database) }
 
-          log(sql, name, binds) do
+          log(sql, name, binds, type_casted_binds) do
             cached = false
             if without_prepared_statement?(binds)
               cursor = @connection.prepare(sql)

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1262,7 +1262,7 @@ module ActiveRecord
       end
 
       protected
-      def log(sql, name = "SQL", binds = [], statement_name = nil) #:nodoc:
+      def log(sql, name = "SQL", binds = [], type_casted_binds = [], statement_name = nil)
         super
       ensure
         log_dbms_output if dbms_output_enabled?


### PR DESCRIPTION
for logging bind values properly

refer rails/rails#25886

This pull request addresses these 3 failures:

```ruby
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/log_subscriber_test.rb
... snip ...
Using oracle
Run options: --seed 62600

# Running:

.....FF..F......

Finished in 0.268538s, 59.5819 runs/s, 521.3415 assertions/s.

  1) Failure:
LogSubscriberTest#test_binary_data_hash [test/cases/log_subscriber_test.rb:222]:
Expected /<7 bytes of binary data>/ to match "(5.7ms)  SELECT cols.column_name AS name, cols.data_type AS sql_type, cols.data_default, cols.nullable, cols.virtual_column, cols.hidden_column, cols.data_type_owner AS sql_type_owner, DECODE(cols.data_type, 'NUMBER', data_precision, 'FLOAT', data_precision, 'VARCHAR2', DECODE(char_used, 'C', char_length, data_length), 'RAW', DECODE(char_used, 'C', char_length, data_length), 'CHAR', DECODE(char_used, 'C', char_length, data_length), NULL) AS limit, DECODE(data_type, 'NUMBER', data_scale, NULL) AS scale, comments.comments as column_comment FROM all_tab_cols cols, all_col_comments comments WHERE cols.owner = 'ARUNIT' AND cols.table_name = 'BINARIES' AND cols.hidden_column = 'NO' AND cols.owner = comments.owner AND cols.table_name = comments.table_name AND cols.column_name = comments.column_name ORDER BY cols.column_idSequence (1.0ms)  select us.sequence_name from all_sequences us where us.sequence_owner = 'ARUNIT' and us.sequence_name = 'BINARIES_SEQ'Primary Key (1.7ms)  SELECT cc.column_name FROM all_constraints c, all_cons_columns cc WHERE c.owner = 'ARUNIT' AND c.table_name = 'BINARIES' AND c.constraint_type = 'P' AND cc.owner = c.owner AND cc.constraint_name = c.constraint_name(0.6ms)  SAVEPOINT active_record_1Sequence (0.9ms)  select us.sequence_name from all_sequences us where us.sequence_owner = 'ARUNIT' and us.sequence_name = 'BINARIES_SEQ'Primary Key (1.9ms)  SELECT cc.column_name FROM all_constraints c, all_cons_columns cc WHERE c.owner = 'ARUNIT' AND c.table_name = 'BINARIES' AND c.constraint_type = 'P' AND cc.owner = c.owner AND cc.constraint_name = c.constraint_namePrimary Key Trigger (1.0ms)            SELECT trigger_name\n          FROM all_triggers\n          WHERE owner = 'ARUNIT'\n            AND trigger_name = 'BINARIES_PKT'\n            AND table_owner = 'ARUNIT'\n            AND table_name = 'BINARIES'\n            AND status = 'ENABLED'".


  2) Failure:
LogSubscriberTest#test_binary_data_is_not_logged [test/cases/log_subscriber_test.rb:216]:
Expected /<16 bytes of binary data>/ to match "(1.0ms)  SAVEPOINT active_record_1".


  3) Failure:
LogSubscriberTest#test_exists_query_logging [test/cases/log_subscriber_test.rb:175]:
Expected: 1
  Actual: 0

16 runs, 140 assertions, 3 failures, 0 errors, 0 skips
$
```

* Environment
```
* Rails master branch
* Oracle enhanced adapter `rails51` branch
* Oracle Database 12c Enterprise Edition Release 12.1.0.2.0 - 64bit Production
* ruby 2.4.0dev (2016-08-04 trunk 55812) [x86_64-linux]
```