### PR TITLE
Enable rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,11 @@
+AllCops:
+  TargetRubyVersion: 2.2
+  DisabledByDefault: true
+
+# No trailing whitespace.
+Style/TrailingWhitespace:
+  enabled: true
+
+# Blank lines should not have any spaces.
+Style/TrailingBlankLines:
+  enabled: true

--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -92,4 +92,3 @@ This adapter is superset of original ActiveRecord Oracle adapter.
   s.add_runtime_dependency(%q<ruby-plsql>, [">= 0.5.0"])
   s.license = 'MIT'
 end
-

--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -69,4 +69,3 @@ class BugTest < Minitest::Test
     assert_equal post.id, Comment.first.post.id
   end
 end
-

--- a/lib/active_record/connection_adapters/oracle_enhanced/column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column.rb
@@ -69,7 +69,7 @@ module ActiveRecord
 #        #TODO: may be deprecated due to conflict with variable
 #        ActiveRecord::Base.connection.column_comment(@table_name, name)
 #      end
-      
+
       private
 
       def self.extract_value_from_default(default)
@@ -85,7 +85,7 @@ module ActiveRecord
         value.respond_to?(:hour) && (value.hour == 0 and value.min == 0 and value.sec == 0) ?
           Date.new(value.year, value.month, value.day) : value
       end
-      
+
       class << self
         protected
 
@@ -128,7 +128,7 @@ module ActiveRecord
           end
           DateTime.strptime(string, OracleEnhancedAdapter.string_to_date_format).to_date
         end
-        
+
       end
     end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -103,8 +103,8 @@ module ActiveRecord
     # Returns array with major and minor version of database (e.g. [12, 1])
     def database_version
       raise NoMethodError, "Not implemented for this raw driver"
-    end 
-    
+    end
+
     class OracleEnhancedConnectionException < StandardError #:nodoc:
     end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/cpk.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/cpk.rb
@@ -7,11 +7,11 @@ module ActiveRecord #:nodoc:
       def supports_count_distinct? #:nodoc:
         @supports_count_distinct ||= ! defined?(CompositePrimaryKeys)
       end
-      
+
       def concat(*columns) #:nodoc:
         "(#{columns.join('||')})"
       end
-      
+
     end
   end
 end

--- a/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
@@ -2,7 +2,7 @@ require 'active_support'
 
 module ActiveRecord #:nodoc:
   # Custom create, update, delete methods functionality.
-  # 
+  #
   # Example:
   #
   #   class Employee < ActiveRecord::Base

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -44,7 +44,7 @@ module ActiveRecord
         end
 
         def default_tablespace_for(type)
