### PR TITLE
Fix deprecated warnings in Ruby 2.4.0+

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -250,12 +250,12 @@ module ActiveRecord
 
       def typecast_result_value(value, get_lob_value)
         case value
-        when Fixnum, Bignum
+        when Integer
           value
         when String
           value
         when Float, BigDecimal
-          # return Fixnum or Bignum if value is integer (to avoid issues with _before_type_cast values for id attributes)
+          # return Integer if value is integer (to avoid issues with _before_type_cast values for id attributes)
           value == (v_to_i = value.to_i) ? v_to_i : value
         when OraNumber
           # change OraNumber value (returned in early versions of ruby-oci8 2.0.x) to BigDecimal

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -206,19 +206,19 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
       expect(@employee2.job_id.class).to eq(BigDecimal)
     end
 
-    it "should return Fixnum value from NUMBER column if column name contains 'id' and emulate_integers_by_column_name is true" do
+    it "should return Integer value from NUMBER column if column name contains 'id' and emulate_integers_by_column_name is true" do
       # ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = true
       class ::Test2Employee < ActiveRecord::Base
         attribute :job_id, :integer
       end
       create_employee2
-      expect(@employee2.job_id.class).to eq(Fixnum)
+      expect(@employee2.job_id.class).to eq(Integer)
     end
 
-    it "should return Fixnum value from NUMBER column with integer value using _before_type_cast method" do
+    it "should return Integer value from NUMBER column with integer value using _before_type_cast method" do
       # ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = true
       create_employee2
-      expect(@employee2.job_id_before_type_cast.class).to eq(Fixnum)
+      expect(@employee2.job_id_before_type_cast.class).to eq(Integer)
     end
 
     it "should return BigDecimal value from NUMBER column if column name does not contain 'id' and emulate_integers_by_column_name is true" do
@@ -227,14 +227,14 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
       expect(@employee2.salary.class).to eq(BigDecimal)
     end
 
-    it "should return Fixnum value from NUMBER column if column specified in set_integer_columns" do
+    it "should return Integer value from NUMBER column if column specified in set_integer_columns" do
       # ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = false
       # Test2Employee.set_integer_columns :job_id
       class ::Test2Employee < ActiveRecord::Base
         attribute :job_id, :integer
       end
       create_employee2
-      expect(@employee2.job_id.class).to eq(Fixnum)
+      expect(@employee2.job_id.class).to eq(Integer)
     end
 
     it "should return Boolean value from NUMBER(1) column if emulate booleans is used" do
@@ -243,23 +243,23 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
       expect(@employee2.is_manager.class).to eq(TrueClass)
     end
 
-    it "should return Fixnum value from NUMBER(1) column if emulate booleans is not used" do
+    it "should return Integer value from NUMBER(1) column if emulate booleans is not used" do
       # ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans = false
       class ::Test2Employee < ActiveRecord::Base
         attribute :is_manager, :integer
       end
       create_employee2
-      expect(@employee2.is_manager.class).to eq(Fixnum)
+      expect(@employee2.is_manager.class).to eq(Integer)
     end
 
-    it "should return Fixnum value from NUMBER(1) column if column specified in set_integer_columns" do
+    it "should return Integer value from NUMBER(1) column if column specified in set_integer_columns" do
       # ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans = true
       # Test2Employee.set_integer_columns :is_manager
       class ::Test2Employee < ActiveRecord::Base
         attribute :is_manager, :integer
       end
       create_employee2
-      expect(@employee2.is_manager.class).to eq(Fixnum)
+      expect(@employee2.is_manager.class).to eq(Integer)
     end
 
   end


### PR DESCRIPTION
Ruby 2.4.0 unifies Fixnum and Bignum into Integer.
https://bugs.ruby-lang.org/issues/12005

Fix following deprecated warnings in Ruby 2.4.0-preview3.

```
warning: constant ::Fixnum is deprecated
warning: constant ::Bignum is deprecated
```

Thanks.
