### PR TITLE
Separate schema migration insert statements correctly

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -117,6 +117,14 @@ module ActiveRecord
           super
         end
 
+        def insert_versions_sql(versions) # :nodoc:
+          sm_table = ActiveRecord::Migrator.schema_migrations_table_name
+
+          versions.map { |version|
+            "INSERT INTO #{sm_table} (version) VALUES ('#{version}')"
+          }.join "\n\n/\n\n"
+        end
+
         def initialize_schema_migrations_table
           super
         end

--- a/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
@@ -260,7 +260,7 @@ describe "OracleEnhancedAdapter structure dump" do
 
     it "should return the character size of nvarchar fields" do
       if /.*unq_nvarchar nvarchar2\((\d+)\).*/ =~ @conn.structure_dump
-         expect("#$1").to eq("255")
+        expect("#$1").to eq("255")
       end
     end
   end
@@ -282,6 +282,37 @@ describe "OracleEnhancedAdapter structure dump" do
     after(:each) do
       @conn.drop_table :temp_tbl
       @conn.drop_table :not_temp_tbl
+    end
+  end
+
+  describe "schema migrations" do
+    let(:versions) do
+      (1..10).map do |i|
+        Time.parse("2016.01.#{i}").strftime("%Y%m%d%H%M%S")
+      end
+    end
+    before do
+      @conn.create_table :schema_migrations, :id => false do |t|
+        t.string :version
+      end
+      versions.each do |i|
+        @conn.execute "insert into schema_migrations (version) values ('#{i}')"
+      end
+    end
+    let(:dump) { ActiveRecord::Base.connection.dump_schema_information }
+    it "should dump schema migrations one version per insert" do
+      versions[0...-1].each do |i|
+        expect(dump).to include "INSERT INTO schema_migrations (version) VALUES ('#{i}')\n\n/\n"
+      end
+    end
+    it "should not add own separator or newline" do
+      expect(dump).to match(/INSERT INTO schema_migrations \(version\) VALUES \('#{versions.last}'\)\z/)
+    end
+    it "should contain expected amount of lines" do
+      expect(dump.lines.length).to eq(4 * (versions.length - 1) + 1)
+    end
+    after do
+      @conn.drop_table :schema_migrations
     end
   end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
@@ -292,11 +292,10 @@ describe "OracleEnhancedAdapter structure dump" do
       end
     end
     before do
-      @conn.create_table :schema_migrations, :id => false do |t|
-        t.string :version
-      end
+      ActiveRecord::SchemaMigration.reset_table_name
+      ActiveRecord::SchemaMigration.create_table
       versions.each do |i|
-        @conn.execute "insert into schema_migrations (version) values ('#{i}')"
+        ActiveRecord::SchemaMigration.create!(:version => i)
       end
     end
     let(:dump) { ActiveRecord::Base.connection.dump_schema_information }
@@ -312,7 +311,7 @@ describe "OracleEnhancedAdapter structure dump" do
       expect(dump.lines.length).to eq(4 * (versions.length - 1) + 1)
     end
     after do
-      @conn.drop_table :schema_migrations
+      ActiveRecord::SchemaMigration.drop_table
     end
   end
 


### PR DESCRIPTION
This pull request updates #1017 to avoid these 3 failures.

```ruby
OCIError: ORA-00942: table or view does not exist: SELECT "XXX_SCHEMA_MIGRATIONS"."VERSION" FROM "XXX_SCHEMA_MIGRATIONS" ORDER BY version
```
