### PR TITLE
Multi insert is not supported

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -483,6 +483,10 @@ module ActiveRecord
         true
       end
 
+      def supports_multi_insert?
+        false
+      end
+
       #:stopdoc:
       DEFAULT_NLS_PARAMETERS = {
         :nls_calendar            => nil,


### PR DESCRIPTION
Dump schema migration versions with multiple SQL statement. Otherwise rails default adapter tries to add all version to single SQL statement which does not work with Oracle.

Should not affect any other functionality.