### PR TITLE
Address `OCIError: ORA-01756: quoted string not properly terminated:`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -753,7 +753,7 @@ module ActiveRecord
                  comments.comments as column_comment
             FROM all_tab_cols#{db_link} cols, all_col_comments#{db_link} comments
            WHERE cols.owner      = '#{owner}'
-             AND cols.table_name = '#{desc_table_name}'
+             AND cols.table_name = #{quote(desc_table_name)}
              AND cols.hidden_column = 'NO'
              AND cols.owner = comments.owner
              AND cols.table_name = comments.table_name
@@ -847,7 +847,7 @@ module ActiveRecord
           select us.sequence_name
           from all_sequences#{db_link} us
           where us.sequence_owner = '#{owner}'
-          and us.sequence_name = '#{desc_table_name}_SEQ'
+          and us.sequence_name = upper(#{quote(default_sequence_name(desc_table_name))})
         SQL
 
         # changed back from user_constraints to all_constraints for consistency
@@ -855,7 +855,7 @@ module ActiveRecord
           SELECT cc.column_name
             FROM all_constraints#{db_link} c, all_cons_columns#{db_link} cc
            WHERE c.owner = '#{owner}'
-             AND c.table_name = '#{desc_table_name}'
+             AND c.table_name = #{quote(desc_table_name)}
              AND c.constraint_type = 'P'
              AND cc.owner = c.owner
              AND cc.constraint_name = c.constraint_name


### PR DESCRIPTION
Refer rails/rails#26784

This pull request addresses these 4 errors:

### Environment:
* Rails master branch
* Oracle enhanced adapter master branch
* Oracle Database 12c 12.1.0.2
* Ruby 2.4.0

```ruby
$ ARCONN=oracle bundle exec ruby -Itest test/cases/view_test.rb
Using oracle
Run options: --seed 9408

# Running:

EEE.E............

Finished in 4.356227s, 3.9025 runs/s, 3.4433 assertions/s.

  1) Error:
ViewWithPrimaryKeyTest#test_attributes:
ActiveRecord::StatementInvalid: OCIError: ORA-01756: quoted string not properly terminated: SELECT cols.column_name AS name, cols.data_type AS sql_type, cols.data_default, cols.nullable, cols.virtual_column, cols.hidden_column, cols.data_type_owner AS sql_type_owner, DECODE(cols.data_type, 'NUMBER', data_precision, 'FLOAT', data_precision, 'VARCHAR2', DECODE(char_used, 'C', char_length, data_length), 'RAW', DECODE(char_used, 'C', char_length, data_length), 'CHAR', DECODE(char_used, 'C', char_length, data_length), NULL) AS limit, DECODE(data_type, 'NUMBER', data_scale, NULL) AS scale, comments.comments as column_comment FROM all_tab_cols cols, all_col_comments comments WHERE cols.owner = 'ARUNIT' AND cols.table_name = 'ebooks'' AND cols.hidden_column = 'NO' AND cols.owner = comments.owner AND cols.table_name = comments.table_name AND cols.column_name = comments.column_name ORDER BY cols.column_id
    stmt.c:82:in oci8lib_240.so
    /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-c6b2b97f2dcf/lib/oci8/cursor.rb:28:in `initialize'
    /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-c6b2b97f2dcf/lib/oci8/oci8.rb:175:in `new'
    /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-c6b2b97f2dcf/lib/oci8/oci8.rb:175:in `parse_internal'
    /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-c6b2b97f2dcf/lib/oci8/oci8.rb:168:in `parse'
    /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/2.4.0/delegate.rb:341:in `block in delegating_block'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:109:in `prepare'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:26:in `block in exec_query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:594:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:587:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1044:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:22:in `exec_query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:374:in `select'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:42:in `select_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:95:in `select_all'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:765:in `columns_without_cache'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:730:in `columns'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:71:in `columns'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:77:in `columns_hash'
    /home/yahonda/git/rails/activerecord/lib/active_record/model_schema.rb:450:in `load_schema!'
    /home/yahonda/git/rails/activerecord/lib/active_record/attributes.rb:233:in `load_schema!'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_decorators.rb:50:in `load_schema!'
    /home/yahonda/git/rails/activerecord/lib/active_record/model_schema.rb:445:in `load_schema'
    /home/yahonda/git/rails/activerecord/lib/active_record/model_schema.rb:339:in `columns_hash'
    /home/yahonda/git/rails/activerecord/lib/active_record/querying.rb:41:in `find_by_sql'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:688:in `exec_queries'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:568:in `load'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:255:in `records'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:251:in `to_a'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation/finder_methods.rb:552:in `find_nth_with_limit'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation/finder_methods.rb:538:in `find_nth'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation/finder_methods.rb:122:in `first'
    /home/yahonda/git/rails/activerecord/lib/active_record/querying.rb:3:in `first'
    test/cases/view_test.rb:65:in `test_attributes'


  2) Error:
