### PR TITLE
Revert "Bump Arel to 8.0"

### DIFF
--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -88,6 +88,6 @@ This adapter is superset of original ActiveRecord Oracle adapter.
     "spec/spec_helper.rb"
   ]
   s.add_runtime_dependency("activerecord", ["~> 5.1.0.alpha"])
-  s.add_runtime_dependency("arel", ["~> 8.0"])
+  s.add_runtime_dependency("arel", ["~> 7.1.4"])
   s.add_runtime_dependency("ruby-plsql")
 end


### PR DESCRIPTION
This reverts commit f218f6ec0c88fd8ddfd941c90d593a20987cd316.

As explained in rails/rails#27497 . Rails master branch is not ready for Arel 8 yet.