### PR TITLE
[QUESTION] enable querying on CLOB/:text fields

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -613,7 +613,9 @@ module ActiveRecord
       def quote(value, column = nil) #:nodoc:
         if value && column
           case column.type
-          when :text, :binary
+          when :text
+            super
+          when :binary
             %Q{empty_#{ type_to_sql(column.type.to_sym).downcase rescue 'blob' }()}
           # NLS_DATE_FORMAT independent TIMESTAMP support
           when :timestamp
@@ -636,6 +638,8 @@ module ActiveRecord
           quote_date_with_to_date(value)
         elsif value.acts_like?(:time)
           value.to_i == value.to_f ? quote_date_with_to_date(value) : quote_timestamp_with_to_timestamp(value)
+        elsif column.type == :text 
+          %Q{empty_#{ type_to_sql(column.type.to_sym).downcase rescue 'blob' }()}
         else
           super
         end


### PR DESCRIPTION
Hi,

I've created this PR as a question, as I find it easier to discuss/describe what I'd like to do.

Currently(v1.6.7) when querying a Rails `:text` field (which equals to CLOB type in Oracle), it's always matched against `empty_clob()` which only matches in case one was looking for empty fields but ignoring 'normal' cases (like `where(text_field: "long description")`.

As I'm not familiar with Oracle's data types, I was wondering if this was intentional. I'd very much like to use Rails' `:text` type, but it looses value if one cannot search for it's content. Is the change this PR is nudging to welcome (if so I'll create a proper PR with tests etc)?



