### PR TITLE
Fallback :bigint to :integer for primary keys

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/column_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column_dumper.rb
@@ -53,6 +53,10 @@ module ActiveRecord #:nodoc:
 
         private
 
+        def default_primary_key?(column)
+          schema_type(column) == :integer
+        end
+
         def schema_virtual_as(column)
           column.virtual_column_data_default if column.virtual?
         end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -1,6 +1,18 @@
 module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced
+      class ReferenceDefinition < ActiveRecord::ConnectionAdapters::ReferenceDefinition # :nodoc:
+        def initialize(
+          name,
+          polymorphic: false,
+          index: true,
+          foreign_key: false,
+          type: :integer,
+          **options)
+          super
+        end
+      end
+
       class SynonymDefinition < Struct.new(:name, :table_owner, :table_name, :db_link) #:nodoc:
       end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -232,6 +232,10 @@ module ActiveRecord
           self.all_schema_indexes = nil
         end
 
+        def add_reference(table_name, *args)
+          ActiveRecord::ConnectionAdapters::OracleEnhanced::ReferenceDefinition.new(*args).add_to(update_table_definition(table_name, self))
+        end
+
         def add_column(table_name, column_name, type, options = {}) #:nodoc:
           if type.to_sym == :virtual
             type = options[:type]


### PR DESCRIPTION
Since Oracle enhanced adapter already handles Rails primary keys as NUMBER(38) Oracle data type.
Here 38 means precision, not bytes to store.

Also Rails :bigint data type is handled as NUMBER(19) Oracle data type which has less precision
than Oracle enhanced adapter :integer. Then this pull request falls back :bigint for primary keys
to Rails :integer.

Refer rails/rails#26266