ViewWithPrimaryKeyTest#test_column_definitions:
ActiveRecord::StatementInvalid: OCIError: ORA-01756: quoted string not properly terminated: SELECT cols.column_name AS name, cols.data_type AS sql_type, cols.data_default, cols.nullable, cols.virtual_column, cols.hidden_column, cols.data_type_owner AS sql_type_owner, DECODE(cols.data_type, 'NUMBER', data_precision, 'FLOAT', data_precision, 'VARCHAR2', DECODE(char_used, 'C', char_length, data_length), 'RAW', DECODE(char_used, 'C', char_length, data_length), 'CHAR', DECODE(char_used, 'C', char_length, data_length), NULL) AS limit, DECODE(data_type, 'NUMBER', data_scale, NULL) AS scale, comments.comments as column_comment FROM all_tab_cols cols, all_col_comments comments WHERE cols.owner = 'ARUNIT' AND cols.table_name = 'ebooks'' AND cols.hidden_column = 'NO' AND cols.owner = comments.owner AND cols.table_name = comments.table_name AND cols.column_name = comments.column_name ORDER BY cols.column_id
    stmt.c:82:in oci8lib_240.so
    /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-c6b2b97f2dcf/lib/oci8/cursor.rb:28:in `initialize'
    /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-c6b2b97f2dcf/lib/oci8/oci8.rb:175:in `new'
    /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-c6b2b97f2dcf/lib/oci8/oci8.rb:175:in `parse_internal'
    /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-c6b2b97f2dcf/lib/oci8/oci8.rb:168:in `parse'
    /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/2.4.0/delegate.rb:341:in `block in delegating_block'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:109:in `prepare'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:26:in `block in exec_query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:594:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:587:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1044:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:22:in `exec_query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:374:in `select'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:42:in `select_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:95:in `select_all'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:765:in `columns_without_cache'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:730:in `columns'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:71:in `columns'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:77:in `columns_hash'
    /home/yahonda/git/rails/activerecord/lib/active_record/model_schema.rb:450:in `load_schema!'
    /home/yahonda/git/rails/activerecord/lib/active_record/attributes.rb:233:in `load_schema!'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_decorators.rb:50:in `load_schema!'
    /home/yahonda/git/rails/activerecord/lib/active_record/model_schema.rb:445:in `load_schema'
    /home/yahonda/git/rails/activerecord/lib/active_record/model_schema.rb:344:in `columns'
    test/cases/view_test.rb:60:in `test_column_definitions'


  3) Error:
ViewWithPrimaryKeyTest#test_does_not_assume_id_column_as_primary_key:
ActiveRecord::StatementInvalid: OCIError: ORA-01756: quoted string not properly terminated: select us.sequence_name from all_sequences us where us.sequence_owner = 'ARUNIT' and us.sequence_name = 'ebooks'_SEQ'
    stmt.c:82:in oci8lib_240.so
    /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-c6b2b97f2dcf/lib/oci8/cursor.rb:28:in `initialize'
    /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-c6b2b97f2dcf/lib/oci8/oci8.rb:175:in `new'
    /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-c6b2b97f2dcf/lib/oci8/oci8.rb:175:in `parse_internal'
    /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-c6b2b97f2dcf/lib/oci8/oci8.rb:168:in `parse'
    /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/2.4.0/delegate.rb:341:in `block in delegating_block'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:109:in `prepare'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:26:in `block in exec_query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:594:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:587:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1044:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:22:in `exec_query'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:82:in `select_rows'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:64:in `select_values'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:846:in `pk_and_sequence_for_without_cache'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:839:in `pk_and_sequence_for'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:877:in `primary_key'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:41:in `primary_keys'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/primary_key.rb:103:in `get_primary_key'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/primary_key.rb:90:in `reset_primary_key'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/primary_key.rb:78:in `primary_key'
    test/cases/view_test.rb:72:in `test_does_not_assume_id_column_as_primary_key'


  4) Error:
ViewWithPrimaryKeyTest#test_reading:
ActiveRecord::StatementInvalid: OCIError: ORA-01756: quoted string not properly terminated: SELECT cols.column_name AS name, cols.data_type AS sql_type, cols.data_default, cols.nullable, cols.virtual_column, cols.hidden_column, cols.data_type_owner AS sql_type_owner, DECODE(cols.data_type, 'NUMBER', data_precision, 'FLOAT', data_precision, 'VARCHAR2', DECODE(char_used, 'C', char_length, data_length), 'RAW', DECODE(char_used, 'C', char_length, data_length), 'CHAR', DECODE(char_used, 'C', char_length, data_length), NULL) AS limit, DECODE(data_type, 'NUMBER', data_scale, NULL) AS scale, comments.comments as column_comment FROM all_tab_cols cols, all_col_comments comments WHERE cols.owner = 'ARUNIT' AND cols.table_name = 'ebooks'' AND cols.hidden_column = 'NO' AND cols.owner = comments.owner AND cols.table_name = comments.table_name AND cols.column_name = comments.column_name ORDER BY cols.column_id
    stmt.c:82:in oci8lib_240.so
    /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-c6b2b97f2dcf/lib/oci8/cursor.rb:28:in `initialize'
    /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-c6b2b97f2dcf/lib/oci8/oci8.rb:175:in `new'
    /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-c6b2b97f2dcf/lib/oci8/oci8.rb:175:in `parse_internal'
    /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-c6b2b97f2dcf/lib/oci8/oci8.rb:168:in `parse'
    /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/2.4.0/delegate.rb:341:in `block in delegating_block'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:109:in `prepare'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:26:in `block in exec_query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:594:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:587:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1044:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:22:in `exec_query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:374:in `select'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:42:in `select_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:95:in `select_all'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:765:in `columns_without_cache'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:730:in `columns'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:71:in `columns'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:77:in `columns_hash'
    /home/yahonda/git/rails/activerecord/lib/active_record/model_schema.rb:450:in `load_schema!'
    /home/yahonda/git/rails/activerecord/lib/active_record/attributes.rb:233:in `load_schema!'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_decorators.rb:50:in `load_schema!'
    /home/yahonda/git/rails/activerecord/lib/active_record/model_schema.rb:445:in `load_schema'
    /home/yahonda/git/rails/activerecord/lib/active_record/model_schema.rb:339:in `columns_hash'
    /home/yahonda/git/rails/activerecord/lib/active_record/querying.rb:41:in `find_by_sql'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:688:in `exec_queries'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:568:in `load'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:255:in `records'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation/delegation.rb:36:in `map'
    test/cases/view_test.rb:33:in `test_reading'

17 runs, 15 assertions, 0 failures, 4 errors, 0 skips
$
```