### PR TITLE
Address git warnings:

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,10 @@
 source 'http://rubygems.org'
 
+git_source(:github) do |repo_name|
+  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
+  "https://github.com/#{repo_name}.git"
+end
+
 group :development do
   gem 'rspec', '~> 3.3'
   gem 'rdoc'


### PR DESCRIPTION
This pull request addresses these git warnings since `Bundler version 1.13.1`.

```ruby
The git source `git://github.com/rails/rails.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
```

Refer https://github.com/bundler/bundler/pull/4127 for this fix.