### PR TITLE
Remove `dump_schema_information` and `initialize_schema_migrations_table`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -112,14 +112,6 @@ module ActiveRecord
           self.all_schema_indexes = nil
         end
 
-        def dump_schema_information #:nodoc:
-          super
-        end
-
-        def initialize_schema_migrations_table
-          super
-        end
-
         def update_table_definition(table_name, base) #:nodoc:
           OracleEnhanced::Table.new(table_name, base)
         end


### PR DESCRIPTION
Remove `dump_schema_information` and `initialize_schema_migrations_table` from Oracle enhanced adapter since they just call super.