### PR TITLE
Address #955

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
@@ -186,7 +186,7 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
     expect {
       @employee.save
     }.to raise_error("Make the transaction rollback")
-    expect(@employee.id).to eq(nil)
+    expect(@employee.new_record?).to be_truthy
     expect(TestEmployee.count).to eq(employees_count)
   end
 


### PR DESCRIPTION
Since #756 b9e79a6774f3b8d213412971bc06e50677b07b09 has overwritten by #707 when rails5 merged to master branch

This pull request addresses this failure:

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:177
==> Loading config from ENV or use default
==> Running specs with MRI version 2.3.1
==> Effective ActiveRecord version 5.0.0.1
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb"=>[177]}}
F

Failures:

  1) OracleEnhancedAdapter custom methods for create, update and destroy should rollback record when exception is raised in after_create callback
     Failure/Error: expect(@employee.id).to eq(nil)

       expected: nil
            got: 1

       (compared using ==)
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-support-3.5.0/lib/rspec/support.rb:87:in `block in <module:Support>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-support-3.5.0/lib/rspec/support.rb:96:in `notify_failure'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/fail_with.rb:27:in `fail_with'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:38:in `handle_failure'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/expectation_target.rb:65:in `to'
     # ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:189:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:23:in `load'
     # /home/yahonda/.rbenv/versions/2.3.1/bin/rspec:23:in `<main>'

Finished in 0.41609 seconds (files took 1.11 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:177 # OracleEnhancedAdapter custom methods for create, update and destroy should rollback record when exception is raised in after_create callback

$
```