### PR TITLE
Remove `add_foreign_key` specs with `table_name_prefix` and `table_name_suffix`

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -639,36 +639,6 @@ end
       end.to raise_error() {|e| expect(e.message).to match(/ORA-02291.*\.#{fk_name}/i)}
     end
 
-    context "with table_name_prefix" do
-      let(:table_name_prefix) { 'xxx_' }
-
-      it "should use table_name_prefix for foreign table" do
-        fk_name = "fk_rails_#{Digest::SHA256.hexdigest("xxx_test_comments_test_post_id_fk").first(10)}"
-        schema_define do
-          add_foreign_key :test_comments, :test_posts
-        end
-
-        expect do
-          TestComment.create(:body => "test", :test_post_id => 1)
-        end.to raise_error() {|e| expect(e.message).to match(/ORA-02291.*\.#{fk_name}/i)}
-      end
-    end
-
-    context "with table_name_suffix" do
-      let(:table_name_suffix) { '_xxx' }
-
-      it "should use table_name_suffix for foreign table" do
-        fk_name = "fk_rails_#{Digest::SHA256.hexdigest("test_comments_xxx_test_post_id_fk").first(10)}"
-        schema_define do
-          add_foreign_key :test_comments, :test_posts
-        end
-
-        expect do
-          TestComment.create(:body => "test", :test_post_id => 1)
-        end.to raise_error() {|e| expect(e.message).to match(/ORA-02291.*\.#{fk_name}/i)}
-      end
-    end
-
     it "should add foreign key with name" do
       schema_define do
         add_foreign_key :test_comments, :test_posts, :name => "comments_posts_fk"


### PR DESCRIPTION
They have been tested at ActiveRecord unit tests:

ActiveRecord::Migration::ForeignKeyTest#test_add_foreign_key_with_prefix
ActiveRecord::Migration::ForeignKeyTest#test_add_foreign_key_with_suffix

Refer #639 rails/rails#20689 and rails/rails#20699