### PR TITLE
Remove `self.emulate_dates` and `self.emulate_dates_by_column_name`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -530,11 +530,7 @@ module ActiveRecord
           if dt = rset.getDATE(i)
             d = dt.dateValue
             t = dt.timeValue
-            if OracleEnhancedAdapter.emulate_dates && t.hours == 0 && t.minutes == 0 && t.seconds == 0
-              Date.new(d.year + 1900, d.month + 1, d.date)
-            else
-              Time.send(Base.default_timezone, d.year + 1900, d.month + 1, d.date, t.hours, t.minutes, t.seconds)
-            end
+            Time.send(Base.default_timezone, d.year + 1900, d.month + 1, d.date, t.hours, t.minutes, t.seconds)
           else
             nil
           end

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -270,11 +270,7 @@ module ActiveRecord
             value
           end
         when Time, DateTime
-          if OracleEnhancedAdapter.emulate_dates && date_without_time?(value)
-            value.to_date
-          else
-            create_time_with_default_timezone(value)
-          end
+          create_time_with_default_timezone(value)
         else
           value
         end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -205,20 +205,6 @@ module ActiveRecord
       cattr_accessor :emulate_booleans
       self.emulate_booleans = true
 
-      ##
-      # :singleton-method:
-      # By default, the OracleEnhancedAdapter will typecast all columns of type <tt>DATE</tt>
-      # to Time or DateTime (if value is out of Time value range) value.
-      # If you wish that DATE values with hour, minutes and seconds equal to 0 are typecasted
-      # to Date then you can add the following line to your initializer file:
-      #
-      #   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates = true
-      #
-      # As this option can have side effects when unnecessary typecasting is done it is recommended
-      # that Date columns are explicily defined with +set_date_columns+ method.
-      cattr_accessor :emulate_dates
-      self.emulate_dates = false
-
        ##
         # :singleton-method:
         # OracleEnhancedAdapter will use the default tablespace, but if you want specific types of
@@ -231,20 +217,6 @@ module ActiveRecord
         # over these settings.
       cattr_accessor :default_tablespaces
       self.default_tablespaces={}
-
-      ##
-      # :singleton-method:
-      # By default, the OracleEnhancedAdapter will typecast all columns of type <tt>DATE</tt>
-      # to Time or DateTime (if value is out of Time value range) value.
-      # If you wish that DATE columns with "date" in their name (e.g. "creation_date") are typecasted
-      # to Date then you can add the following line to your initializer file:
-      #
-      #   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = true
-      #
-      # As this option can have side effects when unnecessary typecasting is done it is recommended
-      # that Date columns are explicily defined with +set_date_columns+ method.
-      cattr_accessor :emulate_dates_by_column_name
-      self.emulate_dates_by_column_name = false
 
       ##
       # :singleton-method:

--- a/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
@@ -95,7 +95,6 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
       END;
     SQL
 
-    ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = true
   end
 
   after(:all) do


### PR DESCRIPTION
Although no deprecate message shown but it should not be necessary anymore
after Rails 5 by using Rails attribute API.