### PR TITLE
Suppress `create_table(:test_employees, {:force=>true})` message

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
@@ -3,10 +3,11 @@ require 'spec_helper'
 if ActiveRecord::Base.method_defined?(:changed?)
 
   describe "OracleEnhancedAdapter dirty object tracking" do
+    include SchemaSpecHelper
 
     before(:all) do
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-      ActiveRecord::Schema.define do
+      schema_define do
         create_table :test_employees, :force => true do |t|
           t.string    :first_name,  limit: 20
           t.string    :last_name,   limit: 25


### PR DESCRIPTION
This pull request suppresses `create_table(:test_employees, {:force=>true})` message.

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
==> Loading config from ENV or use default
==> Running specs with MRI version 2.4.0
... snip ...
-- create_table(:test_employees, {:force=>true})
   -> 0.3052s
...
Finished in 0.98271 seconds (files took 1.82 seconds to load)
11 examples, 0 failures

$
```
