### PR TITLE
Handle ORA-00942 and ORA-00955 as `ActiveRecord::StatementInvalid`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -991,6 +991,8 @@ module ActiveRecord
         case @connection.error_code(exception)
         when 1
           RecordNotUnique.new(message)
+        when 942, 955
+          ActiveRecord::StatementInvalid.new(message)
         when 2291
           InvalidForeignKey.new(message)
         when 12899


### PR DESCRIPTION
not `NativeException` by JRuby

00942, 00000, "table or view does not exist"
00955, 00000, "name is already used by an existing object"

Since rails/rails#27341 changes `translate_exception` to handle `RuntimeError` as exception.

This pull request addresses these two failures when tested with JRuby.


```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:393
==> Loading config from ENV or use default
==> Running specs with JRuby version 9.1.6.0
==> Effective ActiveRecord version 5.1.0.alpha
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb"=>[393]}}
F

Failures:

  1) OracleEnhancedAdapter schema definition drop tables should drop table with :if_exists option no raise error
     Failure/Error: expect do

       expected no Exception, got #<NativeException: java.sql.SQLSyntaxErrorException: ORA-00942: table or view does not exist
       > with backtrace:
         # oracle/jdbc/driver/T4CTTIoer.java:450:in `processError'
         # oracle/jdbc/driver/T4CTTIoer.java:399:in `processError'
         # oracle/jdbc/driver/T4C8Oall.java:1059:in `processError'
         # oracle/jdbc/driver/T4CTTIfun.java:522:in `receive'
         # oracle/jdbc/driver/T4CTTIfun.java:257:in `doRPC'
         # oracle/jdbc/driver/T4C8Oall.java:587:in `doOALL'
         # oracle/jdbc/driver/T4CStatement.java:210:in `doOall8'
         # oracle/jdbc/driver/T4CStatement.java:30:in `doOall8'
         # oracle/jdbc/driver/T4CStatement.java:931:in `executeForRows'
         # oracle/jdbc/driver/OracleStatement.java:1150:in `doExecuteWithTimeout'
         # oracle/jdbc/driver/OracleStatement.java:1792:in `executeInternal'
         # oracle/jdbc/driver/OracleStatement.java:1745:in `execute'
         # oracle/jdbc/driver/OracleStatementWrapper.java:334:in `execute'
         # java/lang/reflect/Method.java:498:in `invoke'
         # org/jruby/javasupport/JavaMethod.java:453:in `invokeDirectWithExceptionHandling'
         # org/jruby/javasupport/JavaMethod.java:314:in `invokeDirect'
         # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:264:in `exec_no_retry'
         # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:248:in `block in exec'
         # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:235:in `with_retry'
         # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:247:in `exec'
         # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `block in execute'
         # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:594:in `block in log'
         # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
         # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:587:in `log'
         # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1042:in `log'
         # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `execute'
         # ./lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:106:in `drop_table'
         # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:395:in `block in (root)'
         # org/jruby/RubyProc.java:324:in `call'
         # org/jruby/RubyProc.java:308:in `call19'
         # org/jruby/RubyProc$INVOKER$i$0$0$call19.gen:-1:in `call'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/matchers/built_in/raise_error.rb:52:in `matches?'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/matchers/built_in/raise_error.rb:71:in `does_not_match?'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:78:in `does_not_match?'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:72:in `block in handle_matcher'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:70:in `handle_matcher'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/expectations/expectation_target.rb:78:in `not_to'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/expectations/expectation_target.rb:106:in `not_to'
         # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:394:in `block in (root)'
         # org/jruby/RubyBasicObject.java:1749:in `yieldUnder'
         # org/jruby/RubyBasicObject.java:1726:in `instance_exec'
         # org/jruby/RubyBasicObject$INVOKER$i$0$3$instance_exec19.gen:-1:in `call'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
         # org/jruby/specialized/RubyArrayOneObject.java:90:in `collect'
         # org/jruby/RubyArray.java:2492:in `map'
         # org/jruby/RubyArray$INVOKER$i$0$0$map19.gen:-1:in `call'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
         # org/jruby/RubyArray.java:2478:in `collect'
         # org/jruby/RubyArray.java:2492:in `map'
         # org/jruby/RubyArray$INVOKER$i$0$0$map19.gen:-1:in `call'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block in run_specs'
         # org/jruby/RubyArray.java:2478:in `collect'
         # org/jruby/RubyArray.java:2492:in `map'
         # org/jruby/RubyArray$INVOKER$i$0$0$map19.gen:-1:in `call'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block in run_specs'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/exe/rspec:4:in `<main>'
         # org/jruby/Ruby.java:862:in `runInterpreter'
         # org/jruby/Ruby.java:2960:in `loadFile'
         # org/jruby/RubyKernel.java:985:in `loadCommon'
         # org/jruby/RubyKernel.java:977:in `load'
         # org/jruby/RubyKernel$INVOKER$s$0$1$load19.gen:-1:in `call'
         # home/yahonda/$_dot_rbenv/versions/jruby_minus_9_dot_1_dot_6_dot_0/bin//home/yahonda/.rbenv/versions/jruby-9.1.6.0/bin/rspec:22:in `invokeOther18:load'
         # home/yahonda/$_dot_rbenv/versions/jruby_minus_9_dot_1_dot_6_dot_0/bin//home/yahonda/.rbenv/versions/jruby-9.1.6.0/bin/rspec:22:in `<main>'
         # java/lang/invoke/MethodHandle.java:627:in `invokeWithArguments'
         # org/jruby/Ruby.java:846:in `runScript'
         # org/jruby/Ruby.java:761:in `runNormally'
         # org/jruby/Ruby.java:779:in `runNormally'
         # org/jruby/Ruby.java:592:in `runFromMain'
         # org/jruby/Main.java:425:in `doRunFromMain'
         # org/jruby/Main.java:313:in `internalRun'
         # org/jruby/Main.java:242:in `run'
         # org/jruby/Main.java:204:in `main'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-support-3.5.0/lib/rspec/support.rb:87:in `block in Support'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-support-3.5.0/lib/rspec/support.rb:96:in `notify_failure'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/expectations/fail_with.rb:27:in `fail_with'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:40:in `handle_failure'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:72:in `block in handle_matcher'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:70:in `handle_matcher'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/expectations/expectation_target.rb:78:in `not_to'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/expectations/expectation_target.rb:106:in `not_to'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:394:in `block in (root)'
     # org/jruby/RubyBasicObject.java:1726:in `instance_exec'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # org/jruby/RubyArray.java:2492:in `map'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
     # org/jruby/RubyArray.java:2492:in `map'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block in run_specs'
     # org/jruby/RubyArray.java:2492:in `map'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/exe/rspec:4:in `<main>'
     # org/jruby/RubyKernel.java:977:in `load'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/bin/rspec:22:in `<main>'

