### PR TITLE
Modify JRUBY_OPTS for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
     - DATABASE_NAME=XE
     - ORA_SDTZ='Europe/Riga' #Needed as a client parameter
     - TZ='Europe/Riga'       #Needed as a DB Server parameter
+    - "JRUBY_OPTS='--debug --dev -J-Xmx1024M'"
 
 before_install:
   - chmod +x .travis/oracle/download.sh


### PR DESCRIPTION
'--dev -J-Xmx1024M' to follow Rails .travis.yml configuration

'--debug' to show simplecov accurate coverage warned below.

```
Coverage may be inaccurate; set the "--debug" command line option, or do JRUBY_OPTS="--debug" or set the "debug.fullTrace=true" option in your .jrubyrc
```

By overriding the default JRUBY_OPTS value, this warning should be addressed by this commit.
`jruby: warning: unknown property jruby.cext.enabled`