-          (ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[type] || 
+          (ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[type] ||
            ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[native_database_types[type][:name]]) rescue nil
         end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -18,7 +18,7 @@ module ActiveRecord
 
       class IndexDefinition < ActiveRecord::ConnectionAdapters::IndexDefinition
         attr_accessor :parameters, :statement_parameters, :tablespace
- 
+
         def initialize(table, name, unique, columns, lengths, orders, where, type, using, parameters, statement_parameters, tablespace)
           @parameters = parameters
           @statement_parameters = statement_parameters

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -366,7 +366,7 @@ module ActiveRecord
           if options[:dependent]
             ActiveSupport::Deprecation.warn "`:dependent` option will be deprecated. Please use `:on_delete` option"
           end
-          case options[:dependent]  
+          case options[:dependent]
           when :delete then options[:on_delete] = :cascade
           when :nullify then options[:on_delete] = :nullify
           else
@@ -449,7 +449,7 @@ module ActiveRecord
 
         def create_alter_table(name)
           OracleEnhanced::AlterTable.new create_table_definition(name, false, {})
-        end 
+        end
 
         def tablespace_for(obj_type, tablespace_option, table_name=nil, column_name=nil)
           tablespace_sql = ''

--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -73,7 +73,7 @@ module ActiveRecord #:nodoc:
 
       def structure_dump_primary_key(table) #:nodoc:
         opts = {:name => '', :cols => []}
-        pks = select_all(<<-SQL, "Primary Keys") 
+        pks = select_all(<<-SQL, "Primary Keys")
           SELECT a.constraint_name, a.column_name, a.position
             FROM all_cons_columns a
             JOIN all_constraints c
@@ -92,7 +92,7 @@ module ActiveRecord #:nodoc:
 
       def structure_dump_unique_keys(table) #:nodoc:
         keys = {}
-        uks = select_all(<<-SQL, "Primary Keys") 
+        uks = select_all(<<-SQL, "Primary Keys")
           SELECT a.constraint_name, a.column_name, a.position
             FROM all_cons_columns a
             JOIN all_constraints c
@@ -215,7 +215,7 @@ module ActiveRecord #:nodoc:
           structure << ddl
         end
 
-        # export views 
+        # export views
         select_all("SELECT view_name, text FROM all_views WHERE owner = SYS_CONTEXT('userenv', 'session_user') ORDER BY view_name ASC").each do |view|
           structure << "CREATE OR REPLACE FORCE VIEW #{view['view_name']} AS\n #{view['text']}"
         end
@@ -298,7 +298,7 @@ module ActiveRecord #:nodoc:
 
       private
 
-      # virtual columns are an 11g feature.  This returns [] if feature is not 
+      # virtual columns are an 11g feature.  This returns [] if feature is not
       # present or none are found.
       # return [{'column_name' => 'FOOS', 'data_default' => '...'}, ...]
       def virtual_columns_for(table)

--- a/lib/active_record/oracle_enhanced/type/integer.rb
+++ b/lib/active_record/oracle_enhanced/type/integer.rb
@@ -1,5 +1,5 @@
 #TODO Need to consider namespace change since paremt class moved to ActiveModel
-module ActiveRecord 
+module ActiveRecord
   module OracleEnhanced
     module Type
       class Integer < ActiveModel::Type::Integer # :nodoc:

--- a/spec/active_record/connection_adapters/oracle_enhanced_cpk_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_cpk_spec.rb
@@ -64,7 +64,7 @@ describe "OracleEnhancedAdapter composite_primary_keys support" do
     before(:all) do
       schema_define do
         create_table  :cpk_write_lobs_test, :primary_key => [:type_category, :date_value], :force => true do |t|
-          t.string  :type_category, :limit => 15, :null => false  
+          t.string  :type_category, :limit => 15, :null => false
           t.date    :date_value, :null => false
           t.text    :results, :null => false
           t.timestamps null: true
@@ -83,7 +83,7 @@ describe "OracleEnhancedAdapter composite_primary_keys support" do
         set_table_name 'non_cpk_write_lobs_test'
       end
     end
-    
+
     after(:all) do
       schema_define do
         drop_table :cpk_write_lobs_test
@@ -98,14 +98,14 @@ describe "OracleEnhancedAdapter composite_primary_keys support" do
         CpkWriteLobsTest.create(:type_category => 'AAA', :date_value => Date.today, :results => 'DATA '*10)
       }.not_to raise_error
     end
-    
+
     it "should create new record in table without CPK and with LOB" do
       expect {
         NonCpkWriteLobsTest.create(:date_value => Date.today, :results => 'DATA '*10)
       }.not_to raise_error
     end
   end
-  
+
   # Other testing was done based on composite_primary_keys tests
 
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -171,7 +171,7 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
         INCREMENT BY 1 START WITH 10040 CACHE 20 NOORDER NOCYCLE
     SQL
   end
-  
+
   after(:all) do
     @conn.execute "DROP TABLE test2_employees"
     @conn.execute "DROP SEQUENCE test2_employees_seq"
@@ -182,7 +182,7 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
       class ::Test2Employee < ActiveRecord::Base
       end
     end
-    
+
     after(:each) do
       Object.send(:remove_const, "Test2Employee")
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans = true
@@ -818,7 +818,7 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
     @employee.reload
     expect(@employee.last_login_at).to eq(@today.to_time)
   end
-  
+
 end
 
 describe "OracleEnhancedAdapter handling of CLOB columns" do
@@ -1403,7 +1403,7 @@ describe "OracleEnhancedAdapter handling of BINARY_FLOAT columns" do
         INCREMENT BY 1 START WITH 10040 CACHE 20 NOORDER NOCYCLE
     SQL
   end
-  
+
   after(:all) do
     @conn.execute "DROP TABLE test2_employees"
     @conn.execute "DROP SEQUENCE test2_employees_seq"

