### PR TITLE
Use Rails migration `create_table` to create table and sequence

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
@@ -6,32 +6,23 @@ if ActiveRecord::Base.method_defined?(:changed?)
 
     before(:all) do
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-      @conn = ActiveRecord::Base.connection
-      @conn.execute "DROP TABLE test_employees" rescue nil
-      @conn.execute "DROP SEQUENCE test_employees_seq" rescue nil
-      @conn.execute <<-SQL
-        CREATE TABLE test_employees (
-          id            NUMBER PRIMARY KEY,
-          first_name    VARCHAR2(20),
-          last_name     VARCHAR2(25),
-          job_id        NUMBER(6,0) NULL,
-          salary        NUMBER(8,2),
-          comments      CLOB,
-          hire_date     DATE
-        )
-      SQL
-      @conn.execute <<-SQL
-        CREATE SEQUENCE test_employees_seq  MINVALUE 1
-          INCREMENT BY 1 CACHE 20 NOORDER NOCYCLE
-      SQL
+      ActiveRecord::Schema.define do
+        create_table :test_employees, :force => true do |t|
+          t.string    :first_name,  limit: 20
+          t.string    :last_name,   limit: 25
+          t.integer   :job_id,      limit: 6, null: true
+          t.decimal   :salary,      precision: 8, scale:2
+          t.text      :comments
+          t.date      :hire_date
+        end
+      end
+
       class TestEmployee < ActiveRecord::Base
       end
     end
   
     after(:all) do
       Object.send(:remove_const, "TestEmployee")
-      @conn.execute "DROP TABLE test_employees"
-      @conn.execute "DROP SEQUENCE test_employees_seq"
       ActiveRecord::Base.clear_cache! if ActiveRecord::Base.respond_to?(:"clear_cache!")
     end  
 


### PR DESCRIPTION
Use Rails migration `create_table` to create table and sequence for dirty object tracking specs.
Not executing SQL statements to create table and sequence.

* SQL statements executed after this commit:

```sql
CREATE TABLE "TEST_EMPLOYEES" ("ID" NUMBER(38) NOT NULL PRIMARY KEY, "FIRST_NAME" VARCHAR2(20), "LAST_NAME" VARCHAR2(25), "JOB_ID" NUMBER(6) NULL, "SALARY" DECIMAL(8,2), "COMMENTS" CLOB, "HIRE_DATE" DATE)
CREATE SEQUENCE "TEST_EMPLOYEES_SEQ" START WITH 10000
```

* SQL statements executed before this commit:
```sql
CREATE TABLE test_employees (
          id            NUMBER PRIMARY KEY,
          first_name    VARCHAR2(20),
          last_name     VARCHAR2(25),
          job_id        NUMBER(6,0) NULL,
          salary        NUMBER(8,2),
          comments      CLOB,
          hire_date     DATE
        )
CREATE SEQUENCE test_employees_seq  MINVALUE 1
INCREMENT BY 1 CACHE 20 NOORDER NOCYCLE
```

* `test_employees` table definition after this commit:
```sql
SQL> select table_name,column_name,DATA_TYPE,DATA_LENGTH,DATA_PRECISION,DATA_SCALE,NULLABLE from user_tab_columns
  2  order by column_id;
TABLE_NAME               COLUMN_NAME              DATA_TYPE  DATA_LENGTH DATA_PRECISION DATA_SCALE N
------------------------ ------------------------ ---------- ----------- -------------- ---------- -
TEST_EMPLOYEES           ID                       NUMBER              22             38          0 N
TEST_EMPLOYEES           FIRST_NAME               VARCHAR2            20                           Y
TEST_EMPLOYEES           LAST_NAME                VARCHAR2            25                           Y
TEST_EMPLOYEES           JOB_ID                   NUMBER              22              6          0 Y
TEST_EMPLOYEES           SALARY                   NUMBER              22              8          2 Y
TEST_EMPLOYEES           COMMENTS                 CLOB              4000                           Y
TEST_EMPLOYEES           HIRE_DATE                DATE                 7                           Y
```

* `test_employees` table definition before this commit:

```sql
TABLE_NAME               COLUMN_NAME              DATA_TYPE  DATA_LENGTH DATA_PRECISION DATA_SCALE N
------------------------ ------------------------ ---------- ----------- -------------- ---------- -
TEST_EMPLOYEES           ID                       NUMBER              22                           N
TEST_EMPLOYEES           FIRST_NAME               VARCHAR2            20                           Y
TEST_EMPLOYEES           LAST_NAME                VARCHAR2            25                           Y
TEST_EMPLOYEES           JOB_ID                   NUMBER              22              6          0 Y
TEST_EMPLOYEES           SALARY                   NUMBER              22              8          2 Y
TEST_EMPLOYEES           COMMENTS                 CLOB              4000                           Y
TEST_EMPLOYEES           HIRE_DATE                DATE                 7                           Y

```
* `test_employees` table definition differences:
`DATA_PRECISION` changes from `NULL` to `38`
`DATA_SCALE` changes from `NULL` to `0`

As far as I remember, they are identical.

* `TEST_EMPLOYEES_SEQ` sequence definition after this commit:

```sql
SQL> select * from user_sequences

SEQUENCE_NAME             MIN_VALUE  MAX_VALUE INCREMENT_BY C O CACHE_SIZE LAST_NUMBER PARTITION_COUNT S K
------------------------ ---------- ---------- ------------ - - ---------- ----------- --------------- - -
TEST_EMPLOYEES_SEQ                1 1.0000E+28            1 N N         20       10000                 N N
```
* `TEST_EMPLOYEES_SEQ` sequence definition before this commit:

```sql
SQL> select * from user_sequences
SEQUENCE_NAME             MIN_VALUE  MAX_VALUE INCREMENT_BY C O CACHE_SIZE LAST_NUMBER PARTITION_COUNT S K
------------------------ ---------- ---------- ------------ - - ---------- ----------- --------------- - -
TEST_EMPLOYEES_SEQ                1 1.0000E+28            1 N N         20           1                 N N

```
* `TEST_EMPLOYEES_SEQ` table definition differences:
`LAST_NUMBER` changes from `1` to `10000`  this is due to Oracle enhanced adapter default value.

