### PR TITLE
Remove specs which set `attribute :hire_date, :date`

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -92,26 +92,6 @@ describe "OracleEnhancedAdapter date type detection based on column names" do
       expect(@employee.created_at.class).to eq(Time)
     end
 
-    it "should return Date value from DATE column if emulate_dates_by_column_name is false but column is defined as date" do
-      class ::TestEmployee < ActiveRecord::Base
-        # set_date_columns :hire_date
-        attribute :hire_date, :date
-      end
-      # ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = false
-      create_test_employee
-      expect(@employee.hire_date.class).to eq(Date)
-    end
-
-    it "should return Date value from DATE column with old date value if emulate_dates_by_column_name is false but column is defined as date" do
-      class ::TestEmployee < ActiveRecord::Base
-        # set_date_columns :hire_date
-        attribute :hire_date, :date
-      end
-      # ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_dates_by_column_name = false
-      create_test_employee(:today => Date.new(1900,1,1))
-      expect(@employee.hire_date.class).to eq(Date)
-    end
-
     it "should return Time value from DATE column if emulate_dates_by_column_name is true but column is defined as datetime" do
       class ::TestEmployee < ActiveRecord::Base
         # set_datetime_columns :hire_date


### PR DESCRIPTION
Since Rails 5 and Oracle enhanced adapter
Oracle `DATE` columns are mapped to Rails `:date` attribute by default.
No need to set attribute explicitly and no need to test here.