### PR TITLE
Alter primary key rebuild tablespace

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -85,6 +85,7 @@ module ActiveRecord
           end
           td.indexes.each { |c,o| add_index table_name, c, o }
 
+          rebuild_primary_key_index_to_default_tablespace(table_name, options)
         end
 
         def create_table_definition(*args)
@@ -502,6 +503,22 @@ module ActiveRecord
         def default_trigger_name(table_name)
           # truncate table name if necessary to fit in max length of identifier
           "#{table_name.to_s[0,table_name_length-4]}_pkt"
+        end
+
+        def rebuild_primary_key_index_to_default_tablespace(table_name, options)
+          tablespace = default_tablespace_for(:index)
+
+          return unless tablespace
+
+          index_name = Base.connection.select_value(
+            "SELECT index_name FROM all_constraints
+                WHERE table_name = #{quote(table_name.upcase)}
+                AND constraint_type = 'P'
+                AND owner = SYS_CONTEXT('userenv', 'current_schema')")
+
+          return unless index_name
+
+          execute("ALTER INDEX #{quote_column_name(index_name)} REBUILD TABLESPACE #{tablespace}")
         end
 
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -804,6 +804,53 @@ end
     end
   end
 
+  describe "primary key in table definition" do
+    before do
+      @conn = ActiveRecord::Base.connection
+
+      class ::TestPost < ActiveRecord::Base
+      end
+    end
+
+    it 'should use default tablespace for primary key' do
+      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[:index] = nil
+      schema_define do
+        create_table :test_posts, :force => true
+      end
+
+      index_name = @conn.select_value(
+        "SELECT index_name FROM all_constraints
+            WHERE table_name = 'TEST_POSTS'
+            AND constraint_type = 'P'
+            AND owner = SYS_CONTEXT('userenv', 'current_schema')")
+
+      expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_indexes WHERE index_name = '#{index_name}'")).to eq('USERS')
+    end
+
+    it 'should use non default tablespace for primary key' do
+      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[:index] = DATABASE_NON_DEFAULT_TABLESPACE
+      schema_define do
+        create_table :test_posts, :force => true
+      end
+
+      index_name = @conn.select_value(
+        "SELECT index_name FROM all_constraints
+            WHERE table_name = 'TEST_POSTS'
+            AND constraint_type = 'P'
+            AND owner = SYS_CONTEXT('userenv', 'current_schema')")
+
+      expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_indexes WHERE index_name = '#{index_name}'")).to eq(DATABASE_NON_DEFAULT_TABLESPACE)
+    end
+
+    after do
+      Object.send(:remove_const, "TestPost")
+      schema_define do
+        drop_table :test_posts rescue nil
+      end
+      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[:index] = nil
+    end
+  end
+
   describe "foreign key in table definition" do
     before(:each) do
       schema_define do


### PR DESCRIPTION
Fix #1027 

This product code fix the additional following error.

```
Failures:

  1) OracleEnhancedAdapter context index Use ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces should store index
of primary key to TS_INDEX
     Failure/Error: expect(@conn.select_value("SELECT tablespace_name FROM user_indexes WHERE index_name = '#{index_name}'")).to
eq('TS_INDEX')

       expected: "TS_INDEX"
            got: "TS_DATA"
```
