### PR TITLE
Address rspec deprecation warning

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
@@ -471,7 +471,7 @@ describe "OracleEnhancedAdapter schema dump" do
     end
 
     it "should dump table comments" do
-      standard_dump.should =~ /comment: "this is a \\"table comment\\"!"/
+      expect(standard_dump).to match(/comment: "this is a \\"table comment\\"!"/)
     end
   end
 


### PR DESCRIPTION
This pull request addresses the rspec deprecation warning below.

```ruby
$ rspec spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:474
==> Loading config from ENV or use default
==> Running specs with MRI version 2.3.3
==> Effective ActiveRecord version 5.1.0.alpha
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb"=>[474]}}
.

Deprecation Warnings:

Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }` instead. Called from /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:474:in `block (3 levels) in <top (required)>'.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

1 deprecation warning total

Finished in 7.93 seconds (files took 1.22 seconds to load)
1 example, 0 failures

```