### PR TITLE
Remove ruby oci8 runtime dependency from gemfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ When using Ruby on Rails version 5.0 then in Gemfile include
 ```ruby
 # Use oracle as the database for Active Record
 gem 'activerecord-oracle_enhanced-adapter', '~> 1.7.0'
+gem 'ruby-oci8' # only for CRuby users
 ```
 
 ### Rails 4.2

--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -90,7 +90,6 @@ This adapter is superset of original ActiveRecord Oracle adapter.
   s.add_runtime_dependency(%q<activerecord>, ["~> 5.0.0"])
   s.add_runtime_dependency(%q<arel>, ["~> 7.1.0"])
   s.add_runtime_dependency(%q<ruby-plsql>, [">= 0.5.0"])
-  s.add_runtime_dependency(%q<ruby-oci8>, [">= 2.2.0"]) if !defined?(RUBY_ENGINE) || RUBY_ENGINE == 'ruby'
   s.license = 'MIT'
 end
 


### PR DESCRIPTION
This pull request addresses #992