### PR TITLE
Support connection strings in DATABASE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,12 @@ environment variable, note that the adapter name uses a dash instead of an under
 DATABASE_URL=oracle-enhanced://localhost/XE
 ```
 
+You can also specify a connection string via the `DATABASE_URL`, as long as it doesn't have any whitespace:
+
+```bash
+DATABASE_URL=oracle-enhanced://user:secret@connection-string/(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1521)))(CONNECT_DATA=(SERVICE_NAME=xe)))
+```
+
 If you deploy JRuby on Rails application in Java application server that supports JNDI connections then you can specify JNDI connection as well:
 
 ```yml

--- a/RUNNING_TESTS.md
+++ b/RUNNING_TESTS.md
@@ -75,7 +75,7 @@ Running tests
         bundle install
 
 * Configure database credentials in one of two ways:
-    * copy spec/spec_config.yaml.template to spec/config.yaml and modify as needed
+    * copy spec/spec_config.yaml.template to spec/spec_config.yaml and modify as needed
     * set required environment variables (see DATABASE_NAME in spec_helper.rb)
 
 * Run tests with

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -109,8 +109,9 @@ module ActiveRecord
           host, port = config[:host], config[:port]
           privilege = config[:privilege] && config[:privilege].to_s
 
-          # connection using TNS alias
-          if database && !host && !config[:url] && ENV['TNS_ADMIN']
+          # connection using TNS alias, or connection-string from DATABASE_URL
+          using_tns_alias = !host && !config[:url] && ENV['TNS_ADMIN']
+          if database && (using_tns_alias || host == 'connection-string')
             url = "jdbc:oracle:thin:@#{database}"
           else
             unless database.match(/^(\:|\/)/)

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -332,8 +332,11 @@ module ActiveRecord
         # get session time_zone from configuration or from TZ environment variable
         time_zone = config[:time_zone] || ENV['TZ']
 
+        # using a connection string via DATABASE_URL
+        connection_string = if host == 'connection-string'
+          database
         # connection using host, port and database name
-        connection_string = if host || port
+        elsif host || port
           host ||= 'localhost'
           host = "[#{host}]" if host =~ /^[^\[].*:/  # IPv6
           port ||= 1521
@@ -344,7 +347,6 @@ module ActiveRecord
         else
           database
         end
-
         conn = OCI8.new username, password, connection_string, privilege
         conn.autocommit = true
         conn.non_blocking = true if async

--- a/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
@@ -137,6 +137,23 @@ describe "OracleEnhancedConnection" do
 
   end
 
+  describe 'with host="connection-string"' do
+    let(:username) { CONNECTION_PARAMS[:username] }
+    let(:password) { CONNECTION_PARAMS[:password] }
+    let(:connection_string) { '(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1521)))(CONNECT_DATA=(SERVICE_NAME=xe)))' }
+    let(:params) { { username: username, password: password, host: 'connection-string', database: connection_string } }
+
+    it 'uses the database param as the connection string' do
+      if ORACLE_ENHANCED_CONNECTION == :jdbc
+        expect(java.sql.DriverManager).to receive(:getConnection).with("jdbc:oracle:thin:@#{connection_string}", anything).and_call_original
+      else
+        expect(OCI8).to receive(:new).with(username, password, connection_string, nil).and_call_original
+      end
+      conn = ActiveRecord::ConnectionAdapters::OracleEnhancedConnection.create(params)
+      expect(conn).to be_active
+    end
+  end
+
   if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
 
     describe "create JDBC connection" do


### PR DESCRIPTION
We are trying to move our Rails apps to stick to using environment variables for configuration, and noticed that we could not put a connection string in the url.

To solve this, I added a simple addition to support putting a connection-string in the URL (as the path), when the host is `connection-string`. This change seemed fairly simple and unlikely to break existing configurations, but I'm open to other ways to pick up on the connection string from there.