### PR TITLE
Address DEPRECATION WARNING: Passing a column to `quote` has been deprecated.

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -84,10 +84,6 @@ module ActiveRecord
           s.gsub(/'/, "''")
         end
 
-        def quote(value, column = nil) #:nodoc:
-          super
-        end
-
         def _quote(value) #:nodoc:
           case value
           when ActiveRecord::OracleEnhanced::Type::NationalCharacterString::Data then

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -1323,8 +1323,10 @@ describe "OracleEnhancedAdapter quoting of NCHAR and NVARCHAR2 columns" do
     columns = @conn.columns('test_items')
     %w(nchar_column nvarchar2_column char_column varchar2_column).each do |col|
       column = columns.detect{|c| c.name == col}
-      expect(@conn.quote('abc', column)).to eq(column.sql_type[0,1] == 'N' ? "N'abc'" : "'abc'")
-      expect(@conn.quote(nil, column)).to eq('NULL')
+      value = @conn.type_cast_from_column(column, 'abc')
+      expect(@conn.quote(value)).to eq(column.sql_type[0,1] == 'N' ? "N'abc'" : "'abc'")
+      nilvalue = @conn.type_cast_from_column(column, nil)
+      expect(@conn.quote(nilvalue)).to eq('NULL')
     end
   end
 


### PR DESCRIPTION
also removed Oracle enhanced own `quote` method which just calls super.