### PR TITLE
Address failures when tested with Ruby 2.3 or lower

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -212,13 +212,13 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
         attribute :job_id, :integer
       end
       create_employee2
-      expect(@employee2.job_id.class).to eq(Integer)
+      expect(@employee2.job_id).to be_a(Integer)
     end
 
     it "should return Integer value from NUMBER column with integer value using _before_type_cast method" do
       # ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = true
       create_employee2
-      expect(@employee2.job_id_before_type_cast.class).to eq(Integer)
+      expect(@employee2.job_id_before_type_cast).to be_a(Integer)
     end
 
     it "should return BigDecimal value from NUMBER column if column name does not contain 'id' and emulate_integers_by_column_name is true" do
@@ -234,7 +234,7 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
         attribute :job_id, :integer
       end
       create_employee2
-      expect(@employee2.job_id.class).to eq(Integer)
+      expect(@employee2.job_id).to be_a(Integer)
     end
 
     it "should return Boolean value from NUMBER(1) column if emulate booleans is used" do
@@ -249,7 +249,7 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
         attribute :is_manager, :integer
       end
       create_employee2
-      expect(@employee2.is_manager.class).to eq(Integer)
+      expect(@employee2.is_manager).to be_a(Integer)
     end
 
     it "should return Integer value from NUMBER(1) column if column specified in set_integer_columns" do
@@ -259,7 +259,7 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
         attribute :is_manager, :integer
       end
       create_employee2
-      expect(@employee2.is_manager.class).to eq(Integer)
+      expect(@employee2.is_manager).to be_a(Integer)
     end
 
   end


### PR DESCRIPTION
This pull request addresses failures #1048 when tested with Ruby 2.3 or lower.