Finished in 1.63 seconds (files took 15.58 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:393 # OracleEnhancedAdapter schema definition drop tables should drop table with :if_exists option no raise error

$
```

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:540
==> Loading config from ENV or use default
==> Running specs with JRuby version 9.1.6.0
==> Effective ActiveRecord version 5.1.0.alpha
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb"=>[540]}}
F

Failures:

  1) OracleEnhancedAdapter schema definition rename index should raise error when current index name and new index name are identical
     Failure/Error: expect do

       expected ActiveRecord::StatementInvalid, got #<NativeException: java.sql.SQLSyntaxErrorException: ORA-00955: name is already used by an existing object
       > with backtrace:
         # oracle/jdbc/driver/T4CTTIoer.java:450:in `processError'
         # oracle/jdbc/driver/T4CTTIoer.java:399:in `processError'
         # oracle/jdbc/driver/T4C8Oall.java:1059:in `processError'
         # oracle/jdbc/driver/T4CTTIfun.java:522:in `receive'
         # oracle/jdbc/driver/T4CTTIfun.java:257:in `doRPC'
         # oracle/jdbc/driver/T4C8Oall.java:587:in `doOALL'
         # oracle/jdbc/driver/T4CPreparedStatement.java:225:in `doOall8'
         # oracle/jdbc/driver/T4CPreparedStatement.java:53:in `doOall8'
         # oracle/jdbc/driver/T4CPreparedStatement.java:943:in `executeForRows'
         # oracle/jdbc/driver/OracleStatement.java:1150:in `doExecuteWithTimeout'
         # oracle/jdbc/driver/OraclePreparedStatement.java:4798:in `executeInternal'
         # oracle/jdbc/driver/OraclePreparedStatement.java:4901:in `execute'
         # oracle/jdbc/driver/OraclePreparedStatementWrapper.java:1385:in `execute'
         # java/lang/reflect/Method.java:498:in `invoke'
         # org/jruby/javasupport/JavaMethod.java:438:in `invokeDirectWithExceptionHandling'
         # org/jruby/javasupport/JavaMethod.java:302:in `invokeDirect'
         # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:268:in `exec_no_retry'
         # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:248:in `block in exec'
         # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:235:in `with_retry'
         # ./lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:247:in `exec'
         # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `block in execute'
         # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:594:in `block in log'
         # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
         # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:587:in `log'
         # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1042:in `log'
         # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `execute'
         # ./lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:230:in `rename_index'
         # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:542:in `block in (root)'
         # org/jruby/RubyProc.java:324:in `call'
         # org/jruby/RubyProc.java:308:in `call19'
         # org/jruby/RubyProc$INVOKER$i$0$0$call19.gen:-1:in `call'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/matchers/built_in/raise_error.rb:52:in `matches?'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/expectations/expectation_target.rb:65:in `to'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/expectations/expectation_target.rb:101:in `to'
         # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:541:in `block in (root)'
         # org/jruby/RubyBasicObject.java:1749:in `yieldUnder'
         # org/jruby/RubyBasicObject.java:1726:in `instance_exec'
         # org/jruby/RubyBasicObject$INVOKER$i$0$3$instance_exec19.gen:-1:in `call'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
         # org/jruby/RubyArray.java:2478:in `collect'
         # org/jruby/RubyArray.java:2492:in `map'
         # org/jruby/RubyArray$INVOKER$i$0$0$map19.gen:-1:in `call'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
         # org/jruby/RubyArray.java:2478:in `collect'
         # org/jruby/RubyArray.java:2492:in `map'
         # org/jruby/RubyArray$INVOKER$i$0$0$map19.gen:-1:in `call'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block in run_specs'
         # org/jruby/RubyArray.java:2478:in `collect'
         # org/jruby/RubyArray.java:2492:in `map'
         # org/jruby/RubyArray$INVOKER$i$0$0$map19.gen:-1:in `call'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block in run_specs'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
         # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/exe/rspec:4:in `<main>'
         # org/jruby/Ruby.java:862:in `runInterpreter'
         # org/jruby/Ruby.java:2960:in `loadFile'
         # org/jruby/RubyKernel.java:985:in `loadCommon'
         # org/jruby/RubyKernel.java:977:in `load'
         # org/jruby/RubyKernel$INVOKER$s$0$1$load19.gen:-1:in `call'
         # home/yahonda/$_dot_rbenv/versions/jruby_minus_9_dot_1_dot_6_dot_0/bin//home/yahonda/.rbenv/versions/jruby-9.1.6.0/bin/rspec:22:in `invokeOther18:load'
         # home/yahonda/$_dot_rbenv/versions/jruby_minus_9_dot_1_dot_6_dot_0/bin//home/yahonda/.rbenv/versions/jruby-9.1.6.0/bin/rspec:22:in `<main>'
         # java/lang/invoke/MethodHandle.java:627:in `invokeWithArguments'
         # org/jruby/Ruby.java:846:in `runScript'
         # org/jruby/Ruby.java:761:in `runNormally'
         # org/jruby/Ruby.java:779:in `runNormally'
         # org/jruby/Ruby.java:592:in `runFromMain'
         # org/jruby/Main.java:425:in `doRunFromMain'
         # org/jruby/Main.java:313:in `internalRun'
         # org/jruby/Main.java:242:in `run'
         # org/jruby/Main.java:204:in `main'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-support-3.5.0/lib/rspec/support.rb:87:in `block in Support'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-support-3.5.0/lib/rspec/support.rb:96:in `notify_failure'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/expectations/fail_with.rb:27:in `fail_with'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:40:in `handle_failure'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/expectations/expectation_target.rb:65:in `to'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-expectations-3.5.0/lib/rspec/expectations/expectation_target.rb:101:in `to'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:541:in `block in (root)'
     # org/jruby/RubyBasicObject.java:1726:in `instance_exec'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # org/jruby/RubyArray.java:2492:in `map'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
     # org/jruby/RubyArray.java:2492:in `map'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block in run_specs'
     # org/jruby/RubyArray.java:2492:in `map'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/lib/ruby/gems/shared/gems/rspec-core-3.5.4/exe/rspec:4:in `<main>'
     # org/jruby/RubyKernel.java:977:in `load'
     # /home/yahonda/.rbenv/versions/jruby-9.1.6.0/bin/rspec:22:in `<main>'

Finished in 18.5 seconds (files took 23.47 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:540 # OracleEnhancedAdapter schema definition rename index should raise error when current index name and new index name are identical

$
```
