### PR TITLE
Respect `default_timezone = :utc` rather than connection `time_zone` value

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -350,7 +350,11 @@ module ActiveRecord
         conn.non_blocking = true if async
         conn.prefetch_rows = prefetch_rows
         conn.exec "alter session set cursor_sharing = #{cursor_sharing}" rescue nil
-        conn.exec "alter session set time_zone = '#{time_zone}'" unless time_zone.blank?
+        if ActiveRecord::Base.default_timezone == :local
+          conn.exec "alter session set time_zone = '#{time_zone}'" unless time_zone.blank?
+        elsif ActiveRecord::Base.default_timezone == :utc
+          conn.exec "alter session set time_zone = '+00:00'"
+        end
         conn.exec "alter session set current_schema = #{schema}" unless schema.blank?
 
         # Initialize NLS parameters

--- a/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
@@ -110,6 +110,33 @@ describe "OracleEnhancedConnection" do
     end
   end
 
+  describe "default_timezone" do
+    before(:all) do
+      ActiveRecord::Base.establish_connection(CONNECTION_WITH_TIMEZONE_PARAMS)
+      ActiveRecord::Schema.define do
+        create_table :posts, :force => true do |t|
+          t.timestamps null: false
+        end
+      end
+      class ::Post < ActiveRecord::Base
+      end
+    end
+
+    after(:all) do
+      Object.send(:remove_const, "Post")
+      ActiveRecord::Base.clear_cache!
+    end
+
+    it "should respect default_timezone = :utc than time_zone setting" do
+      # it expects that ActiveRecord::Base.default_timezone = :utc
+      ActiveRecord::ConnectionAdapters::OracleEnhancedConnection.create(CONNECTION_WITH_TIMEZONE_PARAMS)
+      post = Post.create!
+      created_at = post.created_at
+      expect(post).to eq(Post.find_by!(created_at: created_at))
+    end
+
+  end
+
   if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
 
     describe "create JDBC connection" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -143,6 +143,16 @@ CONNECTION_WITH_SCHEMA_PARAMS = {
   :schema => DATABASE_SCHEMA
 }
 
+CONNECTION_WITH_TIMEZONE_PARAMS = {
+  :adapter => "oracle_enhanced",
+  :database => DATABASE_NAME,
+  :host => DATABASE_HOST,
+  :port => DATABASE_PORT,
+  :username => DATABASE_USER,
+  :password => DATABASE_PASSWORD,
+  :time_zone => "Europe/Riga"
+}
+
 SYS_CONNECTION_PARAMS = {
   :adapter => "oracle_enhanced",
   :database => DATABASE_NAME,


### PR DESCRIPTION
This pull request addresses #755 .

Also it addressed these 3 failures:

```ruby
$ ARCONN=oracle bundle exec ruby -Itest test/cases/finder_test.rb -n test_hash_condition_local_time_interpolation_with_default_timezone_utc
Using oracle
Run options: -n test_hash_condition_local_time_interpolation_with_default_timezone_utc --seed 33869

# Running:

F

Finished in 0.906743s, 1.1028 runs/s, 1.1028 assertions/s.

  1) Failure:
FinderTest#test_hash_condition_local_time_interpolation_with_default_timezone_utc [test/cases/finder_test.rb:847]:
--- expected
+++ actual
@@ -1 +1 @@
-#<Topic id: 1, title: "The First Topic", author_name: "David", author_email_address: "david@loudthinking.com", written_on: "2003-07-16 14:28:11", bonus_time: "2005-01-30 14:28:00", last_read: "2004-04-15", content: "Have a nice day", important: nil, approved: false, replies_count: 1, unique_replies_count: 0, parent_id: nil, parent_title: nil, type: nil, group: nil, created_at: "2016-10-03 13:31:11", updated_at: "2016-10-03 13:31:11">
+nil


1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
```

```ruby
$ ARCONN=oracle bundle exec ruby -Itest test/cases/date_time_precision_test.rb -n test_formatting_datetime_according_to_precision
Using oracle
Run options: -n test_formatting_datetime_according_to_precision --seed 28355

# Running:

F

Finished in 0.254480s, 3.9296 runs/s, 3.9296 assertions/s.

  1) Failure:
DateTimePrecisionTest#test_formatting_datetime_according_to_precision [test/cases/date_time_precision_test.rb:59]:
Failed assertion, no message given.

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
```

```ruby
$ ARCONN=oracle bundle exec ruby -Itest test/cases/time_precision_test.rb -n test_formatting_time_according_to_precision
Using oracle
Run options: -n test_formatting_time_according_to_precision --seed 19533

# Running:

F

Finished in 0.126472s, 7.9069 runs/s, 7.9069 assertions/s.

  1) Failure:
TimePrecisionTest#test_formatting_time_according_to_precision [test/cases/time_precision_test.rb:53]:
Failed assertion, no message given.

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```