--- a/spec/active_record/connection_adapters/oracle_enhanced_database_tasks_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_database_tasks_spec.rb
@@ -90,4 +90,3 @@ describe "Oracle Enhanced adapter database tasks" do
     after { ActiveRecord::Base.connection.execute "DROP TABLE test_posts" rescue nil }
   end
 end
-

--- a/spec/active_record/connection_adapters/oracle_enhanced_dbms_output_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_dbms_output_spec.rb
@@ -51,7 +51,7 @@ describe "OracleEnhancedAdapter logging dbms_output from plsql" do
     @conn.enable_dbms_output
 
     expect(@conn.select_all("select more_than_five_characters_long('hi there') is_it_long from dual").to_a).to eq([{'is_it_long'=>1}])
-    
+
     expect(@logger.output(:debug)).to match(/^DBMS_OUTPUT: before the if -hi there-$/)
     expect(@logger.output(:debug)).to match(/^DBMS_OUTPUT: it is longer than 5$/)
     expect(@logger.output(:debug)).to match(/^DBMS_OUTPUT: about to return: 1$/)
@@ -61,7 +61,7 @@ describe "OracleEnhancedAdapter logging dbms_output from plsql" do
     @conn.enable_dbms_output
 
     expect(@conn.select_all("select more_than_five_characters_long('short') is_it_long from dual").to_a).to eq([{'is_it_long'=>0}])
-    
+
     expect(@logger.output(:debug)).to match(/^DBMS_OUTPUT: before the if -short-$/)
     expect(@logger.output(:debug)).to match(/^DBMS_OUTPUT: it is 5 or shorter$/)
     expect(@logger.output(:debug)).to match(/^DBMS_OUTPUT: about to return: 0$/)

--- a/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
@@ -27,13 +27,13 @@ if ActiveRecord::Base.method_defined?(:changed?)
       class TestEmployee < ActiveRecord::Base
       end
     end
-  
+
     after(:all) do
       Object.send(:remove_const, "TestEmployee")
       @conn.execute "DROP TABLE test_employees"
       @conn.execute "DROP SEQUENCE test_employees_seq"
       ActiveRecord::Base.clear_cache! if ActiveRecord::Base.respond_to?(:"clear_cache!")
-    end  
+    end
 
     it "should not mark empty string (stored as NULL) as changed when reassigning it" do
       @employee = TestEmployee.create!(:first_name => '')
@@ -111,7 +111,7 @@ if ActiveRecord::Base.method_defined?(:changed?)
       @employee = TestEmployee.new
       @employee.job_id = 0
       expect(@employee.save!).to be_truthy
-      
+
       expect(@employee).not_to be_changed
 
       @employee.job_id = '0'

--- a/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
@@ -4,7 +4,7 @@ require 'ruby-plsql'
 
 describe "OracleEnhancedAdapter custom methods for create, update and destroy" do
   include LoggerSpecHelper
-  
+
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
     @conn = ActiveRecord::Base.connection
@@ -67,7 +67,7 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
           VALUES (p_employee_id, p_first_name, p_last_name, p_hire_date, p_salary, p_description,
                                       1, SYSDATE, SYSDATE);
         END create_employee;
