### PR TITLE
Use rails rubocop setting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,12 +2,21 @@ AllCops:
   TargetRubyVersion: 2.2
   DisabledByDefault: true
 
-# No trailing whitespace.
-Style/TrailingWhitespace:
+# Prefer &&/|| over and/or.
+Style/AndOr:
   Enabled: true
 
-# Blank lines should not have any spaces.
-Style/TrailingBlankLines:
+# Do not use braces for hash literals when they are the last argument of a
+# method call.
+Style/BracesAroundHashParameters:
+  Enabled: true
+
+# Align `when` with `case`.
+Style/CaseIndentation:
+  Enabled: true
+
+# Align comments with method definitions.
+Style/CommentIndentation:
   Enabled: true
 
 # No extra empty lines.
@@ -20,4 +29,86 @@ Style/EmptyLinesAroundClassBody:
 
 # In a regular module definition, no empty lines around the body.
 Style/EmptyLinesAroundModuleBody:
+  Enabled: true
+
+# Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }.
+Style/HashSyntax:
+  Enabled: true
+
+# Method definitions after `private` or `protected` isolated calls need one
+# extra level of indentation.
+Style/IndentationConsistency:
+  Enabled: true
+  EnforcedStyle: rails
+
+# Two spaces, no tabs (for indentation).
+Style/IndentationWidth:
+  Enabled: true
+
+Style/SpaceAfterColon:
+  Enabled: true
+
+Style/SpaceAfterComma:
+  Enabled: true
+
+Style/SpaceAroundEqualsInParameterDefault:
+  Enabled: true
+
+Style/SpaceAroundKeyword:
+  Enabled: true
+
+Style/SpaceAroundOperators:
+  Enabled: true
+
+Style/SpaceBeforeFirstArg:
+    Enabled: true
+
+# Defining a method with parameters needs parentheses.
+Style/MethodDefParentheses:
+  Enabled: true
+
+# Use `foo {}` not `foo{}`.
+Style/SpaceBeforeBlockBraces:
+  Enabled: true
+
+# Use `foo { bar }` not `foo {bar}`.
+Style/SpaceInsideBlockBraces:
+  Enabled: true
+
+# Use `{ a: 1 }` not `{a:1}`.
+Style/SpaceInsideHashLiteralBraces:
+  Enabled: true
+
+Style/SpaceInsideParens:
+  Enabled: true
+
+# Check quotes usage according to lint rule below.
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: double_quotes
+
+# Detect hard tabs, no hard tabs.
+Style/Tab:
+  Enabled: true
+
+# Blank lines should not have any spaces.
+Style/TrailingBlankLines:
+  Enabled: true
+
+# No trailing whitespace.
+Style/TrailingWhitespace:
+  Enabled: true
+
+# Use quotes for string literals when they are enough.
+Style/UnneededPercentQ:
+  Enabled: true
+
+# Align `end` with the matching keyword or starting expression except for
+# assignments, where it should be aligned with the LHS.
+Lint/EndAlignment:
+  Enabled: true
+  AlignWith: variable
+
+# Use my_method(my_arg) not my_method( my_arg ) or my_method my_arg.
+Lint/RequireParentheses:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source "http://rubygems.org"
 
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
@@ -6,28 +6,28 @@ git_source(:github) do |repo_name|
 end
 
 group :development do
-  gem 'rspec'
-  gem 'rdoc'
-  gem 'rake'
+  gem "rspec"
+  gem "rdoc"
+  gem "rake"
 
-  gem 'activerecord',   github: 'rails/rails', branch: 'master'
-  gem 'rack',           github: 'rack/rack', branch: 'master'
-  gem 'arel',           github: 'rails/arel', branch: '7-1-stable'
+  gem "activerecord",   github: "rails/rails", branch: "master"
+  gem "rack",           github: "rack/rack", branch: "master"
+  gem "arel",           github: "rails/arel", branch: "7-1-stable"
 
-  gem 'ruby-plsql', '>=0.5.0'
+  gem "ruby-plsql", ">=0.5.0"
 
   platforms :ruby do
-    gem 'ruby-oci8',    github: 'kubo/ruby-oci8'
-    gem 'byebug'
+    gem "ruby-oci8",    github: "kubo/ruby-oci8"
+    gem "byebug"
   end
 
   platforms :jruby do
-    gem 'ruby-debug'
-    gem 'pry'
-    gem 'pry-nav'
+    gem "ruby-debug"
+    gem "pry"
+    gem "pry-nav"
   end
 end
 
 group :test do
-  gem 'simplecov',  github: 'colszowka/simplecov', branch: 'master', :require => false
+  gem "simplecov",  github: "colszowka/simplecov", branch: "master", require: false
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
-require 'rubygems'
-require 'bundler'
-require 'bundler/gem_tasks'
+require "rubygems"
+require "bundler"
+require "bundler/gem_tasks"
 begin
   Bundler.setup(:default, :development)
 rescue Bundler::BundlerError => e
@@ -9,9 +9,9 @@ rescue Bundler::BundlerError => e
   exit e.status_code
 end
 
-require 'rake'
+require "rake"
 
-require 'rspec/core/rake_task'
+require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 
 desc "Clear test database"
@@ -24,17 +24,17 @@ task :clear do
 end
 
 # Clear test database before running spec and rcov
-task :spec => :clear
-task :rcov => :clear
+task spec: :clear
+task rcov: :clear
 
-task :default => :spec
+task default: :spec
 
-require 'rdoc/task'
+require "rdoc/task"
 Rake::RDocTask.new do |rdoc|
-  version = File.exist?('VERSION') ? File.read('VERSION') : ""
+  version = File.exist?("VERSION") ? File.read("VERSION") : ""
 
-  rdoc.rdoc_dir = 'doc'
+  rdoc.rdoc_dir = "doc"
   rdoc.title = "activerecord-oracle_enhanced-adapter #{version}"
-  rdoc.rdoc_files.include('README*')
-  rdoc.rdoc_files.include('lib/**/*.rb')
+  rdoc.rdoc_files.include("README*")
+  rdoc.rdoc_files.include("lib/**/*.rb")
 end

--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -1,16 +1,16 @@
 Gem::Specification.new do |s|
-  s.name = %q{activerecord-oracle_enhanced-adapter}
+  s.name = "activerecord-oracle_enhanced-adapter"
   s.version = "1.8.0.alpha"
 
   s.required_rubygems_version = ">= 1.8.11"
-  s.required_ruby_version     = '>= 2.2.2'
-  s.license = 'MIT'
-  s.authors = [%q{Raimonds Simanovskis}]
-  s.date = %q{2016-12-26}
-  s.description = %q{Oracle "enhanced" ActiveRecord adapter contains useful additional methods for working with new and legacy Oracle databases.
+  s.required_ruby_version     = ">= 2.2.2"
+  s.license = "MIT"
+  s.authors = ["Raimonds Simanovskis"]
+  s.date = "2016-12-26"
+  s.description = 'Oracle "enhanced" ActiveRecord adapter contains useful additional methods for working with new and legacy Oracle databases.
 This adapter is superset of original ActiveRecord Oracle adapter.
-}
-  s.email = %q{raimonds.simanovskis@gmail.com}
+'
+  s.email = "raimonds.simanovskis@gmail.com"
   s.extra_rdoc_files = [
     "README.md"
   ]
@@ -68,9 +68,9 @@ This adapter is superset of original ActiveRecord Oracle adapter.
     "spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb",
     "spec/spec_helper.rb"
   ]
-  s.homepage = %q{http://github.com/rsim/oracle-enhanced}
-  s.require_paths = [%q{lib}]
-  s.summary = %q{Oracle enhanced adapter for ActiveRecord}
+  s.homepage = "http://github.com/rsim/oracle-enhanced"
+  s.require_paths = ["lib"]
+  s.summary = "Oracle enhanced adapter for ActiveRecord"
   s.test_files = [
     "spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb",
     "spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb",
@@ -87,7 +87,7 @@ This adapter is superset of original ActiveRecord Oracle adapter.
     "spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb",
     "spec/spec_helper.rb"
   ]
-  s.add_runtime_dependency(%q<activerecord>, ["~> 5.1.0.alpha"])
-  s.add_runtime_dependency(%q<arel>, ["~> 7.1.4"])
-  s.add_runtime_dependency(%q<ruby-plsql>, [">= 0.5.0"])
+  s.add_runtime_dependency("activerecord", ["~> 5.1.0.alpha"])
+  s.add_runtime_dependency("arel", ["~> 7.1.4"])
+  s.add_runtime_dependency("ruby-plsql", [">= 0.5.0"])
 end

--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -1,41 +1,41 @@
 begin
-  require 'bundler/inline'
+  require "bundler/inline"
 rescue LoadError => e
-  $stderr.puts 'Bundler version 1.10 or later is required. Please update your Bundler'
+  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
   raise e
 end
 
 gemfile(true) do
-  source 'https://rubygems.org'
-  gem 'rails', '~> 5.0.0'
-  gem 'activerecord-oracle_enhanced-adapter', '~> 1.7.0'
-  gem 'ruby-oci8'
-  gem 'minitest'
+  source "https://rubygems.org"
+  gem "rails", "~> 5.0.0"
+  gem "activerecord-oracle_enhanced-adapter", "~> 1.7.0"
+  gem "ruby-oci8"
+  gem "minitest"
 end
 
-require 'active_record'
-require 'minitest/autorun'
-require 'logger'
-require 'active_record/connection_adapters/oracle_enhanced_adapter'
+require "active_record"
+require "minitest/autorun"
+require "logger"
+require "active_record/connection_adapters/oracle_enhanced_adapter"
 
 # Ensure backward compatibility with Minitest 4
 Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)
 
 # Set Oracle enhanced adapter specific connection parameters
-DATABASE_NAME = ENV['DATABASE_NAME'] || 'orcl'
-DATABASE_HOST = ENV['DATABASE_HOST']
-DATABASE_PORT = ENV['DATABASE_PORT']
-DATABASE_USER = ENV['DATABASE_USER'] || 'oracle_enhanced'
-DATABASE_PASSWORD = ENV['DATABASE_PASSWORD'] || 'oracle_enhanced'
-DATABASE_SYS_PASSWORD = ENV['DATABASE_SYS_PASSWORD'] || 'admin'
+DATABASE_NAME = ENV["DATABASE_NAME"] || "orcl"
+DATABASE_HOST = ENV["DATABASE_HOST"]
+DATABASE_PORT = ENV["DATABASE_PORT"]
+DATABASE_USER = ENV["DATABASE_USER"] || "oracle_enhanced"
+DATABASE_PASSWORD = ENV["DATABASE_PASSWORD"] || "oracle_enhanced"
+DATABASE_SYS_PASSWORD = ENV["DATABASE_SYS_PASSWORD"] || "admin"
 
 CONNECTION_PARAMS = {
-  :adapter => "oracle_enhanced",
-  :database => DATABASE_NAME,
-  :host => DATABASE_HOST,
-  :port => DATABASE_PORT,
-  :username => DATABASE_USER,
-  :password => DATABASE_PASSWORD
+  adapter: "oracle_enhanced",
+  database: DATABASE_NAME,
+  host: DATABASE_HOST,
+  port: DATABASE_PORT,
+  username: DATABASE_USER,
+  password: DATABASE_PASSWORD
 }
 
 ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
@@ -43,10 +43,10 @@ ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
 ActiveRecord::Base.logger = Logger.new(STDOUT)
 
 ActiveRecord::Schema.define do
-  create_table :posts, :force => true do |t|
+  create_table :posts, force: true do |t|
   end
 
-  create_table :comments, :force => true do |t|
+  create_table :comments, force: true do |t|
     t.integer :post_id
   end
 end

--- a/guides/bug_report_templates/active_record_gem_spec.rb
+++ b/guides/bug_report_templates/active_record_gem_spec.rb
@@ -1,38 +1,38 @@
 begin
-  require 'bundler/inline'
+  require "bundler/inline"
 rescue LoadError => e
-  $stderr.puts 'Bundler version 1.10 or later is required. Please update your Bundler'
+  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
   raise e
 end
 
 gemfile(true) do
-  source 'https://rubygems.org'
-  gem 'rails', '~> 5.0.0'
-  gem 'activerecord-oracle_enhanced-adapter', '~> 1.7.0'
-  gem 'ruby-oci8'
-  gem 'rspec'
+  source "https://rubygems.org"
+  gem "rails", "~> 5.0.0"
+  gem "activerecord-oracle_enhanced-adapter", "~> 1.7.0"
+  gem "ruby-oci8"
+  gem "rspec"
 end
 
-require 'active_record'
-require 'rspec'
-require 'logger'
-require 'active_record/connection_adapters/oracle_enhanced_adapter'
+require "active_record"
+require "rspec"
+require "logger"
+require "active_record/connection_adapters/oracle_enhanced_adapter"
 
 # Set Oracle enhanced adapter specific connection parameters
-DATABASE_NAME = ENV['DATABASE_NAME'] || 'orcl'
-DATABASE_HOST = ENV['DATABASE_HOST']
-DATABASE_PORT = ENV['DATABASE_PORT']
-DATABASE_USER = ENV['DATABASE_USER'] || 'oracle_enhanced'
-DATABASE_PASSWORD = ENV['DATABASE_PASSWORD'] || 'oracle_enhanced'
-DATABASE_SYS_PASSWORD = ENV['DATABASE_SYS_PASSWORD'] || 'admin'
+DATABASE_NAME = ENV["DATABASE_NAME"] || "orcl"
+DATABASE_HOST = ENV["DATABASE_HOST"]
+DATABASE_PORT = ENV["DATABASE_PORT"]
+DATABASE_USER = ENV["DATABASE_USER"] || "oracle_enhanced"
+DATABASE_PASSWORD = ENV["DATABASE_PASSWORD"] || "oracle_enhanced"
+DATABASE_SYS_PASSWORD = ENV["DATABASE_SYS_PASSWORD"] || "admin"
 
 CONNECTION_PARAMS = {
-  :adapter => "oracle_enhanced",
-  :database => DATABASE_NAME,
-  :host => DATABASE_HOST,
-  :port => DATABASE_PORT,
-  :username => DATABASE_USER,
-  :password => DATABASE_PASSWORD
+  adapter: "oracle_enhanced",
+  database: DATABASE_NAME,
+  host: DATABASE_HOST,
+  port: DATABASE_PORT,
+  username: DATABASE_USER,
+  password: DATABASE_PASSWORD
 }
 
 ActiveRecord::Base.logger = Logger.new(STDOUT)
@@ -41,10 +41,10 @@ describe "bug test" do
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
     ActiveRecord::Schema.define do
-      create_table :posts, :force => true do |t|
+      create_table :posts, force: true do |t|
       end
 
-      create_table :comments, :force => true do |t|
+      create_table :comments, force: true do |t|
         t.integer :post_id
       end
     end

--- a/lib/active_record/connection_adapters/emulation/oracle_adapter.rb
+++ b/lib/active_record/connection_adapters/emulation/oracle_adapter.rb
@@ -1,5 +1,5 @@
 class ActiveRecord::ConnectionAdapters::OracleAdapter < ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter #:nodoc:
   def adapter_name
-    'Oracle'
+    "Oracle"
   end
 end

--- a/lib/active_record/connection_adapters/oracle_enhanced/column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column.rb
@@ -17,7 +17,7 @@ module ActiveRecord
         # Is column NCHAR or NVARCHAR2 (will need to use N'...' value quoting for these data types)?
         # Define only when needed as adapter "quote" method will check at first if instance variable is defined.
         if sql_type_metadata
-          @object_type = sql_type_metadata.sql_type.include? '.'
+          @object_type = sql_type_metadata.sql_type.include? "."
         end
         # TODO: Need to investigate when `sql_type` becomes nil
       end
@@ -64,63 +64,63 @@ module ActiveRecord
 
       private
 
-      def self.extract_value_from_default(default)
-        case default
+        def self.extract_value_from_default(default)
+          case default
           when String
             default.gsub(/''/, "'")
-          else
+            else
             default
+          end
         end
-      end
 
-      def guess_date_or_time(value)
-        value.respond_to?(:hour) && (value.hour == 0 and value.min == 0 and value.sec == 0) ?
-          Date.new(value.year, value.month, value.day) : value
-      end
+        def guess_date_or_time(value)
+          value.respond_to?(:hour) && ((value.hour == 0) && (value.min == 0) && (value.sec == 0)) ?
+            Date.new(value.year, value.month, value.day) : value
+        end
 
-      class << self
-        protected
+        class << self
+          protected
 
-        def fallback_string_to_date(string) #:nodoc:
-          if OracleEnhancedAdapter.string_to_date_format || OracleEnhancedAdapter.string_to_time_format
-            ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          def fallback_string_to_date(string) #:nodoc:
+            if OracleEnhancedAdapter.string_to_date_format || OracleEnhancedAdapter.string_to_time_format
+              ActiveSupport::Deprecation.warn(<<-MSG.squish)
               `fallback_string_to_date` has been deprecated.
               It will be removed from next version of Oracle enhanced adapter.
               Users are unlikely to see this message since this method has gone
               from ActiveRecord::ConnectionAdapters::Column in Rails 4.2.
             MSG
-            return (string_to_date_or_time_using_format(string).to_date rescue super)
+              return (string_to_date_or_time_using_format(string).to_date rescue super)
+            end
+            super
           end
-          super
-        end
 
-        def fallback_string_to_time(string) #:nodoc:
-          if OracleEnhancedAdapter.string_to_time_format || OracleEnhancedAdapter.string_to_date_format
-            ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          def fallback_string_to_time(string) #:nodoc:
+            if OracleEnhancedAdapter.string_to_time_format || OracleEnhancedAdapter.string_to_date_format
+              ActiveSupport::Deprecation.warn(<<-MSG.squish)
               `fallback_string_to_time` has been deprecated.
               It will be removed from next version of Oracle enhanced adapter.
               Users are unlikely to see this message since this method has gone
               from ActiveRecord::ConnectionAdapters::Column in Rails 4.2.
             MSG
-            return (string_to_date_or_time_using_format(string).to_time rescue super)
+              return (string_to_date_or_time_using_format(string).to_time rescue super)
+            end
+            super
           end
-          super
-        end
 
-        def string_to_date_or_time_using_format(string) #:nodoc:
-          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          def string_to_date_or_time_using_format(string) #:nodoc:
+            ActiveSupport::Deprecation.warn(<<-MSG.squish)
             `string_to_date_or_time_using_format` has been deprecated.
             It will be removed from next version of Oracle enhanced adapter.
             Users are unlikely to see this message since `fallback_string_to_date`
             and `fallback_string_to_time` have gone
             from ActiveRecord::ConnectionAdapters::Column in Rails 4.2.
           MSG
-          if OracleEnhancedAdapter.string_to_time_format && dt=Date._strptime(string, OracleEnhancedAdapter.string_to_time_format)
-            return Time.parse("#{dt[:year]}-#{dt[:mon]}-#{dt[:mday]} #{dt[:hour]}:#{dt[:min]}:#{dt[:sec]}#{dt[:zone]}")
+            if OracleEnhancedAdapter.string_to_time_format && dt = Date._strptime(string, OracleEnhancedAdapter.string_to_time_format)
+              return Time.parse("#{dt[:year]}-#{dt[:mon]}-#{dt[:mday]} #{dt[:hour]}:#{dt[:min]}:#{dt[:sec]}#{dt[:zone]}")
+            end
+            DateTime.strptime(string, OracleEnhancedAdapter.string_to_date_format).to_date
           end
-          DateTime.strptime(string, OracleEnhancedAdapter.string_to_date_format).to_date
         end
-      end
     end
   end
 end

--- a/lib/active_record/connection_adapters/oracle_enhanced/column_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column_dumper.rb
@@ -37,9 +37,9 @@ module ActiveRecord #:nodoc:
           end
 
           default = schema_default(column) if column.has_default?
-          spec[:default]   = default unless default.nil?
+          spec[:default] = default unless default.nil?
 
-          spec[:null] = 'false' unless column.null
+          spec[:null] = "false" unless column.null
 
           spec[:comment] = column.comment.inspect if column.comment.present?
 
@@ -53,19 +53,19 @@ module ActiveRecord #:nodoc:
 
         private
 
-        def default_primary_key?(column)
-          schema_type(column) == :integer
-        end
-
-        def schema_virtual_as(column)
-          column.virtual_column_data_default if column.virtual?
-        end
-
-        def schema_virtual_type(column)
-          unless column.type == :decimal
-            column.type.inspect if column.virtual?
+          def default_primary_key?(column)
+            schema_type(column) == :integer
           end
-        end
+
+          def schema_virtual_as(column)
+            column.virtual_column_data_default if column.virtual?
+          end
+
+          def schema_virtual_type(column)
+            unless column.type == :decimal
+              column.type.inspect if column.virtual?
+            end
+          end
       end
     end
   end

--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -29,8 +29,8 @@ module ActiveRecord
       # Used always by JDBC connection as well by OCI connection when describing tables over database link
       def describe(name)
         name = name.to_s
-        if name.include?('@')
-          name, db_link = name.split('@')
+        if name.include?("@")
+          name, db_link = name.split("@")
           default_owner = select_value("SELECT username FROM all_db_links WHERE db_link = '#{db_link.upcase}'")
           db_link = "@#{db_link}"
         else
@@ -38,8 +38,8 @@ module ActiveRecord
           default_owner = @owner
         end
         real_name = ActiveRecord::ConnectionAdapters::OracleEnhanced::Quoting.valid_table_name?(name) ? name.upcase : name
-        if real_name.include?('.')
-          table_owner, table_name = real_name.split('.')
+        if real_name.include?(".")
+          table_owner, table_name = real_name.split(".")
         else
           table_owner, table_name = default_owner, real_name
         end
@@ -65,11 +65,11 @@ module ActiveRecord
             AND synonym_name = '#{real_name}'
         SQL
         if result = select_one(sql)
