### PR TITLE
failing to query clob contents

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -1031,6 +1031,20 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
     expect(@employee.comments).to eq(@char_data)
   end
 
+   it "queries on clob/:text field contents" do
+    @employee = TestEmployee.create!(
+      :first_name => "First",
+      :comments => "initial"
+    )
+
+    # fails
+    expect(TestEmployee.where(Arel::Table.new(:test_employees)[:comments].matches("%initial%")).first.comments).to eq(@employee.comments)
+    expect(TestEmployee.where(comments: 'initial').first.comments).to eq(@employee.comments)
+    # works
+    expect(TestEmployee.where("comments LIKE '%initial%'").first.comments).to eq(@employee.comments)
+    expect(TestEmployee.where("dbms_lob.compare(comments, 'initial') = 0").first.comments).to eq(@employee.comments)
+  end
+
   it "should store serializable ruby data structures" do
     ruby_data1 = {"arbitrary1" => ["ruby", :data, 123]}
     ruby_data2 = {"arbitrary2" => ["ruby", :data, 123]}


### PR DESCRIPTION
A failing spec (based of master) as an example to #981 

Original question:

> Hi,
> 
> I've created this PR as a question, as I find it easier to discuss/describe what I'd like to do.
> 
> Currently(v1.6.7) when querying a Rails :text field (which equals to CLOB type in Oracle), it's always matched against empty_clob() which only matches in case one was looking for empty fields but ignoring 'normal' cases (like where(text_field: "long description").
> 
> As I'm not familiar with Oracle's data types, I was wondering if this was intentional. I'd very much like to use Rails' :text type, but it looses value if one cannot search for it's content. Is the change this PR is nudging to welcome (if so I'll create a proper PR with tests etc)?