-        
+
         PROCEDURE update_employee(
             p_employee_id   NUMBER,
             p_first_name    VARCHAR2,
@@ -85,7 +85,7 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
               version = v_version + 1, update_time = SYSDATE
           WHERE employee_id = p_employee_id;
         END update_employee;
-        
+
         PROCEDURE delete_employee(
             p_employee_id   NUMBER)
         IS
@@ -111,7 +111,7 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
       self.primary_key = :employee_id
 
       validates_presence_of :first_name, :last_name, :hire_date
-      
+
       # should return ID of new record
       set_create_method do
         plsql.test_employees_pkg.create_employee(
@@ -372,5 +372,5 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
     expect(@employee.save).to be_falsey
     expect(@employee.errors[:first_name]).not_to be_blank
   end
-  
+
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
@@ -234,7 +234,7 @@ describe "OracleEnhancedAdapter schema dump" do
       dump = standard_dump
       expect(dump.rindex("create_table")).to be < dump.index("add_foreign_key")
     end
- 
+
     it "should include primary_key when reference column name is not 'id'" do
       schema_define do
         create_table :test_posts, force: true, :primary_key => 'baz_id' do |t|
@@ -253,7 +253,7 @@ describe "OracleEnhancedAdapter schema dump" do
 
       expect(standard_dump).to match(/add_foreign_key "test_comments", "test_posts", column: "baz_id", primary_key: "baz_id", name: "test_comments_baz_id_fk"/)
     end
-    
+
   end
 
   describe "synonyms" do
@@ -415,7 +415,7 @@ describe "OracleEnhancedAdapter schema dump" do
     context "with index on virtual column" do
       before(:all) do
         if @oracle11g_or_higher
-          schema_define do 
+          schema_define do
             add_index 'test_names', 'field_with_leading_space', :name => "index_on_virtual_col"
           end
         end

--- a/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
@@ -22,9 +22,9 @@ describe "OracleEnhancedAdapter structure dump" do
       end
       TestPost.table_name = "test_posts"
     end
-  
+
     after(:each) do
-      @conn.drop_table :test_posts 
+      @conn.drop_table :test_posts
       @conn.drop_table :foos
       @conn.execute "DROP SEQUENCE test_posts_seq" rescue nil
       @conn.execute "ALTER TABLE test_posts drop CONSTRAINT fk_test_post_foo" rescue nil
@@ -40,12 +40,12 @@ describe "OracleEnhancedAdapter structure dump" do
       @conn.execute "DROP VIEW test_posts_view_z" rescue nil
       @conn.execute "DROP VIEW test_posts_view_a" rescue nil
     end
-  
+
     it "should dump single primary key" do
       dump = ActiveRecord::Base.connection.structure_dump
       expect(dump).to match(/CONSTRAINT (.+) PRIMARY KEY \(ID\)\n/)
     end
-  
+
     it "should dump composite primary keys" do
       pk = @conn.send(:select_one, <<-SQL)
         select constraint_name from user_constraints where table_name = 'TEST_POSTS' and constraint_type='P'
@@ -60,43 +60,43 @@ describe "OracleEnhancedAdapter structure dump" do
       dump = ActiveRecord::Base.connection.structure_dump
       expect(dump).to match(/CONSTRAINT (.+) PRIMARY KEY \(ID,TITLE\)\n/)
     end
-  
+
     it "should dump foreign keys" do
       @conn.execute <<-SQL
-        ALTER TABLE TEST_POSTS 
+        ALTER TABLE TEST_POSTS
         ADD CONSTRAINT fk_test_post_foo FOREIGN KEY (foo_id) REFERENCES foos(id)
       SQL
       dump = ActiveRecord::Base.connection.structure_dump_fk_constraints
       expect(dump.split('\n').length).to eq(1)
       expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_FOO\"? FOREIGN KEY \(\"?FOO_ID\"?\) REFERENCES \"?FOOS\"?\(\"?ID\"?\)/i)
     end
-    
+
     it "should dump foreign keys when reference column name is not 'id'" do
       @conn.add_column :foos, :baz_id, :integer
-      
+
       @conn.execute <<-SQL
-        ALTER TABLE FOOS 
+        ALTER TABLE FOOS
         ADD CONSTRAINT UK_BAZ UNIQUE (BAZ_ID)
       SQL
-      
+
       @conn.add_column :test_posts, :baz_id, :integer
-      
+
       @conn.execute <<-SQL
-        ALTER TABLE TEST_POSTS 
+        ALTER TABLE TEST_POSTS
         ADD CONSTRAINT fk_test_post_baz FOREIGN KEY (baz_id) REFERENCES foos(baz_id)
       SQL
-      
+
       dump = ActiveRecord::Base.connection.structure_dump_fk_constraints
       expect(dump.split('\n').length).to eq(1)
       expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_BAZ\"? FOREIGN KEY \(\"?BAZ_ID\"?\) REFERENCES \"?FOOS\"?\(\"?BAZ_ID\"?\)/i)
     end
-    
+
     it "should not error when no foreign keys are present" do
       dump = ActiveRecord::Base.connection.structure_dump_fk_constraints
       expect(dump.split('\n').length).to eq(0)
       expect(dump).to eq('')
     end
-  
+
     it "should dump triggers" do
       @conn.execute <<-SQL
         create or replace TRIGGER TEST_POST_TRIGGER
@@ -110,7 +110,7 @@ describe "OracleEnhancedAdapter structure dump" do
       dump = ActiveRecord::Base.connection.structure_dump_db_stored_code.gsub(/\n|\s+/,' ')
       expect(dump).to match(/CREATE OR REPLACE TRIGGER TEST_POST_TRIGGER/)
     end
-  
+
     it "should dump types" do
       @conn.execute <<-SQL
         create or replace TYPE TEST_TYPE AS TABLE OF VARCHAR2(10);
@@ -125,7 +125,7 @@ describe "OracleEnhancedAdapter structure dump" do
       dump = ActiveRecord::Base.connection.structure_dump_db_stored_code.gsub(/\n|\s+/,' ')
       expect(dump).to match(/CREATE OR REPLACE FORCE VIEW TEST_POSTS_VIEW_A.*CREATE OR REPLACE FORCE VIEW TEST_POSTS_VIEW_Z/)
     end
-  
+
     it "should dump virtual columns" do
       skip "Not supported in this database version" unless @oracle11g_or_higher
       @conn.execute <<-SQL
@@ -159,20 +159,20 @@ describe "OracleEnhancedAdapter structure dump" do
       SQL
       dump = ActiveRecord::Base.connection.structure_dump_unique_keys("test_posts")
       expect(dump).to eq(["ALTER TABLE TEST_POSTS ADD CONSTRAINT UK_FOO_FOO_ID UNIQUE (FOO,FOO_ID)"])
-    
+
       dump = ActiveRecord::Base.connection.structure_dump
       expect(dump).to match(/CONSTRAINT UK_FOO_FOO_ID UNIQUE \(FOO,FOO_ID\)/)
     end
-  
+
     it "should dump indexes" do
       ActiveRecord::Base.connection.add_index(:test_posts, :foo, :name => :ix_test_posts_foo)
       ActiveRecord::Base.connection.add_index(:test_posts, :foo_id, :name => :ix_test_posts_foo_id, :unique => true)
-      
+
       @conn.execute <<-SQL
         ALTER TABLE test_posts
           add CONSTRAINT uk_foo_foo_id UNIQUE (foo, foo_id)
       SQL
-      
+
       dump = ActiveRecord::Base.connection.structure_dump
       expect(dump).to match(/CREATE UNIQUE INDEX "?IX_TEST_POSTS_FOO_ID"? ON "?TEST_POSTS"? \("?FOO_ID"?\)/i)
       expect(dump).to match(/CREATE  INDEX "?IX_TEST_POSTS_FOO\"? ON "?TEST_POSTS"? \("?FOO"?\)/i)
@@ -264,7 +264,7 @@ describe "OracleEnhancedAdapter structure dump" do
       end
     end
   end
-  
+
   describe "temp_table_drop" do
     before(:each) do
       @conn.create_table :temp_tbl, :temporary => true do |t|
@@ -280,13 +280,13 @@ describe "OracleEnhancedAdapter structure dump" do
       expect(dump).not_to match(/DROP TABLE "?NOT_TEMP_TBL"?/i)
     end
     after(:each) do
-      @conn.drop_table :temp_tbl 
+      @conn.drop_table :temp_tbl
       @conn.drop_table :not_temp_tbl
     end
   end
-  
+
   describe "full drop" do
-    before(:each) do 
+    before(:each) do
       @conn.create_table :full_drop_test do |t|
         t.string :foo
       end
@@ -308,7 +308,7 @@ describe "OracleEnhancedAdapter structure dump" do
         end test_package;
       SQL
       @conn.execute <<-SQL
-        create or replace package body full_drop_test_package as 
+        create or replace package body full_drop_test_package as
           function test_func return varchar2 is
             begin
               return ('foo');
@@ -318,10 +318,10 @@ describe "OracleEnhancedAdapter structure dump" do
       #function
       @conn.execute <<-SQL
         create or replace function full_drop_test_function
-          return varchar2 
+          return varchar2
         is
           foo varchar2(3);
-        begin 
+        begin
           return('foo');
         end;
       SQL


### PR DESCRIPTION
At first it is very conservertive ones to remove trailing white space and trailing blank lines
to avoid future pull request and commit diff to show only their concern, not format.

Initial version of .rubocop.yml has been created based on the initial version of Rails.

https://github.com/rails/rails/commit/7d883b829307944f6d7c273f3915ee7059ee3771