### PR TITLE
Suppress `create_table(:posts, {:force=>true})` message

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
@@ -111,9 +111,11 @@ describe "OracleEnhancedConnection" do
   end
 
   describe "default_timezone" do
+    include SchemaSpecHelper
+
     before(:all) do
       ActiveRecord::Base.establish_connection(CONNECTION_WITH_TIMEZONE_PARAMS)
-      ActiveRecord::Schema.define do
+      schema_define do
         create_table :posts, :force => true do |t|
           t.timestamps null: false
         end


### PR DESCRIPTION
This pull request suppresses this `create_table` message when rspec runs.

```ruby
$ rspec spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
==> Loading config from ENV or use default
==> Running specs with MRI version 2.3.3
==> Effective ActiveRecord version 5.0.0.1
.............-- create_table(:posts, {:force=>true})
   -> 0.0702s
....................

Finished in 4.2 seconds (files took 1.3 seconds to load)
33 examples, 0 failures
```