### PR TITLE
Deprecate `fallback_string_to_date`, `fallback_string_to_time`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column.rb
@@ -91,6 +91,12 @@ module ActiveRecord
 
         def fallback_string_to_date(string) #:nodoc:
           if OracleEnhancedAdapter.string_to_date_format || OracleEnhancedAdapter.string_to_time_format
+            ActiveSupport::Deprecation.warn(<<-MSG.squish)
+              `fallback_string_to_date` has been deprecated.
+              It will be removed from next version of Oracle enhanced adapter.
+              Users are unlikely to see this message since this method has gone
+              from ActiveRecord::ConnectionAdapters::Column in Rails 4.2.
+            MSG
             return (string_to_date_or_time_using_format(string).to_date rescue super)
           end
           super
@@ -98,12 +104,25 @@ module ActiveRecord
 
         def fallback_string_to_time(string) #:nodoc:
           if OracleEnhancedAdapter.string_to_time_format || OracleEnhancedAdapter.string_to_date_format
+            ActiveSupport::Deprecation.warn(<<-MSG.squish)
+              `fallback_string_to_time` has been deprecated.
+              It will be removed from next version of Oracle enhanced adapter.
+              Users are unlikely to see this message since this method has gone
+              from ActiveRecord::ConnectionAdapters::Column in Rails 4.2.
+            MSG
             return (string_to_date_or_time_using_format(string).to_time rescue super)
           end
           super
         end
 
         def string_to_date_or_time_using_format(string) #:nodoc:
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            `string_to_date_or_time_using_format` has been deprecated.
+            It will be removed from next version of Oracle enhanced adapter.
+            Users are unlikely to see this message since `fallback_string_to_date`
+            and `fallback_string_to_time` have gone
+            from ActiveRecord::ConnectionAdapters::Column in Rails 4.2.
+          MSG
           if OracleEnhancedAdapter.string_to_time_format && dt=Date._strptime(string, OracleEnhancedAdapter.string_to_time_format)
             return Time.parse("#{dt[:year]}-#{dt[:mon]}-#{dt[:mday]} #{dt[:hour]}:#{dt[:min]}:#{dt[:sec]}#{dt[:zone]}")
           end


### PR DESCRIPTION
and `string_to_date_or_time_using_format` from Oracle enhanced adapter

Since rails/rails#15207 first of these two methods have gone from `ActiveRecord::ConnectionAdapters::Column` in Rails 4.2. The third one is called from first two.