-          case result['name_type']
-          when 'SYNONYM'
+          case result["name_type"]
+          when "SYNONYM"
             describe("#{result['owner'] && "#{result['owner']}."}#{result['table_name']}#{db_link}")
           else
-            db_link ? [result['owner'], result['table_name'], db_link] : [result['owner'], result['table_name']]
+            db_link ? [result["owner"], result["table_name"], db_link] : [result["owner"], result["table_name"]]
           end
         else
           raise OracleEnhancedConnectionException, %Q{"DESC #{name}" failed; does it exist?}
@@ -109,13 +109,13 @@ module ActiveRecord
 end
 
 # if MRI or YARV
-if !defined?(RUBY_ENGINE) || RUBY_ENGINE == 'ruby'
+if !defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby"
   ORACLE_ENHANCED_CONNECTION = :oci
-  require 'active_record/connection_adapters/oracle_enhanced/oci_connection'
+  require "active_record/connection_adapters/oracle_enhanced/oci_connection"
 # if JRuby
-elsif RUBY_ENGINE == 'jruby'
+elsif RUBY_ENGINE == "jruby"
   ORACLE_ENHANCED_CONNECTION = :jdbc
-  require 'active_record/connection_adapters/oracle_enhanced/jdbc_connection'
+  require "active_record/connection_adapters/oracle_enhanced/jdbc_connection"
 else
   raise "Unsupported Ruby engine #{RUBY_ENGINE}"
 end

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -16,7 +16,7 @@ module ActiveRecord
           reload_type_map
         end
 
-        def exec_query(sql, name = 'SQL', binds = [], prepare: false)
+        def exec_query(sql, name = "SQL", binds = [], prepare: false)
           type_casted_binds = binds.map { |attr| type_cast(attr.value_for_database) }
 
           log(sql, name, binds, type_casted_binds) do
@@ -38,14 +38,14 @@ module ActiveRecord
 
             cursor.exec
 
-            if name == 'EXPLAIN' and sql =~ /^EXPLAIN/
+            if (name == "EXPLAIN") && sql =~ /^EXPLAIN/
               res = true
             else
               columns = cursor.get_col_names.map do |col_name|
                 @connection.oracle_downcase(col_name)
               end
               rows = []
-              fetch_options = {:get_lob_value => (name != 'Writable Large Object')}
+              fetch_options = { get_lob_value: (name != "Writable Large Object") }
               while row = cursor.fetch(fetch_options)
                 rows << row
               end
@@ -69,11 +69,11 @@ module ActiveRecord
           sql = "EXPLAIN PLAN FOR #{to_sql(arel, binds)}"
           return if sql =~ /FROM all_/
           if ORACLE_ENHANCED_CONNECTION == :jdbc
-            exec_query(sql, 'EXPLAIN', binds)
+            exec_query(sql, "EXPLAIN", binds)
           else
-            exec_query(sql, 'EXPLAIN')
+            exec_query(sql, "EXPLAIN")
           end
-          select_values("SELECT * FROM TABLE(DBMS_XPLAN.DISPLAY)", 'EXPLAIN').join("\n")
+          select_values("SELECT * FROM TABLE(DBMS_XPLAN.DISPLAY)", "EXPLAIN").join("\n")
         end
 
         # Returns an array of arrays containing the field values.
@@ -144,7 +144,7 @@ module ActiveRecord
               cursor = @connection.prepare(sql)
             else
               cursor = if @statements.key?(sql)
-                         @statements[sql]
+                @statements[sql]
                        else
                          @statements[sql] = @connection.prepare(sql)
                        end
@@ -208,7 +208,7 @@ module ActiveRecord
         # Returns default sequence name for table.
         # Will take all or first 26 characters of table name and append _seq suffix
         def default_sequence_name(table_name, primary_key = nil)
-          table_name.to_s.gsub((/(^|\.)([\w$-]{1,#{sequence_name_length-4}})([\w$-]*)$/), '\1\2_seq')
+          table_name.to_s.gsub((/(^|\.)([\w$-]{1,#{sequence_name_length - 4}})([\w$-]*)$/), '\1\2_seq')
         end
 
         # Inserts the given fixture into the table. Overridden to properly handle lobs.

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_tasks.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_tasks.rb
@@ -1,21 +1,21 @@
-require 'active_record/base'
+require "active_record/base"
 
 module ActiveRecord
   module ConnectionAdapters
     class OracleEnhancedAdapter
       class DatabaseTasks
-        delegate :connection, :establish_connection, :to => ActiveRecord::Base
+        delegate :connection, :establish_connection, to: ActiveRecord::Base
 
         def initialize(config)
           @config = config
         end
 
         def create
-          system_password = ENV.fetch('ORACLE_SYSTEM_PASSWORD') {
+          system_password = ENV.fetch("ORACLE_SYSTEM_PASSWORD") {
             print "Please provide the SYSTEM password for your Oracle installation (set ORACLE_SYSTEM_PASSWORD to avoid this prompt)\n>"
             $stdin.gets.strip
           }
-          establish_connection(@config.merge('username' => 'SYSTEM', 'password' => system_password))
+          establish_connection(@config.merge("username" => "SYSTEM", "password" => system_password))
           begin
             connection.execute "CREATE USER #{@config['username']} IDENTIFIED BY #{@config['password']}"
           rescue => e
@@ -39,14 +39,14 @@ module ActiveRecord
 
         def purge
           drop
-          connection.execute('PURGE RECYCLEBIN') rescue nil
+          connection.execute("PURGE RECYCLEBIN") rescue nil
         end
 
         def structure_dump(filename)
           establish_connection(@config)
-          File.open(filename, 'w:utf-8') { |f| f << connection.structure_dump }
-          if @config['structure_dump'] == 'db_stored_code'
-             File.open(filename, 'a') { |f| f << connection.structure_dump_db_stored_code }
+          File.open(filename, "w:utf-8") { |f| f << connection.structure_dump }
+          if @config["structure_dump"] == "db_stored_code"
+            File.open(filename, "a") { |f| f << connection.structure_dump_db_stored_code }
           end
         end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -9,7 +9,7 @@ begin
     %w(ojdbc5.jar)
   elsif java_version =~ /^1.6/
     %w(ojdbc6.jar)
-  elsif java_version >= '1.7'
+  elsif java_version >= "1.7"
     # Oracle 11g client ojdbc6.jar is also compatible with Java 1.7
     # Oracle 12c client provides new ojdbc7.jar
     %w(ojdbc7.jar ojdbc6.jar)
@@ -17,12 +17,12 @@ begin
     nil
   end
 
-  if ojdbc_jars && ENV_JAVA['java.class.path'] !~ Regexp.new(ojdbc_jars.join('|'))
+  if ojdbc_jars && ENV_JAVA["java.class.path"] !~ Regexp.new(ojdbc_jars.join("|"))
     # On Unix environment variable should be PATH, on Windows it is sometimes Path
-    env_path = (ENV["PATH"] || ENV["Path"] || '').split(File::PATH_SEPARATOR)
+    env_path = (ENV["PATH"] || ENV["Path"] || "").split(File::PATH_SEPARATOR)
     # Look for JDBC driver at first in lib subdirectory (application specific JDBC file version)
     # then in Ruby load path and finally in environment PATH
-    ['./lib'].concat($LOAD_PATH).concat(env_path).detect do |dir|
+    ["./lib"].concat($LOAD_PATH).concat(env_path).detect do |dir|
       # check any compatible JDBC driver in the priority order
       ojdbc_jars.any? do |ojdbc_jar|
         if File.exists?(file_path = File.join(dir, ojdbc_jar))
@@ -74,7 +74,7 @@ module ActiveRecord
 
           # tomcat needs first lookup method, oc4j (and maybe other application servers) need second method
           begin
-            env = ctx.lookup('java:/comp/env')
+            env = ctx.lookup("java:/comp/env")
             ds = env.lookup(jndi)
           rescue
             ds = ctx.lookup(jndi)
@@ -102,13 +102,13 @@ module ActiveRecord
           # to_s needed if username, password or database is specified as number in database.yml file
           username = config[:username] && config[:username].to_s
           password = config[:password] && config[:password].to_s
-          database = config[:database] && config[:database].to_s || 'XE'
+          database = config[:database] && config[:database].to_s || "XE"
           host, port = config[:host], config[:port]
           privilege = config[:privilege] && config[:privilege].to_s
 
           # connection using TNS alias, or connection-string from DATABASE_URL
-          using_tns_alias = !host && !config[:url] && ENV['TNS_ADMIN']
-          if database && (using_tns_alias || host == 'connection-string')
+          using_tns_alias = !host && !config[:url] && ENV["TNS_ADMIN"]
+          if database && (using_tns_alias || host == "connection-string")
             url = "jdbc:oracle:thin:@#{database}"
           else
             unless database.match(/^(\:|\/)/)
@@ -120,7 +120,7 @@ module ActiveRecord
 
           prefetch_rows = config[:prefetch_rows] || 100
           # get session time_zone from configuration or from TZ environment variable
-          time_zone = config[:time_zone] || ENV['TZ'] || java.util.TimeZone.default.getID
+          time_zone = config[:time_zone] || ENV["TZ"] || java.util.TimeZone.default.getID
 
           properties = java.util.Properties.new
           properties.put("user", username)
@@ -144,7 +144,7 @@ module ActiveRecord
           # @raw_connection.setDefaultRowPrefetch(prefetch_rows) if prefetch_rows
         end
 
-        cursor_sharing = config[:cursor_sharing] || 'force'
+        cursor_sharing = config[:cursor_sharing] || "force"
         exec "alter session set cursor_sharing = #{cursor_sharing}"
 
         # Initialize NLS parameters
@@ -327,7 +327,7 @@ module ActiveRecord
           @raw_statement = raw_statement
         end
 
-        def bind_params( *bind_vars )
+        def bind_params(*bind_vars)
           index = 1
           bind_vars.flatten.each do |var|
             if Hash === var
@@ -411,21 +411,21 @@ module ActiveRecord
         end
 
         def column_types
-          @column_types ||= (1..metadata.getColumnCount).map{|i| metadata.getColumnTypeName(i).to_sym}
+          @column_types ||= (1..metadata.getColumnCount).map { |i| metadata.getColumnTypeName(i).to_sym }
         end
 
         def column_names
-          @column_names ||= (1..metadata.getColumnCount).map{|i| metadata.getColumnName(i)}
+          @column_names ||= (1..metadata.getColumnCount).map { |i| metadata.getColumnName(i) }
         end
         alias :get_col_names :column_names
 
-        def fetch(options={})
+        def fetch(options = {})
           if @raw_result_set.next
             get_lob_value = options[:get_lob_value]
             row_values = []
             column_types.each_with_index do |column_type, i|
               row_values <<
-                @connection.get_ruby_value_from_result_set(@raw_result_set, i+1, column_type, get_lob_value)
+                @connection.get_ruby_value_from_result_set(@raw_result_set, i + 1, column_type, get_lob_value)
             end
             row_values
           else
@@ -469,14 +469,14 @@ module ActiveRecord
 
         cols_types_index = (1..column_count).map do |i|
           col_name = oracle_downcase(metadata.getColumnName(i))
-          next if col_name == 'raw_rnum_'
+          next if col_name == "raw_rnum_"
           column_hash[col_name] = nil
           [col_name, metadata.getColumnTypeName(i).to_sym, i]
         end
         cols_types_index.delete(nil)
 
         rows = []
-        get_lob_value = !(name == 'Writable Large Object')
+        get_lob_value = !(name == "Writable Large Object")
 
         while rset.next
           hash = column_hash.dup
@@ -496,7 +496,7 @@ module ActiveRecord
         if is_binary
           lob.setBytes(1, value.to_java_bytes)
         else
-          lob.setString(1,value)
+          lob.setString(1, value)
         end
       end
 
@@ -541,7 +541,7 @@ module ActiveRecord
           get_lob_value ? lob_to_ruby_value(rset.getBlob(i)) : rset.getBlob(i)
         when :RAW
           raw_value = rset.getRAW(i)
-          raw_value && raw_value.getBytes.to_a.pack('C*')
+          raw_value && raw_value.getBytes.to_a.pack("C*")
         else
           nil
         end
@@ -549,22 +549,22 @@ module ActiveRecord
 
       private
 
-      def lob_to_ruby_value(val)
-        case val
-        when ::Java::OracleSql::CLOB
-          if val.isEmptyLob
-            nil
-          else
-            val.getSubString(1, val.length)
-          end
-        when ::Java::OracleSql::BLOB
-          if val.isEmptyLob
-            nil
-          else
-            String.from_java_bytes(val.getBytes(1, val.length))
+        def lob_to_ruby_value(val)
+          case val
+          when ::Java::OracleSql::CLOB
+            if val.isEmptyLob
+              nil
+            else
+              val.getSubString(1, val.length)
+            end
+          when ::Java::OracleSql::BLOB
+            if val.isEmptyLob
+              nil
+            else
+              String.from_java_bytes(val.getBytes(1, val.length))
+            end
           end
         end
-      end
     end
   end
 end

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_quoting.rb
@@ -15,7 +15,7 @@ module ActiveRecord
           when Date, DateTime
             Java::oracle.sql.DATE.new(value.strftime("%Y-%m-%d %H:%M:%S"))
           when Time
-            Java::java.sql.Timestamp.new(value.year-1900, value.month-1, value.day, value.hour, value.min, value.sec, value.usec * 1000)
+            Java::java.sql.Timestamp.new(value.year - 1900, value.month - 1, value.day, value.hour, value.min, value.sec, value.usec * 1000)
           else
             super
           end

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -1,4 +1,4 @@
-require 'delegate'
+require "delegate"
 
 begin
   require "oci8"
@@ -11,7 +11,7 @@ end
 
 # check ruby-oci8 version
 required_oci8_version = [2, 2, 0]
-oci8_version_ints = OCI8::VERSION.scan(/\d+/).map{|s| s.to_i}
+oci8_version_ints = OCI8::VERSION.scan(/\d+/).map { |s| s.to_i }
 if (oci8_version_ints <=> required_oci8_version) < 0
   raise LoadError, "ERROR: ruby-oci8 version #{OCI8::VERSION} is too old. Please install ruby-oci8 version #{required_oci8_version.join('.')} or later."
 end
@@ -98,9 +98,9 @@ module ActiveRecord
       # and return :insert_id value
       def exec_with_returning(sql)
         cursor = @raw_connection.parse(sql)
-        cursor.bind_param(':insert_id', nil, Integer)
+        cursor.bind_param(":insert_id", nil, Integer)
         cursor.exec
-        cursor[':insert_id']
+        cursor[":insert_id"]
       ensure
         cursor.close rescue nil
       end
@@ -115,7 +115,7 @@ module ActiveRecord
           @raw_cursor = raw_cursor
         end
 
-        def bind_params( *bind_vars )
+        def bind_params(*bind_vars)
           index = 1
           bind_vars.flatten.each do |var|
             if Hash === var
@@ -170,7 +170,7 @@ module ActiveRecord
           @raw_cursor.get_col_names
         end
 
-        def fetch(options={})
+        def fetch(options = {})
           if row = @raw_cursor.fetch
             get_lob_value = options[:get_lob_value]
             row.map do |col|
@@ -194,13 +194,13 @@ module ActiveRecord
         # Ignore raw_rnum_ which is used to simulate LIMIT and OFFSET
         cursor.get_col_names.each do |col_name|
           col_name = oracle_downcase(col_name)
-          cols << col_name unless col_name == 'raw_rnum_'
+          cols << col_name unless col_name == "raw_rnum_"
         end
         # Reuse the same hash for all rows
         column_hash = {}
-        cols.each {|c| column_hash[c] = nil}
+        cols.each { |c| column_hash[c] = nil }
         rows = []
-        get_lob_value = !(name == 'Writable Large Object')
+        get_lob_value = !(name == "Writable Large Object")
 
         while row = cursor.fetch
           hash = column_hash.dup
@@ -223,7 +223,7 @@ module ActiveRecord
 
       def describe(name)
         # fall back to SELECT based describe if using database link
-        return super if name.to_s.include?('@')
+        return super if name.to_s.include?("@")
         quoted_name = ActiveRecord::ConnectionAdapters::OracleEnhanced::Quoting.valid_table_name?(name) ? name : "\"#{name}\""
         @raw_connection.describe(quoted_name)
       rescue OCIException => e
@@ -261,7 +261,7 @@ module ActiveRecord
           if get_lob_value
             data = value.read || ""     # if value.read returns nil, then we have an empty_clob() i.e. an empty string
             # In Ruby 1.9.1 always change encoding to ASCII-8BIT for binaries
-            data.force_encoding('ASCII-8BIT') if data.respond_to?(:force_encoding) && value.is_a?(OCI8::BLOB)
+            data.force_encoding("ASCII-8BIT") if data.respond_to?(:force_encoding) && value.is_a?(OCI8::BLOB)
             data
           else
             value
@@ -279,32 +279,32 @@ module ActiveRecord
 
       private
 
-      def date_without_time?(value)
-        case value
-        when OraDate
-          value.hour == 0 && value.minute == 0 && value.second == 0
-        else
-          value.hour == 0 && value.min == 0 && value.sec == 0
+        def date_without_time?(value)
+          case value
+          when OraDate
+            value.hour == 0 && value.minute == 0 && value.second == 0
+          else
+            value.hour == 0 && value.min == 0 && value.sec == 0
+          end
         end
-      end
 
-      def create_time_with_default_timezone(value)
-        year, month, day, hour, min, sec, usec = case value
-        when Time
-          [value.year, value.month, value.day, value.hour, value.min, value.sec, value.usec]
-        when OraDate
-          [value.year, value.month, value.day, value.hour, value.minute, value.second, 0]
-        else
-          [value.year, value.month, value.day, value.hour, value.min, value.sec, 0]
+        def create_time_with_default_timezone(value)
+          year, month, day, hour, min, sec, usec = case value
+                                                   when Time
+                                                     [value.year, value.month, value.day, value.hour, value.min, value.sec, value.usec]
+                                                   when OraDate
+                                                     [value.year, value.month, value.day, value.hour, value.minute, value.second, 0]
+          else
+                                                     [value.year, value.month, value.day, value.hour, value.min, value.sec, 0]
+          end
+          # code from Time.time_with_datetime_fallback
+          begin
+            Time.send(Base.default_timezone, year, month, day, hour, min, sec, usec)
+          rescue
+            offset = Base.default_timezone.to_sym == :local ? ::DateTime.local_offset : 0
+            ::DateTime.civil(year, month, day, hour, min, sec, offset)
+          end
         end
-        # code from Time.time_with_datetime_fallback
-        begin
-          Time.send(Base.default_timezone, year, month, day, hour, min, sec, usec)
-        rescue
-          offset = Base.default_timezone.to_sym == :local ? ::DateTime.local_offset : 0
-          ::DateTime.civil(year, month, day, hour, min, sec, offset)
-        end
-      end
     end
 
     # The OracleEnhancedOCIFactory factors out the code necessary to connect and
@@ -320,16 +320,16 @@ module ActiveRecord
         privilege = config[:privilege] && config[:privilege].to_sym
         async = config[:allow_concurrency]
         prefetch_rows = config[:prefetch_rows] || 100
-        cursor_sharing = config[:cursor_sharing] || 'force'
+        cursor_sharing = config[:cursor_sharing] || "force"
         # get session time_zone from configuration or from TZ environment variable
-        time_zone = config[:time_zone] || ENV['TZ']
+        time_zone = config[:time_zone] || ENV["TZ"]
 
         # using a connection string via DATABASE_URL
-        connection_string = if host == 'connection-string'
+        connection_string = if host == "connection-string"
           database
         # connection using host, port and database name
         elsif host || port
-          host ||= 'localhost'
+          host ||= "localhost"
           host = "[#{host}]" if host =~ /^[^\[].*:/  # IPv6
           port ||= 1521
           database = "/#{database}" unless database.match(/^\//)
@@ -368,8 +368,8 @@ class OCI8 #:nodoc:
   def describe(name)
     info = describe_table(name.to_s)
     raise %Q{"DESC #{name}" failed} if info.nil?
-    if info.respond_to? :obj_link and info.obj_link
-      [info.obj_schema, info.obj_name, '@' + info.obj_link]
+    if info.respond_to?(:obj_link) && info.obj_link
+      [info.obj_schema, info.obj_name, "@" + info.obj_link]
     else
       [info.obj_schema, info.obj_name]
     end
@@ -398,7 +398,7 @@ class OCI8EnhancedAutoRecover < DelegateClass(OCI8) #:nodoc:
     @active = true
     @config = config
     @factory = factory
-    @connection  = @factory.new_connection @config
+    @connection = @factory.new_connection @config
     super @connection
   end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_quoting.rb
@@ -5,16 +5,16 @@ module ActiveRecord
         def _type_cast(value)
           case value
           when ActiveModel::Type::Binary::Data
-            lob_value = value == '' ? ' ' : value
+            lob_value = value == "" ? " " : value
             bind_type = OCI8::BLOB
             ora_value = bind_type.new(@connection.raw_oci_connection, lob_value)
-            ora_value.size = 0 if value == ''
+            ora_value.size = 0 if value == ""
             ora_value
           when ActiveRecord::OracleEnhanced::Type::Text::Data
-            lob_value = value.to_s == '' ? ' ' : value.to_s
+            lob_value = value.to_s == "" ? " " : value.to_s
             bind_type = OCI8::CLOB
             ora_value = bind_type.new(@connection.raw_oci_connection, lob_value)
-            ora_value.size = 0 if value.to_s == ''
+            ora_value.size = 0 if value.to_s == ""
             ora_value
           else
             super

--- a/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
@@ -1,4 +1,4 @@
-require 'active_support'
+require "active_support"
 
 module ActiveRecord #:nodoc:
   # Custom create, update, delete methods functionality.
@@ -96,99 +96,99 @@ module ActiveRecord #:nodoc:
 
     private
 
-    # Creates a record with custom create method
-    # and returns its id.
-    def _create_record
-      # check if class has custom create method
-      if self.class.custom_create_method
-        # run before/after callbacks defined in model
-        run_callbacks(:create) do
-          # timestamp
-          if self.record_timestamps
-            current_time = current_time_from_proper_timezone
+      # Creates a record with custom create method
+      # and returns its id.
+      def _create_record
+        # check if class has custom create method
+        if self.class.custom_create_method
+          # run before/after callbacks defined in model
+          run_callbacks(:create) do
+            # timestamp
+            if self.record_timestamps
+              current_time = current_time_from_proper_timezone
 
-            all_timestamp_attributes.each do |column|
-              if respond_to?(column) && respond_to?("#{column}=") && self.send(column).nil?
-                write_attribute(column.to_s, current_time)
+              all_timestamp_attributes.each do |column|
+                if respond_to?(column) && respond_to?("#{column}=") && self.send(column).nil?
+                  write_attribute(column.to_s, current_time)
+                end
               end
             end
+            # run
+            create_using_custom_method
           end
-          # run
-          create_using_custom_method
+        else
+          super
         end
-      else
-        super
       end
-    end
 
-    def create_using_custom_method
-      log_custom_method("custom create method", "#{self.class.name} Create") do
-        self.id = instance_eval(&self.class.custom_create_method)
+      def create_using_custom_method
+        log_custom_method("custom create method", "#{self.class.name} Create") do
+          self.id = instance_eval(&self.class.custom_create_method)
+        end
+        @new_record = false
+        # Starting from ActiveRecord 3.0.3 @persisted is used instead of @new_record
+        @persisted = true
+        id
       end
-      @new_record = false
-      # Starting from ActiveRecord 3.0.3 @persisted is used instead of @new_record
-      @persisted = true
-      id
-    end
 
-    # Updates the associated record with custom update method
-    # Returns the number of affected rows.
-    def _update_record(attribute_names = @attributes.keys)
-      # check if class has custom update method
-      if self.class.custom_update_method
-        # run before/after callbacks defined in model
-        run_callbacks(:update) do
-          # timestamp
-          if should_record_timestamps?
-            current_time = current_time_from_proper_timezone
+      # Updates the associated record with custom update method
+      # Returns the number of affected rows.
+      def _update_record(attribute_names = @attributes.keys)
+        # check if class has custom update method
+        if self.class.custom_update_method
+          # run before/after callbacks defined in model
+          run_callbacks(:update) do
+            # timestamp
+            if should_record_timestamps?
+              current_time = current_time_from_proper_timezone
 
-            timestamp_attributes_for_update_in_model.each do |column|
-              column = column.to_s
-              next if attribute_changed?(column)
-              write_attribute(column, current_time)
+              timestamp_attributes_for_update_in_model.each do |column|
+                column = column.to_s
+                next if attribute_changed?(column)
+                write_attribute(column, current_time)
+              end
+            end
+            # update just dirty attributes
+            if partial_writes?
+              # Serialized attributes should always be written in case they've been
+              # changed in place.
+              update_using_custom_method(changed | (attributes.keys & self.class.columns.select { |column| column.is_a?(Type::Serialized) }))
+            else
+              update_using_custom_method(attributes.keys)
             end
           end
-          # update just dirty attributes
-          if partial_writes?
-            # Serialized attributes should always be written in case they've been
-            # changed in place.
-            update_using_custom_method(changed | (attributes.keys & self.class.columns.select {|column| column.is_a?(Type::Serialized)}))
-          else
-            update_using_custom_method(attributes.keys)
+        else
+          super
+        end
+      end
+
+      def update_using_custom_method(attribute_names)
+        return 0 if attribute_names.empty?
+        log_custom_method("custom update method with #{self.class.primary_key}=#{self.id}", "#{self.class.name} Update") do
+          instance_eval(&self.class.custom_update_method)
+        end
+        1
+      end
+
+      # Deletes the record in the database with custom delete method
+      # and freezes this instance to reflect that no changes should
+      # be made (since they can't be persisted).
+      def destroy_using_custom_method
+        unless new_record? || @destroyed
+          log_custom_method("custom delete method with #{self.class.primary_key}=#{self.id}", "#{self.class.name} Destroy") do
+            instance_eval(&self.class.custom_delete_method)
           end
         end
-      else
-        super
-      end
-    end
 
-    def update_using_custom_method(attribute_names)
-      return 0 if attribute_names.empty?
-      log_custom_method("custom update method with #{self.class.primary_key}=#{self.id}", "#{self.class.name} Update") do
-        instance_eval(&self.class.custom_update_method)
-      end
-      1
-    end
-
-    # Deletes the record in the database with custom delete method
-    # and freezes this instance to reflect that no changes should
-    # be made (since they can't be persisted).
-    def destroy_using_custom_method
-      unless new_record? || @destroyed
-        log_custom_method("custom delete method with #{self.class.primary_key}=#{self.id}", "#{self.class.name} Destroy") do
-          instance_eval(&self.class.custom_delete_method)
-        end
+        @destroyed = true
+        freeze
       end
 
-      @destroyed = true
-      freeze
-    end
+      def log_custom_method(*args)
+        self.class.connection.send(:log, *args) { yield }
+      end
 
-    def log_custom_method(*args)
-      self.class.connection.send(:log, *args) { yield }
-    end
-
-    alias_method :update_record, :_update_record if private_method_defined?(:_update_record)
-    alias_method :create_record, :_create_record if private_method_defined?(:_create_record)
+      alias_method :update_record, :_update_record if private_method_defined?(:_update_record)
+      alias_method :create_record, :_create_record if private_method_defined?(:_create_record)
   end
 end

--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -76,8 +76,8 @@ module ActiveRecord
         end
 
         def quote_table_name(name) #:nodoc:
-          name, link = name.to_s.split('@')
-          @quoted_table_names[name] ||= [name.split('.').map{|n| quote_column_name(n)}.join('.'), quote_database_link(link)].compact.join('@')
+          name, link = name.to_s.split("@")
+          @quoted_table_names[name] ||= [name.split(".").map { |n| quote_column_name(n) }.join("."), quote_database_link(link)].compact.join("@")
         end
 
         def quote_string(s) #:nodoc:
@@ -87,11 +87,11 @@ module ActiveRecord
         def _quote(value) #:nodoc:
           case value
           when ActiveRecord::OracleEnhanced::Type::NationalCharacterString::Data then
-             "N" << "'#{quote_string(value.to_s)}'"
+            "N" << "'#{quote_string(value.to_s)}'"
           when ActiveModel::Type::Binary::Data then
-            %Q{empty_#{ type_to_sql(column.type.to_sym).downcase rescue 'blob' }()}
+            "empty_#{ type_to_sql(column.type.to_sym).downcase rescue 'blob' }()"
           when ActiveRecord::OracleEnhanced::Type::Text::Data then
-            %Q{empty_#{ type_to_sql(column.type.to_sym).downcase rescue 'clob' }()}
+            "empty_#{ type_to_sql(column.type.to_sym).downcase rescue 'clob' }()"
           else
             super
           end
@@ -143,11 +143,11 @@ module ActiveRecord
 end
 
 # if MRI or YARV
-if !defined?(RUBY_ENGINE) || RUBY_ENGINE == 'ruby'
-  require 'active_record/connection_adapters/oracle_enhanced/oci_quoting'
+if !defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby"
+  require "active_record/connection_adapters/oracle_enhanced/oci_quoting"
 # if JRuby
-elsif RUBY_ENGINE == 'jruby'
-  require 'active_record/connection_adapters/oracle_enhanced/jdbc_quoting'
+elsif RUBY_ENGINE == "jruby"
+  require "active_record/connection_adapters/oracle_enhanced/jdbc_quoting"
 else
   raise "Unsupported Ruby engine #{RUBY_ENGINE}"
 end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -4,8 +4,8 @@ module ActiveRecord
       class SchemaCreation < AbstractAdapter::SchemaCreation
         private
 
-        def visit_ColumnDefinition(o)
-          case
+          def visit_ColumnDefinition(o)
+            case
             when o.type.to_sym == :virtual
               sql_type = type_to_sql(o.default[:type], o.limit, o.precision, o.scale) if o.default[:type]
               return "#{quote_column_name(o.name)} #{sql_type} AS (#{o.default[:as]})"
@@ -14,82 +14,82 @@ module ActiveRecord
                 @lob_tablespaces ||= {}
                 @lob_tablespaces[o.name] = tablespace
               end
-          end
-          super
-        end
-
-        def visit_TableDefinition(o)
-          create_sql = "CREATE#{' GLOBAL TEMPORARY' if o.temporary} TABLE #{quote_table_name(o.name)} "
-          statements = o.columns.map { |c| accept c }
-          statements << accept(o.primary_keys) if o.primary_keys
-
-          if supports_foreign_keys?
-            statements.concat(o.foreign_keys.map { |to_table, options| foreign_key_in_create(o.name, to_table, options) })
+            end
+            super
           end
 
-          create_sql << "(#{statements.join(', ')})" if statements.present?
+          def visit_TableDefinition(o)
+            create_sql = "CREATE#{' GLOBAL TEMPORARY' if o.temporary} TABLE #{quote_table_name(o.name)} "
+            statements = o.columns.map { |c| accept c }
+            statements << accept(o.primary_keys) if o.primary_keys
 
-          unless o.temporary
-            @lob_tablespaces.each do |lob_column, tablespace|
-              create_sql << " LOB (#{quote_column_name(lob_column)}) STORE AS (TABLESPACE #{tablespace}) \n"
-            end if defined?(@lob_tablespaces)
-            create_sql << " ORGANIZATION #{o.organization}" if o.organization
-            if (tablespace = o.tablespace || default_tablespace_for(:table))
-              create_sql << " TABLESPACE #{tablespace}"
+            if supports_foreign_keys?
+              statements.concat(o.foreign_keys.map { |to_table, options| foreign_key_in_create(o.name, to_table, options) })
+            end
+
+            create_sql << "(#{statements.join(', ')})" if statements.present?
+
+            unless o.temporary
+              @lob_tablespaces.each do |lob_column, tablespace|
+                create_sql << " LOB (#{quote_column_name(lob_column)}) STORE AS (TABLESPACE #{tablespace}) \n"
+              end if defined?(@lob_tablespaces)
+              create_sql << " ORGANIZATION #{o.organization}" if o.organization
+              if (tablespace = o.tablespace || default_tablespace_for(:table))
+                create_sql << " TABLESPACE #{tablespace}"
+              end
+            end
+            add_table_options!(create_sql, table_options(o))
+            create_sql << " AS #{@conn.to_sql(o.as)}" if o.as
+            create_sql
+          end
+
+          def default_tablespace_for(type)
+            (ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[type] ||
+             ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[native_database_types[type][:name]]) rescue nil
+          end
+
+          def add_column_options!(sql, options)
+            type = options[:type] || ((column = options[:column]) && column.type)
+            type = type && type.to_sym
+            # handle case of defaults for CLOB columns, which would otherwise get "quoted" incorrectly
+            if options_include_default?(options)
+              if type == :text
+                sql << " DEFAULT #{@conn.quote(options[:default])}"
+              else
+                sql << " DEFAULT #{quote_default_expression(options[:default], options[:column])}"
+              end
+            end
+            # must explicitly add NULL or NOT NULL to allow change_column to work on migrations
+            if options[:null] == false
+              sql << " NOT NULL"
+            elsif options[:null] == true
+              sql << " NULL" unless type == :primary_key
+            end
+            # add AS expression for virtual columns
+            if options[:as].present?
+              sql << " AS (#{options[:as]})"
+            end
+            if options[:primary_key] == true
+              sql << " PRIMARY KEY"
             end
           end
-          add_table_options!(create_sql, table_options(o))
-          create_sql << " AS #{@conn.to_sql(o.as)}" if o.as
-          create_sql
-        end
 
-        def default_tablespace_for(type)
-          (ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[type] ||
-           ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[native_database_types[type][:name]]) rescue nil
-        end
-
-        def add_column_options!(sql, options)
-          type = options[:type] || ((column = options[:column]) && column.type)
-          type = type && type.to_sym
-          # handle case of defaults for CLOB columns, which would otherwise get "quoted" incorrectly
-          if options_include_default?(options)
-            if type == :text
-              sql << " DEFAULT #{@conn.quote(options[:default])}"
-            else
-              sql << " DEFAULT #{quote_default_expression(options[:default], options[:column])}"
-            end
-          end
-          # must explicitly add NULL or NOT NULL to allow change_column to work on migrations
-          if options[:null] == false
-            sql << " NOT NULL"
-          elsif options[:null] == true
-            sql << " NULL" unless type == :primary_key
-          end
-          # add AS expression for virtual columns
-          if options[:as].present?
-            sql << " AS (#{options[:as]})"
-          end
-          if options[:primary_key] == true
-            sql << " PRIMARY KEY"
-          end
-        end
-
-        def action_sql(action, dependency)
-          if action == 'UPDATE'
-            raise ArgumentError, <<-MSG.strip_heredoc
+          def action_sql(action, dependency)
+            if action == "UPDATE"
+              raise ArgumentError, <<-MSG.strip_heredoc
               '#{action}' is not supported by Oracle
             MSG
-          end
-          case dependency
-          when :nullify then "ON #{action} SET NULL"
-          when :cascade  then "ON #{action} CASCADE"
-          else
-            raise ArgumentError, <<-MSG.strip_heredoc
+            end
+            case dependency
+            when :nullify then "ON #{action} SET NULL"
+            when :cascade  then "ON #{action} CASCADE"
+            else
+              raise ArgumentError, <<-MSG.strip_heredoc
               '#{dependency}' is not supported for #{action}
               Supported values are: :nullify, :cascade
             MSG
+            end
           end
-        end
       end
     end
   end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -55,7 +55,7 @@ module ActiveRecord
 
         def column(name, type, options = {})
           if type == :virtual
-            default = {:type => options[:type]}
+            default = { type: options[:type] }
             if options[:as]
               default[:as] = options[:as]
             else
@@ -67,9 +67,9 @@ module ActiveRecord
         end
 
         private
-        def create_column_definition(name, type)
-          OracleEnhanced::ColumnDefinition.new name, type
-        end
+          def create_column_definition(name, type)
+            OracleEnhanced::ColumnDefinition.new name, type
+          end
       end
 
       class AlterTable < ActiveRecord::ConnectionAdapters::AlterTable

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -4,199 +4,199 @@ module ActiveRecord #:nodoc:
       module SchemaDumper #:nodoc:
         private
 
-        def tables(stream)
-          return super unless @connection.respond_to?(:materialized_views)
-          # do not include materialized views in schema dump - they should be created separately after schema creation
-          sorted_tables = (@connection.data_sources - @connection.materialized_views).sort
-          sorted_tables.each do |tbl|
-            # add table prefix or suffix for schema_migrations
-            next if ignored? tbl
-            # change table name inspect method
-            tbl.extend TableInspect
-            table(tbl, stream)
-            # add primary key trigger if table has it
-            primary_key_trigger(tbl, stream)
-          end
-          # following table definitions
-          # add foreign keys if table has them
-          sorted_tables.each do |tbl|
-            next if ignored? tbl
-            foreign_keys(tbl, stream)
+          def tables(stream)
+            return super unless @connection.respond_to?(:materialized_views)
+            # do not include materialized views in schema dump - they should be created separately after schema creation
+            sorted_tables = (@connection.data_sources - @connection.materialized_views).sort
+            sorted_tables.each do |tbl|
+              # add table prefix or suffix for schema_migrations
+              next if ignored? tbl
+              # change table name inspect method
+              tbl.extend TableInspect
+              table(tbl, stream)
+              # add primary key trigger if table has it
+              primary_key_trigger(tbl, stream)
+            end
+            # following table definitions
+            # add foreign keys if table has them
+            sorted_tables.each do |tbl|
+              next if ignored? tbl
+              foreign_keys(tbl, stream)
+            end
+
+            # add synonyms in local schema
+            synonyms(stream)
           end
 
-          # add synonyms in local schema
-          synonyms(stream)
-        end
-
-        def primary_key_trigger(table_name, stream)
-          if @connection.respond_to?(:has_primary_key_trigger?) && @connection.has_primary_key_trigger?(table_name)
-            pk, _pk_seq = @connection.pk_and_sequence_for(table_name)
-            stream.print "  add_primary_key_trigger #{table_name.inspect}"
-            stream.print ", primary_key: \"#{pk}\"" if pk != 'id'
-            stream.print "\n\n"
+          def primary_key_trigger(table_name, stream)
+            if @connection.respond_to?(:has_primary_key_trigger?) && @connection.has_primary_key_trigger?(table_name)
+              pk, _pk_seq = @connection.pk_and_sequence_for(table_name)
+              stream.print "  add_primary_key_trigger #{table_name.inspect}"
+              stream.print ", primary_key: \"#{pk}\"" if pk != "id"
+              stream.print "\n\n"
+            end
           end
-        end
 
-        def synonyms(stream)
-          if @connection.respond_to?(:synonyms)
-            syns = @connection.synonyms
-            syns.each do |syn|
-              next if ignored? syn.name
-              table_name = syn.table_name
-              table_name = "#{syn.table_owner}.#{table_name}" if syn.table_owner
-              table_name = "#{table_name}@#{syn.db_link}" if syn.db_link
-              stream.print "  add_synonym #{syn.name.inspect}, #{table_name.inspect}, force: true"
+          def synonyms(stream)
+            if @connection.respond_to?(:synonyms)
+              syns = @connection.synonyms
+              syns.each do |syn|
+                next if ignored? syn.name
+                table_name = syn.table_name
+                table_name = "#{syn.table_owner}.#{table_name}" if syn.table_owner
+                table_name = "#{table_name}@#{syn.db_link}" if syn.db_link
+                stream.print "  add_synonym #{syn.name.inspect}, #{table_name.inspect}, force: true"
+                stream.puts
+              end
+              stream.puts unless syns.empty?
+            end
+          end
+
+          def indexes(table, stream)
+            if (indexes = @connection.indexes(table)).any?
+              add_index_statements = indexes.map do |index|
+                case index.type
+                when nil
+                  # use table.inspect as it will remove prefix and suffix
+                  statement_parts = [ ("add_index " + table.inspect) ]
+                  statement_parts << index.columns.inspect
+                  statement_parts << ("name: " + index.name.inspect)
+                  statement_parts << "unique: true" if index.unique
+                  statement_parts << "tablespace: " + index.tablespace.inspect if index.tablespace
+                when "CTXSYS.CONTEXT"
+                  if index.statement_parameters
+                    statement_parts = [ ("add_context_index " + table.inspect) ]
+                    statement_parts << index.statement_parameters
+                  else
+                    statement_parts = [ ("add_context_index " + table.inspect) ]
+                    statement_parts << index.columns.inspect
+                    statement_parts << ("name: " + index.name.inspect)
+                  end
+                else
+                  # unrecognized index type
+                  statement_parts = ["# unrecognized index #{index.name.inspect} with type #{index.type.inspect}"]
+                end
+                "  " + statement_parts.join(", ")
+              end
+
+              stream.puts add_index_statements.sort.join("\n")
               stream.puts
             end
-            stream.puts unless syns.empty?
           end
-        end
 
-        def indexes(table, stream)
-          if (indexes = @connection.indexes(table)).any?
-            add_index_statements = indexes.map do |index|
-              case index.type
-              when nil
-                # use table.inspect as it will remove prefix and suffix
-                statement_parts = [ ('add_index ' + table.inspect) ]
-                statement_parts << index.columns.inspect
-                statement_parts << ('name: ' + index.name.inspect)
-                statement_parts << 'unique: true' if index.unique
-                statement_parts << 'tablespace: ' + index.tablespace.inspect if index.tablespace
-              when 'CTXSYS.CONTEXT'
-                if index.statement_parameters
-                  statement_parts = [ ('add_context_index ' + table.inspect) ]
-                  statement_parts << index.statement_parameters
-                else
-                  statement_parts = [ ('add_context_index ' + table.inspect) ]
-                  statement_parts << index.columns.inspect
-                  statement_parts << ('name: ' + index.name.inspect)
-                end
+          def table(table, stream)
+            return super unless @connection.respond_to?(:temporary_table?)
+            columns = @connection.columns(table)
+            begin
+              tbl = StringIO.new
+
+              # first dump primary key column
+              if @connection.respond_to?(:primary_keys)
+                pk = @connection.primary_keys(table)
+                pk = pk.first unless pk.size > 1
               else
-                # unrecognized index type
-                statement_parts = ["# unrecognized index #{index.name.inspect} with type #{index.type.inspect}"]
+                pk = @connection.primary_key(table)
               end
-              '  ' + statement_parts.join(', ')
+
+              tbl.print "  create_table #{table.inspect}"
+
+              # addition to make temporary option work
+              tbl.print ", temporary: true" if @connection.temporary_table?(table)
+
+              table_comments = @connection.table_comment(table)
+              unless table_comments.nil?
+                tbl.print ", comment: #{table_comments.inspect}"
+              end
+
+              case pk
+              when String
+                tbl.print ", primary_key: #{pk.inspect}" unless pk == "id"
+                pkcol = columns.detect { |c| c.name == pk }
+                pkcolspec = @connection.column_spec_for_primary_key(pkcol)
+                if pkcolspec.present?
+                  pkcolspec.each do |key, value|
+                    tbl.print ", #{key}: #{value}"
+                  end
+                end
+              when Array
+                tbl.print ", primary_key: #{pk.inspect}"
+              else
+                tbl.print ", id: false"
+              end
+
+              tbl.print ", force: :cascade"
+              tbl.puts " do |t|"
+
+              # then dump all non-primary key columns
+              column_specs = columns.map do |column|
+                raise StandardError, "Unknown type '#{column.sql_type}' for column '#{column.name}'" unless @connection.valid_type?(column.type)
+                next if column.name == pk
+                @connection.column_spec(column)
+              end.compact
+
+              # find all migration keys used in this table
+              #
+              # TODO `& column_specs.map(&:keys).flatten` should be executed
+              # in migration_keys_with_oracle_enhanced
+              keys = @connection.migration_keys & column_specs.map(&:keys).flatten
+
+              # figure out the lengths for each column based on above keys
+              lengths = keys.map { |key| column_specs.map { |spec| spec[key] ? spec[key].length + 2 : 0 }.max }
+
+              # the string we're going to sprintf our values against, with standardized column widths
+              format_string = lengths.map { |len| "%-#{len}s" }
+
+              # find the max length for the 'type' column, which is special
+              type_length = column_specs.map { |column| column[:type].length }.max
+
+              # add column type definition to our format string
+              format_string.unshift "    t.%-#{type_length}s "
+
+              format_string *= ""
+
+              # dirty hack to replace virtual_type: with type:
+              column_specs.each do |colspec|
+                values = keys.zip(lengths).map { |key, len| colspec.key?(key) ? colspec[key] + ", " : " " * len }
+                values.unshift colspec[:type]
+                tbl.print((format_string % values).gsub(/,\s*$/, "").gsub(/virtual_type:/, "type:"))
+                tbl.puts
+              end
+
+              tbl.puts "  end"
+              tbl.puts
+
+              indexes(table, tbl)
+
+              tbl.rewind
+              stream.print tbl.read
+            rescue => e
+              stream.puts "# Could not dump table #{table.inspect} because of following #{e.class}"
+              stream.puts "#   #{e.message}"
+              stream.puts
             end
 
-            stream.puts add_index_statements.sort.join("\n")
-            stream.puts
+            stream
           end
-        end
 
-        def table(table, stream)
-          return super unless @connection.respond_to?(:temporary_table?)
-          columns = @connection.columns(table)
-          begin
-            tbl = StringIO.new
+          def remove_prefix_and_suffix(table)
+            table.gsub(/^(#{ActiveRecord::Base.table_name_prefix})(.+)(#{ActiveRecord::Base.table_name_suffix})$/,  "\\2")
+          end
 
-            # first dump primary key column
-            if @connection.respond_to?(:primary_keys)
-              pk = @connection.primary_keys(table)
-              pk = pk.first unless pk.size > 1
-            else
-              pk = @connection.primary_key(table)
+          # remove table name prefix and suffix when doing #inspect (which is used in tables method)
+          module TableInspect #:nodoc:
+            def inspect
+              remove_prefix_and_suffix(self)
             end
 
-            tbl.print "  create_table #{table.inspect}"
-
-            # addition to make temporary option work
-            tbl.print ", temporary: true" if @connection.temporary_table?(table)
-
-            table_comments = @connection.table_comment(table)
-            unless table_comments.nil?
-              tbl.print ", comment: #{table_comments.inspect}"
-            end
-
-            case pk
-            when String
-              tbl.print ", primary_key: #{pk.inspect}" unless pk == 'id'
-              pkcol = columns.detect { |c| c.name == pk }
-              pkcolspec = @connection.column_spec_for_primary_key(pkcol)
-              if pkcolspec.present?
-                pkcolspec.each do |key, value|
-                  tbl.print ", #{key}: #{value}"
+            private
+              def remove_prefix_and_suffix(table_name)
+                if table_name =~ /\A#{ActiveRecord::Base.table_name_prefix.to_s.gsub('$', '\$')}(.*)#{ActiveRecord::Base.table_name_suffix.to_s.gsub('$', '\$')}\Z/
+                  "\"#{$1}\""
+                else
+                  "\"#{table_name}\""
                 end
               end
-            when Array
-              tbl.print ", primary_key: #{pk.inspect}"
-            else
-              tbl.print ", id: false"
-            end
-
-            tbl.print ", force: :cascade"
-            tbl.puts " do |t|"
-
-            # then dump all non-primary key columns
-            column_specs = columns.map do |column|
-              raise StandardError, "Unknown type '#{column.sql_type}' for column '#{column.name}'" unless @connection.valid_type?(column.type)
-              next if column.name == pk
-              @connection.column_spec(column)
-            end.compact
-
-            # find all migration keys used in this table
-            #
-            # TODO `& column_specs.map(&:keys).flatten` should be executed
-            # in migration_keys_with_oracle_enhanced
-            keys = @connection.migration_keys & column_specs.map(&:keys).flatten
-
-            # figure out the lengths for each column based on above keys
-            lengths = keys.map{ |key| column_specs.map{ |spec| spec[key] ? spec[key].length + 2 : 0 }.max }
-
-            # the string we're going to sprintf our values against, with standardized column widths
-            format_string = lengths.map{ |len| "%-#{len}s" }
-
-            # find the max length for the 'type' column, which is special
-            type_length = column_specs.map{ |column| column[:type].length }.max
-
-            # add column type definition to our format string
-            format_string.unshift "    t.%-#{type_length}s "
-
-            format_string *= ''
-
-            # dirty hack to replace virtual_type: with type:
-            column_specs.each do |colspec|
-              values = keys.zip(lengths).map{ |key, len| colspec.key?(key) ? colspec[key] + ", " : " " * len }
-              values.unshift colspec[:type]
-              tbl.print((format_string % values).gsub(/,\s*$/, '').gsub(/virtual_type:/, "type:"))
-              tbl.puts
-            end
-
-            tbl.puts "  end"
-            tbl.puts
-
-            indexes(table, tbl)
-
-            tbl.rewind
-            stream.print tbl.read
-          rescue => e
-            stream.puts "# Could not dump table #{table.inspect} because of following #{e.class}"
-            stream.puts "#   #{e.message}"
-            stream.puts
           end
-
-          stream
-        end
-
-        def remove_prefix_and_suffix(table)
-          table.gsub(/^(#{ActiveRecord::Base.table_name_prefix})(.+)(#{ActiveRecord::Base.table_name_suffix})$/,  "\\2")
-        end
-
-        # remove table name prefix and suffix when doing #inspect (which is used in tables method)
-        module TableInspect #:nodoc:
-          def inspect
-            remove_prefix_and_suffix(self)
-          end
-
-          private
-          def remove_prefix_and_suffix(table_name)
-            if table_name =~ /\A#{ActiveRecord::Base.table_name_prefix.to_s.gsub('$','\$')}(.*)#{ActiveRecord::Base.table_name_suffix.to_s.gsub('$','\$')}\Z/
-              "\"#{$1}\""
-            else
-              "\"#{table_name}\""
-            end
-          end
-        end
       end
     end
   end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -1,4 +1,4 @@
-require 'digest/sha1'
+require "digest/sha1"
 
 module ActiveRecord
   module ConnectionAdapters
@@ -83,7 +83,7 @@ module ActiveRecord
               change_column_comment(table_name, column.name, column.comment) if column.comment
             end
           end
-          td.indexes.each { |c,o| add_index table_name, c, o }
+          td.indexes.each { |c, o| add_index table_name, c, o }
 
           rebuild_primary_key_index_to_default_tablespace(table_name, options)
         end
@@ -136,7 +136,7 @@ module ActiveRecord
         def add_index(table_name, column_name, options = {}) #:nodoc:
           index_name, index_type, quoted_column_names, tablespace, index_options = add_index_options(table_name, column_name, options)
           execute "CREATE #{index_type} INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} (#{quoted_column_names})#{tablespace} #{index_options}"
-          if index_type == 'UNIQUE'
+          if index_type == "UNIQUE"
             unless quoted_column_names =~ /\(.*\)/
               execute "ALTER TABLE #{quote_table_name(table_name)} ADD CONSTRAINT #{quote_column_name(index_name)} #{index_type} (#{quoted_column_names})"
             end
@@ -166,7 +166,7 @@ module ActiveRecord
           end
 
           quoted_column_names = column_names.map { |e| quote_column_name_or_expression(e) }.join(", ")
-           [index_name, index_type, quoted_column_names, tablespace, index_options]
+          [index_name, index_type, quoted_column_names, tablespace, index_options]
         end
 
         # Remove the given index from the table.
@@ -204,11 +204,11 @@ module ActiveRecord
 
           # leave just first three letters from each word
           if shortened_name.length > identifier_max_length
-            shortened_name = shortened_name.split('_').map{|w| w[0,3]}.join('_')
+            shortened_name = shortened_name.split("_").map { |w| w[0, 3] }.join("_")
           end
           # generate unique name using hash function
           if shortened_name.length > identifier_max_length
-            shortened_name = 'i'+Digest::SHA1.hexdigest(default_name)[0,identifier_max_length-1]
+            shortened_name = "i" + Digest::SHA1.hexdigest(default_name)[0, identifier_max_length - 1]
           end
           @logger.warn "#{adapter_name} shortened default index name #{default_name} to #{shortened_name}" if @logger
           shortened_name
@@ -256,7 +256,7 @@ module ActiveRecord
           add_column_sql = "ALTER TABLE #{quote_table_name(table_name)} ADD #{quote_column_name(column_name)} "
           add_column_sql << type_to_sql(type, options[:limit], options[:precision], options[:scale]) if type
 
-          add_column_options!(add_column_sql, options.merge(:type=>type, :column_name=>column_name, :table_name=>table_name))
+          add_column_options!(add_column_sql, options.merge(type: type, column_name: column_name, table_name: table_name))
 
           add_column_sql << tablespace_for((type_to_sql(type).downcase.to_sym), nil, table_name, column_name) if type
 
@@ -286,7 +286,7 @@ module ActiveRecord
             execute("UPDATE #{quote_table_name(table_name)} SET #{quote_column_name(column_name)}=#{quote(default)} WHERE #{quote_column_name(column_name)} IS NULL")
           end
 
-          change_column table_name, column_name, column.sql_type, :null => null
+          change_column table_name, column_name, column.sql_type, null: null
         end
 
         def change_column(table_name, column_name, type, options = {}) #:nodoc:
@@ -303,7 +303,7 @@ module ActiveRecord
           change_column_sql = "ALTER TABLE #{quote_table_name(table_name)} MODIFY #{quote_column_name(column_name)} "
           change_column_sql << "#{type_to_sql(type, options[:limit], options[:precision], options[:scale])}" if type
 
-          add_column_options!(change_column_sql, options.merge(:type=>type, :column_name=>column_name, :table_name=>table_name))
+          add_column_options!(change_column_sql, options.merge(type: type, column_name: column_name, table_name: table_name))
 
           change_column_sql << tablespace_for((type_to_sql(type).downcase.to_sym), nil, options[:table_name], options[:column_name]) if type
 
@@ -360,7 +360,7 @@ module ActiveRecord
         # Maps logical Rails types to Oracle-specific data types.
         def type_to_sql(type, limit = nil, precision = nil, scale = nil) #:nodoc:
           # Ignore options for :text and :binary columns
-          return super(type, nil, nil, nil) if ['text', 'binary'].include?(type.to_s)
+          return super(type, nil, nil, nil) if ["text", "binary"].include?(type.to_s)
 
           super
         end
@@ -378,7 +378,7 @@ module ActiveRecord
         def foreign_keys(table_name) #:nodoc:
           (owner, desc_table_name, db_link) = @connection.describe(table_name)
 
-          fk_info = select_all(<<-SQL, 'Foreign Keys')
+          fk_info = select_all(<<-SQL, "Foreign Keys")
             SELECT r.table_name to_table
                   ,rc.column_name references_column
                   ,cc.column_name
@@ -401,19 +401,19 @@ module ActiveRecord
 
           fk_info.map do |row|
             options = {
-              column: oracle_downcase(row['column_name']),
-              name: oracle_downcase(row['name']),
-              primary_key: oracle_downcase(row['references_column'])
+              column: oracle_downcase(row["column_name"]),
+              name: oracle_downcase(row["name"]),
+              primary_key: oracle_downcase(row["references_column"])
             }
-            options[:on_delete] = extract_foreign_key_action(row['delete_rule'])
-            ActiveRecord::ConnectionAdapters::ForeignKeyDefinition.new(oracle_downcase(table_name), oracle_downcase(row['to_table']), options)
+            options[:on_delete] = extract_foreign_key_action(row["delete_rule"])
+            ActiveRecord::ConnectionAdapters::ForeignKeyDefinition.new(oracle_downcase(table_name), oracle_downcase(row["to_table"]), options)
           end
         end
 
         def extract_foreign_key_action(specifier) # :nodoc:
           case specifier
-          when 'CASCADE'; :cascade
-          when 'SET NULL'; :nullify
+          when "CASCADE"; :cascade
+          when "SET NULL"; :nullify
           end
         end
 
@@ -450,42 +450,42 @@ module ActiveRecord
 
         private
 
-        def tablespace_for(obj_type, tablespace_option, table_name=nil, column_name=nil)
-          tablespace_sql = ''
-          if tablespace = (tablespace_option || default_tablespace_for(obj_type))
-            tablespace_sql << if [:blob, :clob].include?(obj_type.to_sym)
-             " LOB (#{quote_column_name(column_name)}) STORE AS #{column_name.to_s[0..10]}_#{table_name.to_s[0..14]}_ls (TABLESPACE #{tablespace})"
-            else
-             " TABLESPACE #{tablespace}"
+          def tablespace_for(obj_type, tablespace_option, table_name = nil, column_name = nil)
+            tablespace_sql = ""
+            if tablespace = (tablespace_option || default_tablespace_for(obj_type))
+              tablespace_sql << if [:blob, :clob].include?(obj_type.to_sym)
+                                  " LOB (#{quote_column_name(column_name)}) STORE AS #{column_name.to_s[0..10]}_#{table_name.to_s[0..14]}_ls (TABLESPACE #{tablespace})"
+              else
+                " TABLESPACE #{tablespace}"
+              end
             end
+            tablespace_sql
           end
-          tablespace_sql
-        end
 
-        def default_tablespace_for(type)
-          (default_tablespaces[type] || default_tablespaces[native_database_types[type][:name]]) rescue nil
-        end
-
-        def column_for(table_name, column_name)
-          unless column = columns(table_name).find { |c| c.name == column_name.to_s }
-            raise "No such column: #{table_name}.#{column_name}"
+          def default_tablespace_for(type)
+            (default_tablespaces[type] || default_tablespaces[native_database_types[type][:name]]) rescue nil
           end
-          column
-        end
 
-        def create_sequence_and_trigger(table_name, options)
-          seq_name = options[:sequence_name] || default_sequence_name(table_name)
-          seq_start_value = options[:sequence_start_value] || default_sequence_start_value
-          execute "CREATE SEQUENCE #{quote_table_name(seq_name)} START WITH #{seq_start_value}"
+          def column_for(table_name, column_name)
+            unless column = columns(table_name).find { |c| c.name == column_name.to_s }
+              raise "No such column: #{table_name}.#{column_name}"
+            end
+            column
+          end
 
-          create_primary_key_trigger(table_name, options) if options[:primary_key_trigger]
-        end
+          def create_sequence_and_trigger(table_name, options)
+            seq_name = options[:sequence_name] || default_sequence_name(table_name)
+            seq_start_value = options[:sequence_start_value] || default_sequence_start_value
+            execute "CREATE SEQUENCE #{quote_table_name(seq_name)} START WITH #{seq_start_value}"
 
-        def create_primary_key_trigger(table_name, options)
-          seq_name = options[:sequence_name] || default_sequence_name(table_name)
-          trigger_name = options[:trigger_name] || default_trigger_name(table_name)
-          primary_key = options[:primary_key] || Base.get_primary_key(table_name.to_s.singularize)
-          execute compress_lines(<<-SQL)
+            create_primary_key_trigger(table_name, options) if options[:primary_key_trigger]
+          end
+
+          def create_primary_key_trigger(table_name, options)
+            seq_name = options[:sequence_name] || default_sequence_name(table_name)
+            trigger_name = options[:trigger_name] || default_trigger_name(table_name)
+            primary_key = options[:primary_key] || Base.get_primary_key(table_name.to_s.singularize)
+            execute compress_lines(<<-SQL)
             CREATE OR REPLACE TRIGGER #{quote_table_name(trigger_name)}
             BEFORE INSERT ON #{quote_table_name(table_name)} FOR EACH ROW
             BEGIN
@@ -496,28 +496,28 @@ module ActiveRecord
               END IF;
             END;
           SQL
-        end
+          end
 
-        def default_trigger_name(table_name)
-          # truncate table name if necessary to fit in max length of identifier
-          "#{table_name.to_s[0,table_name_length-4]}_pkt"
-        end
+          def default_trigger_name(table_name)
+            # truncate table name if necessary to fit in max length of identifier
+            "#{table_name.to_s[0, table_name_length - 4]}_pkt"
+          end
 
-        def rebuild_primary_key_index_to_default_tablespace(table_name, options)
-          tablespace = default_tablespace_for(:index)
+          def rebuild_primary_key_index_to_default_tablespace(table_name, options)
+            tablespace = default_tablespace_for(:index)
 
-          return unless tablespace
+            return unless tablespace
 
-          index_name = Base.connection.select_value(
-            "SELECT index_name FROM all_constraints
-                WHERE table_name = #{quote(table_name.upcase)}
-                AND constraint_type = 'P'
-                AND owner = SYS_CONTEXT('userenv', 'current_schema')")
+            index_name = Base.connection.select_value(
+              "SELECT index_name FROM all_constraints
+                  WHERE table_name = #{quote(table_name.upcase)}
+                  AND constraint_type = 'P'
+                  AND owner = SYS_CONTEXT('userenv', 'current_schema')")
 
-          return unless index_name
+            return unless index_name
 
-          execute("ALTER INDEX #{quote_column_name(index_name)} REBUILD TABLESPACE #{tablespace}")
-        end
+            execute("ALTER INDEX #{quote_column_name(index_name)} REBUILD TABLESPACE #{tablespace}")
+          end
       end
     end
   end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements_ext.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements_ext.rb
@@ -16,7 +16,7 @@ module ActiveRecord
         #     # ...
         #   end
         #
-        def add_primary_key_trigger(table_name, options={})
+        def add_primary_key_trigger(table_name, options = {})
           # call the same private method that is used for create_table :primary_key_trigger => true
           create_primary_key_trigger(table_name, options)
         end
@@ -50,8 +50,8 @@ module ActiveRecord
         # get synonyms for schema dump
         def synonyms #:nodoc:
           select_all("SELECT synonym_name, table_owner, table_name, db_link FROM all_synonyms where owner = SYS_CONTEXT('userenv', 'session_user')").collect do |row|
-            OracleEnhanced::SynonymDefinition.new(oracle_downcase(row['synonym_name']),
-              oracle_downcase(row['table_owner']), oracle_downcase(row['table_name']), oracle_downcase(row['db_link']))
+            OracleEnhanced::SynonymDefinition.new(oracle_downcase(row["synonym_name"]),
+              oracle_downcase(row["table_owner"]), oracle_downcase(row["table_name"]), oracle_downcase(row["db_link"]))
           end
         end
       end

--- a/lib/active_record/connection_adapters/oracle_enhanced/version.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/version.rb
@@ -1,1 +1,1 @@
-ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter::VERSION = File.read(File.expand_path('../../../../../VERSION', __FILE__)).chomp
+ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter::VERSION = File.read(File.expand_path("../../../../../VERSION", __FILE__)).chomp

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -28,17 +28,17 @@
 # contribution.
 # portions Copyright 2005 Graham Jenkins
 
-require 'active_record/connection_adapters/abstract_adapter'
-require 'active_record/connection_adapters/oracle_enhanced/connection'
-require 'active_record/connection_adapters/oracle_enhanced/database_statements'
-require 'active_record/connection_adapters/oracle_enhanced/schema_statements'
-require 'active_record/connection_adapters/oracle_enhanced/schema_statements_ext'
-require 'active_record/connection_adapters/oracle_enhanced/column_dumper'
-require 'active_record/connection_adapters/oracle_enhanced/context_index'
-require 'active_record/connection_adapters/oracle_enhanced/column'
-require 'active_record/connection_adapters/oracle_enhanced/quoting'
+require "active_record/connection_adapters/abstract_adapter"
+require "active_record/connection_adapters/oracle_enhanced/connection"
+require "active_record/connection_adapters/oracle_enhanced/database_statements"
+require "active_record/connection_adapters/oracle_enhanced/schema_statements"
+require "active_record/connection_adapters/oracle_enhanced/schema_statements_ext"
+require "active_record/connection_adapters/oracle_enhanced/column_dumper"
+require "active_record/connection_adapters/oracle_enhanced/context_index"
+require "active_record/connection_adapters/oracle_enhanced/column"
+require "active_record/connection_adapters/oracle_enhanced/quoting"
 
-require 'digest/sha1'
+require "digest/sha1"
 
 ActiveRecord::Base.class_eval do
   class_attribute :custom_create_method, :custom_update_method, :custom_delete_method
@@ -64,21 +64,21 @@ module ActiveRecord
 
     private
 
-    def enhanced_write_lobs
-      if self.class.connection.is_a?(ConnectionAdapters::OracleEnhancedAdapter) &&
-          !(
-            (self.class.custom_create_method || self.class.custom_create_method) ||
-            (self.class.custom_update_method || self.class.custom_update_method)
-          )
-        self.class.connection.write_lobs(self.class.table_name, self.class, attributes, @changed_lob_columns)
+      def enhanced_write_lobs
+        if self.class.connection.is_a?(ConnectionAdapters::OracleEnhancedAdapter) &&
+            !(
+              (self.class.custom_create_method || self.class.custom_create_method) ||
+              (self.class.custom_update_method || self.class.custom_update_method)
+            )
+          self.class.connection.write_lobs(self.class.table_name, self.class, attributes, @changed_lob_columns)
+        end
       end
-    end
 
-    def record_changed_lobs
-      @changed_lob_columns = self.class.lob_columns.select do |col|
-        self.attribute_changed?(col.name) && !self.class.readonly_attributes.to_a.include?(col.name)
+      def record_changed_lobs
+        @changed_lob_columns = self.class.lob_columns.select do |col|
+          self.attribute_changed?(col.name) && !self.class.readonly_attributes.to_a.include?(col.name)
+        end
       end
-    end
   end
 end
 
@@ -89,7 +89,7 @@ module ActiveRecord
       if config[:emulate_oracle_adapter] == true
         # allows the enhanced adapter to look like the OracleAdapter. Useful to pick up
         # conditionals in the rails activerecord test suite
-        require 'active_record/connection_adapters/emulation/oracle_adapter'
+        require "active_record/connection_adapters/emulation/oracle_adapter"
         ConnectionAdapters::OracleAdapter.new(
           ConnectionAdapters::OracleEnhancedConnection.create(config), logger, config)
       else
@@ -184,18 +184,18 @@ module ActiveRecord
       cattr_accessor :emulate_booleans
       self.emulate_booleans = true
 
-       ##
-        # :singleton-method:
-        # OracleEnhancedAdapter will use the default tablespace, but if you want specific types of
-        # objects to go into specific tablespaces, specify them like this in an initializer:
-        #
-        #   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces =
-        #  {:clob => 'TS_LOB', :blob => 'TS_LOB', :index => 'TS_INDEX', :table => 'TS_DATA'}
-        #
-        # Using the :tablespace option where available (e.g create_table) will take precedence
-        # over these settings.
+      ##
+      # :singleton-method:
+      # OracleEnhancedAdapter will use the default tablespace, but if you want specific types of
+      # objects to go into specific tablespaces, specify them like this in an initializer:
+      #
+      #   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces =
+      #  {:clob => 'TS_LOB', :blob => 'TS_LOB', :index => 'TS_INDEX', :table => 'TS_DATA'}
+      #
+      # Using the :tablespace option where available (e.g create_table) will take precedence
+      # over these settings.
       cattr_accessor :default_tablespaces
-      self.default_tablespaces={}
+      self.default_tablespaces = {}
 
       ##
       # :singleton-method:
@@ -254,7 +254,7 @@ module ActiveRecord
         @enable_dbms_output = false
       end
 
-      ADAPTER_NAME = 'OracleEnhanced'.freeze
+      ADAPTER_NAME = "OracleEnhanced".freeze
 
       def adapter_name #:nodoc:
         ADAPTER_NAME
@@ -293,7 +293,7 @@ module ActiveRecord
       end
 
       def supports_fetch_first_n_rows_and_offset?
-        if !use_old_oracle_visitor && @connection.database_version == [12,1]
+        if !use_old_oracle_visitor && @connection.database_version == [12, 1]
           true
         else
           false
@@ -314,45 +314,45 @@ module ActiveRecord
 
       #:stopdoc:
       DEFAULT_NLS_PARAMETERS = {
-        :nls_calendar            => nil,
-        :nls_comp                => nil,
-        :nls_currency            => nil,
-        :nls_date_format         => 'YYYY-MM-DD HH24:MI:SS',
-        :nls_date_language       => nil,
-        :nls_dual_currency       => nil,
-        :nls_iso_currency        => nil,
-        :nls_language            => nil,
-        :nls_length_semantics    => 'CHAR',
-        :nls_nchar_conv_excp     => nil,
-        :nls_numeric_characters  => nil,
-        :nls_sort                => nil,
-        :nls_territory           => nil,
-        :nls_timestamp_format    => 'YYYY-MM-DD HH24:MI:SS:FF6',
-        :nls_timestamp_tz_format => nil,
-        :nls_time_format         => nil,
-        :nls_time_tz_format      => nil
+        nls_calendar: nil,
+        nls_comp: nil,
+        nls_currency: nil,
+        nls_date_format: "YYYY-MM-DD HH24:MI:SS",
+        nls_date_language: nil,
+        nls_dual_currency: nil,
+        nls_iso_currency: nil,
+        nls_language: nil,
+        nls_length_semantics: "CHAR",
+        nls_nchar_conv_excp: nil,
+        nls_numeric_characters: nil,
+        nls_sort: nil,
+        nls_territory: nil,
+        nls_timestamp_format: "YYYY-MM-DD HH24:MI:SS:FF6",
+        nls_timestamp_tz_format: nil,
+        nls_time_format: nil,
+        nls_time_tz_format: nil
       }
 
       #:stopdoc:
       NATIVE_DATABASE_TYPES = {
-        :primary_key => "NUMBER(38) NOT NULL PRIMARY KEY",
-        :string      => { :name => "VARCHAR2", :limit => 255 },
-        :text        => { :name => "CLOB" },
-        :integer     => { :name => "NUMBER", :limit => 38 },
-        :float       => { :name => "BINARY_FLOAT" },
-        :decimal     => { :name => "DECIMAL" },
-        :datetime    => { :name => "TIMESTAMP" },
-        :timestamp   => { :name => "TIMESTAMP" },
-        :time        => { :name => "TIMESTAMP" },
-        :date        => { :name => "DATE" },
-        :binary      => { :name => "BLOB" },
-        :boolean     => { :name => "NUMBER", :limit => 1 },
-        :raw         => { :name => "RAW", :limit => 2000 },
-        :bigint      => { :name => "NUMBER", :limit => 19 }
+        primary_key: "NUMBER(38) NOT NULL PRIMARY KEY",
+        string: { name: "VARCHAR2", limit: 255 },
+        text: { name: "CLOB" },
+        integer: { name: "NUMBER", limit: 38 },
+        float: { name: "BINARY_FLOAT" },
+        decimal: { name: "DECIMAL" },
+        datetime: { name: "TIMESTAMP" },
+        timestamp: { name: "TIMESTAMP" },
+        time: { name: "TIMESTAMP" },
+        date: { name: "DATE" },
+        binary: { name: "BLOB" },
+        boolean: { name: "NUMBER", limit: 1 },
+        raw: { name: "RAW", limit: 2000 },
+        bigint: { name: "NUMBER", limit: 19 }
       }
       # if emulate_booleans_from_strings then store booleans in VARCHAR2
       NATIVE_DATABASE_TYPES_BOOLEAN_STRINGS = NATIVE_DATABASE_TYPES.dup.merge(
-        :boolean     => { :name => "VARCHAR2", :limit => 1 }
+        boolean: { name: "VARCHAR2", limit: 1 }
       )
       #:startdoc:
 
@@ -454,7 +454,7 @@ module ActiveRecord
       end
 
       # use in set_sequence_name to avoid fetching primary key value from sequence
-      AUTOGENERATED_SEQUENCE_NAME = 'autogenerated'.freeze
+      AUTOGENERATED_SEQUENCE_NAME = "autogenerated".freeze
 
       # Returns the next sequence value from a sequence generator. Not generally
       # called directly; used by ActiveRecord to get the next primary key value
@@ -490,8 +490,8 @@ module ActiveRecord
 
       def reset_pk_sequence!(table_name, primary_key = nil, sequence_name = nil) #:nodoc:
         return nil unless data_source_exists?(table_name)
-        unless primary_key and sequence_name
-        # *Note*: Only primary key is implemented - sequence will be nil.
+        unless primary_key && sequence_name
+          # *Note*: Only primary key is implemented - sequence will be nil.
           primary_key, sequence_name = pk_and_sequence_for(table_name)
           # TODO This sequence_name implemantation is just enough
           # to satisty fixures. To get correct sequence_name always
@@ -522,7 +522,7 @@ module ActiveRecord
         # is class with composite primary key>
         is_with_cpk = klass.respond_to?(:composite?) && klass.composite?
         if is_with_cpk
-          id = klass.primary_key.map {|pk| attributes[pk.to_s] }
+          id = klass.primary_key.map { |pk| attributes[pk.to_s] }
         else
           id = quote(attributes[klass.primary_key])
         end
@@ -536,7 +536,7 @@ module ActiveRecord
           uncached do
             sql = is_with_cpk ? "SELECT #{quote_column_name(col.name)} FROM #{quote_table_name(table_name)} WHERE #{klass.composite_where_clause(id)} FOR UPDATE" :
               "SELECT #{quote_column_name(col.name)} FROM #{quote_table_name(table_name)} WHERE #{quote_column_name(klass.primary_key)} = #{id} FOR UPDATE"
-            unless lob_record = select_one(sql, 'Writable Large Object')
+            unless lob_record = select_one(sql, "Writable Large Object")
               raise ActiveRecord::RecordNotFound, "statement #{sql} returned no rows"
             end
             lob = lob_record[col.name]
@@ -584,7 +584,7 @@ module ActiveRecord
       def data_sources
         select_values(
         "SELECT DECODE(table_name, UPPER(table_name), LOWER(table_name), table_name) FROM all_tables WHERE owner = SYS_CONTEXT('userenv', 'current_schema') AND secondary = 'N'",
-        'SCHEMA')
+        "SCHEMA")
       end
 
       def table_exists?(table_name)
@@ -622,7 +622,7 @@ module ActiveRecord
         (owner, table_name, db_link) = @connection.describe(table_name)
         unless all_schema_indexes
           default_tablespace_name = default_tablespace
-          result = select_all(<<-SQL.strip.gsub(/\s+/, ' '))
+          result = select_all(<<-SQL.strip.gsub(/\s+/, " "))
             SELECT LOWER(i.table_name) AS table_name, LOWER(i.index_name) AS index_name, i.uniqueness,
               i.index_type, i.ityp_owner, i.ityp_name, i.parameters,
               LOWER(i.tablespace_name) AS tablespace_name,
@@ -647,10 +647,10 @@ module ActiveRecord
           result.each do |row|
             # have to keep track of indexes because above query returns dups
             # there is probably a better query we could figure out
-            if current_index != row['index_name']
+            if current_index != row["index_name"]
               statement_parameters = nil
-              if row['index_type'] == 'DOMAIN' && row['ityp_owner'] == 'CTXSYS' && row['ityp_name'] == 'CONTEXT'
-                procedure_name = default_datastore_procedure(row['index_name'])
+              if row["index_type"] == "DOMAIN" && row["ityp_owner"] == "CTXSYS" && row["ityp_name"] == "CONTEXT"
+                procedure_name = default_datastore_procedure(row["index_name"])
                 source = select_values(<<-SQL).join
                   SELECT text
                   FROM all_source#{db_link}
@@ -663,36 +663,36 @@ module ActiveRecord
                 end
               end
               all_schema_indexes << OracleEnhanced::IndexDefinition.new(
-                row['table_name'],
-                row['index_name'],
-                row['uniqueness'] == "UNIQUE",
+                row["table_name"],
+                row["index_name"],
+                row["uniqueness"] == "UNIQUE",
                 [],
                 nil,
                 nil,
                 nil,
-                row['index_type'] == 'DOMAIN' ? "#{row['ityp_owner']}.#{row['ityp_name']}" : nil,
+                row["index_type"] == "DOMAIN" ? "#{row['ityp_owner']}.#{row['ityp_name']}" : nil,
                 nil,
-                row['parameters'],
+                row["parameters"],
                 statement_parameters,
-                row['tablespace_name'] == default_tablespace_name ? nil : row['tablespace_name'])
-              current_index = row['index_name']
+                row["tablespace_name"] == default_tablespace_name ? nil : row["tablespace_name"])
+              current_index = row["index_name"]
             end
 
             # Functional index columns and virtual columns both get stored as column expressions,
             # but re-creating a virtual column index as an expression (instead of using the virtual column's name)
             # results in a ORA-54018 error.  Thus, we only want the column expression value returned
             # when the column is not virtual.
-            if row['column_expression'] && row['virtual_column'] != 'YES'
-              all_schema_indexes.last.columns << row['column_expression']
+            if row["column_expression"] && row["virtual_column"] != "YES"
+              all_schema_indexes.last.columns << row["column_expression"]
             else
-              all_schema_indexes.last.columns << row['column_name'].downcase
+              all_schema_indexes.last.columns << row["column_name"].downcase
             end
           end
         end
 
         # Return the indexes just for the requested table, since AR is structured that way
         table_name = table_name.downcase
-        all_schema_indexes.select{|i| i.table == table_name}
+        all_schema_indexes.select { |i| i.table == table_name }
       end
 
       # check if table has primary key trigger with _pkt suffix
@@ -709,7 +709,7 @@ module ActiveRecord
             AND table_name = '#{desc_table_name}'
             AND status = 'ENABLED'
         SQL
-        select_value(pkt_sql, 'Primary Key Trigger') ? true : false
+        select_value(pkt_sql, "Primary Key Trigger") ? true : false
       end
 
       ##
@@ -739,7 +739,7 @@ module ActiveRecord
         # reset do_not_prefetch_primary_key cache for this table
         @@do_not_prefetch_primary_key[table_name] = nil
 
-        table_cols = <<-SQL.strip.gsub(/\s+/, ' ')
+        table_cols = <<-SQL.strip.gsub(/\s+/, " ")
           SELECT cols.column_name AS name, cols.data_type AS sql_type,
                  cols.data_default, cols.nullable, cols.virtual_column, cols.hidden_column,
                  cols.data_type_owner AS sql_type_owner,
@@ -763,43 +763,43 @@ module ActiveRecord
 
         # added deletion of ignored columns
         select_all(table_cols, name).to_a.map do |row|
-          limit, scale = row['limit'], row['scale']
+          limit, scale = row["limit"], row["scale"]
           if limit || scale
-            row['sql_type'] += "(#{(limit || 38).to_i}" + ((scale = scale.to_i) > 0 ? ",#{scale})" : ")")
+            row["sql_type"] += "(#{(limit || 38).to_i}" + ((scale = scale.to_i) > 0 ? ",#{scale})" : ")")
           end
 
-          if row['sql_type_owner']
-            row['sql_type'] = row['sql_type_owner'] + '.' + row['sql_type']
+          if row["sql_type_owner"]
+            row["sql_type"] = row["sql_type_owner"] + "." + row["sql_type"]
           end
 
-          is_virtual = row['virtual_column']=='YES'
+          is_virtual = row["virtual_column"] == "YES"
 
           # clean up odd default spacing from Oracle
-          if row['data_default'] && !is_virtual
-            row['data_default'].sub!(/^(.*?)\s*$/, '\1')
+          if row["data_default"] && !is_virtual
+            row["data_default"].sub!(/^(.*?)\s*$/, '\1')
 
             # If a default contains a newline these cleanup regexes need to
             # match newlines.
-            row['data_default'].sub!(/^'(.*)'$/m, '\1')
-            row['data_default'] = nil if row['data_default'] =~ /^(null|empty_[bc]lob\(\))$/i
+            row["data_default"].sub!(/^'(.*)'$/m, '\1')
+            row["data_default"] = nil if row["data_default"] =~ /^(null|empty_[bc]lob\(\))$/i
             # TODO: Needs better fix to fallback "N" to false
-            row['data_default'] = false if (row['data_default'] == "N" && OracleEnhancedAdapter.emulate_booleans_from_strings)
+            row["data_default"] = false if (row["data_default"] == "N" && OracleEnhancedAdapter.emulate_booleans_from_strings)
           end
 
-          type_metadata = fetch_type_metadata(row['sql_type'])
-          new_column(oracle_downcase(row['name']),
-                           row['data_default'],
+          type_metadata = fetch_type_metadata(row["sql_type"])
+          new_column(oracle_downcase(row["name"]),
+                           row["data_default"],
                            type_metadata,
-                           row['nullable'] == 'Y',
+                           row["nullable"] == "Y",
                            table_name,
                            is_virtual,
                            false,
-                           row['column_comment']
+                           row["column_comment"]
                     )
         end
       end
 
-      def new_column(name, default, sql_type_metadata = nil, null = true, table_name = nil, virtual = false, returning_id = false,comment = nil) # :nodoc:
+      def new_column(name, default, sql_type_metadata = nil, null = true, table_name = nil, virtual = false, returning_id = false, comment = nil) # :nodoc:
         OracleEnhancedColumn.new(name, default, sql_type_metadata, null, table_name, virtual, returning_id, comment)
       end
 
@@ -827,7 +827,7 @@ module ActiveRecord
 
       # Find a table's primary key and sequence.
       # *Note*: Only primary key is implemented - sequence will be nil.
-      def pk_and_sequence_for(table_name, owner=nil, desc_table_name=nil, db_link=nil) #:nodoc:
+      def pk_and_sequence_for(table_name, owner = nil, desc_table_name = nil, db_link = nil) #:nodoc:
         if @@cache_columns
           @@pk_and_sequence_for_cache ||= {}
           if @@pk_and_sequence_for_cache.key?(table_name)
@@ -840,10 +840,10 @@ module ActiveRecord
         end
       end
 
-      def pk_and_sequence_for_without_cache(table_name, owner=nil, desc_table_name=nil, db_link=nil) #:nodoc:
+      def pk_and_sequence_for_without_cache(table_name, owner = nil, desc_table_name = nil, db_link = nil) #:nodoc:
         (owner, desc_table_name, db_link) = @connection.describe(table_name) unless owner
 
-        seqs = select_values(<<-SQL.strip.gsub(/\s+/, ' '), 'Sequence')
+        seqs = select_values(<<-SQL.strip.gsub(/\s+/, " "), "Sequence")
           select us.sequence_name
           from all_sequences#{db_link} us
           where us.sequence_owner = '#{owner}'
@@ -851,7 +851,7 @@ module ActiveRecord
         SQL
 
         # changed back from user_constraints to all_constraints for consistency
-        pks = select_values(<<-SQL.strip.gsub(/\s+/, ' '), 'Primary Key')
+        pks = select_values(<<-SQL.strip.gsub(/\s+/, " "), "Primary Key")
           SELECT cc.column_name
             FROM all_constraints#{db_link} c, all_cons_columns#{db_link} cc
            WHERE c.owner = '#{owner}'
@@ -878,14 +878,14 @@ module ActiveRecord
         pk_and_sequence && pk_and_sequence.first
       end
 
-      def has_primary_key?(table_name, owner=nil, desc_table_name=nil, db_link=nil) #:nodoc:
+      def has_primary_key?(table_name, owner = nil, desc_table_name = nil, db_link = nil) #:nodoc:
         !pk_and_sequence_for(table_name, owner, desc_table_name, db_link).nil?
       end
 
       def primary_keys(table_name) # :nodoc:
         (owner, desc_table_name, db_link) = @connection.describe(table_name) unless owner
 
-        pks = select_values(<<-SQL.strip_heredoc, 'Primary Keys')
+        pks = select_values(<<-SQL.strip_heredoc, "Primary Keys")
           SELECT cc.column_name
             FROM all_constraints#{db_link} c, all_cons_columns#{db_link} cc
            WHERE c.owner = '#{owner}'
@@ -895,7 +895,7 @@ module ActiveRecord
              AND cc.constraint_name = c.constraint_name
              order by cc.position
         SQL
-        pks.map {|pk| oracle_downcase(pk)}
+        pks.map { |pk| oracle_downcase(pk) }
       end
 
       def columns_for_distinct(columns, orders) #:nodoc:
@@ -904,18 +904,18 @@ module ActiveRecord
         # the inclusion of these columns doesn't invalidate the DISTINCT
         #
         # It does not construct DISTINCT clause. Just return column names for distinct.
-        order_columns = orders.reject(&:blank?).map{ |s|
-          s = s.to_sql unless s.is_a?(String)
-          # remove any ASC/DESC modifiers
-          s.gsub(/\s+(ASC|DESC)\s*?/i, '')
-          }.reject(&:blank?).map.with_index { |column,i|
+        order_columns = orders.reject(&:blank?).map { |s|
+            s = s.to_sql unless s.is_a?(String)
+            # remove any ASC/DESC modifiers
+            s.gsub(/\s+(ASC|DESC)\s*?/i, "")
+          }.reject(&:blank?).map.with_index { |column, i|
             "FIRST_VALUE(#{column}) OVER (PARTITION BY #{columns} ORDER BY #{column}) AS alias_#{i}__"
           }
-          [super, *order_columns].join(', ')
+        [super, *order_columns].join(", ")
       end
 
       def temporary_table?(table_name) #:nodoc:
-        select_value("SELECT temporary FROM all_tables WHERE table_name = '#{table_name.upcase}' and owner = SYS_CONTEXT('userenv', 'session_user')") == 'Y'
+        select_value("SELECT temporary FROM all_tables WHERE table_name = '#{table_name.upcase}' and owner = SYS_CONTEXT('userenv', 'session_user')") == "Y"
       end
 
       def valid_type?(type)
@@ -931,7 +931,7 @@ module ActiveRecord
         offset: nil
       ) # :nodoc:
         result = from_clause + join_clause + where_clause + having_clause
-        if RUBY_ENGINE == 'jruby' && !supports_fetch_first_n_rows_and_offset? && offset && limit
+        if RUBY_ENGINE == "jruby" && !supports_fetch_first_n_rows_and_offset? && offset && limit
           result << offset
           result << limit
           result << offset
@@ -948,69 +948,69 @@ module ActiveRecord
 
       protected
 
-      def initialize_type_map(m)
-        super
-        # oracle
-        register_class_with_limit m, %r(raw)i,            ActiveRecord::OracleEnhanced::Type::Raw
-        register_class_with_limit m, %r(char)i,           ActiveRecord::OracleEnhanced::Type::String
-        register_class_with_limit m, %r(clob)i,           ActiveRecord::OracleEnhanced::Type::Text
-
-        m.register_type  'NCHAR', ActiveRecord::OracleEnhanced::Type::NationalCharacterString.new
-        m.alias_type %r(NVARCHAR2)i,    'NCHAR'
-
-        m.register_type(%r(NUMBER)i) do |sql_type|
-          scale = extract_scale(sql_type)
-          precision = extract_precision(sql_type)
-          limit = extract_limit(sql_type)
-          if scale == 0
-            ActiveRecord::OracleEnhanced::Type::Integer.new(precision: precision, limit: limit)
-          else
-            Type::Decimal.new(precision: precision, scale: scale)
-          end
-        end
-
-        if OracleEnhancedAdapter.emulate_booleans
-          if OracleEnhancedAdapter.emulate_booleans_from_strings
-            m.register_type %r(^VARCHAR2\(1\))i, ActiveRecord::OracleEnhanced::Type::Boolean.new
-          else
-            m.register_type %r(^NUMBER\(1\))i, Type::Boolean.new
-          end
-        end
-      end
-
-      def extract_limit(sql_type) #:nodoc:
-        case sql_type
-        when /^bigint/i
-          19
-        when /\((.*)\)/
-          $1.to_i
-        end
-      end
-
-      def translate_exception(exception, message) #:nodoc:
-        case @connection.error_code(exception)
-        when 1
-          RecordNotUnique.new(message)
-        when 942, 955
-          ActiveRecord::StatementInvalid.new(message)
-        when 2291
-          InvalidForeignKey.new(message)
-        when 12899
-          ValueTooLong.new(message)
-        else
+        def initialize_type_map(m)
           super
+          # oracle
+          register_class_with_limit m, %r(raw)i,            ActiveRecord::OracleEnhanced::Type::Raw
+          register_class_with_limit m, %r(char)i,           ActiveRecord::OracleEnhanced::Type::String
+          register_class_with_limit m, %r(clob)i,           ActiveRecord::OracleEnhanced::Type::Text
+
+          m.register_type "NCHAR", ActiveRecord::OracleEnhanced::Type::NationalCharacterString.new
+          m.alias_type %r(NVARCHAR2)i,    "NCHAR"
+
+          m.register_type(%r(NUMBER)i) do |sql_type|
+            scale = extract_scale(sql_type)
+            precision = extract_precision(sql_type)
+            limit = extract_limit(sql_type)
+            if scale == 0
+              ActiveRecord::OracleEnhanced::Type::Integer.new(precision: precision, limit: limit)
+            else
+              Type::Decimal.new(precision: precision, scale: scale)
+            end
+          end
+
+          if OracleEnhancedAdapter.emulate_booleans
+            if OracleEnhancedAdapter.emulate_booleans_from_strings
+              m.register_type %r(^VARCHAR2\(1\))i, ActiveRecord::OracleEnhanced::Type::Boolean.new
+            else
+              m.register_type %r(^NUMBER\(1\))i, Type::Boolean.new
+            end
+          end
         end
-      end
+
+        def extract_limit(sql_type) #:nodoc:
+          case sql_type
+          when /^bigint/i
+            19
+          when /\((.*)\)/
+            $1.to_i
+          end
+        end
+
+        def translate_exception(exception, message) #:nodoc:
+          case @connection.error_code(exception)
+          when 1
+            RecordNotUnique.new(message)
+          when 942, 955
+            ActiveRecord::StatementInvalid.new(message)
+          when 2291
+            InvalidForeignKey.new(message)
+          when 12899
+            ValueTooLong.new(message)
+          else
+            super
+          end
+        end
 
       private
 
-      def oracle_downcase(column_name)
-        @connection.oracle_downcase(column_name)
-      end
+        def oracle_downcase(column_name)
+          @connection.oracle_downcase(column_name)
+        end
 
-      def compress_lines(string, join_with = "\n")
-        string.split($/).map { |line| line.strip }.join(join_with)
-      end
+        def compress_lines(string, join_with = "\n")
+          string.split($/).map { |line| line.strip }.join(join_with)
+        end
 
       public
       # DBMS_OUTPUT =============================================
@@ -1040,84 +1040,84 @@ module ActiveRecord
       end
 
       protected
-      def log(sql, name = "SQL", binds = [], type_casted_binds = [], statement_name = nil)
-        super
-      ensure
-        log_dbms_output if dbms_output_enabled?
-      end
+        def log(sql, name = "SQL", binds = [], type_casted_binds = [], statement_name = nil)
+          super
+        ensure
+          log_dbms_output if dbms_output_enabled?
+        end
 
       private
 
-      def set_dbms_output_plsql_connection
-        raise OracleEnhancedConnectionException, "ruby-plsql gem is required for logging DBMS output" unless self.respond_to?(:plsql)
-        # do not reset plsql connection if it is the same (as resetting will clear PL/SQL metadata cache)
-        unless plsql(:dbms_output).connection && plsql(:dbms_output).connection.raw_connection == raw_connection
-          plsql(:dbms_output).connection = raw_connection
+        def set_dbms_output_plsql_connection
+          raise OracleEnhancedConnectionException, "ruby-plsql gem is required for logging DBMS output" unless self.respond_to?(:plsql)
+          # do not reset plsql connection if it is the same (as resetting will clear PL/SQL metadata cache)
+          unless plsql(:dbms_output).connection && plsql(:dbms_output).connection.raw_connection == raw_connection
+            plsql(:dbms_output).connection = raw_connection
+          end
         end
-      end
 
-      def log_dbms_output
-        while true do
-          result = plsql(:dbms_output).sys.dbms_output.get_line(:line => '', :status => 0)
-          break unless result[:status] == 0
-          @logger.debug "DBMS_OUTPUT: #{result[:line]}" if @logger
+        def log_dbms_output
+          while true do
+            result = plsql(:dbms_output).sys.dbms_output.get_line(line: "", status: 0)
+            break unless result[:status] == 0
+            @logger.debug "DBMS_OUTPUT: #{result[:line]}" if @logger
+          end
         end
-      end
     end
   end
 end
 
 # Implementation of standard schema definition statements and extensions for schema definition
-require 'active_record/connection_adapters/oracle_enhanced/schema_statements'
-require 'active_record/connection_adapters/oracle_enhanced/schema_statements_ext'
+require "active_record/connection_adapters/oracle_enhanced/schema_statements"
+require "active_record/connection_adapters/oracle_enhanced/schema_statements_ext"
 
 # Extensions for schema definition
-require 'active_record/connection_adapters/oracle_enhanced/schema_definitions'
+require "active_record/connection_adapters/oracle_enhanced/schema_definitions"
 
 # Extensions for context index definition
-require 'active_record/connection_adapters/oracle_enhanced/context_index'
+require "active_record/connection_adapters/oracle_enhanced/context_index"
 
 # Load additional methods for composite_primary_keys support
-require 'active_record/connection_adapters/oracle_enhanced/cpk'
+require "active_record/connection_adapters/oracle_enhanced/cpk"
 
 # Patches and enhancements for schema dumper
-require 'active_record/connection_adapters/oracle_enhanced/schema_dumper'
+require "active_record/connection_adapters/oracle_enhanced/schema_dumper"
 
 # Implementation of structure dump
-require 'active_record/connection_adapters/oracle_enhanced/structure_dump'
+require "active_record/connection_adapters/oracle_enhanced/structure_dump"
 
-require 'active_record/connection_adapters/oracle_enhanced/version'
+require "active_record/connection_adapters/oracle_enhanced/version"
 
 module ActiveRecord
-  autoload :OracleEnhancedProcedures, 'active_record/connection_adapters/oracle_enhanced/procedures'
+  autoload :OracleEnhancedProcedures, "active_record/connection_adapters/oracle_enhanced/procedures"
 end
 
 # Patches and enhancements for column dumper
-require 'active_record/connection_adapters/oracle_enhanced/column_dumper'
+require "active_record/connection_adapters/oracle_enhanced/column_dumper"
 
 # Moved SchemaCreation class
-require 'active_record/connection_adapters/oracle_enhanced/schema_creation'
+require "active_record/connection_adapters/oracle_enhanced/schema_creation"
 
 # Moved DatabaseStetements
-require 'active_record/connection_adapters/oracle_enhanced/database_statements'
+require "active_record/connection_adapters/oracle_enhanced/database_statements"
 
 # Add Type:Raw
-require 'active_record/oracle_enhanced/type/raw'
+require "active_record/oracle_enhanced/type/raw"
 
 # Add OracleEnhanced::Type::Integer
-require 'active_record/oracle_enhanced/type/integer'
+require "active_record/oracle_enhanced/type/integer"
 
 # Add OracleEnhanced::Type::String
-require 'active_record/oracle_enhanced/type/string'
+require "active_record/oracle_enhanced/type/string"
 
 # Add OracleEnhanced::Type::NationalCharacterString
-require 'active_record/oracle_enhanced/type/national_character_string'
+require "active_record/oracle_enhanced/type/national_character_string"
 
 # Add OracleEnhanced::Type::Text
-require 'active_record/oracle_enhanced/type/text'
+require "active_record/oracle_enhanced/type/text"
 
 # Add OracleEnhanced::Type::Boolean
-require 'active_record/oracle_enhanced/type/boolean'
+require "active_record/oracle_enhanced/type/boolean"
 
 # To use :boolean type for Attribute API, each type needs registered explicitly.
 ActiveRecord::Type.register(:boolean, ActiveRecord::OracleEnhanced::Type::Boolean, adapter: :oracleenhanced)

--- a/lib/active_record/oracle_enhanced/type/boolean.rb
+++ b/lib/active_record/oracle_enhanced/type/boolean.rb
@@ -4,14 +4,14 @@ module ActiveRecord
       class Boolean < ActiveModel::Type::Boolean # :nodoc:
         private
 
-        def cast_value(value)
-          # Kind of adding 'n' and 'N' to  `FALSE_VALUES`
-          if ['n', 'N'].include?(value)
-            false
-          else
-            super
+          def cast_value(value)
+            # Kind of adding 'n' and 'N' to  `FALSE_VALUES`
+            if ["n", "N"].include?(value)
+              false
+            else
+              super
+            end
           end
-        end
       end
     end
   end

--- a/lib/active_record/oracle_enhanced/type/integer.rb
+++ b/lib/active_record/oracle_enhanced/type/integer.rb
@@ -4,9 +4,9 @@ module ActiveRecord
       class Integer < ActiveModel::Type::Integer # :nodoc:
         private
 
-        def max_value
-          ("9"*38).to_i
-        end
+          def max_value
+            ("9" * 38).to_i
+          end
       end
     end
   end

--- a/lib/active_record/oracle_enhanced/type/national_character_string.rb
+++ b/lib/active_record/oracle_enhanced/type/national_character_string.rb
@@ -1,4 +1,4 @@
-require 'active_model/type/string'
+require "active_model/type/string"
 
 module ActiveRecord
   module OracleEnhanced

--- a/lib/active_record/oracle_enhanced/type/raw.rb
+++ b/lib/active_record/oracle_enhanced/type/raw.rb
@@ -1,4 +1,4 @@
-require 'active_model/type/string'
+require "active_model/type/string"
 
 module ActiveRecord
   module OracleEnhanced
@@ -13,7 +13,7 @@ module ActiveRecord
           if value.nil?
             super
           else
-            value = value.unpack('C*')
+            value = value.unpack("C*")
             value.map { |x| "%02X" % x }.join
           end
         end

--- a/lib/active_record/oracle_enhanced/type/string.rb
+++ b/lib/active_record/oracle_enhanced/type/string.rb
@@ -1,4 +1,4 @@
-require 'active_model/type/string'
+require "active_model/type/string"
 
 module ActiveRecord
   module OracleEnhanced
@@ -15,7 +15,7 @@ module ActiveRecord
 
         def changed_in_place?(raw_old_value, new_value)
           if raw_old_value.nil?
-            new_value = nil if new_value == ''
+            new_value = nil if new_value == ""
             raw_old_value != new_value
           else
             super

--- a/lib/active_record/oracle_enhanced/type/text.rb
+++ b/lib/active_record/oracle_enhanced/type/text.rb
@@ -1,4 +1,4 @@
-require 'active_model/type/string'
+require "active_model/type/string"
 
 module ActiveRecord
   module OracleEnhanced

--- a/lib/activerecord-oracle_enhanced-adapter.rb
+++ b/lib/activerecord-oracle_enhanced-adapter.rb
@@ -3,11 +3,11 @@ if defined?(Rails)
     module ConnectionAdapters
       class OracleEnhancedRailtie < ::Rails::Railtie
         rake_tasks do
-          load 'active_record/connection_adapters/oracle_enhanced/database_tasks.rb'
+          load "active_record/connection_adapters/oracle_enhanced/database_tasks.rb"
         end
 
         ActiveSupport.on_load(:active_record) do
-          require 'active_record/connection_adapters/oracle_enhanced_adapter'
+          require "active_record/connection_adapters/oracle_enhanced_adapter"
 
           # Cache column descriptions between requests in test and production environments
           if Rails.env.test? || Rails.env.production?

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe "OracleEnhancedAdapter establish connection" do
 
@@ -63,7 +63,7 @@ describe "OracleEnhancedAdapter" do
           hire_date     DATE
         )
       SQL
-      @column_names = ['id', 'first_name', 'last_name', 'full_name', 'hire_date']
+      @column_names = ["id", "first_name", "last_name", "full_name", "hire_date"]
       @column_sql_types = ["NUMBER", "VARCHAR2(20)", "VARCHAR2(25)", "VARCHAR2(46)", "DATE"]
       class ::TestEmployee < ActiveRecord::Base
       end
@@ -99,33 +99,33 @@ describe "OracleEnhancedAdapter" do
         ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.cache_columns = false
       end
 
-      it 'should identify virtual columns as such' do
+      it "should identify virtual columns as such" do
         skip "Not supported in this database version" unless @oracle11g_or_higher
-        te = TestEmployee.connection.columns('test_employees').detect(&:virtual?)
-        expect(te.name).to eq('full_name')
+        te = TestEmployee.connection.columns("test_employees").detect(&:virtual?)
+        expect(te.name).to eq("full_name")
       end
 
       it "should get columns from database at first time" do
-        expect(TestEmployee.connection.columns('test_employees').map(&:name)).to eq(@column_names)
+        expect(TestEmployee.connection.columns("test_employees").map(&:name)).to eq(@column_names)
         expect(@logger.logged(:debug).last).to match(/select .* from all_tab_cols/im)
       end
 
       it "should get columns from database at second time" do
-        TestEmployee.connection.columns('test_employees')
+        TestEmployee.connection.columns("test_employees")
         @logger.clear(:debug)
-        expect(TestEmployee.connection.columns('test_employees').map(&:name)).to eq(@column_names)
+        expect(TestEmployee.connection.columns("test_employees").map(&:name)).to eq(@column_names)
         expect(@logger.logged(:debug).last).to match(/select .* from all_tab_cols/im)
       end
 
       it "should get primary key from database at first time" do
-        expect(TestEmployee.connection.pk_and_sequence_for('test_employees')).to eq(['id', nil])
+        expect(TestEmployee.connection.pk_and_sequence_for("test_employees")).to eq(["id", nil])
         expect(@logger.logged(:debug).last).to match(/select .* from all_constraints/im)
       end
 
       it "should get primary key from database at first time" do
-        expect(TestEmployee.connection.pk_and_sequence_for('test_employees')).to eq(['id', nil])
+        expect(TestEmployee.connection.pk_and_sequence_for("test_employees")).to eq(["id", nil])
         @logger.clear(:debug)
-        expect(TestEmployee.connection.pk_and_sequence_for('test_employees')).to eq(['id', nil])
+        expect(TestEmployee.connection.pk_and_sequence_for("test_employees")).to eq(["id", nil])
         expect(@logger.logged(:debug).last).to match(/select .* from all_constraints/im)
       end
 
@@ -145,33 +145,33 @@ describe "OracleEnhancedAdapter" do
       end
 
       it "should get columns from database at first time" do
-        expect(TestEmployee.connection.columns('test_employees').map(&:name)).to eq(@column_names)
+        expect(TestEmployee.connection.columns("test_employees").map(&:name)).to eq(@column_names)
         expect(@logger.logged(:debug).last).to match(/select .* from all_tab_cols/im)
       end
 
       it "should get columns from cache at second time" do
-        TestEmployee.connection.columns('test_employees')
+        TestEmployee.connection.columns("test_employees")
         @logger.clear(:debug)
-        expect(TestEmployee.connection.columns('test_employees').map(&:name)).to eq(@column_names)
+        expect(TestEmployee.connection.columns("test_employees").map(&:name)).to eq(@column_names)
         expect(@logger.logged(:debug).last).to be_blank
       end
 
       it "should get primary key from database at first time" do
-        expect(TestEmployee.connection.pk_and_sequence_for('test_employees')).to eq(['id', nil])
+        expect(TestEmployee.connection.pk_and_sequence_for("test_employees")).to eq(["id", nil])
         expect(@logger.logged(:debug).last).to match(/select .* from all_constraints/im)
       end
 
       it "should get primary key from cache at first time" do
-        expect(TestEmployee.connection.pk_and_sequence_for('test_employees')).to eq(['id', nil])
+        expect(TestEmployee.connection.pk_and_sequence_for("test_employees")).to eq(["id", nil])
         @logger.clear(:debug)
-        expect(TestEmployee.connection.pk_and_sequence_for('test_employees')).to eq(['id', nil])
+        expect(TestEmployee.connection.pk_and_sequence_for("test_employees")).to eq(["id", nil])
         expect(@logger.logged(:debug).last).to be_blank
       end
 
       it "should store primary key as nil in cache at first time for table without primary key" do
-        expect(TestEmployee.connection.pk_and_sequence_for('test_employees_without_pk')).to eq(nil)
+        expect(TestEmployee.connection.pk_and_sequence_for("test_employees_without_pk")).to eq(nil)
         @logger.clear(:debug)
-        expect(TestEmployee.connection.pk_and_sequence_for('test_employees_without_pk')).to eq(nil)
+        expect(TestEmployee.connection.pk_and_sequence_for("test_employees_without_pk")).to eq(nil)
         expect(@logger.logged(:debug).last).to be_blank
       end
 
@@ -190,7 +190,7 @@ describe "OracleEnhancedAdapter" do
           name          VARCHAR2(50)
         )
       SQL
-      Object.send(:remove_const, 'CompositePrimaryKeys') if defined?(CompositePrimaryKeys)
+      Object.send(:remove_const, "CompositePrimaryKeys") if defined?(CompositePrimaryKeys)
       class ::TestEmployee < ActiveRecord::Base
         self.primary_key = :employee_id
       end
@@ -250,9 +250,9 @@ describe "OracleEnhancedAdapter" do
 
     it "should create record" do
       attrs = {
-        :varchar2 => 'dummy',
-        :integer => 1,
-        :comment => 'dummy'
+        varchar2: "dummy",
+        integer: 1,
+        comment: "dummy"
       }
       record = TestReservedWord.create!(attrs)
       record.reload
@@ -371,7 +371,7 @@ describe "OracleEnhancedAdapter" do
         self.table_name = "warehouse-things"
       end
 
-      wh = WarehouseThing.create!(:name => "Foo", :foo => 2)
+      wh = WarehouseThing.create!(name: "Foo", foo: 2)
       expect(wh.id).not_to be_nil
 
       expect(@conn.data_sources).to include("warehouse-things")
@@ -383,14 +383,14 @@ describe "OracleEnhancedAdapter" do
         self.table_name = "CamelCase"
       end
 
-      cc = CamelCase.create!(:name => "Foo", :foo => 2)
+      cc = CamelCase.create!(name: "Foo", foo: 2)
       expect(cc.id).not_to be_nil
 
       expect(@conn.data_sources).to include("CamelCase")
     end
 
     it "properly quotes database links" do
-      expect(@conn.quote_table_name('asdf@some.link')).to eq('"ASDF"@"SOME.LINK"')
+      expect(@conn.quote_table_name("asdf@some.link")).to eq('"ASDF"@"SOME.LINK"')
     end
   end
 
@@ -428,7 +428,7 @@ describe "OracleEnhancedAdapter" do
     end
 
     it "should verify database link" do
-      @conn.select_value("select * from dual@#{@db_link}") == 'X'
+      @conn.select_value("select * from dual@#{@db_link}") == "X"
     end
 
     it "should get column names" do
@@ -436,7 +436,7 @@ describe "OracleEnhancedAdapter" do
     end
 
     it "should create record" do
-      p = TestPost.create(:title => "Title", :body => "Body")
+      p = TestPost.create(title: "Title", body: "Body")
       expect(p.id).not_to be_nil
       expect(TestPost.find(p.id)).not_to be_nil
     end
@@ -450,7 +450,7 @@ describe "OracleEnhancedAdapter" do
 
     it "should get current database name" do
       # get database name if using //host:port/database connection string
-      database_name = CONNECTION_PARAMS[:database].split('/').last
+      database_name = CONNECTION_PARAMS[:database].split("/").last
       expect(@conn.current_database.upcase).to eq(database_name.upcase)
     end
 
@@ -461,25 +461,25 @@ describe "OracleEnhancedAdapter" do
 
   describe "temporary tables" do
     before(:all) do
-      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[:table] = 'UNUSED'
-      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[:clob] = 'UNUSED'
+      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[:table] = "UNUSED"
+      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[:clob] = "UNUSED"
       @conn = ActiveRecord::Base.connection
     end
     after(:all) do
-      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces={}
+      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces = {}
     end
 
     after(:each) do
       @conn.drop_table :foos rescue nil
     end
     it "should create ok" do
-      @conn.create_table :foos, :temporary => true, :id => false do |t|
+      @conn.create_table :foos, temporary: true, id: false do |t|
         t.integer :id
         t.text :bar
       end
     end
     it "should show up as temporary" do
-      @conn.create_table :foos, :temporary => true, :id => false do |t|
+      @conn.create_table :foos, temporary: true, id: false do |t|
         t.integer :id
       end
       expect(@conn.temporary_table?("foos")).to be_truthy
@@ -507,8 +507,8 @@ describe "OracleEnhancedAdapter" do
       @ids = (1..1010).to_a
       TestPost.transaction do
         @ids.each do |id|
-          TestPost.create!(:id => id, :title => "Title #{id}")
-          TestComment.create!(:test_post_id => id, :description => "Description #{id}")
+          TestPost.create!(id: id, title: "Title #{id}")
+          TestComment.create!(test_post_id: id, description: "Description #{id}")
         end
       end
     end
@@ -532,7 +532,7 @@ describe "OracleEnhancedAdapter" do
 
   describe "with statement pool" do
     before(:all) do
-      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(:statement_limit => 3))
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(statement_limit: 3))
       @conn = ActiveRecord::Base.connection
       schema_define do
         drop_table :test_posts rescue nil
@@ -604,13 +604,13 @@ describe "OracleEnhancedAdapter" do
     end
 
     it "should explain query" do
-      explain = TestPost.where(:id => 1).explain
+      explain = TestPost.where(id: 1).explain
       expect(explain).to include("Cost")
       expect(explain).to include("INDEX UNIQUE SCAN")
     end
 
     it "should explain query with binds" do
-      pending "Pending until further investigation made for #908" if RUBY_ENGINE == 'jruby'
+      pending "Pending until further investigation made for #908" if RUBY_ENGINE == "jruby"
       pk = TestPost.columns_hash[TestPost.primary_key]
       sub = Arel::Nodes::BindParam.new.to_sql
       binds = [ActiveRecord::Relation::QueryAttribute.new(pk, 1, ActiveRecord::Type::Integer.new)]
@@ -643,11 +643,11 @@ describe "OracleEnhancedAdapter" do
         self.table_name = :test_employees
       end
       i = 0
-      @employee.create!(sort_order: i+=1, first_name: 'Peter',   last_name: 'Parker')
-      @employee.create!(sort_order: i+=1, first_name: 'Tony',    last_name: 'Stark')
-      @employee.create!(sort_order: i+=1, first_name: 'Steven',  last_name: 'Rogers')
-      @employee.create!(sort_order: i+=1, first_name: 'Bruce',   last_name: 'Banner')
-      @employee.create!(sort_order: i+=1, first_name: 'Natasha', last_name: 'Romanova')
+      @employee.create!(sort_order: i += 1, first_name: "Peter",   last_name: "Parker")
+      @employee.create!(sort_order: i += 1, first_name: "Tony",    last_name: "Stark")
+      @employee.create!(sort_order: i += 1, first_name: "Steven",  last_name: "Rogers")
+      @employee.create!(sort_order: i += 1, first_name: "Bruce",   last_name: "Banner")
+      @employee.create!(sort_order: i += 1, first_name: "Natasha", last_name: "Romanova")
     end
 
     after(:all) do
@@ -690,7 +690,7 @@ describe "OracleEnhancedAdapter" do
     end
 
     it "returns true when passed a valid type" do
-      column = @conn.columns('test_employees').find { |col| col.name == 'first_name' }
+      column = @conn.columns("test_employees").find { |col| col.name == "first_name" }
       expect(@conn.valid_type?(column.type)).to be true
     end
 
@@ -699,7 +699,7 @@ describe "OracleEnhancedAdapter" do
     end
   end
 
-  describe 'serialized column' do
+  describe "serialized column" do
     before(:all) do
       schema_define do
         create_table :test_serialized_columns do |t|
@@ -715,7 +715,7 @@ describe "OracleEnhancedAdapter" do
       schema_define do
         drop_table :test_serialized_columns
       end
-      Object.send(:remove_const, 'TestSerializedColumn')
+      Object.send(:remove_const, "TestSerializedColumn")
       ActiveRecord::Base.table_name_prefix = nil
       ActiveRecord::Base.clear_cache!
     end
@@ -728,8 +728,8 @@ describe "OracleEnhancedAdapter" do
       clear_logger
     end
 
-    it 'should serialize' do
-      new_value = 'new_value'
+    it "should serialize" do
+      new_value = "new_value"
       serialized_column = TestSerializedColumn.new
 
       expect(serialized_column.serialized).to eq([])

--- a/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe "OracleEnhancedConnection" do
 
@@ -61,26 +61,26 @@ describe "OracleEnhancedConnection" do
 
   describe "create connection with NLS parameters" do
     after do
-      ENV['NLS_DATE_FORMAT'] = nil
+      ENV["NLS_DATE_FORMAT"] = nil
     end
 
     it "should use NLS_DATE_FORMAT environment variable" do
-      ENV['NLS_DATE_FORMAT'] = 'YYYY-MM-DD'
+      ENV["NLS_DATE_FORMAT"] = "YYYY-MM-DD"
       @conn = ActiveRecord::ConnectionAdapters::OracleEnhancedConnection.create(CONNECTION_PARAMS)
-      expect(@conn.select("select SYS_CONTEXT('userenv', 'NLS_DATE_FORMAT') as value from dual")).to eq([{'value' => 'YYYY-MM-DD'}])
+      expect(@conn.select("select SYS_CONTEXT('userenv', 'NLS_DATE_FORMAT') as value from dual")).to eq([{ "value" => "YYYY-MM-DD" }])
     end
 
     it "should use configuration value and ignore NLS_DATE_FORMAT environment variable" do
-      ENV['NLS_DATE_FORMAT'] = 'YYYY-MM-DD'
-      @conn = ActiveRecord::ConnectionAdapters::OracleEnhancedConnection.create(CONNECTION_PARAMS.merge(:nls_date_format => 'YYYY-MM-DD HH24:MI'))
-      expect(@conn.select("select SYS_CONTEXT('userenv', 'NLS_DATE_FORMAT') as value from dual")).to eq([{'value' => 'YYYY-MM-DD HH24:MI'}])
+      ENV["NLS_DATE_FORMAT"] = "YYYY-MM-DD"
+      @conn = ActiveRecord::ConnectionAdapters::OracleEnhancedConnection.create(CONNECTION_PARAMS.merge(nls_date_format: "YYYY-MM-DD HH24:MI"))
+      expect(@conn.select("select SYS_CONTEXT('userenv', 'NLS_DATE_FORMAT') as value from dual")).to eq([{ "value" => "YYYY-MM-DD HH24:MI" }])
     end
 
     it "should use default value when NLS_DATE_FORMAT environment variable is not set" do
-      ENV['NLS_DATE_FORMAT'] = nil
+      ENV["NLS_DATE_FORMAT"] = nil
       @conn = ActiveRecord::ConnectionAdapters::OracleEnhancedConnection.create(CONNECTION_PARAMS)
       default = ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter::DEFAULT_NLS_PARAMETERS[:nls_date_format]
-      expect(@conn.select("select SYS_CONTEXT('userenv', 'NLS_DATE_FORMAT') as value from dual")).to eq([{'value' => default}])
+      expect(@conn.select("select SYS_CONTEXT('userenv', 'NLS_DATE_FORMAT') as value from dual")).to eq([{ "value" => default }])
     end
   end
 
@@ -116,7 +116,7 @@ describe "OracleEnhancedConnection" do
     before(:all) do
       ActiveRecord::Base.establish_connection(CONNECTION_WITH_TIMEZONE_PARAMS)
       schema_define do
-        create_table :posts, :force => true do |t|
+        create_table :posts, force: true do |t|
           t.timestamps null: false
         end
       end
@@ -143,9 +143,9 @@ describe "OracleEnhancedConnection" do
     let(:username) { CONNECTION_PARAMS[:username] }
     let(:password) { CONNECTION_PARAMS[:password] }
     let(:connection_string) { "(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=tcp)(HOST=#{DATABASE_HOST})(PORT=#{DATABASE_PORT})))(CONNECT_DATA=(SERVICE_NAME=#{DATABASE_NAME})))" }
-    let(:params) { { username: username, password: password, host: 'connection-string', database: connection_string } }
+    let(:params) { { username: username, password: password, host: "connection-string", database: connection_string } }
 
-    it 'uses the database param as the connection string' do
+    it "uses the database param as the connection string" do
       if ORACLE_ENHANCED_CONNECTION == :jdbc
         expect(java.sql.DriverManager).to receive(:getConnection).with("jdbc:oracle:thin:@#{connection_string}", anything).and_call_original
       else
@@ -156,7 +156,7 @@ describe "OracleEnhancedConnection" do
     end
   end
 
-  if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
+  if defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
 
     describe "create JDBC connection" do
 
@@ -189,11 +189,11 @@ describe "OracleEnhancedConnection" do
       it "should create a new connection using JNDI" do
 
         begin
-          import 'oracle.jdbc.driver.OracleDriver'
-          import 'org.apache.commons.pool.impl.GenericObjectPool'
-          import 'org.apache.commons.dbcp.PoolingDataSource'
-          import 'org.apache.commons.dbcp.PoolableConnectionFactory'
-          import 'org.apache.commons.dbcp.DriverManagerConnectionFactory'
+          import "oracle.jdbc.driver.OracleDriver"
+          import "org.apache.commons.pool.impl.GenericObjectPool"
+          import "org.apache.commons.dbcp.PoolingDataSource"
+          import "org.apache.commons.dbcp.PoolableConnectionFactory"
+          import "org.apache.commons.dbcp.DriverManagerConnectionFactory"
         rescue NameError => e
           return skip e.message
         end
@@ -203,12 +203,12 @@ describe "OracleEnhancedConnection" do
             connection_pool = GenericObjectPool.new(nil)
             uri = "jdbc:oracle:thin:@#{DATABASE_HOST && "#{DATABASE_HOST}:"}#{DATABASE_PORT && "#{DATABASE_PORT}:"}#{DATABASE_NAME}"
             connection_factory = DriverManagerConnectionFactory.new(uri, DATABASE_USER, DATABASE_PASSWORD)
-            poolable_connection_factory = PoolableConnectionFactory.new(connection_factory,connection_pool,nil,nil,false,true)
+            poolable_connection_factory = PoolableConnectionFactory.new(connection_factory, connection_pool, nil, nil, false, true)
             @data_source = PoolingDataSource.new(connection_pool)
             @data_source.access_to_underlying_connection_allowed = true
           end
           def lookup(path)
-            if (path == 'java:/comp/env')
+            if (path == "java:/comp/env")
               return self
             else
               return @data_source
@@ -219,7 +219,7 @@ describe "OracleEnhancedConnection" do
         allow(javax.naming.InitialContext).to receive(:new).and_return(InitialContextMock.new)
 
         params = {}
-        params[:jndi] = 'java:comp/env/jdbc/test'
+        params[:jndi] = "java:comp/env/jdbc/test"
         @conn = ActiveRecord::ConnectionAdapters::OracleEnhancedConnection.create(params)
         expect(@conn).to be_active
       end
@@ -231,7 +231,7 @@ describe "OracleEnhancedConnection" do
       params[:url] = "jdbc:oracle:thin:@#{DATABASE_HOST && "//#{DATABASE_HOST}#{DATABASE_PORT && ":#{DATABASE_PORT}"}/"}#{DATABASE_NAME}"
       params[:host] = nil
       params[:database] = nil
-      allow(java.sql.DriverManager).to receive(:getConnection).and_raise('no suitable driver found')
+      allow(java.sql.DriverManager).to receive(:getConnection).and_raise("no suitable driver found")
       @conn = ActiveRecord::ConnectionAdapters::OracleEnhancedConnection.create(params)
       expect(@conn).to be_active
     end
@@ -248,11 +248,11 @@ describe "OracleEnhancedConnection" do
     end
 
     it "should execute SQL select" do
-      expect(@conn.select("SELECT * FROM dual")).to eq([{'dummy' => 'X'}])
+      expect(@conn.select("SELECT * FROM dual")).to eq([{ "dummy" => "X" }])
     end
 
     it "should execute SQL select and return also columns" do
-      expect(@conn.select("SELECT * FROM dual", nil, true)).to eq([ [{'dummy' => 'X'}], ['dummy'] ])
+      expect(@conn.select("SELECT * FROM dual", nil, true)).to eq([ [{ "dummy" => "X" }], ["dummy"] ])
     end
 
   end
@@ -266,7 +266,7 @@ describe "OracleEnhancedConnection" do
       cursor = @conn.prepare("SELECT * FROM dual WHERE :1 = 1")
       cursor.bind_param(1, 1)
       cursor.exec
-      expect(cursor.get_col_names).to eq(['DUMMY'])
+      expect(cursor.get_col_names).to eq(["DUMMY"])
       expect(cursor.fetch).to eq(["X"])
       cursor.close
     end
@@ -285,20 +285,20 @@ describe "OracleEnhancedConnection" do
 
   describe "SQL with bind parameters when NLS_NUMERIC_CHARACTERS is set to ', '" do
     before(:all) do
-      ENV['NLS_NUMERIC_CHARACTERS'] = ", "
+      ENV["NLS_NUMERIC_CHARACTERS"] = ", "
       @conn = ActiveRecord::ConnectionAdapters::OracleEnhancedConnection.create(CONNECTION_PARAMS)
       @conn.exec "CREATE TABLE test_employees (age NUMBER(10,2))"
     end
 
     after(:all) do
-      ENV['NLS_NUMERIC_CHARACTERS'] = nil
+      ENV["NLS_NUMERIC_CHARACTERS"] = nil
       @conn.exec "DROP TABLE test_employees" rescue nil
     end
 
     it "should execute prepared statement with decimal bind parameter " do
       cursor = @conn.prepare("INSERT INTO test_employees VALUES(:1)")
       type_metadata = ActiveRecord::ConnectionAdapters::SqlTypeMetadata.new(sql_type: "NUMBER", type: :decimal, limit: 10, precision: nil, scale: 2)
-      column = ActiveRecord::ConnectionAdapters::OracleEnhancedColumn.new('age', nil, type_metadata, false, "test_employees", false, false, nil)
+      column = ActiveRecord::ConnectionAdapters::OracleEnhancedColumn.new("age", nil, type_metadata, false, "test_employees", false, false, nil)
       expect(column.type).to eq(:decimal)
       # Here 1.5 expects that this value has been type casted already
       # it should use bind_params in the long term.
@@ -324,10 +324,10 @@ describe "OracleEnhancedConnection" do
     end
 
     def kill_current_session
-      audsid = @conn.select("SELECT userenv('sessionid') audsid FROM dual").first['audsid']
+      audsid = @conn.select("SELECT userenv('sessionid') audsid FROM dual").first["audsid"]
       sid_serial = @sys_conn.select("SELECT s.sid||','||s.serial# sid_serial
           FROM   v$session s
-          WHERE  audsid = '#{audsid}'").first['sid_serial']
+          WHERE  audsid = '#{audsid}'").first["sid_serial"]
       @sys_conn.exec "ALTER SYSTEM KILL SESSION '#{sid_serial}' IMMEDIATE"
     end
 
@@ -342,7 +342,7 @@ describe "OracleEnhancedConnection" do
       # @conn.auto_retry = false
       ActiveRecord::Base.connection.auto_retry = false
       kill_current_session
-      if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
+      if defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
         expect { @conn.exec("SELECT * FROM dual") }.to raise_error(NativeException)
       else
         expect { @conn.exec("SELECT * FROM dual") }.to raise_error(OCIError)
@@ -353,14 +353,14 @@ describe "OracleEnhancedConnection" do
       # @conn.auto_retry = true
       ActiveRecord::Base.connection.auto_retry = true
       kill_current_session
-      expect(@conn.select("SELECT * FROM dual")).to eq([{'dummy' => 'X'}])
+      expect(@conn.select("SELECT * FROM dual")).to eq([{ "dummy" => "X" }])
     end
 
     it "should not reconnect and execute SQL select if connection is lost and auto retry is disabled" do
       # @conn.auto_retry = false
       ActiveRecord::Base.connection.auto_retry = false
       kill_current_session
-      if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
+      if defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
         expect { @conn.select("SELECT * FROM dual") }.to raise_error(NativeException)
       else
         expect { @conn.select("SELECT * FROM dual") }.to raise_error(OCIError)

--- a/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe "OracleEnhancedAdapter context index" do
   include SchemaSpecHelper
@@ -68,8 +68,8 @@ describe "OracleEnhancedAdapter context index" do
         has_context_index
       end
       @post0 = Post.create(title: "dummy title", body: "dummy body")
-      @post1 = Post.create(title: @title_words.join(' '), body: @body_words.join(' '))
-      @post2 = Post.create(title: (@title_words*2).join(' '), body: (@body_words*2).join(' '))
+      @post1 = Post.create(title: @title_words.join(" "), body: @body_words.join(" "))
+      @post2 = Post.create(title: (@title_words * 2).join(" "), body: (@body_words * 2).join(" "))
       @post_with_null_body = Post.create(title: "withnull", body: nil)
       @post_with_null_title = Post.create(title: nil, body: "withnull")
     end
@@ -102,13 +102,13 @@ describe "OracleEnhancedAdapter context index" do
 
     it "should not include text index secondary tables in user tables list" do
       @conn.add_context_index :posts, :title
-      expect(@conn.data_sources.any?{|t| t =~ /^dr\$/i}).to be_falsey
+      expect(@conn.data_sources.any? { |t| t =~ /^dr\$/i }).to be_falsey
       @conn.remove_context_index :posts, :title
     end
 
     it "should create multiple column index" do
       @conn.add_context_index :posts, [:title, :body]
-      (@title_words+@body_words).each do |word|
+      (@title_words + @body_words).each do |word|
         expect(Post.contains(:title, word).to_a).to eq([@post2, @post1])
       end
       @conn.remove_context_index :posts, [:title, :body]
@@ -122,7 +122,7 @@ describe "OracleEnhancedAdapter context index" do
 
     it "should create multiple column index with specified main index column" do
       @conn.add_context_index :posts, [:title, :body],
-        index_column: :all_text, sync: 'ON COMMIT'
+        index_column: :all_text, sync: "ON COMMIT"
       @post = Post.create(title: "abc", body: "def")
       expect(Post.contains(:all_text, "abc").to_a).to eq([@post])
       expect(Post.contains(:all_text, "def").to_a).to eq([@post])
@@ -138,7 +138,7 @@ describe "OracleEnhancedAdapter context index" do
     it "should create multiple column index with trigger updated main index column" do
       @conn.add_context_index :posts, [:title, :body],
         index_column: :all_text, index_column_trigger_on: [:created_at, :updated_at],
-        sync: 'ON COMMIT'
+        sync: "ON COMMIT"
       @post = Post.create(title: "abc", body: "def")
       expect(Post.contains(:all_text, "abc").to_a).to eq([@post])
       expect(Post.contains(:all_text, "def").to_a).to eq([@post])
@@ -151,7 +151,7 @@ describe "OracleEnhancedAdapter context index" do
     it "should use base letter conversion with BASIC_LEXER" do
       @post = Post.create!(title: "āčē", body: "dummy")
       @conn.add_context_index :posts, :title,
-        lexer: { type: "BASIC_LEXER", base_letter_type: 'GENERIC', base_letter: true }
+        lexer: { type: "BASIC_LEXER", base_letter_type: "GENERIC", base_letter: true }
       expect(Post.contains(:title, "āčē").to_a).to eq([@post])
       expect(Post.contains(:title, "ace").to_a).to eq([@post])
       expect(Post.contains(:title, "ACE").to_a).to eq([@post])
@@ -172,7 +172,7 @@ describe "OracleEnhancedAdapter context index" do
     it "should use index when contains has schema_name.table_name syntax" do
       @conn.add_context_index :posts, :title
       @title_words.each do |word|
-        expect(Post.contains('posts.title', word).to_a).to eq([@post2, @post1])
+        expect(Post.contains("posts.title", word).to_a).to eq([@post2, @post1])
       end
       @conn.remove_context_index :posts, :title
     end
@@ -199,7 +199,7 @@ describe "OracleEnhancedAdapter context index" do
     end
 
     after(:each) do
-      @conn.remove_context_index :posts, name: 'post_and_comments_index' rescue nil
+      @conn.remove_context_index :posts, name: "post_and_comments_index" rescue nil
       @conn.remove_context_index :posts, index_column: :all_text rescue nil
       Post.destroy_all
     end
@@ -210,9 +210,9 @@ describe "OracleEnhancedAdapter context index" do
         # specify aliases always with AS keyword
         "SELECT comments.author AS comment_author, comments.body AS comment_body FROM comments WHERE comments.post_id = :id"
         ],
-        name: 'post_and_comments_index',
+        name: "post_and_comments_index",
         index_column: :all_text, index_column_trigger_on: [:updated_at, :comments_count],
-        sync: 'ON COMMIT'
+        sync: "ON COMMIT"
       @post = Post.create!(title: "aaa", body: "bbb")
       @post.comments.create!(author: "ccc", body: "ddd")
       @post.comments.create!(author: "eee", body: "fff")
@@ -231,9 +231,9 @@ describe "OracleEnhancedAdapter context index" do
             FROM comments
             WHERE comments.post_id = :id }
         ],
-        name: 'post_and_comments_index',
+        name: "post_and_comments_index",
         index_column: :all_text, index_column_trigger_on: [:updated_at, :comments_count],
-        sync: 'ON COMMIT'
+        sync: "ON COMMIT"
       @post = Post.create!(title: "aaa", body: "bbb")
       @post.comments.create!(author: "ccc", body: "ddd")
       @post.comments.create!(author: "eee", body: "fff")
@@ -270,7 +270,7 @@ describe "OracleEnhancedAdapter context index" do
       class ::Post < ActiveRecord::Base
         has_context_index
       end
-      @post = Post.create(title: 'aaa', body: 'bbb')
+      @post = Post.create(title: "aaa", body: "bbb")
       @tablespace = @conn.default_tablespace
       set_logger
       @conn = ActiveRecord::Base.connection
@@ -287,7 +287,7 @@ describe "OracleEnhancedAdapter context index" do
     end
 
     def verify_logged_statements
-      ['K_TABLE_CLAUSE', 'R_TABLE_CLAUSE', 'N_TABLE_CLAUSE', 'I_INDEX_CLAUSE', 'P_TABLE_CLAUSE'].each do |clause|
+      ["K_TABLE_CLAUSE", "R_TABLE_CLAUSE", "N_TABLE_CLAUSE", "I_INDEX_CLAUSE", "P_TABLE_CLAUSE"].each do |clause|
         expect(@logger.output(:debug)).to match(/CTX_DDL\.SET_ATTRIBUTE\('index_posts_on_title_sto', '#{clause}', '.*TABLESPACE #{@tablespace}'\)/)
       end
       expect(@logger.output(:debug)).to match(/CREATE INDEX .* PARAMETERS \('STORAGE index_posts_on_title_sto'\)/)
@@ -296,15 +296,15 @@ describe "OracleEnhancedAdapter context index" do
     it "should create index on single column" do
       @conn.add_context_index :posts, :title, tablespace: @tablespace
       verify_logged_statements
-      expect(Post.contains(:title, 'aaa').to_a).to eq([@post])
+      expect(Post.contains(:title, "aaa").to_a).to eq([@post])
       @conn.remove_context_index :posts, :title
     end
 
     it "should create index on multiple columns" do
-      @conn.add_context_index :posts, [:title, :body], name: 'index_posts_text', tablespace: @conn.default_tablespace
+      @conn.add_context_index :posts, [:title, :body], name: "index_posts_text", tablespace: @conn.default_tablespace
       verify_logged_statements
-      expect(Post.contains(:title, 'aaa AND bbb').to_a).to eq([@post])
-      @conn.remove_context_index :posts, name: 'index_posts_text'
+      expect(Post.contains(:title, "aaa AND bbb").to_a).to eq([@post])
+      @conn.remove_context_index :posts, name: "index_posts_text"
     end
 
   end
@@ -343,56 +343,56 @@ describe "OracleEnhancedAdapter context index" do
 
       it "should dump definition of multiple table index with options" do
         options = {
-          name: 'post_and_comments_index',
+          name: "post_and_comments_index",
           index_column: :all_text, index_column_trigger_on: :updated_at,
           transactional: true,
-          sync: 'ON COMMIT'
+          sync: "ON COMMIT"
         }
         sub_query = "SELECT comments.author AS comment_author, comments.body AS comment_body FROM comments WHERE comments.post_id = :id"
         @conn.add_context_index :posts, [:title, :body, sub_query], options
         expect(standard_dump).to match(/add_context_index "posts", \[:title, :body, "#{sub_query}"\], #{options.inspect[1..-2]}$/)
-        @conn.remove_context_index :posts, name: 'post_and_comments_index'
+        @conn.remove_context_index :posts, name: "post_and_comments_index"
       end
 
       it "should dump definition of multiple table index with options (when definition is larger than 4000 bytes)" do
         options = {
-          name: 'post_and_comments_index',
+          name: "post_and_comments_index",
           index_column: :all_text, index_column_trigger_on: :updated_at,
           transactional: true,
-          sync: 'ON COMMIT'
+          sync: "ON COMMIT"
         }
         sub_query = "SELECT comments.author AS comment_author, comments.body AS comment_body FROM comments WHERE comments.post_id = :id#{' AND 1=1' * 500}"
         @conn.add_context_index :posts, [:title, :body, sub_query], options
         expect(standard_dump).to match(/add_context_index "posts", \[:title, :body, "#{sub_query}"\], #{options.inspect[1..-2]}$/)
-        @conn.remove_context_index :posts, name: 'post_and_comments_index'
+        @conn.remove_context_index :posts, name: "post_and_comments_index"
       end
 
       it "should dump definition of multiple table index with options (when subquery has newlines)" do
         options = {
-          name: 'post_and_comments_index',
+          name: "post_and_comments_index",
           index_column: :all_text, index_column_trigger_on: :updated_at,
           transactional: true,
-          sync: 'ON COMMIT'
+          sync: "ON COMMIT"
         }
         sub_query = "SELECT comments.author AS comment_author, comments.body AS comment_body\nFROM comments\nWHERE comments.post_id = :id"
         @conn.add_context_index :posts, [:title, :body, sub_query], options
         expect(standard_dump).to match(/add_context_index "posts", \[:title, :body, "#{sub_query.gsub(/\n/, ' ')}"\], #{options.inspect[1..-2]}$/)
-        @conn.remove_context_index :posts, name: 'post_and_comments_index'
+        @conn.remove_context_index :posts, name: "post_and_comments_index"
       end
 
     end
 
     describe "with table prefix and suffix" do
       before(:all) do
-        ActiveRecord::Base.table_name_prefix = 'xxx_'
-        ActiveRecord::Base.table_name_suffix = '_xxx'
+        ActiveRecord::Base.table_name_prefix = "xxx_"
+        ActiveRecord::Base.table_name_suffix = "_xxx"
         create_tables
       end
 
       after(:all) do
         drop_tables
-        ActiveRecord::Base.table_name_prefix = ''
-        ActiveRecord::Base.table_name_suffix = ''
+        ActiveRecord::Base.table_name_prefix = ""
+        ActiveRecord::Base.table_name_suffix = ""
       end
 
       it "should dump definition of single column index" do
@@ -409,11 +409,11 @@ describe "OracleEnhancedAdapter context index" do
 
       it "should dump definition of multiple table index with options" do
         options = {
-          name: 'xxx_post_and_comments_i',
+          name: "xxx_post_and_comments_i",
           index_column: :all_text, index_column_trigger_on: :updated_at,
-          lexer: { type: "BASIC_LEXER", base_letter_type: 'GENERIC', base_letter: true },
+          lexer: { type: "BASIC_LEXER", base_letter_type: "GENERIC", base_letter: true },
           wordlist: { type: "BASIC_WORDLIST", prefix_index: true },
-          sync: 'ON COMMIT'
+          sync: "ON COMMIT"
         }
         schema_define do
           add_context_index :posts,
@@ -422,8 +422,8 @@ describe "OracleEnhancedAdapter context index" do
             ], options
         end
         expect(standard_dump).to match(/add_context_index "posts", \[:title, :body, "SELECT comments.author AS comment_author, comments.body AS comment_body FROM comments WHERE comments.post_id = :id"\], #{
-          options.inspect[1..-2].gsub(/[{}]/){|s| '\\'<<s }}$/)
-        schema_define { remove_context_index :posts, name: 'xxx_post_and_comments_i' }
+          options.inspect[1..-2].gsub(/[{}]/) { |s| '\\' << s }}$/)
+        schema_define { remove_context_index :posts, name: "xxx_post_and_comments_i" }
       end
 
     end

--- a/spec/active_record/connection_adapters/oracle_enhanced_cpk_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_cpk_spec.rb
@@ -1,113 +1,113 @@
-require 'spec_helper'
+require "spec_helper"
 
 unless defined?(NO_COMPOSITE_PRIMARY_KEYS)
 
-describe "OracleEnhancedAdapter composite_primary_keys support" do
-  include SchemaSpecHelper
+  describe "OracleEnhancedAdapter composite_primary_keys support" do
+    include SchemaSpecHelper
 
-  before(:all) do
-    if defined?(::ActiveRecord::ConnectionAdapters::OracleAdapter)
-      @old_oracle_adapter = ::ActiveRecord::ConnectionAdapters::OracleAdapter
-      ::ActiveRecord::ConnectionAdapters.send(:remove_const, :OracleAdapter)
-    end
-    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    if $cpk_oracle_adapter
-      ::ActiveRecord::ConnectionAdapters::OracleAdapter = $cpk_oracle_adapter
-      $cpk_oracle_adapter = nil
-    end
-    require 'composite_primary_keys'
-  end
-
-  after(:all) do
-    # Object.send(:remove_const, 'CompositePrimaryKeys') if defined?(CompositePrimaryKeys)
-    if defined?(::ActiveRecord::ConnectionAdapters::OracleAdapter)
-      $cpk_oracle_adapter = ::ActiveRecord::ConnectionAdapters::OracleAdapter
-      ::ActiveRecord::ConnectionAdapters.send(:remove_const, :OracleAdapter)
-    end
-    if @old_oracle_adapter
-      ::ActiveRecord::ConnectionAdapters::OracleAdapter = @old_oracle_adapter
-      @old_oracle_adapter = nil
-    end
-  end
-
-  describe "do not use count distinct" do
     before(:all) do
-      schema_define do
-        create_table :job_history, :primary_key => [:employee_id, :start_date], :force => true do |t|
-          t.integer :employee_id
-          t.date    :start_date
-        end
+      if defined?(::ActiveRecord::ConnectionAdapters::OracleAdapter)
+        @old_oracle_adapter = ::ActiveRecord::ConnectionAdapters::OracleAdapter
+        ::ActiveRecord::ConnectionAdapters.send(:remove_const, :OracleAdapter)
       end
-      class ::JobHistory < ActiveRecord::Base
-        set_table_name "job_history"
-        set_primary_keys :employee_id, :start_date
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+      if $cpk_oracle_adapter
+        ::ActiveRecord::ConnectionAdapters::OracleAdapter = $cpk_oracle_adapter
+        $cpk_oracle_adapter = nil
       end
+      require "composite_primary_keys"
     end
 
     after(:all) do
-      Object.send(:remove_const, 'JobHistory') if defined?(JobHistory)
-      schema_define do
-        drop_table :job_history
+      # Object.send(:remove_const, 'CompositePrimaryKeys') if defined?(CompositePrimaryKeys)
+      if defined?(::ActiveRecord::ConnectionAdapters::OracleAdapter)
+        $cpk_oracle_adapter = ::ActiveRecord::ConnectionAdapters::OracleAdapter
+        ::ActiveRecord::ConnectionAdapters.send(:remove_const, :OracleAdapter)
+      end
+      if @old_oracle_adapter
+        ::ActiveRecord::ConnectionAdapters::OracleAdapter = @old_oracle_adapter
+        @old_oracle_adapter = nil
       end
     end
 
-    it "should tell ActiveRecord that count distinct is not supported" do
-      expect(ActiveRecord::Base.connection.supports_count_distinct?).to be_falsey
-    end
-
-    it "should execute correct SQL COUNT DISTINCT statement on table with composite primary keys" do
-      expect { JobHistory.count(:distinct => true) }.not_to raise_error
-    end
-  end
-
-  describe "table with LOB" do
-    before(:all) do
-      schema_define do
-        create_table  :cpk_write_lobs_test, :primary_key => [:type_category, :date_value], :force => true do |t|
-          t.string  :type_category, :limit => 15, :null => false
-          t.date    :date_value, :null => false
-          t.text    :results, :null => false
-          t.timestamps null: true
+    describe "do not use count distinct" do
+      before(:all) do
+        schema_define do
+          create_table :job_history, primary_key: [:employee_id, :start_date], force: true do |t|
+            t.integer :employee_id
+            t.date    :start_date
+          end
         end
-        create_table :non_cpk_write_lobs_test, :force => true do |t|
-          t.date    :date_value, :null => false
-          t.text    :results, :null => false
-          t.timestamps null: true
+        class ::JobHistory < ActiveRecord::Base
+          set_table_name "job_history"
+          set_primary_keys :employee_id, :start_date
         end
       end
-      class ::CpkWriteLobsTest < ActiveRecord::Base
-        set_table_name 'cpk_write_lobs_test'
-        set_primary_keys :type_category, :date_value
+
+      after(:all) do
+        Object.send(:remove_const, "JobHistory") if defined?(JobHistory)
+        schema_define do
+          drop_table :job_history
+        end
       end
-      class ::NonCpkWriteLobsTest < ActiveRecord::Base
-        set_table_name 'non_cpk_write_lobs_test'
+
+      it "should tell ActiveRecord that count distinct is not supported" do
+        expect(ActiveRecord::Base.connection.supports_count_distinct?).to be_falsey
+      end
+
+      it "should execute correct SQL COUNT DISTINCT statement on table with composite primary keys" do
+        expect { JobHistory.count(distinct: true) }.not_to raise_error
       end
     end
 
-    after(:all) do
-      schema_define do
-        drop_table :cpk_write_lobs_test
-        drop_table :non_cpk_write_lobs_test
+    describe "table with LOB" do
+      before(:all) do
+        schema_define do
+          create_table :cpk_write_lobs_test, primary_key: [:type_category, :date_value], force: true do |t|
+            t.string  :type_category, limit: 15, null: false
+            t.date    :date_value, null: false
+            t.text    :results, null: false
+            t.timestamps null: true
+          end
+          create_table :non_cpk_write_lobs_test, force: true do |t|
+            t.date    :date_value, null: false
+            t.text    :results, null: false
+            t.timestamps null: true
+          end
+        end
+        class ::CpkWriteLobsTest < ActiveRecord::Base
+          set_table_name "cpk_write_lobs_test"
+          set_primary_keys :type_category, :date_value
+        end
+        class ::NonCpkWriteLobsTest < ActiveRecord::Base
+          set_table_name "non_cpk_write_lobs_test"
+        end
       end
-      Object.send(:remove_const, "CpkWriteLobsTest")
-      Object.send(:remove_const, "NonCpkWriteLobsTest")
+
+      after(:all) do
+        schema_define do
+          drop_table :cpk_write_lobs_test
+          drop_table :non_cpk_write_lobs_test
+        end
+        Object.send(:remove_const, "CpkWriteLobsTest")
+        Object.send(:remove_const, "NonCpkWriteLobsTest")
+      end
+
+      it "should create new record in table with CPK and LOB" do
+        expect {
+          CpkWriteLobsTest.create(type_category: "AAA", date_value: Date.today, results: "DATA " * 10)
+        }.not_to raise_error
+      end
+
+      it "should create new record in table without CPK and with LOB" do
+        expect {
+          NonCpkWriteLobsTest.create(date_value: Date.today, results: "DATA " * 10)
+        }.not_to raise_error
+      end
     end
 
-    it "should create new record in table with CPK and LOB" do
-      expect {
-        CpkWriteLobsTest.create(:type_category => 'AAA', :date_value => Date.today, :results => 'DATA '*10)
-      }.not_to raise_error
-    end
+    # Other testing was done based on composite_primary_keys tests
 
-    it "should create new record in table without CPK and with LOB" do
-      expect {
-        NonCpkWriteLobsTest.create(:date_value => Date.today, :results => 'DATA '*10)
-      }.not_to raise_error
-    end
   end
-
-  # Other testing was done based on composite_primary_keys tests
-
-end
 
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe "OracleEnhancedAdapter date type detection based on column names" do
   before(:all) do
@@ -41,14 +41,14 @@ describe "OracleEnhancedAdapter date type detection based on column names" do
       end
     end
 
-    def create_test_employee(params={})
-      @today = params[:today] || Date.new(2008,8,19)
-      @now = params[:now] || Time.local(2008,8,19,17,03,59)
+    def create_test_employee(params = {})
+      @today = params[:today] || Date.new(2008, 8, 19)
+      @now = params[:now] || Time.local(2008, 8, 19, 17, 03, 59)
       @employee = TestEmployee.create(
-        :first_name => "First",
-        :last_name => "Last",
-        :hire_date => @today,
-        :created_at => @now
+        first_name: "First",
+        last_name: "Last",
+        hire_date: @today,
+        created_at: @now
       )
       @employee.reload
     end
@@ -73,7 +73,7 @@ describe "OracleEnhancedAdapter date type detection based on column names" do
     end
 
     it "should return Date value from DATE column with old date value if column name contains 'date' and emulate_dates_by_column_name is true" do
-      create_test_employee(:today => Date.new(1900,1,1))
+      create_test_employee(today: Date.new(1900, 1, 1))
       expect(@employee.hire_date.class).to eq(Date)
     end
 
@@ -163,11 +163,11 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
 
     def create_employee2
       @employee2 = Test2Employee.create(
-        :first_name => "First",
-        :last_name => "Last",
-        :job_id => 1,
-        :is_manager => 1,
-        :salary => 1000
+        first_name: "First",
+        last_name: "Last",
+        job_id: 1,
+        is_manager: 1,
+        salary: 1000
       )
       @employee2.reload
     end
@@ -282,8 +282,8 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
 
       it "are Y or N" do
         subject = Test3Employee.new
-        expect(subject.has_phone).to eq('Y')
-        expect(subject.manager_yn).to eq('N')
+        expect(subject.has_phone).to eq("Y")
+        expect(subject.manager_yn).to eq("N")
       end
     end
 
@@ -319,15 +319,15 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
       ActiveRecord::Base.clear_cache!
     end
 
-    def create_employee3(params={})
+    def create_employee3(params = {})
       @employee3 = Test3Employee.create(
         {
-        :first_name => "First",
-        :last_name => "Last",
-        :has_email => true,
-        :has_phone => false,
-        :active_flag => true,
-        :manager_yn => false
+        first_name: "First",
+        last_name: "Last",
+        has_email: true,
+        has_phone: false,
+        active_flag: true,
+        manager_yn: false
         }.merge(params)
       )
       @employee3.reload
@@ -352,11 +352,11 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
       create_employee3
       %w(has_email active_flag).each do |col|
         expect(@employee3.send(col.to_sym).class).to eq(TrueClass)
-        expect(@employee3.send((col+"_before_type_cast").to_sym)).to eq("Y")
+        expect(@employee3.send((col + "_before_type_cast").to_sym)).to eq("Y")
       end
       %w(has_phone manager_yn).each do |col|
         expect(@employee3.send(col.to_sym).class).to eq(FalseClass)
-        expect(@employee3.send((col+"_before_type_cast").to_sym)).to eq("N")
+        expect(@employee3.send((col + "_before_type_cast").to_sym)).to eq("N")
       end
     end
 
@@ -371,16 +371,16 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
       class ::Test3Employee < ActiveRecord::Base
         attribute :test_boolean, :boolean
       end
-      create_employee3(:test_boolean => true)
+      create_employee3(test_boolean: true)
       expect(@employee3.test_boolean.class).to eq(TrueClass)
       expect(@employee3.test_boolean_before_type_cast).to eq("Y")
-      create_employee3(:test_boolean => false)
+      create_employee3(test_boolean: false)
       expect(@employee3.test_boolean.class).to eq(FalseClass)
       expect(@employee3.test_boolean_before_type_cast).to eq("N")
-      create_employee3(:test_boolean => nil)
+      create_employee3(test_boolean: nil)
       expect(@employee3.test_boolean.class).to eq(NilClass)
       expect(@employee3.test_boolean_before_type_cast).to eq(nil)
-      create_employee3(:test_boolean => "")
+      create_employee3(test_boolean: "")
       expect(@employee3.test_boolean.class).to eq(NilClass)
       expect(@employee3.test_boolean_before_type_cast).to eq(nil)
     end
@@ -405,7 +405,7 @@ describe "OracleEnhancedAdapter boolean support when emulate_booleans_from_strin
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = true
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
     schema_define do
-      create_table :posts, :force => true do |t|
+      create_table :posts, force: true do |t|
         t.string  :name,        null: false
         t.boolean :is_default, default: false
       end
@@ -427,7 +427,7 @@ describe "OracleEnhancedAdapter boolean support when emulate_booleans_from_strin
   end
 
   it "boolean should not change after reload" do
-    post = Post.create(name: 'Test 1', is_default: false)
+    post = Post.create(name: "Test 1", is_default: false)
     expect(post.is_default).to be false
     post.reload
     expect(post.is_default).to be false
@@ -482,11 +482,11 @@ describe "OracleEnhancedAdapter timestamp with timezone support" do
     end
 
     it "should return Time value from TIMESTAMP columns" do
-      @now = Time.local(2008,5,26,23,11,11,0)
+      @now = Time.local(2008, 5, 26, 23, 11, 11, 0)
       @employee = TestEmployee.create(
-        :created_at => @now,
-        :created_at_tz => @now,
-        :created_at_ltz => @now
+        created_at: @now,
+        created_at_tz: @now,
+        created_at_ltz: @now
       )
       @employee.reload
       [:created_at, :created_at_tz, :created_at_ltz].each do |c|
@@ -496,11 +496,11 @@ describe "OracleEnhancedAdapter timestamp with timezone support" do
     end
 
     it "should return Time value with fractional seconds from TIMESTAMP columns" do
-      @now = Time.local(2008,5,26,23,11,11,10)
+      @now = Time.local(2008, 5, 26, 23, 11, 11, 10)
       @employee = TestEmployee.create(
-        :created_at => @now,
-        :created_at_tz => @now,
-        :created_at_ltz => @now
+        created_at: @now,
+        created_at_tz: @now,
+        created_at_ltz: @now
       )
       @employee.reload
       [:created_at, :created_at_tz, :created_at_ltz].each do |c|
@@ -539,9 +539,9 @@ describe "OracleEnhancedAdapter date and timestamp with different NLS date forma
         INCREMENT BY 1 CACHE 20 NOORDER NOCYCLE
     SQL
     # @conn.execute %q{alter session set nls_date_format = 'YYYY-MM-DD HH24:MI:SS'}
-    @conn.execute %q{alter session set nls_date_format = 'DD-MON-YYYY HH24:MI:SS'}
+    @conn.execute "alter session set nls_date_format = 'DD-MON-YYYY HH24:MI:SS'"
     # @conn.execute %q{alter session set nls_timestamp_format = 'YYYY-MM-DD HH24:MI:SS'}
-    @conn.execute %q{alter session set nls_timestamp_format = 'DD-MON-YYYY HH24:MI:SS'}
+    @conn.execute "alter session set nls_timestamp_format = 'DD-MON-YYYY HH24:MI:SS'"
   end
 
   after(:all) do
@@ -553,8 +553,8 @@ describe "OracleEnhancedAdapter date and timestamp with different NLS date forma
     class ::TestEmployee < ActiveRecord::Base
       self.primary_key = "employee_id"
     end
-    @today = Date.new(2008,6,28)
-    @now = Time.local(2008,6,28,13,34,33)
+    @today = Date.new(2008, 6, 28)
+    @now = Time.local(2008, 6, 28, 13, 34, 33)
   end
 
   after(:each) do
@@ -565,11 +565,11 @@ describe "OracleEnhancedAdapter date and timestamp with different NLS date forma
 
   def create_test_employee
     @employee = TestEmployee.create(
-      :first_name => "First",
-      :last_name => "Last",
-      :hire_date => @today,
-      :created_at => @now,
-      :created_at_ts => @now
+      first_name: "First",
+      last_name: "Last",
+      hire_date: @today,
+      created_at: @now,
+      created_at_ts: @now
     )
     @employee.reload
   end
@@ -629,11 +629,11 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
       self.primary_key = "employee_id"
       attribute :last_login_at, :datetime
     end
-    @today = Date.new(2008,6,28)
+    @today = Date.new(2008, 6, 28)
     @today_iso = "2008-06-28"
     @today_nls = "28.06.2008"
     @nls_date_format = "%d.%m.%Y"
-    @now = Time.local(2008,6,28,13,34,33)
+    @now = Time.local(2008, 6, 28, 13, 34, 33)
     @now_iso = "2008-06-28 13:34:33"
     @now_nls = "28.06.2008 13:34:33"
     @nls_time_format = "%d.%m.%Y %H:%M:%S"
@@ -655,9 +655,9 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
 
   it "should assign ISO string to date column" do
     @employee = TestEmployee.create(
-      :first_name => "First",
-      :last_name => "Last",
-      :hire_date => @today_iso
+      first_name: "First",
+      last_name: "Last",
+      hire_date: @today_iso
     )
     expect(@employee.hire_date).to eq(@today)
     @employee.reload
@@ -666,9 +666,9 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
 
   it "should assign NLS string to date column" do
     @employee = TestEmployee.create(
-      :first_name => "First",
-      :last_name => "Last",
-      :hire_date => @today_nls
+      first_name: "First",
+      last_name: "Last",
+      hire_date: @today_nls
     )
     expect(@employee.hire_date).to eq(@today)
     @employee.reload
@@ -677,9 +677,9 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
 
   it "should assign ISO time string to date column" do
     @employee = TestEmployee.create(
-      :first_name => "First",
-      :last_name => "Last",
-      :hire_date => @now_iso
+      first_name: "First",
+      last_name: "Last",
+      hire_date: @now_iso
     )
     expect(@employee.hire_date).to eq(@today)
     @employee.reload
@@ -688,9 +688,9 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
 
   it "should assign NLS time string to date column" do
     @employee = TestEmployee.create(
-      :first_name => "First",
-      :last_name => "Last",
-      :hire_date => @now_nls
+      first_name: "First",
+      last_name: "Last",
+      hire_date: @now_nls
     )
     expect(@employee.hire_date).to eq(@today)
     @employee.reload
@@ -700,9 +700,9 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
   it "should assign ISO time string to datetime column" do
     ActiveRecord::Base.default_timezone = :local
     @employee = TestEmployee.create(
-      :first_name => "First",
-      :last_name => "Last",
-      :last_login_at => @now_iso
+      first_name: "First",
+      last_name: "Last",
+      last_login_at: @now_iso
     )
     expect(@employee.last_login_at).to eq(@now)
     @employee.reload
@@ -712,9 +712,9 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
   it "should assign NLS time string to datetime column" do
     ActiveRecord::Base.default_timezone = :local
     @employee = TestEmployee.create(
-      :first_name => "First",
-      :last_name => "Last",
-      :last_login_at => @now_nls
+      first_name: "First",
+      last_name: "Last",
+      last_login_at: @now_nls
     )
     expect(@employee.last_login_at).to eq(@now)
     @employee.reload
@@ -723,9 +723,9 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
 
   it "should assign NLS time string with time zone to datetime column" do
     @employee = TestEmployee.create(
-      :first_name => "First",
-      :last_name => "Last",
-      :last_login_at => @now_nls_with_tz
+      first_name: "First",
+      last_name: "Last",
+      last_login_at: @now_nls_with_tz
     )
     expect(@employee.last_login_at).to eq(@now_with_tz)
     @employee.reload
@@ -735,9 +735,9 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
   it "should assign ISO date string to datetime column" do
     ActiveRecord::Base.default_timezone = :local
     @employee = TestEmployee.create(
-      :first_name => "First",
-      :last_name => "Last",
-      :last_login_at => @today_iso
+      first_name: "First",
+      last_name: "Last",
+      last_login_at: @today_iso
     )
     expect(@employee.last_login_at).to eq(@today.to_time)
     @employee.reload
@@ -747,9 +747,9 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
   it "should assign NLS date string to datetime column" do
     ActiveRecord::Base.default_timezone = :local
     @employee = TestEmployee.create(
-      :first_name => "First",
-      :last_name => "Last",
-      :last_login_at => @today_nls
+      first_name: "First",
+      last_name: "Last",
+      last_login_at: @today_nls
     )
     expect(@employee.last_login_at).to eq(@today.to_time)
     @employee.reload
@@ -832,8 +832,8 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
 
   it "should create record without CLOB data when attribute is serialized" do
     @employee = Test2Employee.create!(
-      :first_name => "First",
-      :last_name => "Last"
+      first_name: "First",
+      last_name: "Last"
     )
     expect(@employee).to be_valid
     @employee.reload
@@ -842,29 +842,29 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
 
   it "should accept Symbol value for CLOB column" do
     @employee = TestEmployee.create!(
-      :comments => :test_comment
+      comments: :test_comment
     )
     expect(@employee).to be_valid
   end
 
   it "should respect attr_readonly setting for CLOB column" do
     @employee = TestEmployeeReadOnlyClob.create!(
-      :first_name => "First",
-      :comments => "initial"
+      first_name: "First",
+      comments: "initial"
     )
     expect(@employee).to be_valid
     @employee.reload
-    expect(@employee.comments).to eq('initial')
+    expect(@employee.comments).to eq("initial")
     @employee.comments = "changed"
     expect(@employee.save).to eq(true)
     @employee.reload
-    expect(@employee.comments).to eq('initial')
+    expect(@employee.comments).to eq("initial")
   end
 
   it "should work for serialized readonly CLOB columns", serialized: true do
     @employee = TestSerializeEmployee.new(
-      :first_name => "First",
-      :comments => nil
+      first_name: "First",
+      comments: nil
     )
     expect(@employee.comments).to be_nil
     expect(@employee.save).to eq(true)
@@ -880,9 +880,9 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
 
   it "should create record with CLOB data" do
     @employee = TestEmployee.create!(
-      :first_name => "First",
-      :last_name => "Last",
-      :comments => @char_data
+      first_name: "First",
+      last_name: "Last",
+      comments: @char_data
     )
     @employee.reload
     expect(@employee.comments).to eq(@char_data)
@@ -890,8 +890,8 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
 
   it "should update record with CLOB data" do
     @employee = TestEmployee.create!(
-      :first_name => "First",
-      :last_name => "Last"
+      first_name: "First",
+      last_name: "Last"
     )
     @employee.reload
     expect(@employee.comments).to be_nil
@@ -903,22 +903,22 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
 
   it "should update record with zero-length CLOB data" do
     @employee = TestEmployee.create!(
-      :first_name => "First",
-      :last_name => "Last"
+      first_name: "First",
+      last_name: "Last"
     )
     @employee.reload
     expect(@employee.comments).to be_nil
-    @employee.comments = ''
+    @employee.comments = ""
     @employee.save!
     @employee.reload
-    expect(@employee.comments).to eq('')
+    expect(@employee.comments).to eq("")
   end
 
   it "should update record that has existing CLOB data with different CLOB data" do
     @employee = TestEmployee.create!(
-      :first_name => "First",
-      :last_name => "Last",
-      :comments => @char_data
+      first_name: "First",
+      last_name: "Last",
+      comments: @char_data
     )
     @employee.reload
     @employee.comments = @char_data2
@@ -929,9 +929,9 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
 
   it "should update record that has existing CLOB data with nil" do
     @employee = TestEmployee.create!(
-      :first_name => "First",
-      :last_name => "Last",
-      :comments => @char_data
+      first_name: "First",
+      last_name: "Last",
+      comments: @char_data
     )
     @employee.reload
     @employee.comments = nil
@@ -942,25 +942,25 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
 
   it "should update record that has existing CLOB data with zero-length CLOB data" do
     @employee = TestEmployee.create!(
-      :first_name => "First",
-      :last_name => "Last",
-      :comments => @char_data
+      first_name: "First",
+      last_name: "Last",
+      comments: @char_data
     )
     @employee.reload
-    @employee.comments = ''
+    @employee.comments = ""
     @employee.save!
     @employee.reload
-    expect(@employee.comments).to eq('')
+    expect(@employee.comments).to eq("")
   end
 
   it "should update record that has zero-length CLOB data with non-empty CLOB data" do
     @employee = TestEmployee.create!(
-      :first_name => "First",
-      :last_name => "Last",
-      :comments => ''
+      first_name: "First",
+      last_name: "Last",
+      comments: ""
     )
     @employee.reload
-    expect(@employee.comments).to eq('')
+    expect(@employee.comments).to eq("")
     @employee.comments = @char_data
     @employee.save!
     @employee.reload
@@ -968,10 +968,10 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
   end
 
   it "should store serializable ruby data structures" do
-    ruby_data1 = {"arbitrary1" => ["ruby", :data, 123]}
-    ruby_data2 = {"arbitrary2" => ["ruby", :data, 123]}
+    ruby_data1 = { "arbitrary1" => ["ruby", :data, 123] }
+    ruby_data2 = { "arbitrary2" => ["ruby", :data, 123] }
     @employee = Test2Employee.create!(
-      :comments => ruby_data1
+      comments: ruby_data1
     )
     @employee.reload
     expect(@employee.comments).to eq(ruby_data1)
@@ -983,9 +983,9 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
 
   it "should keep unchanged serialized data when other columns changed" do
     @employee = Test2Employee.create!(
-      :first_name => "First",
-      :last_name => "Last",
-      :comments => "initial serialized data"
+      first_name: "First",
+      last_name: "Last",
+      comments: "initial serialized data"
     )
     @employee.first_name = "Steve"
     @employee.save
@@ -995,14 +995,14 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
 
   it "should keep serialized data after save" do
     @employee = Test2Employee.new
-    @employee.comments = {:length=>{:is=>1}}
+    @employee.comments = { length: { is: 1 } }
     @employee.save
     @employee.reload
-    expect(@employee.comments).to eq({:length=>{:is=>1}})
-    @employee.comments = {:length=>{:is=>2}}
+    expect(@employee.comments).to eq(length: { is: 1 })
+    @employee.comments = { length: { is: 2 } }
     @employee.save
     @employee.reload
-    expect(@employee.comments).to eq({:length=>{:is=>2}})
+    expect(@employee.comments).to eq(length: { is: 2 })
   end
 end
 
@@ -1022,8 +1022,8 @@ describe "OracleEnhancedAdapter handling of BLOB columns" do
       CREATE SEQUENCE test_employees_seq  MINVALUE 1
         INCREMENT BY 1 CACHE 20 NOORDER NOCYCLE
     SQL
-    @binary_data = "\0\1\2\3\4\5\6\7\8\9"*10000
-    @binary_data2 = "\1\2\3\4\5\6\7\8\9\0"*10000
+    @binary_data = "\0\1\2\3\4\5\6\7\8\9" * 10000
+    @binary_data2 = "\1\2\3\4\5\6\7\8\9\0" * 10000
   end
 
   after(:all) do
@@ -1044,9 +1044,9 @@ describe "OracleEnhancedAdapter handling of BLOB columns" do
 
   it "should create record with BLOB data" do
     @employee = TestEmployee.create!(
-      :first_name => "First",
-      :last_name => "Last",
-      :binary_data => @binary_data
+      first_name: "First",
+      last_name: "Last",
+      binary_data: @binary_data
     )
     @employee.reload
     expect(@employee.binary_data).to eq(@binary_data)
@@ -1054,8 +1054,8 @@ describe "OracleEnhancedAdapter handling of BLOB columns" do
 
   it "should update record with BLOB data" do
     @employee = TestEmployee.create!(
-      :first_name => "First",
-      :last_name => "Last"
+      first_name: "First",
+      last_name: "Last"
     )
     @employee.reload
     expect(@employee.binary_data).to be_nil
@@ -1067,22 +1067,22 @@ describe "OracleEnhancedAdapter handling of BLOB columns" do
 
   it "should update record with zero-length BLOB data" do
     @employee = TestEmployee.create!(
-      :first_name => "First",
-      :last_name => "Last"
+      first_name: "First",
+      last_name: "Last"
     )
     @employee.reload
     expect(@employee.binary_data).to be_nil
-    @employee.binary_data = ''
+    @employee.binary_data = ""
     @employee.save!
     @employee.reload
-    expect(@employee.binary_data).to eq('')
+    expect(@employee.binary_data).to eq("")
   end
 
   it "should update record that has existing BLOB data with different BLOB data" do
     @employee = TestEmployee.create!(
-      :first_name => "First",
-      :last_name => "Last",
-      :binary_data => @binary_data
+      first_name: "First",
+      last_name: "Last",
+      binary_data: @binary_data
     )
     @employee.reload
     @employee.binary_data = @binary_data2
@@ -1093,9 +1093,9 @@ describe "OracleEnhancedAdapter handling of BLOB columns" do
 
   it "should update record that has existing BLOB data with nil" do
     @employee = TestEmployee.create!(
-      :first_name => "First",
-      :last_name => "Last",
-      :binary_data => @binary_data
+      first_name: "First",
+      last_name: "Last",
+      binary_data: @binary_data
     )
     @employee.reload
     @employee.binary_data = nil
@@ -1106,25 +1106,25 @@ describe "OracleEnhancedAdapter handling of BLOB columns" do
 
   it "should update record that has existing BLOB data with zero-length BLOB data" do
     @employee = TestEmployee.create!(
-      :first_name => "First",
-      :last_name => "Last",
-      :binary_data => @binary_data
+      first_name: "First",
+      last_name: "Last",
+      binary_data: @binary_data
     )
     @employee.reload
-    @employee.binary_data = ''
+    @employee.binary_data = ""
     @employee.save!
     @employee.reload
-    expect(@employee.binary_data).to eq('')
+    expect(@employee.binary_data).to eq("")
   end
 
   it "should update record that has zero-length BLOB data with non-empty BLOB data" do
     @employee = TestEmployee.create!(
-      :first_name => "First",
-      :last_name => "Last",
-      :binary_data => ''
+      first_name: "First",
+      last_name: "Last",
+      binary_data: ""
     )
     @employee.reload
-    expect(@employee.binary_data).to eq('')
+    expect(@employee.binary_data).to eq("")
     @employee.binary_data = @binary_data
     @employee.save!
     @employee.reload
@@ -1148,8 +1148,8 @@ describe "OracleEnhancedAdapter handling of RAW columns" do
       CREATE SEQUENCE test_employees_seq  MINVALUE 1
         INCREMENT BY 1 CACHE 20 NOORDER NOCYCLE
     SQL
-    @binary_data = "\0\1\2\3\4\5\6\7\8\9"*100
-    @binary_data2 = "\1\2\3\4\5\6\7\8\9\0"*100
+    @binary_data = "\0\1\2\3\4\5\6\7\8\9" * 100
+    @binary_data2 = "\1\2\3\4\5\6\7\8\9\0" * 100
   end
 
   after(:all) do
@@ -1170,9 +1170,9 @@ describe "OracleEnhancedAdapter handling of RAW columns" do
 
   it "should create record with RAW data" do
     @employee = TestEmployee.create!(
-      :first_name => "First",
-      :last_name => "Last",
-      :binary_data => @binary_data
+      first_name: "First",
+      last_name: "Last",
+      binary_data: @binary_data
     )
     @employee.reload
     expect(@employee.binary_data).to eq(@binary_data)
@@ -1180,8 +1180,8 @@ describe "OracleEnhancedAdapter handling of RAW columns" do
 
   it "should update record with RAW data" do
     @employee = TestEmployee.create!(
-      :first_name => "First",
-      :last_name => "Last"
+      first_name: "First",
+      last_name: "Last"
     )
     @employee.reload
     expect(@employee.binary_data).to be_nil
@@ -1193,12 +1193,12 @@ describe "OracleEnhancedAdapter handling of RAW columns" do
 
   it "should update record with zero-length RAW data" do
     @employee = TestEmployee.create!(
-      :first_name => "First",
-      :last_name => "Last"
+      first_name: "First",
+      last_name: "Last"
     )
     @employee.reload
     expect(@employee.binary_data).to be_nil
-    @employee.binary_data = ''
+    @employee.binary_data = ""
     @employee.save!
     @employee.reload
     expect(@employee.binary_data).to be_nil
@@ -1206,9 +1206,9 @@ describe "OracleEnhancedAdapter handling of RAW columns" do
 
   it "should update record that has existing RAW data with different RAW data" do
     @employee = TestEmployee.create!(
-      :first_name => "First",
-      :last_name => "Last",
-      :binary_data => @binary_data
+      first_name: "First",
+      last_name: "Last",
+      binary_data: @binary_data
     )
     @employee.reload
     @employee.binary_data = @binary_data2
@@ -1219,9 +1219,9 @@ describe "OracleEnhancedAdapter handling of RAW columns" do
 
   it "should update record that has existing RAW data with nil" do
     @employee = TestEmployee.create!(
-      :first_name => "First",
-      :last_name => "Last",
-      :binary_data => @binary_data
+      first_name: "First",
+      last_name: "Last",
+      binary_data: @binary_data
     )
     @employee.reload
     @employee.binary_data = nil
@@ -1232,12 +1232,12 @@ describe "OracleEnhancedAdapter handling of RAW columns" do
 
   it "should update record that has existing RAW data with zero-length RAW data" do
     @employee = TestEmployee.create!(
-      :first_name => "First",
-      :last_name => "Last",
-      :binary_data => @binary_data
+      first_name: "First",
+      last_name: "Last",
+      binary_data: @binary_data
     )
     @employee.reload
-    @employee.binary_data = ''
+    @employee.binary_data = ""
     @employee.save!
     @employee.reload
     expect(@employee.binary_data).to be_nil
@@ -1245,9 +1245,9 @@ describe "OracleEnhancedAdapter handling of RAW columns" do
 
   it "should update record that has zero-length BLOB data with non-empty RAW data" do
     @employee = TestEmployee.create!(
-      :first_name => "First",
-      :last_name => "Last",
-      :binary_data => ''
+      first_name: "First",
+      last_name: "Last",
+      binary_data: ""
     )
     @employee.reload
     @employee.binary_data = @binary_data
@@ -1289,23 +1289,23 @@ describe "OracleEnhancedAdapter quoting of NCHAR and NVARCHAR2 columns" do
   end
 
   it "should quote with N prefix" do
-    columns = @conn.columns('test_items')
+    columns = @conn.columns("test_items")
     %w(nchar_column nvarchar2_column char_column varchar2_column).each do |col|
-      column = columns.detect{|c| c.name == col}
-      value = @conn.type_cast_from_column(column, 'abc')
-      expect(@conn.quote(value)).to eq(column.sql_type[0,1] == 'N' ? "N'abc'" : "'abc'")
+      column = columns.detect { |c| c.name == col }
+      value = @conn.type_cast_from_column(column, "abc")
+      expect(@conn.quote(value)).to eq(column.sql_type[0, 1] == "N" ? "N'abc'" : "'abc'")
       nilvalue = @conn.type_cast_from_column(column, nil)
-      expect(@conn.quote(nilvalue)).to eq('NULL')
+      expect(@conn.quote(nilvalue)).to eq("NULL")
     end
   end
 
   it "should create record" do
-    nchar_data = 'āčē'
+    nchar_data = "āčē"
     item = TestItem.create(
-      :nchar_column => nchar_data,
-      :nvarchar2_column => nchar_data
+      nchar_column: nchar_data,
+      nvarchar2_column: nchar_data
     ).reload
-    expect(item.nchar_column).to eq(nchar_data + ' '*17)
+    expect(item.nchar_column).to eq(nchar_data + " " * 17)
     expect(item.nvarchar2_column).to eq(nchar_data)
   end
 
@@ -1347,8 +1347,8 @@ describe "OracleEnhancedAdapter handling of BINARY_FLOAT columns" do
   end
 
   it "should set BINARY_FLOAT column type as float" do
-    columns = @conn.columns('test2_employees')
-    column = columns.detect{|c| c.name == "hourly_rate"}
+    columns = @conn.columns("test2_employees")
+    column = columns.detect { |c| c.name == "hourly_rate" }
     expect(column.type).to eq(:float)
   end
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced_database_tasks_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_database_tasks_spec.rb
@@ -1,13 +1,13 @@
-require 'spec_helper'
-require 'active_record/connection_adapters/oracle_enhanced/database_tasks'
-require 'stringio'
-require 'tempfile'
+require "spec_helper"
+require "active_record/connection_adapters/oracle_enhanced/database_tasks"
+require "stringio"
+require "tempfile"
 
 describe "Oracle Enhanced adapter database tasks" do
   let(:config) { CONNECTION_PARAMS.with_indifferent_access }
 
   describe "create" do
-    let(:new_user_config) { config.merge({username: "oracle_enhanced_test_user"}) }
+    let(:new_user_config) { config.merge(username: "oracle_enhanced_test_user") }
     before do
       fake_terminal(SYSTEM_CONNECTION_PARAMS[:password]) do
         ActiveRecord::Tasks::DatabaseTasks.create(new_user_config)
@@ -75,7 +75,7 @@ describe "Oracle Enhanced adapter database tasks" do
         it "dumps the database structure to a file without the schema information" do
           contents = File.read(temp_file)
           expect(contents).to include('CREATE TABLE "TEST_POSTS"')
-          expect(contents).not_to include('INSERT INTO schema_migrations')
+          expect(contents).not_to include("INSERT INTO schema_migrations")
         end
       end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_dbms_output_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_dbms_output_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe "OracleEnhancedAdapter logging dbms_output from plsql" do
   include LoggerSpecHelper
@@ -42,7 +42,7 @@ describe "OracleEnhancedAdapter logging dbms_output from plsql" do
   it "should NOT log dbms output when dbms output is disabled" do
     @conn.disable_dbms_output
 
-    expect(@conn.select_all("select more_than_five_characters_long('hi there') is_it_long from dual").to_a).to eq([{'is_it_long'=>1}])
+    expect(@conn.select_all("select more_than_five_characters_long('hi there') is_it_long from dual").to_a).to eq([{ "is_it_long" => 1 }])
 
     expect(@logger.output(:debug)).not_to match(/^DBMS_OUTPUT/)
   end
@@ -50,7 +50,7 @@ describe "OracleEnhancedAdapter logging dbms_output from plsql" do
   it "should log dbms output lines to the rails log" do
     @conn.enable_dbms_output
 
-    expect(@conn.select_all("select more_than_five_characters_long('hi there') is_it_long from dual").to_a).to eq([{'is_it_long'=>1}])
+    expect(@conn.select_all("select more_than_five_characters_long('hi there') is_it_long from dual").to_a).to eq([{ "is_it_long" => 1 }])
 
     expect(@logger.output(:debug)).to match(/^DBMS_OUTPUT: before the if -hi there-$/)
     expect(@logger.output(:debug)).to match(/^DBMS_OUTPUT: it is longer than 5$/)
@@ -60,7 +60,7 @@ describe "OracleEnhancedAdapter logging dbms_output from plsql" do
   it "should log dbms output lines to the rails log" do
     @conn.enable_dbms_output
 
-    expect(@conn.select_all("select more_than_five_characters_long('short') is_it_long from dual").to_a).to eq([{'is_it_long'=>0}])
+    expect(@conn.select_all("select more_than_five_characters_long('short') is_it_long from dual").to_a).to eq([{ "is_it_long" => 0 }])
 
     expect(@logger.output(:debug)).to match(/^DBMS_OUTPUT: before the if -short-$/)
     expect(@logger.output(:debug)).to match(/^DBMS_OUTPUT: it is 5 or shorter$/)

--- a/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 if ActiveRecord::Base.method_defined?(:changed?)
 
@@ -8,11 +8,11 @@ if ActiveRecord::Base.method_defined?(:changed?)
     before(:all) do
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
       schema_define do
-        create_table :test_employees, :force => true do |t|
+        create_table :test_employees, force: true do |t|
           t.string    :first_name,  limit: 20
           t.string    :last_name,   limit: 25
           t.integer   :job_id,      limit: 6, null: true
-          t.decimal   :salary,      precision: 8, scale:2
+          t.decimal   :salary,      precision: 8, scale: 2
           t.text      :comments
           t.date      :hire_date
         end
@@ -31,34 +31,34 @@ if ActiveRecord::Base.method_defined?(:changed?)
     end
 
     it "should not mark empty string (stored as NULL) as changed when reassigning it" do
-      @employee = TestEmployee.create!(:first_name => '')
-      @employee.first_name = ''
+      @employee = TestEmployee.create!(first_name: "")
+      @employee.first_name = ""
       expect(@employee).not_to be_changed
       @employee.reload
-      @employee.first_name = ''
+      @employee.first_name = ""
       expect(@employee).not_to be_changed
     end
 
     it "should not mark empty integer (stored as NULL) as changed when reassigning it" do
-      @employee = TestEmployee.create!(:job_id => '')
-      @employee.job_id = ''
+      @employee = TestEmployee.create!(job_id: "")
+      @employee.job_id = ""
       expect(@employee).not_to be_changed
       @employee.reload
-      @employee.job_id = ''
+      @employee.job_id = ""
       expect(@employee).not_to be_changed
     end
 
     it "should not mark empty decimal (stored as NULL) as changed when reassigning it" do
-      @employee = TestEmployee.create!(:salary => '')
-      @employee.salary = ''
+      @employee = TestEmployee.create!(salary: "")
+      @employee.salary = ""
       expect(@employee).not_to be_changed
       @employee.reload
-      @employee.salary = ''
+      @employee.salary = ""
       expect(@employee).not_to be_changed
     end
 
     it "should not mark empty text (stored as NULL) as changed when reassigning it" do
-      @employee = TestEmployee.create!(:comments => nil)
+      @employee = TestEmployee.create!(comments: nil)
       @employee.comments = nil
       expect(@employee).not_to be_changed
       @employee.reload
@@ -67,16 +67,16 @@ if ActiveRecord::Base.method_defined?(:changed?)
     end
 
     it "should not mark empty text (stored as empty_clob()) as changed when reassigning it" do
-      @employee = TestEmployee.create!(:comments => '')
-      @employee.comments = ''
+      @employee = TestEmployee.create!(comments: "")
+      @employee.comments = ""
       expect(@employee).not_to be_changed
       @employee.reload
-      @employee.comments = ''
+      @employee.comments = ""
       expect(@employee).not_to be_changed
     end
 
     it "should mark empty text (stored as empty_clob()) as changed when assigning nil to it" do
-      @employee = TestEmployee.create!(:comments => '')
+      @employee = TestEmployee.create!(comments: "")
       @employee.comments = nil
       expect(@employee).to be_changed
       @employee.reload
@@ -85,20 +85,20 @@ if ActiveRecord::Base.method_defined?(:changed?)
     end
 
     it "should mark empty text (stored as NULL) as changed when assigning '' to it" do
-      @employee = TestEmployee.create!(:comments => nil)
-      @employee.comments = ''
+      @employee = TestEmployee.create!(comments: nil)
+      @employee.comments = ""
       expect(@employee).to be_changed
       @employee.reload
-      @employee.comments = ''
+      @employee.comments = ""
       expect(@employee).to be_changed
     end
 
     it "should not mark empty date (stored as NULL) as changed when reassigning it" do
-      @employee = TestEmployee.create!(:hire_date => '')
-      @employee.hire_date = ''
+      @employee = TestEmployee.create!(hire_date: "")
+      @employee.hire_date = ""
       expect(@employee).not_to be_changed
       @employee.reload
-      @employee.hire_date = ''
+      @employee.hire_date = ""
       expect(@employee).not_to be_changed
     end
 
@@ -109,30 +109,30 @@ if ActiveRecord::Base.method_defined?(:changed?)
 
       expect(@employee).not_to be_changed
 
-      @employee.job_id = '0'
+      @employee.job_id = "0"
       expect(@employee).not_to be_changed
     end
 
     it "should not update unchanged CLOBs" do
       @employee = TestEmployee.create!(
-          :comments => "initial"
+          comments: "initial"
       )
       expect(@employee.save!).to be_truthy
       @employee.reload
-      expect(@employee.comments).to eq('initial')
+      expect(@employee.comments).to eq("initial")
 
-      oci_conn = @conn.instance_variable_get('@connection')
+      oci_conn = @conn.instance_variable_get("@connection")
       class << oci_conn
          def write_lob(lob, value, is_binary = false); raise "don't do this'"; end
       end
-      expect{@employee.save!}.not_to raise_exception(RuntimeError, "don't do this'")
+      expect { @employee.save! }.not_to raise_exception(RuntimeError, "don't do this'")
       class << oci_conn
         remove_method :write_lob
       end
     end
 
     it "should be able to handle attributes which are not backed by a column" do
-      TestEmployee.create!(:comments => "initial")
+      TestEmployee.create!(comments: "initial")
       @employee = TestEmployee.select("#{TestEmployee.quoted_table_name}.*, 24 ranking").first
       expect { @employee.ranking = 25 }.to_not raise_error
     end

--- a/spec/active_record/connection_adapters/oracle_enhanced_emulate_oracle_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_emulate_oracle_adapter_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe "OracleEnhancedAdapter emulate OracleAdapter" do
 
@@ -10,7 +10,7 @@ describe "OracleEnhancedAdapter emulate OracleAdapter" do
   end
 
   it "should be an OracleAdapter" do
-    @conn = ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(:emulate_oracle_adapter => true))
+    @conn = ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(emulate_oracle_adapter: true))
     expect(ActiveRecord::Base.connection).not_to be_nil
     expect(ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::OracleAdapter)).to be_truthy
   end

--- a/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
@@ -1,6 +1,6 @@
-require 'spec_helper'
+require "spec_helper"
 
-require 'ruby-plsql'
+require "ruby-plsql"
 
 describe "OracleEnhancedAdapter custom methods for create, update and destroy" do
   include LoggerSpecHelper
@@ -114,42 +114,42 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
       # should return ID of new record
       set_create_method do
         plsql.test_employees_pkg.create_employee(
-          :p_first_name => first_name,
-          :p_last_name => last_name,
-          :p_hire_date => hire_date,
-          :p_salary => salary,
-          :p_description => "#{first_name} #{last_name}",
-          :p_employee_id => nil
+          p_first_name: first_name,
+          p_last_name: last_name,
+          p_hire_date: hire_date,
+          p_salary: salary,
+          p_description: "#{first_name} #{last_name}",
+          p_employee_id: nil
         )[:p_employee_id]
       end
 
       # return value is ignored
       set_update_method do
         plsql.test_employees_pkg.update_employee(
-          :p_employee_id => id,
-          :p_first_name => first_name,
-          :p_last_name => last_name,
-          :p_hire_date => hire_date,
-          :p_salary => salary,
-          :p_description => "#{first_name} #{last_name}"
+          p_employee_id: id,
+          p_first_name: first_name,
+          p_last_name: last_name,
+          p_hire_date: hire_date,
+          p_salary: salary,
+          p_description: "#{first_name} #{last_name}"
         )
       end
 
       # return value is ignored
       set_delete_method do
         plsql.test_employees_pkg.delete_employee(
-          :p_employee_id => id
+          p_employee_id: id
         )
       end
 
       private
 
-      def raise_make_transaction_rollback
-        raise "Make the transaction rollback"
-      end
+        def raise_make_transaction_rollback
+          raise "Make the transaction rollback"
+        end
     end
 
-    @today = Date.new(2008,6,28)
+    @today = Date.new(2008, 6, 28)
     @buffer = StringIO.new
   end
 
@@ -160,9 +160,9 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
 
   it "should create record" do
     @employee = TestEmployee.create(
-      :first_name => "First",
-      :last_name => "Last",
-      :hire_date => @today
+      first_name: "First",
+      last_name: "Last",
+      hire_date: @today
     )
     @employee.reload
     expect(@employee.first_name).to eq("First")
@@ -177,9 +177,9 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
     TestEmployee.after_create :raise_make_transaction_rollback
 
     @employee = TestEmployee.new(
-      :first_name => "First",
-      :last_name => "Last",
-      :hire_date => @today
+      first_name: "First",
+      last_name: "Last",
+      hire_date: @today
     )
     employees_count = TestEmployee.count
     expect {
@@ -191,10 +191,10 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
 
   it "should update record" do
     @employee = TestEmployee.create(
-      :first_name => "First",
-      :last_name => "Last",
-      :hire_date => @today,
-      :description => "description"
+      first_name: "First",
+      last_name: "Last",
+      hire_date: @today,
+      description: "description"
     )
     @employee.reload
     @employee.first_name = "Second"
@@ -207,10 +207,10 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
     TestEmployee.after_update :raise_make_transaction_rollback
 
     @employee = TestEmployee.create(
-      :first_name => "First",
-      :last_name => "Last",
-      :hire_date => @today,
-      :description => "description"
+      first_name: "First",
+      last_name: "Last",
+      hire_date: @today,
+      description: "description"
     )
     empl_id = @employee.id
     @employee.reload
@@ -225,9 +225,9 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
   it "should not update record if nothing is changed and partial writes are enabled" do
     TestEmployee.partial_writes = true
     @employee = TestEmployee.create(
-      :first_name => "First",
-      :last_name => "Last",
-      :hire_date => @today
+      first_name: "First",
+      last_name: "Last",
+      hire_date: @today
     )
     @employee.reload
     @employee.save!
@@ -238,9 +238,9 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
   it "should update record if nothing is changed and partial writes are disabled" do
     TestEmployee.partial_writes = false
     @employee = TestEmployee.create(
-      :first_name => "First",
-      :last_name => "Last",
-      :hire_date => @today
+      first_name: "First",
+      last_name: "Last",
+      hire_date: @today
     )
     @employee.reload
     @employee.save!
@@ -250,9 +250,9 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
 
   it "should delete record" do
     @employee = TestEmployee.create(
-      :first_name => "First",
-      :last_name => "Last",
-      :hire_date => @today
+      first_name: "First",
+      last_name: "Last",
+      hire_date: @today
     )
     @employee.reload
     empl_id = @employee.id
@@ -263,9 +263,9 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
 
   it "should delete record and set destroyed flag" do
     @employee = TestEmployee.create(
-      :first_name => "First",
-      :last_name => "Last",
-      :hire_date => @today
+      first_name: "First",
+      last_name: "Last",
+      hire_date: @today
     )
     @employee.reload
     @employee.destroy
@@ -277,9 +277,9 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
     TestEmployee.after_destroy :raise_make_transaction_rollback
 
     @employee = TestEmployee.create(
-      :first_name => "First",
-      :last_name => "Last",
-      :hire_date => @today
+      first_name: "First",
+      last_name: "Last",
+      hire_date: @today
     )
     @employee.reload
     empl_id = @employee.id
@@ -293,9 +293,9 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
 
   it "should set timestamps when creating record" do
     @employee = TestEmployee.create(
-      :first_name => "First",
-      :last_name => "Last",
-      :hire_date => @today
+      first_name: "First",
+      last_name: "Last",
+      hire_date: @today
     )
     expect(@employee.created_at).not_to be_nil
     expect(@employee.updated_at).not_to be_nil
@@ -303,9 +303,9 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
 
   it "should set timestamps when updating record" do
     @employee = TestEmployee.create(
-      :first_name => "First",
-      :last_name => "Last",
-      :hire_date => @today
+      first_name: "First",
+      last_name: "Last",
+      hire_date: @today
     )
     @employee.reload
     expect(@employee.created_at).to be_nil
@@ -319,9 +319,9 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
   it "should log create record" do
     set_logger
     @employee = TestEmployee.create(
-      :first_name => "First",
-      :last_name => "Last",
-      :hire_date => @today
+      first_name: "First",
+      last_name: "Last",
+      hire_date: @today
     )
     expect(@logger.logged(:debug).last).to match(/^TestEmployee Create \(\d+\.\d+(ms)?\)  custom create method$/)
     clear_logger
@@ -330,9 +330,9 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
   it "should log update record" do
     (TestEmployee.partial_writes = false) rescue nil
     @employee = TestEmployee.create(
-      :first_name => "First",
-      :last_name => "Last",
-      :hire_date => @today
+      first_name: "First",
+      last_name: "Last",
+      hire_date: @today
     )
     set_logger
     @employee.save!
@@ -342,9 +342,9 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
 
   it "should log delete record" do
     @employee = TestEmployee.create(
-      :first_name => "First",
-      :last_name => "Last",
-      :hire_date => @today
+      first_name: "First",
+      last_name: "Last",
+      hire_date: @today
     )
     set_logger
     @employee.destroy
@@ -354,8 +354,8 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
 
   it "should validate new record before creation" do
     @employee = TestEmployee.new(
-      :last_name => "Last",
-      :hire_date => @today
+      last_name: "Last",
+      hire_date: @today
     )
     expect(@employee.save).to be_falsey
     expect(@employee.errors[:first_name]).not_to be_blank
@@ -363,9 +363,9 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
 
   it "should validate existing record before update" do
     @employee = TestEmployee.create(
-      :first_name => "First",
-      :last_name => "Last",
-      :hire_date => @today
+      first_name: "First",
+      last_name: "Last",
+      hire_date: @today
     )
     @employee.first_name = nil
     expect(@employee.save).to be_falsey

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe "OracleEnhancedAdapter schema dump" do
   include SchemaSpecHelper
@@ -12,7 +12,7 @@ describe "OracleEnhancedAdapter schema dump" do
 
   def standard_dump(options = {})
     stream = StringIO.new
-    ActiveRecord::SchemaDumper.ignore_tables = options[:ignore_tables]||[]
+    ActiveRecord::SchemaDumper.ignore_tables = options[:ignore_tables] || []
     ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, stream)
     stream.string
   end
@@ -78,42 +78,42 @@ describe "OracleEnhancedAdapter schema dump" do
       drop_test_posts_table
       @conn.drop_table(ActiveRecord::Migrator.schema_migrations_table_name) if @conn.data_source_exists?(ActiveRecord::Migrator.schema_migrations_table_name)
       @conn.drop_table(ActiveRecord::InternalMetadata.table_name) if @conn.data_source_exists?(ActiveRecord::InternalMetadata.table_name)
-      ActiveRecord::Base.table_name_prefix = ''
-      ActiveRecord::Base.table_name_suffix = ''
+      ActiveRecord::Base.table_name_prefix = ""
+      ActiveRecord::Base.table_name_suffix = ""
     end
 
     it "should remove table prefix in schema dump" do
-      ActiveRecord::Base.table_name_prefix = 'xxx_'
+      ActiveRecord::Base.table_name_prefix = "xxx_"
       create_test_posts_table
       expect(standard_dump).to match(/create_table "test_posts".*add_index "test_posts"/m)
     end
 
     it "should remove table prefix with $ sign in schema dump" do
-      ActiveRecord::Base.table_name_prefix = 'xxx$'
+      ActiveRecord::Base.table_name_prefix = "xxx$"
       create_test_posts_table
       expect(standard_dump).to match(/create_table "test_posts".*add_index "test_posts"/m)
     end
 
     it "should remove table suffix in schema dump" do
-      ActiveRecord::Base.table_name_suffix = '_xxx'
+      ActiveRecord::Base.table_name_suffix = "_xxx"
       create_test_posts_table
       expect(standard_dump).to match(/create_table "test_posts".*add_index "test_posts"/m)
     end
 
     it "should remove table suffix with $ sign in schema dump" do
-      ActiveRecord::Base.table_name_suffix = '$xxx'
+      ActiveRecord::Base.table_name_suffix = "$xxx"
       create_test_posts_table
       expect(standard_dump).to match(/create_table "test_posts".*add_index "test_posts"/m)
     end
 
     it "should not include schema_migrations table with prefix in schema dump" do
-      ActiveRecord::Base.table_name_prefix = 'xxx_'
+      ActiveRecord::Base.table_name_prefix = "xxx_"
       @conn.initialize_schema_migrations_table
       expect(standard_dump).not_to match(/schema_migrations/)
     end
 
     it "should not include schema_migrations table with suffix in schema dump" do
-      ActiveRecord::Base.table_name_suffix = '_xxx'
+      ActiveRecord::Base.table_name_suffix = "_xxx"
       @conn.initialize_schema_migrations_table
       expect(standard_dump).not_to match(/schema_migrations/)
     end
@@ -126,7 +126,7 @@ describe "OracleEnhancedAdapter schema dump" do
     end
 
     it "should include non-default primary key in schema dump" do
-      create_test_posts_table(primary_key: 'post_id')
+      create_test_posts_table(primary_key: "post_id")
       expect(standard_dump).to match(/create_table "test_posts", primary_key: "post_id"/)
     end
 
@@ -145,7 +145,7 @@ describe "OracleEnhancedAdapter schema dump" do
     end
 
     it "should include primary key trigger with non-default primary key in schema dump" do
-      create_test_posts_table(primary_key_trigger: true, primary_key: 'post_id')
+      create_test_posts_table(primary_key_trigger: true, primary_key: "post_id")
       expect(standard_dump).to match(/create_table "test_posts", primary_key: "post_id".*add_primary_key_trigger "test_posts", primary_key: "post_id"/m)
     end
 
@@ -167,7 +167,7 @@ describe "OracleEnhancedAdapter schema dump" do
     after(:each) do
       schema_define do
         remove_foreign_key :test_comments, :test_posts rescue nil
-        remove_foreign_key :test_comments, name: 'comments_posts_baz_fooz_fk' rescue nil
+        remove_foreign_key :test_comments, name: "comments_posts_baz_fooz_fk" rescue nil
       end
     end
     after(:all) do
@@ -238,7 +238,7 @@ describe "OracleEnhancedAdapter schema dump" do
 
     it "should include primary_key when reference column name is not 'id'" do
       schema_define do
-        create_table :test_posts, force: true, :primary_key => 'baz_id' do |t|
+        create_table :test_posts, force: true, primary_key: "baz_id" do |t|
           t.string :title
         end
         create_table :test_comments, force: true do |t|
@@ -324,7 +324,7 @@ describe "OracleEnhancedAdapter schema dump" do
 
     it "should specify non-default tablespace in add index" do
       tablespace_name = @conn.default_tablespace
-      allow(@conn).to receive(:default_tablespace).and_return('dummy')
+      allow(@conn).to receive(:default_tablespace).and_return("dummy")
       create_test_posts_table
       expect(standard_dump).to match(/add_index "test_posts", \["title"\], name: "index_test_posts_on_title", tablespace: "#{tablespace_name}"$/)
     end
@@ -350,19 +350,19 @@ describe "OracleEnhancedAdapter schema dump" do
     end
   end
 
-  describe 'virtual columns' do
+  describe "virtual columns" do
     before(:all) do
       skip "Not supported in this database version" unless @oracle11g_or_higher
       schema_define do
-        create_table :test_names, :force => true do |t|
+        create_table :test_names, force: true do |t|
           t.string :first_name
           t.string :last_name
-          t.virtual :full_name,       :as => "first_name || ', ' || last_name"
-          t.virtual :short_name,      :as => "COALESCE(first_name, last_name)", :type => :string, :limit => 300
-          t.virtual :abbrev_name,     :as => "SUBSTR(first_name,1,50) || ' ' || SUBSTR(last_name,1,1) || '.'", :type => "VARCHAR(100)"
-          t.virtual :name_ratio,      :as => '(LENGTH(first_name)*10/LENGTH(last_name)*10)'
-          t.column :full_name_length, :virtual, :as => "length(first_name || ', ' || last_name)", :type => :integer
-          t.virtual :field_with_leading_space, :as => "' ' || first_name || ' '", :limit => 300, :type => :string
+          t.virtual :full_name,       as: "first_name || ', ' || last_name"
+          t.virtual :short_name,      as: "COALESCE(first_name, last_name)", type: :string, limit: 300
+          t.virtual :abbrev_name,     as: "SUBSTR(first_name,1,50) || ' ' || SUBSTR(last_name,1,1) || '.'", type: "VARCHAR(100)"
+          t.virtual :name_ratio,      as: "(LENGTH(first_name)*10/LENGTH(last_name)*10)"
+          t.column :full_name_length, :virtual, as: "length(first_name || ', ' || last_name)", type: :integer
+          t.virtual :field_with_leading_space, as: "' ' || first_name || ' '", limit: 300, type: :string
         end
       end
     end
@@ -383,7 +383,7 @@ describe "OracleEnhancedAdapter schema dump" do
       end
     end
 
-    it 'should dump correctly' do
+    it "should dump correctly" do
       expect(standard_dump).to match(/t\.virtual "full_name",(\s*)limit: 512,(\s*)as: "\\"FIRST_NAME\\"\|\|', '\|\|\\"LAST_NAME\\"",(\s*)type: :string/)
       expect(standard_dump).to match(/t\.virtual "short_name",(\s*)limit: 300,(\s*)as:(.*),(\s*)type: :string/)
       expect(standard_dump).to match(/t\.virtual "full_name_length",(\s*)precision: 38,(\s*)as:(.*),(\s*)type: :integer/)
@@ -392,7 +392,7 @@ describe "OracleEnhancedAdapter schema dump" do
       expect(standard_dump).to match(/t\.virtual "field_with_leading_space",(\s*)limit: 300,(\s*)as: "' '\|\|\\"FIRST_NAME\\"\|\|' '",(\s*)type: :string/)
     end
 
-    context 'with column cache' do
+    context "with column cache" do
       before(:all) do
         @old_cache = ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.cache_columns
         ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.cache_columns = true
@@ -400,8 +400,8 @@ describe "OracleEnhancedAdapter schema dump" do
       after(:all) do
         ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.cache_columns = @old_cache
       end
-      it 'should not change column defaults after several dumps' do
-        col = TestName.columns.detect{|c| c.name == 'full_name'}
+      it "should not change column defaults after several dumps" do
+        col = TestName.columns.detect { |c| c.name == "full_name" }
         expect(col).not_to be_nil
         expect(col.virtual_column_data_default).not_to match(/:as/)
 
@@ -417,18 +417,18 @@ describe "OracleEnhancedAdapter schema dump" do
       before(:all) do
         if @oracle11g_or_higher
           schema_define do
-            add_index 'test_names', 'field_with_leading_space', :name => "index_on_virtual_col"
+            add_index "test_names", "field_with_leading_space", name: "index_on_virtual_col"
           end
         end
       end
       after(:all) do
         if @oracle11g_or_higher
           schema_define do
-            remove_index 'test_names', :name => 'index_on_virtual_col'
+            remove_index "test_names", name: "index_on_virtual_col"
           end
         end
       end
-      it 'should dump correctly' do
+      it "should dump correctly" do
         expect(standard_dump).not_to match(/add_index "test_names".+FIRST_NAME.+$/)
         expect(standard_dump).to     match(/add_index "test_names".+field_with_leading_space.+$/)
       end
@@ -458,7 +458,7 @@ describe "OracleEnhancedAdapter schema dump" do
   describe "table comments" do
     before(:each) do
       schema_define do
-        create_table :test_table_comments, :comment => "this is a \"table comment\"!", force: true do |t|
+        create_table :test_table_comments, comment: "this is a \"table comment\"!", force: true do |t|
           t.string :blah
         end
       end
@@ -479,7 +479,7 @@ describe "OracleEnhancedAdapter schema dump" do
     before(:each) do
       schema_define do
         create_table :test_column_comments, force: true do |t|
-          t.string :blah, :comment => "this is a \"column comment\"!"
+          t.string :blah, comment: "this is a \"column comment\"!"
         end
       end
     end
@@ -498,7 +498,7 @@ describe "OracleEnhancedAdapter schema dump" do
   describe "table comments" do
     before(:each) do
       schema_define do
-        create_table :test_table_comments, :comment => "this is a \"table comment\"!", force: true do |t|
+        create_table :test_table_comments, comment: "this is a \"table comment\"!", force: true do |t|
           t.string :blah
         end
       end
@@ -519,7 +519,7 @@ describe "OracleEnhancedAdapter schema dump" do
     before(:each) do
       schema_define do
         create_table :test_column_comments, force: true do |t|
-          t.string :blah, :comment => "this is a \"column comment\"!"
+          t.string :blah, comment: "this is a \"column comment\"!"
         end
       end
     end

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe "OracleEnhancedAdapter schema definition" do
   include SchemaSpecHelper
@@ -10,11 +10,11 @@ describe "OracleEnhancedAdapter schema definition" do
       "select * from product_component_version where product like 'Oracle%' and to_number(substr(version,1,2)) >= 11")
   end
 
-  describe 'option to create sequence when adding a column' do
+  describe "option to create sequence when adding a column" do
     before do
       @conn = ActiveRecord::Base.connection
       schema_define do
-        create_table :keyboards, :force => true, :id  => false do |t|
+        create_table :keyboards, force: true, id: false do |t|
           t.string      :name
         end
         add_column :keyboards, :id, :primary_key
@@ -22,7 +22,7 @@ describe "OracleEnhancedAdapter schema definition" do
       class ::Keyboard < ActiveRecord::Base; end
     end
 
-    it 'creates a sequence when adding a column with create_sequence = true' do
+    it "creates a sequence when adding a column with create_sequence = true" do
       _, sequence_name = ActiveRecord::Base.connection.pk_and_sequence_for_without_cache(:keyboards)
 
       expect(sequence_name).to eq(Keyboard.sequence_name)
@@ -34,11 +34,11 @@ describe "OracleEnhancedAdapter schema definition" do
     before(:all) do
       @conn = ActiveRecord::Base.connection
       schema_define do
-        create_table :keyboards, :force => true, :id  => false do |t|
+        create_table :keyboards, force: true, id: false do |t|
           t.primary_key :key_number
           t.string      :name
         end
-        create_table :id_keyboards, :force => true do |t|
+        create_table :id_keyboards, force: true do |t|
           t.string      :name
         end
       end
@@ -72,7 +72,7 @@ describe "OracleEnhancedAdapter schema definition" do
 
     it "should return sequence name without truncating too much" do
       seq_name_length = ActiveRecord::Base.connection.sequence_name_length
-      tname = "#{DATABASE_USER}" + "." + "a"*(seq_name_length - DATABASE_USER.length) + "z"*(DATABASE_USER).length
+      tname = "#{DATABASE_USER}" + "." + "a" * (seq_name_length - DATABASE_USER.length) + "z" * (DATABASE_USER).length
       expect(ActiveRecord::Base.connection.default_sequence_name(tname)).to match (/z_seq$/)
     end
   end
@@ -81,7 +81,7 @@ describe "OracleEnhancedAdapter schema definition" do
 
     def create_test_employees_table(sequence_start_value = nil)
       schema_define do
-        create_table :test_employees, sequence_start_value ? {:sequence_start_value => sequence_start_value} : {} do |t|
+        create_table :test_employees, sequence_start_value ? { sequence_start_value: sequence_start_value } : {} do |t|
           t.string      :first_name
           t.string      :last_name
         end
@@ -155,7 +155,7 @@ describe "OracleEnhancedAdapter schema definition" do
 
   describe "create table with primary key trigger" do
     def create_table_with_trigger(options = {})
-      options.merge! :primary_key_trigger => true, :force => true
+      options.merge! primary_key_trigger: true, force: true
       schema_define do
         create_table :test_employees, options do |t|
           t.string      :first_name
@@ -165,7 +165,7 @@ describe "OracleEnhancedAdapter schema definition" do
     end
 
     def create_table_and_separately_trigger(options = {})
-      options.merge! :force => true
+      options.merge! force: true
       schema_define do
         create_table :test_employees, options do |t|
           t.string      :first_name
@@ -178,7 +178,7 @@ describe "OracleEnhancedAdapter schema definition" do
     def drop_table_with_trigger(options = {})
       seq_name = options[:sequence_name]
       schema_define do
-        drop_table :test_employees, (seq_name ? {:sequence_name => seq_name} : {})
+        drop_table :test_employees, (seq_name ? { sequence_name: seq_name } : {})
       end
       Object.send(:remove_const, "TestEmployee")
       @conn.clear_prefetch_primary_key
@@ -209,7 +209,7 @@ describe "OracleEnhancedAdapter schema definition" do
       end
 
       it "should create new record for model" do
-        e = TestEmployee.create!(:first_name => 'Raimonds')
+        e = TestEmployee.create!(first_name: "Raimonds")
         expect(@conn.select_value("SELECT test_employees_seq.currval FROM dual")).to eq(e.id)
       end
 
@@ -248,7 +248,7 @@ describe "OracleEnhancedAdapter schema definition" do
       end
 
       it "should create new record for model" do
-        e = TestEmployee.create!(:first_name => 'Raimonds')
+        e = TestEmployee.create!(first_name: "Raimonds")
         expect(@conn.select_value("SELECT test_employees_seq.currval FROM dual")).to eq(e.id)
       end
     end
@@ -259,14 +259,14 @@ describe "OracleEnhancedAdapter schema definition" do
         @conn = ActiveRecord::Base.connection
         @primary_key = "employee_id"
         @sequence_name = "test_employees_s"
-        create_table_with_trigger(:primary_key => @primary_key, :sequence_name => @sequence_name)
+        create_table_with_trigger(primary_key: @primary_key, sequence_name: @sequence_name)
         class ::TestEmployee < ActiveRecord::Base
           self.primary_key = "employee_id"
         end
       end
 
       after(:all) do
-        drop_table_with_trigger(:sequence_name => @sequence_name)
+        drop_table_with_trigger(sequence_name: @sequence_name)
       end
 
       it "should populate primary key using trigger" do
@@ -281,7 +281,7 @@ describe "OracleEnhancedAdapter schema definition" do
       end
 
       it "should create new record for model with autogenerated sequence option" do
-        e = TestEmployee.create!(:first_name => 'Raimonds')
+        e = TestEmployee.create!(first_name: "Raimonds")
         expect(@conn.select_value("SELECT #{@sequence_name}.currval FROM dual")).to eq(e.id)
       end
     end
@@ -291,14 +291,14 @@ describe "OracleEnhancedAdapter schema definition" do
         ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
         @conn = ActiveRecord::Base.connection
         @sequence_name = "test_employees_s"
-        create_table_with_trigger(:sequence_name => @sequence_name, :trigger_name => "test_employees_t1")
+        create_table_with_trigger(sequence_name: @sequence_name, trigger_name: "test_employees_t1")
         class ::TestEmployee < ActiveRecord::Base
           self.sequence_name = :autogenerated
         end
       end
 
       after(:all) do
-        drop_table_with_trigger(:sequence_name => @sequence_name)
+        drop_table_with_trigger(sequence_name: @sequence_name)
       end
 
       it "should populate primary key using trigger" do
@@ -313,7 +313,7 @@ describe "OracleEnhancedAdapter schema definition" do
       end
 
       it "should create new record for model with autogenerated sequence option" do
-        e = TestEmployee.create!(:first_name => 'Raimonds')
+        e = TestEmployee.create!(first_name: "Raimonds")
         expect(@conn.select_value("SELECT #{@sequence_name}.currval FROM dual")).to eq(e.id)
       end
     end
@@ -322,11 +322,11 @@ describe "OracleEnhancedAdapter schema definition" do
 
   describe "table and column comments" do
 
-    def create_test_employees_table(table_comment=nil, column_comments={})
+    def create_test_employees_table(table_comment = nil, column_comments = {})
       schema_define do
-        create_table :test_employees, :comment => table_comment do |t|
-          t.string      :first_name, :comment => column_comments[:first_name]
-          t.string      :last_name, :comment => column_comments[:last_name]
+        create_table :test_employees, comment: table_comment do |t|
+          t.string      :first_name, comment: column_comments[:first_name]
+          t.string      :last_name, comment: column_comments[:last_name]
         end
       end
     end
@@ -340,7 +340,7 @@ describe "OracleEnhancedAdapter schema definition" do
         drop_table :test_employees
       end
       Object.send(:remove_const, "TestEmployee")
-      ActiveRecord::Base.table_name_prefix = ''
+      ActiveRecord::Base.table_name_prefix = ""
       ActiveRecord::Base.clear_cache!
     end
 
@@ -354,7 +354,7 @@ describe "OracleEnhancedAdapter schema definition" do
     end
 
     it "should create table with columns comment" do
-      column_comments = {:first_name => "Given Name", :last_name => "Surname"}
+      column_comments = { first_name: "Given Name", last_name: "Surname" }
       create_test_employees_table(nil, column_comments)
       class ::TestEmployee < ActiveRecord::Base; end
 
@@ -369,7 +369,7 @@ describe "OracleEnhancedAdapter schema definition" do
     it "should create table with table and columns comment and custom table name prefix" do
       ActiveRecord::Base.table_name_prefix = "xxx_"
       table_comment = "Test Employees"
-      column_comments = {:first_name => "Given Name", :last_name => "Surname"}
+      column_comments = { first_name: "Given Name", last_name: "Surname" }
       create_test_employees_table(table_comment, column_comments)
       class ::TestEmployee < ActiveRecord::Base; end
 
@@ -400,21 +400,21 @@ describe "OracleEnhancedAdapter schema definition" do
   describe "rename tables and sequences" do
     before(:each) do
       @conn = ActiveRecord::Base.connection
-        schema_define do
-          drop_table :test_employees rescue nil
-          drop_table :new_test_employees rescue nil
-          drop_table :test_employees_no_primary_key rescue nil
+      schema_define do
+        drop_table :test_employees rescue nil
+        drop_table :new_test_employees rescue nil
+        drop_table :test_employees_no_primary_key rescue nil
 
-          create_table  :test_employees do |t|
-            t.string    :first_name
-            t.string    :last_name
-          end
-
-          create_table  :test_employees_no_pkey, :id => false do |t|
-            t.string    :first_name
-            t.string    :last_name
-          end
+        create_table  :test_employees do |t|
+          t.string    :first_name
+          t.string    :last_name
         end
+
+        create_table  :test_employees_no_pkey, id: false do |t|
+          t.string    :first_name
+          t.string    :last_name
+        end
+      end
     end
 
     after(:each) do
@@ -429,25 +429,25 @@ describe "OracleEnhancedAdapter schema definition" do
 
     it "should rename table name with new one" do
       expect do
-        @conn.rename_table("test_employees","new_test_employees")
+        @conn.rename_table("test_employees", "new_test_employees")
       end.not_to raise_error
     end
 
     it "should raise error when new table name length is too long" do
       expect do
-        @conn.rename_table("test_employees","a"*31)
+        @conn.rename_table("test_employees", "a" * 31)
       end.to raise_error(ArgumentError)
     end
 
     it "should not raise error when new sequence name length is too long" do
       expect do
-        @conn.rename_table("test_employees","a"*27)
+        @conn.rename_table("test_employees", "a" * 27)
       end.not_to raise_error
     end
 
     it "should rename table when table has no primary key and sequence" do
       expect do
-        @conn.rename_table("test_employees_no_pkey","new_test_employees_no_pkey")
+        @conn.rename_table("test_employees_no_pkey", "new_test_employees_no_pkey")
       end.not_to raise_error
     end
 
@@ -497,69 +497,69 @@ describe "OracleEnhancedAdapter schema definition" do
     end
 
     it "should return default index name if it is not larger than 30 characters" do
-      expect(@conn.index_name("employees", :column => "first_name")).to eq("index_employees_on_first_name")
+      expect(@conn.index_name("employees", column: "first_name")).to eq("index_employees_on_first_name")
     end
 
     it "should return shortened index name by removing 'index', 'on' and 'and' keywords" do
-      expect(@conn.index_name("employees", :column => ["first_name", "email"])).to eq("i_employees_first_name_email")
+      expect(@conn.index_name("employees", column: ["first_name", "email"])).to eq("i_employees_first_name_email")
     end
 
     it "should return shortened index name by shortening table and column names" do
-      expect(@conn.index_name("employees", :column => ["first_name", "last_name"])).to eq("i_emp_fir_nam_las_nam")
+      expect(@conn.index_name("employees", column: ["first_name", "last_name"])).to eq("i_emp_fir_nam_las_nam")
     end
 
     it "should raise error if too large index name cannot be shortened" do
-      expect(@conn.index_name("test_employees", :column => ["first_name", "middle_name", "last_name"])).to eq(
-        'i'+Digest::SHA1.hexdigest("index_test_employees_on_first_name_and_middle_name_and_last_name")[0,29]
+      expect(@conn.index_name("test_employees", column: ["first_name", "middle_name", "last_name"])).to eq(
+        "i" + Digest::SHA1.hexdigest("index_test_employees_on_first_name_and_middle_name_and_last_name")[0, 29]
       )
     end
 
   end
 
   describe "rename index" do
-    before(:each) do
-      @conn = ActiveRecord::Base.connection
-        schema_define do
-          create_table  :test_employees do |t|
-            t.string    :first_name
-            t.string    :last_name
-          end
-          add_index :test_employees, :first_name
+  before(:each) do
+    @conn = ActiveRecord::Base.connection
+    schema_define do
+      create_table  :test_employees do |t|
+        t.string    :first_name
+        t.string    :last_name
       end
-      class ::TestEmployee < ActiveRecord::Base; end
+      add_index :test_employees, :first_name
     end
+    class ::TestEmployee < ActiveRecord::Base; end
+  end
 
-    after(:each) do
-      schema_define do
-        drop_table :test_employees
-      end
-      Object.send(:remove_const, "TestEmployee")
-      ActiveRecord::Base.clear_cache!
+  after(:each) do
+    schema_define do
+      drop_table :test_employees
     end
+    Object.send(:remove_const, "TestEmployee")
+    ActiveRecord::Base.clear_cache!
+  end
 
-    it "should raise error when current index name and new index name are identical" do
-      expect do
-        @conn.rename_index("test_employees","i_test_employees_first_name","i_test_employees_first_name")
-      end.to raise_error(ActiveRecord::StatementInvalid)
-    end
+  it "should raise error when current index name and new index name are identical" do
+    expect do
+      @conn.rename_index("test_employees", "i_test_employees_first_name", "i_test_employees_first_name")
+    end.to raise_error(ActiveRecord::StatementInvalid)
+  end
 
-    it "should raise error when new index name length is too long" do
-      expect do
-        @conn.rename_index("test_employees","i_test_employees_first_name","a"*31)
-      end.to raise_error(ArgumentError)
-    end
+  it "should raise error when new index name length is too long" do
+    expect do
+      @conn.rename_index("test_employees", "i_test_employees_first_name", "a" * 31)
+    end.to raise_error(ArgumentError)
+  end
 
-    it "should raise error when current index name does not exist" do
-      expect do
-        @conn.rename_index("test_employees","nonexist_index_name","new_index_name")
-      end.to raise_error(ArgumentError)
-    end
+  it "should raise error when current index name does not exist" do
+    expect do
+      @conn.rename_index("test_employees", "nonexist_index_name", "new_index_name")
+    end.to raise_error(ArgumentError)
+  end
 
-    it "should rename index name with new one" do
-      expect do
-        @conn.rename_index("test_employees","i_test_employees_first_name","new_index_name")
-      end.not_to raise_error
-    end
+  it "should rename index name with new one" do
+    expect do
+      @conn.rename_index("test_employees", "i_test_employees_first_name", "new_index_name")
+    end.not_to raise_error
+  end
 end
 
   describe "ignore options for LOB columns" do
@@ -572,8 +572,8 @@ end
     it "should ignore :limit option for :text column" do
       expect do
         schema_define do
-          create_table :test_posts, :force => true do |t|
-            t.text :body, :limit => 10000
+          create_table :test_posts, force: true do |t|
+            t.text :body, limit: 10000
           end
         end
       end.not_to raise_error
@@ -582,8 +582,8 @@ end
     it "should ignore :limit option for :binary column" do
       expect do
         schema_define do
-          create_table :test_posts, :force => true do |t|
-            t.binary :picture, :limit => 10000
+          create_table :test_posts, force: true do |t|
+            t.binary :picture, limit: 10000
           end
         end
       end.not_to raise_error
@@ -592,18 +592,18 @@ end
   end
 
   describe "foreign key constraints" do
-    let(:table_name_prefix) { '' }
-    let(:table_name_suffix) { '' }
+    let(:table_name_prefix) { "" }
+    let(:table_name_suffix) { "" }
 
     before(:each) do
       ActiveRecord::Base.table_name_prefix = table_name_prefix
       ActiveRecord::Base.table_name_suffix = table_name_suffix
       schema_define do
-        create_table :test_posts, :force => true do |t|
+        create_table :test_posts, force: true do |t|
           t.string :title
         end
-        create_table :test_comments, :force => true do |t|
-          t.string :body, :limit => 4000
+        create_table :test_comments, force: true do |t|
+          t.string :body, limit: 4000
           t.references :test_post
           t.integer :post_id
         end
@@ -623,8 +623,8 @@ end
         drop_table :test_comments rescue nil
         drop_table :test_posts rescue nil
       end
-      ActiveRecord::Base.table_name_prefix = ''
-      ActiveRecord::Base.table_name_suffix = ''
+      ActiveRecord::Base.table_name_prefix = ""
+      ActiveRecord::Base.table_name_suffix = ""
       ActiveRecord::Base.clear_cache!
     end
 
@@ -635,46 +635,46 @@ end
         add_foreign_key :test_comments, :test_posts
       end
       expect do
-        TestComment.create(:body => "test", :test_post_id => 1)
-      end.to raise_error() {|e| expect(e.message).to match(/ORA-02291.*\.#{fk_name}/i)}
+        TestComment.create(body: "test", test_post_id: 1)
+      end.to raise_error() { |e| expect(e.message).to match(/ORA-02291.*\.#{fk_name}/i) }
     end
 
     it "should add foreign key with name" do
       schema_define do
-        add_foreign_key :test_comments, :test_posts, :name => "comments_posts_fk"
+        add_foreign_key :test_comments, :test_posts, name: "comments_posts_fk"
       end
       expect do
-        TestComment.create(:body => "test", :test_post_id => 1)
-      end.to raise_error() {|e| expect(e.message).to match(/ORA-02291.*\.COMMENTS_POSTS_FK/)}
+        TestComment.create(body: "test", test_post_id: 1)
+      end.to raise_error() { |e| expect(e.message).to match(/ORA-02291.*\.COMMENTS_POSTS_FK/) }
     end
 
     it "should add foreign key with column" do
       fk_name = "fk_rails_#{Digest::SHA256.hexdigest("test_comments_post_id_fk").first(10)}"
 
       schema_define do
-        add_foreign_key :test_comments, :test_posts, :column => "post_id"
+        add_foreign_key :test_comments, :test_posts, column: "post_id"
       end
       expect do
-        TestComment.create(:body => "test", :post_id => 1)
-      end.to raise_error() {|e| expect(e.message).to match(/ORA-02291.*\.#{fk_name}/i)}
+        TestComment.create(body: "test", post_id: 1)
+      end.to raise_error() { |e| expect(e.message).to match(/ORA-02291.*\.#{fk_name}/i) }
     end
 
     it "should add foreign key with delete dependency" do
       schema_define do
-        add_foreign_key :test_comments, :test_posts, :on_delete => :cascade
+        add_foreign_key :test_comments, :test_posts, on_delete: :cascade
       end
-      p = TestPost.create(:title => "test")
-      c = TestComment.create(:body => "test", :test_post => p)
+      p = TestPost.create(title: "test")
+      c = TestComment.create(body: "test", test_post: p)
       TestPost.delete(p.id)
       expect(TestComment.find_by_id(c.id)).to be_nil
     end
 
     it "should add foreign key with nullify dependency" do
       schema_define do
-        add_foreign_key :test_comments, :test_posts, :on_delete => :nullify
+        add_foreign_key :test_comments, :test_posts, on_delete: :nullify
       end
-      p = TestPost.create(:title => "test")
-      c = TestComment.create(:body => "test", :test_post => p)
+      p = TestPost.create(title: "test")
+      c = TestComment.create(body: "test", test_post: p)
       TestPost.delete(p.id)
       expect(TestComment.find_by_id(c.id).test_post_id).to be_nil
     end
@@ -685,27 +685,27 @@ end
         remove_foreign_key :test_comments, :test_posts
       end
       expect do
-        TestComment.create(:body => "test", :test_post_id => 1)
+        TestComment.create(body: "test", test_post_id: 1)
       end.not_to raise_error
     end
 
     it "should remove foreign key by constraint name" do
       schema_define do
-        add_foreign_key :test_comments, :test_posts, :name => "comments_posts_fk"
-        remove_foreign_key :test_comments, :name => "comments_posts_fk"
+        add_foreign_key :test_comments, :test_posts, name: "comments_posts_fk"
+        remove_foreign_key :test_comments, name: "comments_posts_fk"
       end
       expect do
-        TestComment.create(:body => "test", :test_post_id => 1)
+        TestComment.create(body: "test", test_post_id: 1)
       end.not_to raise_error
     end
 
     it "should remove foreign key by column name" do
       schema_define do
         add_foreign_key :test_comments, :test_posts
-        remove_foreign_key :test_comments, :column => "test_post_id"
+        remove_foreign_key :test_comments, column: "test_post_id"
       end
       expect do
-        TestComment.create(:body => "test", :test_post_id => 1)
+        TestComment.create(body: "test", test_post_id: 1)
       end.not_to raise_error
     end
 
@@ -716,11 +716,11 @@ end
       class ::TestPost < ActiveRecord::Base
       end
     end
-    it 'should use default tablespace for clobs' do
+    it "should use default tablespace for clobs" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[:clob] = DATABASE_NON_DEFAULT_TABLESPACE
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[:blob] = nil
       schema_define do
-        create_table :test_posts, :force => true do |t|
+        create_table :test_posts, force: true do |t|
           t.text :test_clob
           t.binary :test_blob
         end
@@ -729,11 +729,11 @@ end
       expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_BLOB'")).not_to eq(DATABASE_NON_DEFAULT_TABLESPACE)
     end
 
-    it 'should use default tablespace for blobs' do
+    it "should use default tablespace for blobs" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[:blob] = DATABASE_NON_DEFAULT_TABLESPACE
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[:clob] = nil
       schema_define do
-        create_table :test_posts, :force => true do |t|
+        create_table :test_posts, force: true do |t|
           t.text :test_clob
           t.binary :test_blob
         end
@@ -758,10 +758,10 @@ end
       end
     end
 
-    it 'should use default tablespace for primary key' do
+    it "should use default tablespace for primary key" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[:index] = nil
       schema_define do
-        create_table :test_posts, :force => true
+        create_table :test_posts, force: true
       end
 
       index_name = @conn.select_value(
@@ -770,13 +770,13 @@ end
             AND constraint_type = 'P'
             AND owner = SYS_CONTEXT('userenv', 'current_schema')")
 
-      expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_indexes WHERE index_name = '#{index_name}'")).to eq('USERS')
+      expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_indexes WHERE index_name = '#{index_name}'")).to eq("USERS")
     end
 
-    it 'should use non default tablespace for primary key' do
+    it "should use non default tablespace for primary key" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[:index] = DATABASE_NON_DEFAULT_TABLESPACE
       schema_define do
-        create_table :test_posts, :force => true
+        create_table :test_posts, force: true
       end
 
       index_name = @conn.select_value(
@@ -800,7 +800,7 @@ end
   describe "foreign key in table definition" do
     before(:each) do
       schema_define do
-        create_table :test_posts, :force => true do |t|
+        create_table :test_posts, force: true do |t|
           t.string :title
         end
       end
@@ -824,33 +824,33 @@ end
 
     it "should add foreign key in create_table" do
       schema_define do
-        create_table :test_comments, :force => true do |t|
-          t.string :body, :limit => 4000
+        create_table :test_comments, force: true do |t|
+          t.string :body, limit: 4000
           t.references :test_post
           t.foreign_key :test_posts
         end
       end
       expect do
-        TestComment.create(:body => "test", :test_post_id => 1)
-      end.to raise_error() {|e| expect(e.message).to match(/ORA-02291/)}
+        TestComment.create(body: "test", test_post_id: 1)
+      end.to raise_error() { |e| expect(e.message).to match(/ORA-02291/) }
     end
 
     it "should add foreign key in create_table references" do
       schema_define do
-        create_table :test_comments, :force => true do |t|
-          t.string :body, :limit => 4000
-          t.references :test_post, :foreign_key => true
+        create_table :test_comments, force: true do |t|
+          t.string :body, limit: 4000
+          t.references :test_post, foreign_key: true
         end
       end
       expect do
-        TestComment.create(:body => "test", :test_post_id => 1)
-      end.to raise_error() {|e| expect(e.message).to match(/ORA-02291/)}
+        TestComment.create(body: "test", test_post_id: 1)
+      end.to raise_error() { |e| expect(e.message).to match(/ORA-02291/) }
     end
 
     it "should add foreign key in change_table" do
       schema_define do
-        create_table :test_comments, :force => true do |t|
-          t.string :body, :limit => 4000
+        create_table :test_comments, force: true do |t|
+          t.string :body, limit: 4000
           t.references :test_post
         end
         change_table :test_comments do |t|
@@ -858,22 +858,22 @@ end
         end
       end
       expect do
-        TestComment.create(:body => "test", :test_post_id => 1)
-      end.to raise_error() {|e| expect(e.message).to match(/ORA-02291/)}
+        TestComment.create(body: "test", test_post_id: 1)
+      end.to raise_error() { |e| expect(e.message).to match(/ORA-02291/) }
     end
 
     it "should add foreign key in change_table references" do
       schema_define do
-        create_table :test_comments, :force => true do |t|
-          t.string :body, :limit => 4000
+        create_table :test_comments, force: true do |t|
+          t.string :body, limit: 4000
         end
         change_table :test_comments do |t|
-          t.references :test_post, :foreign_key => true
+          t.references :test_post, foreign_key: true
         end
       end
       expect do
-        TestComment.create(:body => "test", :test_post_id => 1)
-      end.to raise_error() {|e| expect(e.message).to match(/ORA-02291/)}
+        TestComment.create(body: "test", test_post_id: 1)
+      end.to raise_error() { |e| expect(e.message).to match(/ORA-02291/) }
     end
 
   end
@@ -885,16 +885,16 @@ end
 
     before(:each) do
       schema_define do
-        create_table :test_posts, :force => true do |t|
+        create_table :test_posts, force: true do |t|
           t.string :title
         end
-        create_table :test_comments, :force => true do |t|
-          t.string :body, :limit => 4000
-          t.references :test_post, :foreign_key => true
+        create_table :test_comments, force: true do |t|
+          t.string :body, limit: 4000
+          t.references :test_post, foreign_key: true
         end
-        create_table "test_Mixed_Comments", :force => true do |t|
-          t.string :body, :limit => 4000
-          t.references :test_post, :foreign_key => true
+        create_table "test_Mixed_Comments", force: true do |t|
+          t.string :body, limit: 4000
+          t.references :test_post, foreign_key: true
         end
       end
     end
@@ -935,7 +935,7 @@ end
       @conn.execute "DROP DATABASE LINK #{@db_link}" rescue nil
       @conn.execute "CREATE DATABASE LINK #{@db_link} CONNECT TO #{@db_link_username} IDENTIFIED BY \"#{@db_link_password}\" USING '#{@db_link_database}'"
       schema_define do
-        create_table :test_posts, :force => true do |t|
+        create_table :test_posts, force: true do |t|
           t.string :title
         end
       end
@@ -966,22 +966,22 @@ end
     it "should create synonym to table and sequence" do
       schema_name = @username
       schema_define do
-        add_synonym :synonym_to_posts, "#{schema_name}.test_posts", :force => true
-        add_synonym :synonym_to_posts_seq, "#{schema_name}.test_posts_seq", :force => true
+        add_synonym :synonym_to_posts, "#{schema_name}.test_posts", force: true
+        add_synonym :synonym_to_posts_seq, "#{schema_name}.test_posts_seq", force: true
       end
       expect do
-        TestPost.create(:title => "test")
+        TestPost.create(title: "test")
       end.not_to raise_error
     end
 
     it "should create synonym to table over database link" do
       db_link = @db_link
       schema_define do
-        add_synonym :synonym_to_posts, "test_posts@#{db_link}", :force => true
-        add_synonym :synonym_to_posts_seq, "test_posts_seq@#{db_link}", :force => true
+        add_synonym :synonym_to_posts, "test_posts@#{db_link}", force: true
+        add_synonym :synonym_to_posts_seq, "test_posts_seq@#{db_link}", force: true
       end
       expect do
-        TestPost.create(:title => "test")
+        TestPost.create(title: "test")
       end.not_to raise_error
     end
 
@@ -1004,13 +1004,13 @@ end
 
     before(:each) do
       schema_define do
-        create_table :test_posts, :force => true do |t|
-          t.string :title, :null => false
+        create_table :test_posts, force: true do |t|
+          t.string :title, null: false
           t.string :content
         end
       end
       class ::TestPost < ActiveRecord::Base; end
-      expect(TestPost.columns_hash['title'].null).to be_falsey
+      expect(TestPost.columns_hash["title"].null).to be_falsey
     end
 
     after(:each) do
@@ -1021,10 +1021,10 @@ end
 
     it "should change column to nullable" do
       schema_define do
-        change_column :test_posts, :title, :string, :null => true
+        change_column :test_posts, :title, :string, null: true
       end
       TestPost.reset_column_information
-      expect(TestPost.columns_hash['title'].null).to be_truthy
+      expect(TestPost.columns_hash["title"].null).to be_truthy
     end
 
     it "should add column" do
@@ -1032,7 +1032,7 @@ end
         add_column :test_posts, :body, :string
       end
       TestPost.reset_column_information
-      expect(TestPost.columns_hash['body']).not_to be_nil
+      expect(TestPost.columns_hash["body"]).not_to be_nil
     end
 
     it "should add lob column with non_default tablespace" do
@@ -1056,8 +1056,8 @@ end
         rename_column :test_posts, :title, :subject
       end
       TestPost.reset_column_information
-      expect(TestPost.columns_hash['subject']).not_to be_nil
-      expect(TestPost.columns_hash['title']).to be_nil
+      expect(TestPost.columns_hash["subject"]).not_to be_nil
+      expect(TestPost.columns_hash["title"]).to be_nil
     end
 
     it "should remove column" do
@@ -1065,7 +1065,7 @@ end
         remove_column :test_posts, :title
       end
       TestPost.reset_column_information
-      expect(TestPost.columns_hash['title']).to be_nil
+      expect(TestPost.columns_hash["title"]).to be_nil
     end
 
     it "should remove column when using change_table" do
@@ -1075,7 +1075,7 @@ end
         end
       end
       TestPost.reset_column_information
-      expect(TestPost.columns_hash['title']).to be_nil
+      expect(TestPost.columns_hash["title"]).to be_nil
     end
 
     it "should remove multiple columns when using change_table" do
@@ -1085,8 +1085,8 @@ end
         end
       end
       TestPost.reset_column_information
-      expect(TestPost.columns_hash['title']).to be_nil
-      expect(TestPost.columns_hash['content']).to be_nil
+      expect(TestPost.columns_hash["title"]).to be_nil
+      expect(TestPost.columns_hash["content"]).to be_nil
     end
 
     it "should ignore type and options parameter and remove column" do
@@ -1094,16 +1094,16 @@ end
         remove_column :test_posts, :title, :string, {}
       end
       TestPost.reset_column_information
-      expect(TestPost.columns_hash['title']).to be_nil
+      expect(TestPost.columns_hash["title"]).to be_nil
     end
   end
 
-  describe 'virtual columns in create_table' do
+  describe "virtual columns in create_table" do
     before(:each) do
       skip "Not supported in this database version" unless @oracle11g_or_higher
     end
 
-    it 'should raise error if column expression is not provided' do
+    it "should raise error if column expression is not provided" do
       expect {
         schema_define do
           create_table :test_fractions do |t|
@@ -1115,15 +1115,15 @@ end
     end
   end
 
-  describe 'virtual columns' do
+  describe "virtual columns" do
     before(:each) do
       skip "Not supported in this database version" unless @oracle11g_or_higher
       expr = "( numerator/NULLIF(denominator,0) )*100"
       schema_define do
-        create_table :test_fractions, :force => true do |t|
-          t.integer :numerator, :default=>0
-          t.integer :denominator, :default=>0
-          t.virtual :percent, :as => expr
+        create_table :test_fractions, force: true do |t|
+          t.integer :numerator, default: 0
+          t.integer :denominator, default: 0
+          t.virtual :percent, as: expr
         end
       end
       class ::TestFraction < ActiveRecord::Base
@@ -1140,13 +1140,13 @@ end
       end
     end
 
-    it 'should include virtual columns and not try to update them' do
+    it "should include virtual columns and not try to update them" do
       tf = TestFraction.columns.detect { |c| c.virtual? }
       expect(tf).not_to be nil
       expect(tf.name).to eq("percent")
       expect(tf.virtual?).to be true
       expect do
-        tf = TestFraction.new(:numerator=>20, :denominator=>100)
+        tf = TestFraction.new(numerator: 20, denominator: 100)
         expect(tf.percent).to be nil # not whatever is in DATA_DEFAULT column
         tf.save!
         tf.reload
@@ -1154,16 +1154,16 @@ end
       expect(tf.percent.to_i).to eq(20)
     end
 
-    it 'should add virtual column' do
+    it "should add virtual column" do
       schema_define do
-        add_column :test_fractions, :rem, :virtual, :as => 'remainder(numerator, NULLIF(denominator,0))'
+        add_column :test_fractions, :rem, :virtual, as: "remainder(numerator, NULLIF(denominator,0))"
       end
       TestFraction.reset_column_information
-      tf = TestFraction.columns.detect { |c| c.name == 'rem' }
+      tf = TestFraction.columns.detect { |c| c.name == "rem" }
       expect(tf).not_to be nil
       expect(tf.virtual?).to be true
       expect do
-        tf = TestFraction.new(:numerator=>7, :denominator=>5)
+        tf = TestFraction.new(numerator: 7, denominator: 5)
         expect(tf.rem).to be nil
         tf.save!
         tf.reload
@@ -1171,64 +1171,64 @@ end
       expect(tf.rem.to_i).to eq(2)
     end
 
-    it 'should add virtual column with explicit type' do
+    it "should add virtual column with explicit type" do
       schema_define do
-        add_column :test_fractions, :expression, :virtual, :as => "TO_CHAR(numerator) || '/' || TO_CHAR(denominator)", :type => :string, :limit => 100
+        add_column :test_fractions, :expression, :virtual, as: "TO_CHAR(numerator) || '/' || TO_CHAR(denominator)", type: :string, limit: 100
       end
       TestFraction.reset_column_information
-      tf = TestFraction.columns.detect { |c| c.name == 'expression' }
+      tf = TestFraction.columns.detect { |c| c.name == "expression" }
       expect(tf).not_to be nil
       expect(tf.virtual?).to be true
       expect(tf.type).to be :string
       expect(tf.limit).to be 100
       expect do
-        tf = TestFraction.new(:numerator=>7, :denominator=>5)
+        tf = TestFraction.new(numerator: 7, denominator: 5)
         expect(tf.expression).to be nil
         tf.save!
         tf.reload
       end.not_to raise_error
-      expect(tf.expression).to eq('7/5')
+      expect(tf.expression).to eq("7/5")
     end
 
-    it 'should change virtual column definition' do
+    it "should change virtual column definition" do
       schema_define do
         change_column :test_fractions, :percent, :virtual,
-          :as => "ROUND((numerator/NULLIF(denominator,0))*100, 2)", :type => :decimal, :precision => 15, :scale => 2
+          as: "ROUND((numerator/NULLIF(denominator,0))*100, 2)", type: :decimal, precision: 15, scale: 2
       end
       TestFraction.reset_column_information
-      tf = TestFraction.columns.detect { |c| c.name == 'percent' }
+      tf = TestFraction.columns.detect { |c| c.name == "percent" }
       expect(tf).not_to be nil
       expect(tf.virtual?).to be true
       expect(tf.type).to be :decimal
       expect(tf.precision).to be 15
       expect(tf.scale).to be 2
       expect do
-        tf = TestFraction.new(:numerator=>11, :denominator=>17)
+        tf = TestFraction.new(numerator: 11, denominator: 17)
         expect(tf.percent).to be nil
         tf.save!
         tf.reload
       end.not_to raise_error
-      expect(tf.percent).to eq('64.71'.to_d)
+      expect(tf.percent).to eq("64.71".to_d)
     end
 
-    it 'should change virtual column type' do
+    it "should change virtual column type" do
       schema_define do
-        change_column :test_fractions, :percent, :virtual, :type => :decimal, :precision => 12, :scale => 5
+        change_column :test_fractions, :percent, :virtual, type: :decimal, precision: 12, scale: 5
       end
       TestFraction.reset_column_information
-      tf = TestFraction.columns.detect { |c| c.name == 'percent' }
+      tf = TestFraction.columns.detect { |c| c.name == "percent" }
       expect(tf).not_to be nil
       expect(tf.virtual?).to be true
       expect(tf.type).to be :decimal
       expect(tf.precision).to be 12
       expect(tf.scale).to be 5
       expect do
-        tf = TestFraction.new(:numerator=>11, :denominator=>17)
+        tf = TestFraction.new(numerator: 11, denominator: 17)
         expect(tf.percent).to be nil
         tf.save!
         tf.reload
       end.not_to raise_error
-      expect(tf.percent).to eq('64.70588'.to_d)
+      expect(tf.percent).to eq("64.70588".to_d)
     end
   end
 
@@ -1238,9 +1238,9 @@ end
     end
 
     before(:each) do
-      @conn.instance_variable_set :@would_execute_sql, @would_execute_sql=''
+      @conn.instance_variable_set :@would_execute_sql, @would_execute_sql = ""
       class <<@conn
-        def execute(sql,name=nil); @would_execute_sql << sql << ";\n"; end
+        def execute(sql, name = nil); @would_execute_sql << sql << ";\n"; end
         def index_name_exists?(table_name, index_name, default); default; end
       end
     end
@@ -1249,13 +1249,13 @@ end
       class <<@conn
         remove_method :execute
       end
-      @conn.instance_eval{ remove_instance_variable :@would_execute_sql }
+      @conn.instance_eval { remove_instance_variable :@would_execute_sql }
     end
 
     it "should support the :options option to create_table" do
       schema_define do
-        create_table :test_posts, :options=>'NOLOGGING', :force => true do |t|
-          t.string :title, :null => false
+        create_table :test_posts, options: "NOLOGGING", force: true do |t|
+          t.string :title, null: false
         end
       end
       expect(@would_execute_sql).to match(/CREATE +TABLE .* \(.*\) NOLOGGING/)
@@ -1263,8 +1263,8 @@ end
 
     it "should support the :tablespace option to create_table" do
       schema_define do
-        create_table :test_posts, :tablespace=>'bogus', :force => true do |t|
-          t.string :title, :null => false
+        create_table :test_posts, tablespace: "bogus", force: true do |t|
+          t.string :title, null: false
         end
       end
       expect(@would_execute_sql).to match(/CREATE +TABLE .* \(.*\) TABLESPACE bogus/)
@@ -1290,7 +1290,7 @@ end
         ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces.delete(:table)
       end
       it "should use correct tablespace" do
-        @conn.create_table :tablespace_tests, :id=>false, :organization=>'INDEX INITRANS 4 COMPRESS 1', :tablespace=>'bogus' do |t|
+        @conn.create_table :tablespace_tests, id: false, organization: "INDEX INITRANS 4 COMPRESS 1", tablespace: "bogus" do |t|
           t.integer :id
         end
         expect(@would_execute_sql).to match(/CREATE +TABLE .*\(.*\)\s+ORGANIZATION INDEX INITRANS 4 COMPRESS 1 TABLESPACE bogus/)
@@ -1299,14 +1299,14 @@ end
 
     it "should support the :options option to add_index" do
       schema_define do
-        add_index :keyboards, :name, :options=>'NOLOGGING'
+        add_index :keyboards, :name, options: "NOLOGGING"
       end
       expect(@would_execute_sql).to match(/CREATE +INDEX .* ON .* \(.*\) NOLOGGING/)
     end
 
     it "should support the :tablespace option to add_index" do
       schema_define do
-        add_index :keyboards, :name, :tablespace=>'bogus'
+        add_index :keyboards, :name, tablespace: "bogus"
       end
       expect(@would_execute_sql).to match(/CREATE +INDEX .* ON .* \(.*\) TABLESPACE bogus/)
     end
@@ -1322,7 +1322,7 @@ end
 
     it "should create unique function index but not create unique constraints" do
       schema_define do
-        add_index :keyboards, 'lower(name)', unique: true, name: :index_keyboards_on_lower_name
+        add_index :keyboards, "lower(name)", unique: true, name: :index_keyboards_on_lower_name
       end
       expect(@would_execute_sql).not_to match(/ALTER +TABLE .* ADD CONSTRAINT .* UNIQUE \(.*\(.*\)\)/)
     end

--- a/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe "OracleEnhancedAdapter structure dump" do
   include LoggerSpecHelper
@@ -11,7 +11,7 @@ describe "OracleEnhancedAdapter structure dump" do
   end
   describe "structure dump" do
     before(:each) do
-      @conn.create_table :test_posts, :force => true do |t|
+      @conn.create_table :test_posts, force: true do |t|
         t.string      :title
         t.string      :foo
         t.integer     :foo_id
@@ -94,7 +94,7 @@ describe "OracleEnhancedAdapter structure dump" do
     it "should not error when no foreign keys are present" do
       dump = ActiveRecord::Base.connection.structure_dump_fk_constraints
       expect(dump.split('\n').length).to eq(0)
-      expect(dump).to eq('')
+      expect(dump).to eq("")
     end
 
     it "should dump triggers" do
@@ -107,7 +107,7 @@ describe "OracleEnhancedAdapter structure dump" do
           SELECT 'bar' INTO :new.FOO FROM DUAL;
         END;
       SQL
-      dump = ActiveRecord::Base.connection.structure_dump_db_stored_code.gsub(/\n|\s+/,' ')
+      dump = ActiveRecord::Base.connection.structure_dump_db_stored_code.gsub(/\n|\s+/, " ")
       expect(dump).to match(/CREATE OR REPLACE TRIGGER TEST_POST_TRIGGER/)
     end
 
@@ -115,14 +115,14 @@ describe "OracleEnhancedAdapter structure dump" do
       @conn.execute <<-SQL
         create or replace TYPE TEST_TYPE AS TABLE OF VARCHAR2(10);
       SQL
-      dump = ActiveRecord::Base.connection.structure_dump_db_stored_code.gsub(/\n|\s+/,' ')
+      dump = ActiveRecord::Base.connection.structure_dump_db_stored_code.gsub(/\n|\s+/, " ")
       expect(dump).to match(/CREATE OR REPLACE TYPE TEST_TYPE/)
     end
 
     it "should dump views" do
       @conn.execute "create or replace VIEW test_posts_view_z as select * from test_posts"
       @conn.execute "create or replace VIEW test_posts_view_a as select * from test_posts_view_z"
-      dump = ActiveRecord::Base.connection.structure_dump_db_stored_code.gsub(/\n|\s+/,' ')
+      dump = ActiveRecord::Base.connection.structure_dump_db_stored_code.gsub(/\n|\s+/, " ")
       expect(dump).to match(/CREATE OR REPLACE FORCE VIEW TEST_POSTS_VIEW_A.*CREATE OR REPLACE FORCE VIEW TEST_POSTS_VIEW_Z/)
     end
 
@@ -165,8 +165,8 @@ describe "OracleEnhancedAdapter structure dump" do
     end
 
     it "should dump indexes" do
-      ActiveRecord::Base.connection.add_index(:test_posts, :foo, :name => :ix_test_posts_foo)
-      ActiveRecord::Base.connection.add_index(:test_posts, :foo_id, :name => :ix_test_posts_foo_id, :unique => true)
+      ActiveRecord::Base.connection.add_index(:test_posts, :foo, name: :ix_test_posts_foo)
+      ActiveRecord::Base.connection.add_index(:test_posts, :foo_id, name: :ix_test_posts_foo_id, unique: true)
 
       @conn.execute <<-SQL
         ALTER TABLE test_posts
@@ -180,7 +180,7 @@ describe "OracleEnhancedAdapter structure dump" do
     end
 
     it "should dump multi-value and function value indexes" do
-      ActiveRecord::Base.connection.add_index(:test_posts, [:foo, :foo_id], :name => :ix_test_posts_foo_foo_id)
+      ActiveRecord::Base.connection.add_index(:test_posts, [:foo, :foo_id], name: :ix_test_posts_foo_foo_id)
 
       @conn.execute <<-SQL
         CREATE INDEX "IX_TEST_POSTS_FUNCTION" ON "TEST_POSTS" (TO_CHAR(LENGTH("FOO"))||"FOO")
@@ -237,7 +237,7 @@ describe "OracleEnhancedAdapter structure dump" do
       @conn.drop_table :test_comments rescue nil
     end
     it "should dump correctly" do
-      @conn.create_table :test_comments, :temporary => true, :id => false do |t|
+      @conn.create_table :test_comments, temporary: true, id: false do |t|
         t.integer :post_id
       end
       dump = ActiveRecord::Base.connection.structure_dump
@@ -267,7 +267,7 @@ describe "OracleEnhancedAdapter structure dump" do
 
   describe "temp_table_drop" do
     before(:each) do
-      @conn.create_table :temp_tbl, :temporary => true do |t|
+      @conn.create_table :temp_tbl, temporary: true do |t|
         t.string :foo
       end
       @conn.create_table :not_temp_tbl do |t|
@@ -298,7 +298,7 @@ describe "OracleEnhancedAdapter structure dump" do
       ActiveRecord::SchemaMigration.reset_table_name
       ActiveRecord::SchemaMigration.create_table
       versions.each do |i|
-        ActiveRecord::SchemaMigration.create!(:version => i)
+        ActiveRecord::SchemaMigration.create!(version: i)
       end
     end
 
@@ -347,7 +347,7 @@ describe "OracleEnhancedAdapter structure dump" do
       @conn.create_table :full_drop_test do |t|
         t.string :foo
       end
-      @conn.create_table :full_drop_test_temp, :temporary => true do |t|
+      @conn.create_table :full_drop_test_temp, temporary: true do |t|
         t.string :foo
       end
       #view

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,43 +1,43 @@
-require 'simplecov'
+require "simplecov"
 SimpleCov.start
 require "rubygems"
 require "bundler"
 require "yaml"
 Bundler.setup(:default, :development)
 
-$:.unshift(File.expand_path('../../lib', __FILE__))
-config_path = File.expand_path('../spec_config.yaml', __FILE__)
+$:.unshift(File.expand_path("../../lib", __FILE__))
+config_path = File.expand_path("../spec_config.yaml", __FILE__)
 if File.exist?(config_path)
   puts "==> Loading config from #{config_path}"
   config = YAML.load_file(config_path)
 else
   puts "==> Loading config from ENV or use default"
-  config = {"rails" => {}, "database" => {}}
+  config = { "rails" => {}, "database" => {} }
 end
 
-require 'rspec'
+require "rspec"
 
-if !defined?(RUBY_ENGINE) || RUBY_ENGINE == 'ruby'
+if !defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby"
   puts "==> Running specs with MRI version #{RUBY_VERSION}"
-  require 'oci8'
-elsif RUBY_ENGINE == 'jruby'
+  require "oci8"
+elsif RUBY_ENGINE == "jruby"
   puts "==> Running specs with JRuby version #{JRUBY_VERSION}"
 end
 
 NO_COMPOSITE_PRIMARY_KEYS = true
 
-require 'active_record'
+require "active_record"
 
-require 'active_support/core_ext/module/attribute_accessors'
-require 'active_support/core_ext/class/attribute_accessors'
+require "active_support/core_ext/module/attribute_accessors"
+require "active_support/core_ext/class/attribute_accessors"
 
 require "active_support/log_subscriber"
-require 'active_record/log_subscriber'
+require "active_record/log_subscriber"
 
-require 'logger'
+require "logger"
 
-require 'active_record/connection_adapters/oracle_enhanced_adapter'
-require 'ruby-plsql'
+require "active_record/connection_adapters/oracle_enhanced_adapter"
+require "ruby-plsql"
 
 puts "==> Effective ActiveRecord version #{ActiveRecord::VERSION::STRING}"
 
@@ -63,7 +63,7 @@ module LoggerSpecHelper
 
     def initialize
       @flush_count = 0
-      @logged = Hash.new { |h,k| h[k] = [] }
+      @logged = Hash.new { |h, k| h[k] = [] }
     end
 
     # used in AtiveRecord 2.x
@@ -117,66 +117,66 @@ module SchemaSpecHelper
   end
 end
 
-DATABASE_NAME         = config["database"]["name"]         || ENV['DATABASE_NAME']         || 'orcl'
-DATABASE_HOST         = config["database"]["host"]         || ENV['DATABASE_HOST']         || "127.0.0.1"
-DATABASE_PORT         = config["database"]["port"]         || ENV['DATABASE_PORT']         || 1521
-DATABASE_USER         = config["database"]["user"]         || ENV['DATABASE_USER']         || 'oracle_enhanced'
-DATABASE_PASSWORD     = config["database"]["password"]     || ENV['DATABASE_PASSWORD']     || 'oracle_enhanced'
-DATABASE_SCHEMA       = config["database"]["schema"]       || ENV['DATABASE_SCHEMA']       || 'oracle_enhanced_schema'
-DATABASE_SYS_PASSWORD = config["database"]["sys_password"] || ENV['DATABASE_SYS_PASSWORD'] || 'admin'
+DATABASE_NAME         = config["database"]["name"]         || ENV["DATABASE_NAME"]         || "orcl"
+DATABASE_HOST         = config["database"]["host"]         || ENV["DATABASE_HOST"]         || "127.0.0.1"
+DATABASE_PORT         = config["database"]["port"]         || ENV["DATABASE_PORT"]         || 1521
+DATABASE_USER         = config["database"]["user"]         || ENV["DATABASE_USER"]         || "oracle_enhanced"
+DATABASE_PASSWORD     = config["database"]["password"]     || ENV["DATABASE_PASSWORD"]     || "oracle_enhanced"
+DATABASE_SCHEMA       = config["database"]["schema"]       || ENV["DATABASE_SCHEMA"]       || "oracle_enhanced_schema"
+DATABASE_SYS_PASSWORD = config["database"]["sys_password"] || ENV["DATABASE_SYS_PASSWORD"] || "admin"
 
 CONNECTION_PARAMS = {
-  :adapter => "oracle_enhanced",
-  :database => DATABASE_NAME,
-  :host => DATABASE_HOST,
-  :port => DATABASE_PORT,
-  :username => DATABASE_USER,
-  :password => DATABASE_PASSWORD
+  adapter: "oracle_enhanced",
+  database: DATABASE_NAME,
+  host: DATABASE_HOST,
+  port: DATABASE_PORT,
+  username: DATABASE_USER,
+  password: DATABASE_PASSWORD
 }
 
 CONNECTION_WITH_SCHEMA_PARAMS = {
-  :adapter => "oracle_enhanced",
-  :database => DATABASE_NAME,
-  :host => DATABASE_HOST,
-  :port => DATABASE_PORT,
-  :username => DATABASE_USER,
-  :password => DATABASE_PASSWORD,
-  :schema => DATABASE_SCHEMA
+  adapter: "oracle_enhanced",
+  database: DATABASE_NAME,
+  host: DATABASE_HOST,
+  port: DATABASE_PORT,
+  username: DATABASE_USER,
+  password: DATABASE_PASSWORD,
+  schema: DATABASE_SCHEMA
 }
 
 CONNECTION_WITH_TIMEZONE_PARAMS = {
-  :adapter => "oracle_enhanced",
-  :database => DATABASE_NAME,
-  :host => DATABASE_HOST,
-  :port => DATABASE_PORT,
-  :username => DATABASE_USER,
-  :password => DATABASE_PASSWORD,
-  :time_zone => "Europe/Riga"
+  adapter: "oracle_enhanced",
+  database: DATABASE_NAME,
+  host: DATABASE_HOST,
+  port: DATABASE_PORT,
+  username: DATABASE_USER,
+  password: DATABASE_PASSWORD,
+  time_zone: "Europe/Riga"
 }
 
 SYS_CONNECTION_PARAMS = {
-  :adapter => "oracle_enhanced",
-  :database => DATABASE_NAME,
-  :host => DATABASE_HOST,
-  :port => DATABASE_PORT,
-  :username => "sys",
-  :password => DATABASE_SYS_PASSWORD,
-  :privilege => "SYSDBA"
+  adapter: "oracle_enhanced",
+  database: DATABASE_NAME,
+  host: DATABASE_HOST,
+  port: DATABASE_PORT,
+  username: "sys",
+  password: DATABASE_SYS_PASSWORD,
+  privilege: "SYSDBA"
 }
 
 SYSTEM_CONNECTION_PARAMS = {
-  :adapter => "oracle_enhanced",
-  :database => DATABASE_NAME,
-  :host => DATABASE_HOST,
-  :port => DATABASE_PORT,
-  :username => "system",
-  :password => DATABASE_SYS_PASSWORD
+  adapter: "oracle_enhanced",
+  database: DATABASE_NAME,
+  host: DATABASE_HOST,
+  port: DATABASE_PORT,
+  username: "system",
+  password: DATABASE_SYS_PASSWORD
 }
 
-DATABASE_NON_DEFAULT_TABLESPACE = config["database"]["non_default_tablespace"] || ENV['DATABASE_NON_DEFAULT_TABLESPACE'] || "SYSTEM"
+DATABASE_NON_DEFAULT_TABLESPACE = config["database"]["non_default_tablespace"] || ENV["DATABASE_NON_DEFAULT_TABLESPACE"] || "SYSTEM"
 
 # set default time zone in TZ environment variable
 # which will be used to set session time zone
-ENV['TZ'] ||= config["timezone"] || 'Europe/Riga'
+ENV["TZ"] ||= config["timezone"] || "Europe/Riga"
 
 # ActiveRecord::Base.logger = Logger.new(STDOUT)


### PR DESCRIPTION
This pull request implements rubocop styles used by [Rails master branch](https://github.com/rails/rails/blob/4273ab34c484f38fa9f77d133cd83256d721e7c8/.rubocop.yml).

It is a reasonable to choice to follow styles used by Rails because Oracle enhanced adapter is a 3rd party ActiveRecord database adapter,

Thanks everyone who contributes to the .rubocop.yml at Rails.

