### PR TITLE
Remove deprecated `table_exists?` and `tables` 

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -374,7 +374,7 @@ describe "OracleEnhancedAdapter" do
       wh = WarehouseThing.create!(:name => "Foo", :foo => 2)
       expect(wh.id).not_to be_nil
 
-      expect(@conn.tables).to include("warehouse-things")
+      expect(@conn.data_sources).to include("warehouse-things")
     end
 
     it "should allow creation of a table with CamelCase name" do
@@ -386,7 +386,7 @@ describe "OracleEnhancedAdapter" do
       cc = CamelCase.create!(:name => "Foo", :foo => 2)
       expect(cc.id).not_to be_nil
 
-      expect(@conn.tables).to include("CamelCase")
+      expect(@conn.data_sources).to include("CamelCase")
     end
 
     it "properly quotes database links" do

--- a/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
@@ -102,7 +102,7 @@ describe "OracleEnhancedAdapter context index" do
 
     it "should not include text index secondary tables in user tables list" do
       @conn.add_context_index :posts, :title
-      expect(@conn.tables.any?{|t| t =~ /^dr\$/i}).to be_falsey
+      expect(@conn.data_sources.any?{|t| t =~ /^dr\$/i}).to be_falsey
       @conn.remove_context_index :posts, :title
     end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_database_tasks_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_database_tasks_spec.rb
@@ -42,14 +42,14 @@ describe "Oracle Enhanced adapter database tasks" do
     describe "drop" do
       before { ActiveRecord::Tasks::DatabaseTasks.drop(config) }
       it "drops all tables" do
-        expect(ActiveRecord::Base.connection.table_exists?(:test_posts)).to be_falsey
+        expect(ActiveRecord::Base.connection.data_source_exists?(:test_posts)).to be_falsey
       end
     end
 
     describe "purge" do
       before { ActiveRecord::Tasks::DatabaseTasks.purge(config) }
       it "drops all tables" do
-        expect(ActiveRecord::Base.connection.table_exists?(:test_posts)).to be_falsey
+        expect(ActiveRecord::Base.connection.data_source_exists?(:test_posts)).to be_falsey
         expect(ActiveRecord::Base.connection.select_value("SELECT COUNT(*) FROM RECYCLEBIN")).to eq(0)
       end
     end
@@ -77,7 +77,7 @@ describe "Oracle Enhanced adapter database tasks" do
           ActiveRecord::Tasks::DatabaseTasks.structure_load(config, temp_file)
         end
         it "loads the database structure from a file" do
-          expect(ActiveRecord::Base.connection.table_exists?(:test_posts)).to be_truthy
+          expect(ActiveRecord::Base.connection.data_source_exists?(:test_posts)).to be_truthy
         end
       end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
@@ -76,8 +76,8 @@ describe "OracleEnhancedAdapter schema dump" do
   describe "table prefixes and suffixes" do
     after(:each) do
       drop_test_posts_table
-      @conn.drop_table(ActiveRecord::Migrator.schema_migrations_table_name) if @conn.table_exists?(ActiveRecord::Migrator.schema_migrations_table_name)
-      @conn.drop_table(ActiveRecord::InternalMetadata.table_name) if @conn.table_exists?(ActiveRecord::InternalMetadata.table_name)
+      @conn.drop_table(ActiveRecord::Migrator.schema_migrations_table_name) if @conn.data_source_exists?(ActiveRecord::Migrator.schema_migrations_table_name)
+      @conn.drop_table(ActiveRecord::InternalMetadata.table_name) if @conn.data_source_exists?(ActiveRecord::InternalMetadata.table_name)
       ActiveRecord::Base.table_name_prefix = ''
       ActiveRecord::Base.table_name_suffix = ''
     end


### PR DESCRIPTION
This pull request addresses these deprecate warnings:

```ruby
[yahonda@li127-48 oracle-enhanced (suppress_tables_warnings)]$ rake spec

DEPRECATION WARNING: #tables currently returns both tables and views. This behavior is deprecated and will be changed with Rails 5.1 to only return tables. Use #data_sources instead. (called from block (3 levels) in <top (required)> at /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:377)
DEPRECATION WARNING: #tables currently returns both tables and views. This behavior is deprecated and will be changed with Rails 5.1 to only return tables. Use #data_sources instead. (called from block (3 levels) in <top (required)> at /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:389)
DEPRECATION WARNING: #tables currently returns both tables and views. This behavior is deprecated and will be changed with Rails 5.1 to only return tables. Use #data_sources instead. (called from block (3 levels) in <top (required)> at /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb:105)
DEPRECATION WARNING: #table_exists? currently checks both tables and views. This behavior is deprecated and will be changed with Rails 5.1 to only check tables. Use #data_source_exists? instead. (called from block (4 levels) in <top (required)> at /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_database_tasks_spec.rb:45)
DEPRECATION WARNING: #table_exists? currently checks both tables and views. This behavior is deprecated and will be changed with Rails 5.1 to only check tables. Use #data_source_exists? instead. (called from block (4 levels) in <top (required)> at /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_database_tasks_spec.rb:52)
DEPRECATION WARNING: #table_exists? currently checks both tables and views. This behavior is deprecated and will be changed with Rails 5.1 to only check tables. Use #data_source_exists? instead. (called from block (5 levels) in <top (required)> at /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_database_tasks_spec.rb:80)
DEPRECATION WARNING: #table_exists? currently checks both tables and views. This behavior is deprecated and will be changed with Rails 5.1 to only check tables. Use #data_source_exists? instead. (called from block (3 levels) in <top (required)> at /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:79)
DEPRECATION WARNING: #table_exists? currently checks both tables and views. This behavior is deprecated and will be changed with Rails 5.1 to only check tables. Use #data_source_exists? instead. (called from block (3 levels) in <top (required)> at /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:80)
```