### PR TITLE
Enabled needs capitalized

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,8 +4,8 @@ AllCops:
 
 # No trailing whitespace.
 Style/TrailingWhitespace:
-  enabled: true
+  Enabled: true
 
 # Blank lines should not have any spaces.
 Style/TrailingBlankLines:
-  enabled: true
+  Enabled: true


### PR DESCRIPTION
To avoid these warnings:

```ruby

Warning: unrecognized parameter Style/TrailingWhitespace:enabled found in /home/yahonda/git/oracle-enhanced/.rubocop.yml
Warning: unrecognized parameter Style/TrailingBlankLines:enabled found in /home/yahonda/git/oracle-enhanced/.rubocop.yml
```