### PR TITLE
Perform `drop_table :test_employees`

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
@@ -23,6 +23,9 @@ if ActiveRecord::Base.method_defined?(:changed?)
     end
 
     after(:all) do
+      schema_define do
+        drop_table :test_employees
+      end
       Object.send(:remove_const, "TestEmployee")
       ActiveRecord::Base.clear_cache! if ActiveRecord::Base.respond_to?(:"clear_cache!")
     end


### PR DESCRIPTION
This pull request addresses these failures:

```ruby
$ rake spec
...

Failures:

  1) OracleEnhancedAdapter schema definition sequence creation parameters should use default sequence start value 10000
     Got 0 failures and 2 other errors:

     1.1) Failure/Error: @connection.exec(sql, *bindvars, &block)

          ActiveRecord::StatementInvalid:
            OCIError: ORA-00955: name is already used by an existing object: CREATE SEQUENCE "TEST_EMPLOYEES_SEQ" START WITH 10000
          # stmt.c:243:in oci8lib_230.so
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/bundler/gems/ruby-oci8-d3a1a3dedde6/lib/oci8/cursor.rb:129:in `exec'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/bundler/gems/ruby-oci8-d3a1a3dedde6/lib/oci8/oci8.rb:276:in `exec_internal'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/bundler/gems/ruby-oci8-d3a1a3dedde6/lib/oci8/oci8.rb:267:in `exec'
          # ./lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:443:in `exec'
          # ./lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:90:in `exec'
          # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `block in execute'
          # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:594:in `block in log'
          # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
          # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:587:in `log'
          # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1042:in `log'
          # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `execute'
          # ./lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:467:in `create_sequence_and_trigger'
          # ./lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:78:in `create_table'
          # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:848:in `block in method_missing'
          # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:817:in `block in say_with_time'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/2.3.0/benchmark.rb:293:in `measure'
          # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:817:in `say_with_time'
          # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:837:in `method_missing'
          # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:84:in `block in create_test_employees_table'
          # ./spec/spec_helper.rb:112:in `instance_eval'
          # ./spec/spec_helper.rb:112:in `block (2 levels) in schema_define'
          # /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:825:in `suppress_messages'
          # ./spec/spec_helper.rb:111:in `block in schema_define'
          # /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:48:in `instance_eval'
          # /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:48:in `define'
          # /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:44:in `define'
          # ./spec/spec_helper.rb:110:in `schema_define'
          # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:83:in `create_test_employees_table'
          # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:119:in `block (3 levels) in <top (required)>'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<main>'
          # ------------------
          # --- Caused by: ---
          # OCIError:
          #   ORA-00955: name is already used by an existing object
          #   stmt.c:243:in oci8lib_230.so

     1.2) Failure/Error: Object.send(:remove_const, "TestEmployee")

          NameError:
            constant Object::TestEmployee not defined
          # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:112:in `remove_const'
          # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:112:in `block (3 levels) in <top (required)>'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:357:in `run'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:507:in `block in run_owned_hooks_for'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:506:in `each'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:506:in `run_owned_hooks_for'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:593:in `block in run_example_hooks_for'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:592:in `each'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:592:in `run_example_hooks_for'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:463:in `run'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:503:in `run_after_example'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:269:in `block in run'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
          # /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<main>'

Deprecation Warnings:

Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }` instead. Called from /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb:175:in `block (4 levels) in <top (required)>'.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

1 deprecation warning total

Finished in 3 minutes 56.4 seconds (files took 0.70385 seconds to load)
363 examples, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:116 # OracleEnhancedAdapter schema definition sequence creation parameters should use default sequence start value 10000

/home/yahonda/.rbenv/versions/2.3.3/bin/ruby -I/home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib:/home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-support-3.5.0/lib /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb failed
$
```
