### PR TITLE
Revert "Skip `explain should explain query with bind` with JRuby"

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -610,7 +610,6 @@ describe "OracleEnhancedAdapter" do
     end
 
     it "should explain query with binds" do
-      skip "Skip until further investigation made for #908" if RUBY_ENGINE == 'jruby'
       pk = TestPost.columns_hash[TestPost.primary_key]
       sub = Arel::Nodes::BindParam.new.to_sql
       binds = [ActiveRecord::Relation::QueryAttribute.new(pk, 1, ActiveRecord::Type::Integer.new)]


### PR DESCRIPTION
This reverts commit 2588a80bea095e9cc1dc9522db7e0aae0d5d7e2e.

Reverts #1091