### PR TITLE
Fix ORA-00933 error when executing `rails db:schema:load`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -118,11 +118,23 @@ module ActiveRecord
         end
 
         def insert_versions_sql(versions) # :nodoc:
-          sm_table = ActiveRecord::Migrator.schema_migrations_table_name
+          sm_table = quote_table_name(ActiveRecord::Migrator.schema_migrations_table_name)
 
-          versions.map { |version|
-            "INSERT INTO #{sm_table} (version) VALUES ('#{version}')"
-          }.join "\n\n/\n\n"
+          if supports_multi_insert?
+            versions.inject("INSERT ALL\n") { |sql, version|
+              sql << "INTO #{sm_table} (version) VALUES (#{quote(version)})\n"
+            } << "SELECT * FROM DUAL\n"
+          else
+            if versions.is_a?(Array)
+              # called from ActiveRecord::Base.connection#dump_schema_information
+              versions.map { |version|
+                "INSERT INTO #{sm_table} (version) VALUES (#{quote(version)})"
+              }.join("\n\n/\n\n")
+            else
+              # called from ActiveRecord::Base.connection#assume_migrated_upto_version
+              "INSERT INTO #{sm_table} (version) VALUES (#{quote(versions)})"
+            end
+          end
         end
 
         def initialize_schema_migrations_table

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -493,7 +493,7 @@ module ActiveRecord
       end
 
       def supports_multi_insert?
-        false
+        @connection.database_version.to_s >= [11, 2].to_s
       end
 
       #:stopdoc:


### PR DESCRIPTION
ORA-00933 error occurred when executing `rails db:schema:load`.

I think that it is probably due to not being able to process `/` by ruby-oci8. In this PR it is a proposal to insert multiple lines without using `/`.

I'm added a reproduction test in active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb.

This PR passed the following reproduction test.

```sh
Failures:

  1) OracleEnhancedAdapter schema definition load schema should loads the migration schema table from insert versions sql
       Failure/Error:
         expect {
           @conn.execute insert_versions_sql
         }.not_to raise_error

         expected no Exception, got #<ActiveRecord::StatementInvalid: OCIError: ORA-00933: SQL command not properly ended:
INSERT INTO sc...on) VALUES ('20160102000000')

        /

       INSERT INTO schema_migrations (version) VALUES ('20160103000000')> with backtrace:
         # stmt.c:243:in oci8lib_230.so
         # /home/vagrant/.rvm/gems/ruby-2.3.3/bundler/gems/ruby-oci8-d3a1a3dedde6/lib/oci8/cursor.rb:129:in `exec'
         # /home/vagrant/.rvm/gems/ruby-2.3.3/bundler/gems/ruby-oci8-d3a1a3dedde6/lib/oci8/oci8.rb:276:in `exec_internal'
         # /home/vagrant/.rvm/gems/ruby-2.3.3/bundler/gems/ruby-oci8-d3a1a3dedde6/lib/oci8/oci8.rb:267:in `exec'
         # ./lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:447:in `exec'
         # ./lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:90:in `exec'
         # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `block in execute'
         #
/home/vagrant/.rvm/gems/ruby-2.3.3/bundler/gems/rails-a19810583625/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
         #
/home/vagrant/.rvm/gems/ruby-2.3.3/bundler/gems/rails-a19810583625/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
         #
/home/vagrant/.rvm/gems/ruby-2.3.3/bundler/gems/rails-a19810583625/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
         # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1284:in `log'
         # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `execute'
         # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1449:in `block (4 levels) in <top
(required)>'
```

Related PR is #1074 .

Thanks.
