### PR TITLE
Address `Java::JavaSql::SQLException: Missing IN or OUT parameter at index:: 3:`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1165,11 +1165,17 @@ module ActiveRecord
         offset: nil
       ) # :nodoc:
         result = from_clause + join_clause + where_clause + having_clause
-        if offset
+        if RUBY_ENGINE == 'jruby' && !supports_fetch_first_n_rows_and_offset? && offset && limit
           result << offset
-        end
-        if limit
           result << limit
+          result << offset
+        else
+          if offset
+            result << offset
+          end
+          if limit
+            result << limit
+          end
         end
         result
       end


### PR DESCRIPTION
This pull request address `Java::JavaSql::SQLException: Missing IN or OUT parameter at index:: 3:` when `offset` and `limit` used at the same time with JRuby and Oracle 11gR2 or lower.

Since https://github.com/rails/arel/pull/450 needs 3 bind variables,
`:a1`, `:a2` and `:a1` again. It is probably due to Oracle enhanced adapter
JDBC implementation handles bind variables by their order, not their name.
Then we need to handle first `:a1` for `offset` and last `:a1` separately.

It addresses #1030 and this spec failure.

```ruby
rspec ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:742 # OracleEnhancedAdapter using offset and limit should return the records starting from offset n with offset(n)
```
```ruby
  2) OracleEnhancedAdapter using offset and limit should return the records starting from offset n with offset(n)
     Failure/Error: Unable to find oracle.jdbc.driver.OraclePreparedStatement.processCompletedBindRow(oracle/jdbc/driver/OraclePreparedStatement.java to read failed line
     
     ActiveRecord::StatementInvalid:
       Java::JavaSql::SQLException: Missing IN or OUT parameter at index:: 3: 
                     SELECT * FROM (
                       SELECT raw_sql_.*, rownum raw_rnum_
                       FROM (SELECT  "TEST_EMPLOYEES".* FROM "TEST_EMPLOYEES" ORDER BY "TEST_EMPLOYEES"."SORT_ORDER" ASC ) raw_sql_ WHERE rownum <= (:a1 + :a2) ) WHERE raw_rnum_ > :a1
     # oracle.jdbc.driver.OraclePreparedStatement.processCompletedBindRow(oracle/jdbc/driver/OraclePreparedStatement.java:1821)
     # oracle.jdbc.driver.OraclePreparedStatement.executeInternal(oracle/jdbc/driver/OraclePreparedStatement.java:3571)
     # oracle.jdbc.driver.OraclePreparedStatement.executeQuery(oracle/jdbc/driver/OraclePreparedStatement.java:3620)
     # oracle.jdbc.driver.OraclePreparedStatementWrapper.executeQuery(oracle/jdbc/driver/OraclePreparedStatementWrapper.java:1491)
     # java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:606)
     # org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:438)
     # org.jruby.javasupport.JavaMethod.invokeDirect(org/jruby/javasupport/JavaMethod.java:302)
     # home.travis.build.rsim.oracle_minus_enhanced.lib.active_record.connection_adapters.oracle_enhanced.jdbc_connection.exec(/home/travis/build/rsim/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:403)
     # home.travis.build.rsim.oracle_minus_enhanced.lib.active_record.connection_adapters.oracle_enhanced.database_statements.block in exec_query(/home/travis/build/rsim/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:39)
     # home.travis.$_dot_rvm.gems.jruby_minus_9_dot_1_dot_2_dot_0.bundler.gems.rails_minus_b0b4a9a65861.activerecord.lib.active_record.connection_adapters.abstract_adapter.block in log(/home/travis/.rvm/gems/jruby-9.1.2.0/bundler/gems/rails-b0b4a9a65861/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589)
     # home.travis.$_dot_rvm.gems.jruby_minus_9_dot_1_dot_2_dot_0.bundler.gems.rails_minus_b0b4a9a65861.activesupport.lib.active_support.notifications.instrumenter.instrument(/home/travis/.rvm/gems/jruby-9.1.2.0/bundler/gems/rails-b0b4a9a65861/activesupport/lib/active_support/notifications/instrumenter.rb:21)
     # home.travis.$_dot_rvm.gems.jruby_minus_9_dot_1_dot_2_dot_0.bundler.gems.rails_minus_b0b4a9a65861.activerecord.lib.active_record.connection_adapters.abstract_adapter.log(/home/travis/.rvm/gems/jruby-9.1.2.0/bundler/gems/rails-b0b4a9a65861/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583)
     # home.travis.build.rsim.oracle_minus_enhanced.lib.active_record.connection_adapters.oracle_enhanced_adapter.log(/home/travis/build/rsim/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1270)
     # home.travis.build.rsim.oracle_minus_enhanced.lib.active_record.connection_adapters.oracle_enhanced.database_statements.exec_query(/home/travis/build/rsim/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:22)
     # RUBY.select_prepared(/home/travis/.rvm/gems/jruby-9.1.2.0/bundler/gems/rails-b0b4a9a65861/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:377)
     # RUBY.select_all(/home/travis/.rvm/gems/jruby-9.1.2.0/bundler/gems/rails-b0b4a9a65861/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:39)
     # RUBY.select_all(/home/travis/.rvm/gems/jruby-9.1.2.0/bundler/gems/rails-b0b4a9a65861/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:70)
     # RUBY.find_by_sql(/home/travis/.rvm/gems/jruby-9.1.2.0/bundler/gems/rails-b0b4a9a65861/activerecord/lib/active_record/querying.rb:39)
     # RUBY.exec_queries(/home/travis/.rvm/gems/jruby-9.1.2.0/bundler/gems/rails-b0b4a9a65861/activerecord/lib/active_record/relation.rb:699)
     # RUBY.load(/home/travis/.rvm/gems/jruby-9.1.2.0/bundler/gems/rails-b0b4a9a65861/activerecord/lib/active_record/relation.rb:580)
     # RUBY.records(/home/travis/.rvm/gems/jruby-9.1.2.0/bundler/gems/rails-b0b4a9a65861/activerecord/lib/active_record/relation.rb:260)
     # RUBY.to_a(/home/travis/.rvm/gems/jruby-9.1.2.0/bundler/gems/rails-b0b4a9a65861/activerecord/lib/active_record/relation.rb:256)
     # RUBY.find_nth_with_limit(/home/travis/.rvm/gems/jruby-9.1.2.0/bundler/gems/rails-b0b4a9a65861/activerecord/lib/active_record/relation/finder_methods.rb:563)
     # RUBY.find_nth_with_limit_and_offset(/home/travis/.rvm/gems/jruby-9.1.2.0/bundler/gems/rails-b0b4a9a65861/activerecord/lib/active_record/relation/finder_methods.rb:592)
     # RUBY.find_nth(/home/travis/.rvm/gems/jruby-9.1.2.0/bundler/gems/rails-b0b4a9a65861/activerecord/lib/active_record/relation/finder_methods.rb:545)
     # RUBY.first(/home/travis/.rvm/gems/jruby-9.1.2.0/bundler/gems/rails-b0b4a9a65861/activerecord/lib/active_record/relation/finder_methods.rb:122)
     # RUBY.block in (root)(/home/travis/build/rsim/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:744)
     # org.jruby.RubyBasicObject.yieldUnder(org/jruby/RubyBasicObject.java:1707)
     # org.jruby.RubyBasicObject.instance_exec(org/jruby/RubyBasicObject.java:1684)
     # home.travis.$_dot_rvm.gems.jruby_minus_9_dot_1_dot_2_dot_0.gems.rspec_minus_core_minus_3_dot_5_dot_4.lib.rspec.core.example.block in run(/home/travis/.rvm/gems/jruby-9.1.2.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254)
     # home.travis.$_dot_rvm.gems.jruby_minus_9_dot_1_dot_2_dot_0.gems.rspec_minus_core_minus_3_dot_5_dot_4.lib.rspec.core.example.block in with_around_and_singleton_context_hooks(/home/travis/.rvm/gems/jruby-9.1.2.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496)
     # home.travis.$_dot_rvm.gems.jruby_minus_9_dot_1_dot_2_dot_0.gems.rspec_minus_core_minus_3_dot_5_dot_4.lib.rspec.core.example.block in with_around_example_hooks(/home/travis/.rvm/gems/jruby-9.1.2.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453)
     # home.travis.$_dot_rvm.gems.jruby_minus_9_dot_1_dot_2_dot_0.gems.rspec_minus_core_minus_3_dot_5_dot_4.lib.rspec.core.hooks.block in run(/home/travis/.rvm/gems/jruby-9.1.2.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464)
     # home.travis.$_dot_rvm.gems.jruby_minus_9_dot_1_dot_2_dot_0.gems.rspec_minus_core_minus_3_dot_5_dot_4.lib.rspec.core.hooks.run_around_example_hooks_for(/home/travis/.rvm/gems/jruby-9.1.2.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602)
     # home.travis.$_dot_rvm.gems.jruby_minus_9_dot_1_dot_2_dot_0.gems.rspec_minus_core_minus_3_dot_5_dot_4.lib.rspec.core.hooks.run(/home/travis/.rvm/gems/jruby-9.1.2.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464)
     # home.travis.$_dot_rvm.gems.jruby_minus_9_dot_1_dot_2_dot_0.gems.rspec_minus_core_minus_3_dot_5_dot_4.lib.rspec.core.example.with_around_example_hooks(/home/travis/.rvm/gems/jruby-9.1.2.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453)
     # home.travis.$_dot_rvm.gems.jruby_minus_9_dot_1_dot_2_dot_0.gems.rspec_minus_core_minus_3_dot_5_dot_4.lib.rspec.core.example.with_around_and_singleton_context_hooks(/home/travis/.rvm/gems/jruby-9.1.2.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496)
     # home.travis.$_dot_rvm.gems.jruby_minus_9_dot_1_dot_2_dot_0.gems.rspec_minus_core_minus_3_dot_5_dot_4.lib.rspec.core.example.run(/home/travis/.rvm/gems/jruby-9.1.2.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251)
     # home.travis.$_dot_rvm.gems.jruby_minus_9_dot_1_dot_2_dot_0.gems.rspec_minus_core_minus_3_dot_5_dot_4.lib.rspec.core.example_group.block in run_examples(/home/travis/.rvm/gems/jruby-9.1.2.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run_examples(/home/travis/.rvm/gems/jruby-9.1.2.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623)
     # RUBY.run(/home/travis/.rvm/gems/jruby-9.1.2.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589)
     # RUBY.block in run(/home/travis/.rvm/gems/jruby-9.1.2.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.run(/home/travis/.rvm/gems/jruby-9.1.2.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590)
     # RUBY.block in run_specs(/home/travis/.rvm/gems/jruby-9.1.2.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113)
     # org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2341)
     # org.jruby.RubyArray.map(org/jruby/RubyArray.java:2355)
     # RUBY.block in run_specs(/home/travis/.rvm/gems/jruby-9.1.2.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113)
     # RUBY.with_suite_hooks(/home/travis/.rvm/gems/jruby-9.1.2.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835)
     # RUBY.block in run_specs(/home/travis/.rvm/gems/jruby-9.1.2.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112)
     # RUBY.report(/home/travis/.rvm/gems/jruby-9.1.2.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77)
     # RUBY.run_specs(/home/travis/.rvm/gems/jruby-9.1.2.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111)
     # RUBY.run(/home/travis/.rvm/gems/jruby-9.1.2.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87)
     # RUBY.run(/home/travis/.rvm/gems/jruby-9.1.2.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71)
     # RUBY.invoke(/home/travis/.rvm/gems/jruby-9.1.2.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45)
     # home.travis.$_dot_rvm.gems.jruby_minus_9_dot_1_dot_2_dot_0.gems.rspec_minus_core_minus_3_dot_5_dot_4.exe.rspec.<top>(/home/travis/.rvm/gems/jruby-9.1.2.0/gems/rspec-core-3.5.4/exe/rspec:4)
     # java.lang.invoke.MethodHandle.invokeWithArguments(java/lang/invoke/MethodHandle.java:599)
     # org.jruby.Ruby.runScript(org/jruby/Ruby.java:833)
     # org.jruby.Ruby.runScript(org/jruby/Ruby.java:825)
     # org.jruby.Ruby.runNormally(org/jruby/Ruby.java:760)
     # org.jruby.Ruby.runFromMain(org/jruby/Ruby.java:579)
     # org.jruby.Main.doRunFromMain(org/jruby/Main.java:425)
     # org.jruby.Main.internalRun(org/jruby/Main.java:313)
     # org.jruby.Main.run(org/jruby/Main.java:242)
     # org.jruby.Main.main(org/jruby/Main.java:204)
     # ------------------
     # --- Caused by: ---
     # Java::JavaSql::SQLException:
     #   Missing IN or OUT parameter at index:: 3
     #   oracle.jdbc.driver.OraclePreparedStatement.processCompletedBindRow(oracle/jdbc/driver/OraclePreparedStatement.java:1821)
```