### PR TITLE
Using the gem in non-rails apps

### DIFF
--- a/lib/activerecord-oracle_enhanced-adapter.rb
+++ b/lib/activerecord-oracle_enhanced-adapter.rb
@@ -1,20 +1,22 @@
-module ActiveRecord
-  module ConnectionAdapters
-    class OracleEnhancedRailtie < ::Rails::Railtie
-      rake_tasks do
-        load 'active_record/connection_adapters/oracle_enhanced/database_tasks.rb'
-      end
+if defined?(Rails)
+  module ActiveRecord
+    module ConnectionAdapters
+      class OracleEnhancedRailtie < ::Rails::Railtie
+        rake_tasks do
+          load 'active_record/connection_adapters/oracle_enhanced/database_tasks.rb'
+        end
 
-      ActiveSupport.on_load(:active_record) do
-        require 'active_record/connection_adapters/oracle_enhanced_adapter'
+        ActiveSupport.on_load(:active_record) do
+          require 'active_record/connection_adapters/oracle_enhanced_adapter'
 
-        # Cache column descriptions between requests in test and production environments
-        if Rails.env.test? || Rails.env.production?
-          ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.cache_columns = true
+          # Cache column descriptions between requests in test and production environments
+          if Rails.env.test? || Rails.env.production?
+            ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.cache_columns = true
+          end
+
         end
 
       end
-
     end
   end
 end


### PR DESCRIPTION
I'm using this gem in a sinatra app with ActiveRecord out of the Rails box.
I think it's worth to keep a `if defined?(Rails)` condition before `OracleEnhancedRailtie` definition for those like me who want to use this great gem in non-rails apps.