### PR TITLE
Remove `fallback_string_to_date`, `fallback_string_to_time`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column.rb
@@ -79,50 +79,6 @@ module ActiveRecord
           Date.new(value.year, value.month, value.day) : value
       end
       
-      class << self
-        protected
-
-        def fallback_string_to_date(string) #:nodoc:
-          if OracleEnhancedAdapter.string_to_date_format || OracleEnhancedAdapter.string_to_time_format
-            ActiveSupport::Deprecation.warn(<<-MSG.squish)
-              `fallback_string_to_date` has been deprecated.
-              It will be removed from next version of Oracle enhanced adapter.
-              Users are unlikely to see this message since this method has gone
-              from ActiveRecord::ConnectionAdapters::Column in Rails 4.2.
-            MSG
-            return (string_to_date_or_time_using_format(string).to_date rescue super)
-          end
-          super
-        end
-
-        def fallback_string_to_time(string) #:nodoc:
-          if OracleEnhancedAdapter.string_to_time_format || OracleEnhancedAdapter.string_to_date_format
-            ActiveSupport::Deprecation.warn(<<-MSG.squish)
-              `fallback_string_to_time` has been deprecated.
-              It will be removed from next version of Oracle enhanced adapter.
-              Users are unlikely to see this message since this method has gone
-              from ActiveRecord::ConnectionAdapters::Column in Rails 4.2.
-            MSG
-            return (string_to_date_or_time_using_format(string).to_time rescue super)
-          end
-          super
-        end
-
-        def string_to_date_or_time_using_format(string) #:nodoc:
-          ActiveSupport::Deprecation.warn(<<-MSG.squish)
-            `string_to_date_or_time_using_format` has been deprecated.
-            It will be removed from next version of Oracle enhanced adapter.
-            Users are unlikely to see this message since `fallback_string_to_date`
-            and `fallback_string_to_time` have gone
-            from ActiveRecord::ConnectionAdapters::Column in Rails 4.2.
-          MSG
-          if OracleEnhancedAdapter.string_to_time_format && dt=Date._strptime(string, OracleEnhancedAdapter.string_to_time_format)
-            return Time.parse("#{dt[:year]}-#{dt[:mon]}-#{dt[:mday]} #{dt[:hour]}:#{dt[:min]}:#{dt[:sec]}#{dt[:zone]}")
-          end
-          DateTime.strptime(string, OracleEnhancedAdapter.string_to_date_format).to_date
-        end
-        
-      end
     end
 
   end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -208,22 +208,6 @@ module ActiveRecord
       cattr_accessor :emulate_booleans_from_strings
       self.emulate_booleans_from_strings = false
 
-      ##
-      # :singleton-method:
-      # Specify non-default date format that should be used when assigning string values to :date columns, e.g.:
-      #
-      #   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.string_to_date_format = “%d.%m.%Y”
-      cattr_accessor :string_to_date_format
-      self.string_to_date_format = nil
-
-      ##
-      # :singleton-method:
-      # Specify non-default time format that should be used when assigning string values to :datetime columns, e.g.:
-      #
-      #   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.string_to_time_format = “%d.%m.%Y %H:%M:%S”
-      cattr_accessor :string_to_time_format
-      self.string_to_time_format = nil
-
       class StatementPool
         include Enumerable
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -687,7 +687,7 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
   end
 
   it "should assign NLS string to date column" do
-    ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.string_to_date_format = @nls_date_format
+  #  ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.string_to_date_format = @nls_date_format
     @employee = TestEmployee.create(
       :first_name => "First",
       :last_name => "Last",
@@ -711,7 +711,7 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
 
   it "should assign NLS time string to date column" do
     # ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.string_to_date_format = @nls_date_format
-    ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.string_to_time_format = @nls_time_format
+    # ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.string_to_time_format = @nls_time_format
     @employee = TestEmployee.create(
       :first_name => "First",
       :last_name => "Last",
@@ -736,7 +736,7 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
 
   it "should assign NLS time string to datetime column" do
     ActiveRecord::Base.default_timezone = :local
-    ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.string_to_time_format = @nls_time_format
+    # ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.string_to_time_format = @nls_time_format
     @employee = TestEmployee.create(
       :first_name => "First",
       :last_name => "Last",
@@ -748,7 +748,7 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
   end
 
   it "should assign NLS time string with time zone to datetime column" do
-    ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.string_to_time_format = @nls_with_tz_time_format
+    # ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.string_to_time_format = @nls_with_tz_time_format
     @employee = TestEmployee.create(
       :first_name => "First",
       :last_name => "Last",
@@ -773,7 +773,7 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
 
   it "should assign NLS date string to datetime column" do
     ActiveRecord::Base.default_timezone = :local
-    ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.string_to_date_format = @nls_date_format
+    # ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.string_to_date_format = @nls_date_format
     # ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.string_to_time_format = @nls_time_format
     @employee = TestEmployee.create(
       :first_name => "First",


### PR DESCRIPTION
and `string_to_date_or_time_using_format` from Oracle enhanced adapter

Also removed these variables:
`ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.string_to_date_format`
`ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.string_to_date_format`

Refer #974