### PR TITLE
Quoting booleans should return a frozen string

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -103,7 +103,7 @@ module ActiveRecord
 
         def quoted_true #:nodoc:
           return "'#{self.class.boolean_to_string(true)}'" if emulate_booleans_from_strings
-          "1"
+          "1".freeze
         end
 
         def unquoted_true #:nodoc:
@@ -113,7 +113,7 @@ module ActiveRecord
 
         def quoted_false #:nodoc:
           return "'#{self.class.boolean_to_string(false)}'" if emulate_booleans_from_strings
-          "0"
+          "0".freeze
         end
 
         def unquoted_false #:nodoc:


### PR DESCRIPTION
refer rails/rails#25408

This pull request addresses this failure when tested with Rails 5.0.1.rc2.

```ruby
$ ARCONN=oracle bundle exec ruby -w -Itest test/cases/quoting_test.rb
Using oracle
Run options: --seed 52690

# Running:

...........................F

Finished in 0.051142s, 547.4907 runs/s, 684.3634 assertions/s.

  1) Failure:
ActiveRecord::ConnectionAdapters::QuoteBooleanTest#test_quote_returns_frozen_string [test/cases/quoting_test.rb:159]:
Expected "1" to be frozen?.

28 runs, 35 assertions, 1 failures, 0 errors, 0 skips
$
```