```ruby
$ ruby -v
ruby 2.3.2p217 (2016-11-15 revision 56796) [x86_64-linux]
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
==> Loading config from ENV or use default
==> Running specs with MRI version 2.3.2
==> Effective ActiveRecord version 5.0.0.1
.........FF.F.FF........-- create_table(:posts, {:force=>true})
   -> 0.0849s
.*...........................................DEPRECATION WARNING: Passing a column to `quote` has been deprecated. It is only used for type casting, which should be handled elsewhere. See https://github.com/rails/arel/commit/6160bfbda1d1781c3b08a33ec4955f170e95be11 for more information. (called from quote at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:88)
DEPRECATION WARNING: Passing a column to `quote` has been deprecated. It is only used for type casting, which should be handled elsewhere. See https://github.com/rails/arel/commit/6160bfbda1d1781c3b08a33ec4955f170e95be11 for more information. (called from quote at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:88)
DEPRECATION WARNING: Passing a column to `quote` has been deprecated. It is only used for type casting, which should be handled elsewhere. See https://github.com/rails/arel/commit/6160bfbda1d1781c3b08a33ec4955f170e95be11 for more information. (called from quote at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:88)
DEPRECATION WARNING: Passing a column to `quote` has been deprecated. It is only used for type casting, which should be handled elsewhere. See https://github.com/rails/arel/commit/6160bfbda1d1781c3b08a33ec4955f170e95be11 for more information. (called from quote at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:88)
DEPRECATION WARNING: Passing a column to `quote` has been deprecated. It is only used for type casting, which should be handled elsewhere. See https://github.com/rails/arel/commit/6160bfbda1d1781c3b08a33ec4955f170e95be11 for more information. (called from quote at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:88)
DEPRECATION WARNING: Passing a column to `quote` has been deprecated. It is only used for type casting, which should be handled elsewhere. See https://github.com/rails/arel/commit/6160bfbda1d1781c3b08a33ec4955f170e95be11 for more information. (called from quote at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:88)
DEPRECATION WARNING: Passing a column to `quote` has been deprecated. It is only used for type casting, which should be handled elsewhere. See https://github.com/rails/arel/commit/6160bfbda1d1781c3b08a33ec4955f170e95be11 for more information. (called from quote at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:88)
DEPRECATION WARNING: Passing a column to `quote` has been deprecated. It is only used for type casting, which should be handled elsewhere. See https://github.com/rails/arel/commit/6160bfbda1d1781c3b08a33ec4955f170e95be11 for more information. (called from quote at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:88)
...

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) OracleEnhancedAdapter timestamp with timezone support should set TIMESTAMP columns type as datetime
     # TIMESTAMP sql_type should be :datetime in Rails 5
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:511


Failures:

  1) OracleEnhancedAdapter integer type detection based on column names / NUMBER values from ActiveRecord model should return Integer value from NUMBER column if column name contains 'id' and emulate_integers_by_column_name is true
     Failure/Error: expect(@employee2.job_id.class).to eq(Integer)

       expected: Integer
            got: Fixnum

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
       -Integer
       +Fixnum

     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-support-3.5.0/lib/rspec/support.rb:87:in `block in <module:Support>'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-support-3.5.0/lib/rspec/support.rb:96:in `notify_failure'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/fail_with.rb:27:in `fail_with'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:38:in `handle_failure'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/expectation_target.rb:65:in `to'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:215:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.2/bin/rspec:22:in `load'
     # /home/yahonda/.rbenv/versions/2.3.2/bin/rspec:22:in `<main>'

  2) OracleEnhancedAdapter integer type detection based on column names / NUMBER values from ActiveRecord model should return Integer value from NUMBER column with integer value using _before_type_cast method
     Failure/Error: expect(@employee2.job_id_before_type_cast.class).to eq(Integer)

       expected: Integer
            got: Fixnum

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
       -Integer
       +Fixnum

     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-support-3.5.0/lib/rspec/support.rb:87:in `block in <module:Support>'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-support-3.5.0/lib/rspec/support.rb:96:in `notify_failure'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/fail_with.rb:27:in `fail_with'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:38:in `handle_failure'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/expectation_target.rb:65:in `to'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:221:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.2/bin/rspec:22:in `load'
     # /home/yahonda/.rbenv/versions/2.3.2/bin/rspec:22:in `<main>'

  3) OracleEnhancedAdapter integer type detection based on column names / NUMBER values from ActiveRecord model should return Integer value from NUMBER column if column specified in set_integer_columns
     Failure/Error: expect(@employee2.job_id.class).to eq(Integer)

       expected: Integer
            got: Fixnum

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
       -Integer
       +Fixnum

     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-support-3.5.0/lib/rspec/support.rb:87:in `block in <module:Support>'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-support-3.5.0/lib/rspec/support.rb:96:in `notify_failure'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/fail_with.rb:27:in `fail_with'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:38:in `handle_failure'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/expectation_target.rb:65:in `to'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:237:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.2/bin/rspec:22:in `load'
     # /home/yahonda/.rbenv/versions/2.3.2/bin/rspec:22:in `<main>'

  4) OracleEnhancedAdapter integer type detection based on column names / NUMBER values from ActiveRecord model should return Integer value from NUMBER(1) column if emulate booleans is not used
     Failure/Error: expect(@employee2.is_manager.class).to eq(Integer)

       expected: Integer
            got: Fixnum

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
       -Integer
       +Fixnum

     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-support-3.5.0/lib/rspec/support.rb:87:in `block in <module:Support>'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-support-3.5.0/lib/rspec/support.rb:96:in `notify_failure'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/fail_with.rb:27:in `fail_with'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:38:in `handle_failure'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/expectation_target.rb:65:in `to'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:252:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.2/bin/rspec:22:in `load'
     # /home/yahonda/.rbenv/versions/2.3.2/bin/rspec:22:in `<main>'

  5) OracleEnhancedAdapter integer type detection based on column names / NUMBER values from ActiveRecord model should return Integer value from NUMBER(1) column if column specified in set_integer_columns
     Failure/Error: expect(@employee2.is_manager.class).to eq(Integer)

       expected: Integer
            got: Fixnum

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
       -Integer
       +Fixnum

     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-support-3.5.0/lib/rspec/support.rb:87:in `block in <module:Support>'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-support-3.5.0/lib/rspec/support.rb:96:in `notify_failure'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/fail_with.rb:27:in `fail_with'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:38:in `handle_failure'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/expectation_target.rb:65:in `to'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:262:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.3.2/bin/rspec:22:in `load'
     # /home/yahonda/.rbenv/versions/2.3.2/bin/rspec:22:in `<main>'

Finished in 13.21 seconds (files took 1.19 seconds to load)
72 examples, 5 failures, 1 pending

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:209 # OracleEnhancedAdapter integer type detection based on column names / NUMBER values from ActiveRecord model should return Integer value from NUMBER column if column name contains 'id' and emulate_integers_by_column_name is true
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:218 # OracleEnhancedAdapter integer type detection based on column names / NUMBER values from ActiveRecord model should return Integer value from NUMBER column with integer value using _before_type_cast method
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:230 # OracleEnhancedAdapter integer type detection based on column names / NUMBER values from ActiveRecord model should return Integer value from NUMBER column if column specified in set_integer_columns
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:246 # OracleEnhancedAdapter integer type detection based on column names / NUMBER values from ActiveRecord model should return Integer value from NUMBER(1) column if emulate booleans is not used
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:255 # OracleEnhancedAdapter integer type detection based on column names / NUMBER values from ActiveRecord model should return Integer value from NUMBER(1) column if column specified in set_integer_columns

$
```