### PR TITLE
Drop `ActiveRecord::InternalMetadata.table_name` after each spec

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
@@ -77,6 +77,7 @@ describe "OracleEnhancedAdapter schema dump" do
     after(:each) do
       drop_test_posts_table
       @conn.drop_table(ActiveRecord::Migrator.schema_migrations_table_name) if @conn.table_exists?(ActiveRecord::Migrator.schema_migrations_table_name)
+      @conn.drop_table(ActiveRecord::InternalMetadata.table_name) if @conn.table_exists?(ActiveRecord::InternalMetadata.table_name)
       ActiveRecord::Base.table_name_prefix = ''
       ActiveRecord::Base.table_name_suffix = ''
     end


### PR DESCRIPTION
This pull request drops leftover InternalMetadata tables with prefixes or suffixes when this spec executed.

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
```

* Without this commit:

```sql
$ sqlplus oracle_enhanced/oracle_enhanced

SQL> select table_name from user_tables;

TABLE_NAME
--------------------------------------------------------------------------------
XXX$AR_INTERNAL_METADATA
AR_INTERNAL_METADATA
XXX_AR_INTERNAL_METADATA
AR_INTERNAL_METADATA_XXX
AR_INTERNAL_METADATA$XXX

SQL>
```


* With this commit
```sql
SQL> select table_name from user_tables;

TABLE_NAME
--------------------------------------------------------------------------------
AR_INTERNAL_METADATA

SQL>
```
