### PR TITLE
Address `Lint/EndAlignment` offences by changing code ifself

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -143,11 +143,11 @@ module ActiveRecord
             if without_prepared_statement?(binds)
               cursor = @connection.prepare(sql)
             else
-              cursor = if @statements.key?(sql)
-                @statements[sql]
-                       else
-                         @statements[sql] = @connection.prepare(sql)
-                       end
+              if @statements.key?(sql)
+                cursor = @statements[sql]
+              else
+                cursor = @statements[sql] = @connection.prepare(sql)
+              end
 
               cursor.bind_params(type_casted_binds)
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -453,10 +453,10 @@ module ActiveRecord
           def tablespace_for(obj_type, tablespace_option, table_name = nil, column_name = nil)
             tablespace_sql = ""
             if tablespace = (tablespace_option || default_tablespace_for(obj_type))
-              tablespace_sql << if [:blob, :clob].include?(obj_type.to_sym)
-                                  " LOB (#{quote_column_name(column_name)}) STORE AS #{column_name.to_s[0..10]}_#{table_name.to_s[0..14]}_ls (TABLESPACE #{tablespace})"
+              if [:blob, :clob].include?(obj_type.to_sym)
+                tablespace_sql << " LOB (#{quote_column_name(column_name)}) STORE AS #{column_name.to_s[0..10]}_#{table_name.to_s[0..14]}_ls (TABLESPACE #{tablespace})"
               else
-                " TABLESPACE #{tablespace}"
+                tablespace_sql << " TABLESPACE #{tablespace}"
               end
             end
             tablespace_sql


### PR DESCRIPTION
since `rubocop -a` creates these offenses, which cannot be fixed by `rubocop -a`.

Follow up for #1111.