### PR TITLE
Introduce OracleEnhanced `ColumnMethods` module and `AlterTable` `Table` classes

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -1,6 +1,13 @@
 module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced
+      module ColumnMethods
+        def primary_key(name, type = :primary_key, **options)
+          # This is a placeholder for future :auto_increment support
+          super
+        end
+      end
+
       class ReferenceDefinition < ActiveRecord::ConnectionAdapters::ReferenceDefinition # :nodoc:
         def initialize(
           name,
@@ -31,6 +38,8 @@ module ActiveRecord
       end
 
       class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
+        include ActiveRecord::ConnectionAdapters::OracleEnhanced::ColumnMethods
+
         attr_accessor :tablespace, :organization
         def initialize(name, temporary = false, options = nil, as = nil, tablespace = nil, organization = nil, comment: nil)
           @tablespace = tablespace
@@ -61,6 +70,13 @@ module ActiveRecord
         def create_column_definition(name, type)
           OracleEnhanced::ColumnDefinition.new name, type
         end
+      end
+
+      class AlterTable < ActiveRecord::ConnectionAdapters::AlterTable
+      end
+
+      class Table < ActiveRecord::ConnectionAdapters::Table
+        include ActiveRecord::ConnectionAdapters::OracleEnhanced::ColumnMethods
       end
     end
   end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -428,6 +428,14 @@ module ActiveRecord
           end
         end
 
+        def create_alter_table(name)
+          ActiveRecord::ConnectionAdapters::OracleEnhanced::AlterTable.new create_table_definition(name, false, {})
+        end
+
+        def update_table_definition(table_name, base)
+          ActiveRecord::ConnectionAdapters::OracleEnhanced::Table.new(table_name, base)
+        end
+
         private
 
         def tablespace_for(obj_type, tablespace_option, table_name=nil, column_name=nil)


### PR DESCRIPTION
These modules and classes will be prepared for future `:auto_increment` support

	ActiveRecord::ConnectionAdapters::OracleEnhanced::ColumnMethods
	ActiveRecord::ConnectionAdapters::OracleEnhanced::AlterTable
	ActiveRecord::ConnectionAdapters::OracleEnhanced::Table

