### PR TITLE
Use rdoc 5.0.0.beta2 or higher to support ruby 2.4.0.preview2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'http://rubygems.org'
 
 group :development do
   gem 'rspec', '~> 3.3'
-  gem 'rdoc'
+  gem 'rdoc', '~> 5.0.0.beta2'
   gem 'rake'
 
   gem 'activerecord',   github: 'rails/rails', branch: '5-0-stable'


### PR DESCRIPTION
It removes dependency with json 1.8.3, which is not compatible
with ruby 2.4.0.