### PR TITLE
CI against ruby 2.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,6 @@ rvm:
   - 2.3.3
   - jruby-9.0.5.0
   - jruby-9.1.6.0
-  - 2.4.0-rc1
+  - 2.4.0
 notifications:
     email: false


### PR DESCRIPTION
[Ruby 2.4.0 released](http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/78822). Then this Ruby version is available on Travis CI.

http://rubies.travis-ci.org