### PR TITLE
Suppress `Dropped database 'ORCL'` messages while running rspec

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_database_tasks_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_database_tasks_spec.rb
@@ -34,6 +34,15 @@ describe "Oracle Enhanced adapter database tasks" do
   end
 
   context "with test table" do
+    before(:all) do
+      $stdout, @original_stdout = StringIO.new, $stdout
+      $stderr, @original_stderr = StringIO.new, $stderr
+    end
+
+    after(:all) do
+      $stdout, $stderr = @original_stdout, @original_stderr
+    end
+
     before do
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
       ActiveRecord::Base.connection.execute "CREATE TABLE test_posts (name VARCHAR2(20))"


### PR DESCRIPTION
This pull request suppress `Dropped database 'ORCL'` messages while running rspec.

### Environment:
* Rails master branch
* Oracle enhanced adapter master branch
* Oracle Database 12c 12.1.0.2
* Ruby 2.4.0

```ruby
$ rspec spec/active_record/connection_adapters/oracle_enhanced_database_tasks_spec.rb 
==> Loading config from ENV or use default
==> Running specs with MRI version 2.4.0
==> Effective ActiveRecord version 5.1.0.alpha
.Dropped database 'ORCL'
...Dropped database 'ORCL'
.

Finished in 4.69 seconds (files took 1.48 seconds to load)
5 examples, 0 failures

$
``` 

Referred https://github.com/rails/rails/pull/24551 implementation.