### PR TITLE
Quote table name in disable_referential_integrity

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -434,12 +434,12 @@ module ActiveRecord
           old_constraints = select_all(sql_constraints)
           begin
             old_constraints.each do |constraint|
-              execute "ALTER TABLE #{constraint["table_name"]} DISABLE CONSTRAINT #{constraint["constraint_name"]}"
+              execute "ALTER TABLE #{quote_table_name(constraint["table_name"])} DISABLE CONSTRAINT #{quote_table_name(constraint["constraint_name"])}"
             end
             yield
           ensure
             old_constraints.each do |constraint|
-              execute "ALTER TABLE #{constraint["table_name"]} ENABLE CONSTRAINT #{constraint["constraint_name"]}"
+              execute "ALTER TABLE #{quote_table_name(constraint["table_name"])} ENABLE CONSTRAINT #{quote_table_name(constraint["constraint_name"])}"
             end
           end
         end

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -917,11 +917,16 @@ end
           t.string :body, :limit => 4000
           t.references :test_post, :foreign_key => true
         end
+        create_table "test_Mixed_Comments", :force => true do |t|
+          t.string :body, :limit => 4000
+          t.references :test_post, :foreign_key => true
+        end
       end
     end
 
     after(:each) do
       schema_define do
+        drop_table "test_Mixed_Comments" rescue nil
         drop_table :test_comments rescue nil
         drop_table :test_posts rescue nil
       end
@@ -933,6 +938,7 @@ end
       end.to raise_error(ActiveRecord::InvalidForeignKey)
       @conn.disable_referential_integrity do
         expect do
+          @conn.execute "INSERT INTO \"test_Mixed_Comments\" (id, body, test_post_id) VALUES (2, 'test', 2)"
           @conn.execute "INSERT INTO test_comments (id, body, test_post_id) VALUES (2, 'test', 2)"
           @conn.execute "INSERT INTO test_posts (id, title) VALUES (2, 'test')"
         end.not_to raise_error


### PR DESCRIPTION
* With this commit:
```sql
ALTER TABLE "FK_TEST_HAS_FK" DISABLE CONSTRAINT "FK_NAME"
ALTER TABLE "FK_TEST_HAS_FK" ENABLE CONSTRAINT "FK_NAME"
```

* Without this commit:
```sql
ALTER TABLE FK_TEST_HAS_FK DISABLE CONSTRAINT FK_NAME
ALTER TABLE FK_TEST_HAS_FK ENABLE CONSTRAINT FK_NAME
```

Refer #1012