### PR TITLE
Address rspec deprecation warning

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
@@ -172,7 +172,7 @@ describe "OracleEnhancedAdapter context index" do
     it "should use index when contains has schema_name.table_name syntax" do
       @conn.add_context_index :posts, :title
       @title_words.each do |word|
-        Post.contains('posts.title', word).to_a.should == [@post2, @post1]
+        expect(Post.contains('posts.title', word).to_a).to eq([@post2, @post1])
       end
       @conn.remove_context_index :posts, :title
     end


### PR DESCRIPTION
This pull request removes a rspec deprecation warning below.

```ruby
$ rspec spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb:175
==> Loading config from ENV or use default
==> Running specs with MRI version 2.3.3
==> Effective ActiveRecord version 5.1.0.alpha
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb"=>[175]}}
.

Deprecation Warnings:

Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }` instead. Called from /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb:175:in `block (4 levels) in <top (required)>'.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

1 deprecation warning total

Finished in 0.88728 seconds (files took 1.39 seconds to load)
1 example, 0 failures

$
```
