### PR TITLE
Replace `all_timestamp_attributes` with `all_timestamp_attributes_in_…

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
@@ -107,7 +107,7 @@ module ActiveRecord #:nodoc:
             if self.record_timestamps
               current_time = current_time_from_proper_timezone
 
-              all_timestamp_attributes.each do |column|
+              all_timestamp_attributes_in_model.each do |column|
                 if respond_to?(column) && respond_to?("#{column}=") && self.send(column).nil?
                   write_attribute(column.to_s, current_time)
                 end


### PR DESCRIPTION
…model`

Refer rails/rails#27543

#### Environment
- Rails master branch
- Oracle enhanced adapter master branch
- ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-linux]
- Oracle Database 12c 12.1.0.2

This pull request addresses these 15 failures:

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
/home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:215: warning: assigned but unused variable - empl_id
==> Loading config from ENV or use default
==> Running specs with MRI version 2.4.0
/home/yahonda/git/rails/activesupport/lib/active_support/core_ext/enumerable.rb:20: warning: method redefined; discarding old sum
/home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-plsql-439c68ae933c/lib/plsql/variable.rb:87: warning: shadowing outer local variable - column
/home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-plsql-439c68ae933c/lib/plsql/table.rb:61: warning: assigned but unused variable - data_type_mod
/home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-plsql-439c68ae933c/lib/plsql/type.rb:70: warning: assigned but unused variable - data_type_mod
/home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-plsql-439c68ae933c/lib/plsql/oci_connection.rb:219: warning: assigned but unused variable - attr_length
/home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-plsql-439c68ae933c/lib/plsql/oci_connection.rb:238: warning: assigned but unused variable - attr_length
==> Effective ActiveRecord version 5.1.0.alpha
FFFFFFFFFFFFFF.F

Failures:

  1) OracleEnhancedAdapter custom methods for create, update and destroy should create record
     Failure/Error:
       all_timestamp_attributes.each do |column|
         if respond_to?(column) && respond_to?("#{column}=") && self.send(column).nil?
           write_attribute(column.to_s, current_time)
         end

     NameError:
       undefined local variable or method `all_timestamp_attributes' for #<TestEmployee:0x0055580381c878>
       Did you mean?  clear_timestamp_attributes
     # /home/yahonda/git/rails/activemodel/lib/active_model/attribute_methods.rb:432:in `method_missing'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:110:in `block in _create_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:138:in `run_callbacks'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:105:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:549:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:104:in `run_callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:817:in `_run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:125:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:44:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:35:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block (2 levels) in save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:385:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:186:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:382:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block in save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `rollback_active_record_state!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:308:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:42:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:34:in `create'
     # ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:162:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `load'
     # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `<main>'

  2) OracleEnhancedAdapter custom methods for create, update and destroy should rollback record when exception is raised in after_create callback
     Failure/Error:
       expect {
         @employee.save
       }.to raise_error("Make the transaction rollback")

       expected Exception with "Make the transaction rollback", got #<NameError: undefined local variable or method `all_timestamp_attributes' for #<TestEmployee:0x005558031ad910>
       Did you mean?  clear_timestamp_attributes> with backtrace:
         # /home/yahonda/git/rails/activemodel/lib/active_model/attribute_methods.rb:432:in `method_missing'
         # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:110:in `block in _create_record'
         # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:138:in `run_callbacks'
         # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:105:in `_create_record'
         # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:549:in `create_or_update'
         # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `block in create_or_update'
         # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:104:in `run_callbacks'
         # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:817:in `_run_save_callbacks'
         # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `create_or_update'
         # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:125:in `save'
         # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:44:in `save'
         # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:35:in `save'
         # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block (2 levels) in save'
         # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:385:in `block in with_transaction_returning_status'
         # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `block in transaction'
         # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:186:in `within_new_transaction'
         # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `transaction'
         # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
         # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:382:in `with_transaction_returning_status'
         # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block in save'
         # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `rollback_active_record_state!'
         # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:308:in `save'
         # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:42:in `save'
         # ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:186:in `block (3 levels) in <top (required)>'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-expectations-3.5.0/lib/rspec/matchers/built_in/raise_error.rb:52:in `matches?'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/expectation_target.rb:65:in `to'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/expectation_target.rb:101:in `to'
         # ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:185:in `block (2 levels) in <top (required)>'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
         # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
         # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `load'
         # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `<main>'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-support-3.5.0/lib/rspec/support.rb:87:in `block in <module:Support>'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-support-3.5.0/lib/rspec/support.rb:96:in `notify_failure'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/fail_with.rb:27:in `fail_with'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:40:in `handle_failure'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/expectation_target.rb:65:in `to'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/expectation_target.rb:101:in `to'
     # ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:185:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `load'
     # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `<main>'

  3) OracleEnhancedAdapter custom methods for create, update and destroy should update record
     Failure/Error:
       all_timestamp_attributes.each do |column|
         if respond_to?(column) && respond_to?("#{column}=") && self.send(column).nil?
           write_attribute(column.to_s, current_time)
         end

     NameError:
       undefined local variable or method `all_timestamp_attributes' for #<TestEmployee:0x00555803a58150>
       Did you mean?  clear_timestamp_attributes
     # /home/yahonda/git/rails/activemodel/lib/active_model/attribute_methods.rb:432:in `method_missing'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:110:in `block in _create_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:138:in `run_callbacks'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:105:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:549:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:104:in `run_callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:817:in `_run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:125:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:44:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:35:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block (2 levels) in save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:385:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:186:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:382:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block in save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `rollback_active_record_state!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:308:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:42:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:34:in `create'
     # ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:193:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `load'
     # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `<main>'

  4) OracleEnhancedAdapter custom methods for create, update and destroy should rollback record when exception is raised in after_update callback
     Failure/Error:
       all_timestamp_attributes.each do |column|
         if respond_to?(column) && respond_to?("#{column}=") && self.send(column).nil?
           write_attribute(column.to_s, current_time)
         end

     NameError:
       undefined local variable or method `all_timestamp_attributes' for #<TestEmployee:0x0055580391cd68>
       Did you mean?  clear_timestamp_attributes
     # /home/yahonda/git/rails/activemodel/lib/active_model/attribute_methods.rb:432:in `method_missing'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:110:in `block in _create_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:138:in `run_callbacks'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:105:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:549:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:104:in `run_callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:817:in `_run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:125:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:44:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:35:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block (2 levels) in save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:385:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:186:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:382:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block in save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `rollback_active_record_state!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:308:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:42:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:34:in `create'
     # ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:209:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `load'
     # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `<main>'

  5) OracleEnhancedAdapter custom methods for create, update and destroy should not update record if nothing is changed and partial writes are enabled
     Failure/Error:
       all_timestamp_attributes.each do |column|
         if respond_to?(column) && respond_to?("#{column}=") && self.send(column).nil?
           write_attribute(column.to_s, current_time)
         end

     NameError:
       undefined local variable or method `all_timestamp_attributes' for #<TestEmployee:0x005558037c26c0>
       Did you mean?  clear_timestamp_attributes
     # /home/yahonda/git/rails/activemodel/lib/active_model/attribute_methods.rb:432:in `method_missing'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:110:in `block in _create_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:138:in `run_callbacks'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:105:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:549:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:104:in `run_callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:817:in `_run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:125:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:44:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:35:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block (2 levels) in save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:385:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:186:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:382:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block in save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `rollback_active_record_state!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:308:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:42:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:34:in `create'
     # ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:227:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `load'
     # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `<main>'

  6) OracleEnhancedAdapter custom methods for create, update and destroy should update record if nothing is changed and partial writes are disabled
     Failure/Error:
       all_timestamp_attributes.each do |column|
         if respond_to?(column) && respond_to?("#{column}=") && self.send(column).nil?
           write_attribute(column.to_s, current_time)
         end

     NameError:
       undefined local variable or method `all_timestamp_attributes' for #<TestEmployee:0x005558030e8980>
       Did you mean?  clear_timestamp_attributes
     # /home/yahonda/git/rails/activemodel/lib/active_model/attribute_methods.rb:432:in `method_missing'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:110:in `block in _create_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:138:in `run_callbacks'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:105:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:549:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:104:in `run_callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:817:in `_run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:125:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:44:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:35:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block (2 levels) in save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:385:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:186:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:382:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block in save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `rollback_active_record_state!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:308:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:42:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:34:in `create'
     # ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:240:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `load'
     # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `<main>'

  7) OracleEnhancedAdapter custom methods for create, update and destroy should delete record
     Failure/Error:
       all_timestamp_attributes.each do |column|
         if respond_to?(column) && respond_to?("#{column}=") && self.send(column).nil?
           write_attribute(column.to_s, current_time)
         end

     NameError:
       undefined local variable or method `all_timestamp_attributes' for #<TestEmployee:0x00555802550258>
       Did you mean?  clear_timestamp_attributes
     # /home/yahonda/git/rails/activemodel/lib/active_model/attribute_methods.rb:432:in `method_missing'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:110:in `block in _create_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:138:in `run_callbacks'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:105:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:549:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:104:in `run_callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:817:in `_run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:125:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:44:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:35:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block (2 levels) in save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:385:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:186:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:382:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block in save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `rollback_active_record_state!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:308:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:42:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:34:in `create'
     # ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:252:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `load'
     # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `<main>'

  8) OracleEnhancedAdapter custom methods for create, update and destroy should delete record and set destroyed flag
     Failure/Error:
       all_timestamp_attributes.each do |column|
         if respond_to?(column) && respond_to?("#{column}=") && self.send(column).nil?
           write_attribute(column.to_s, current_time)
         end

     NameError:
       undefined local variable or method `all_timestamp_attributes' for #<TestEmployee:0x00555803ba97c0>
       Did you mean?  clear_timestamp_attributes
     # /home/yahonda/git/rails/activemodel/lib/active_model/attribute_methods.rb:432:in `method_missing'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:110:in `block in _create_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:138:in `run_callbacks'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:105:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:549:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:104:in `run_callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:817:in `_run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:125:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:44:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:35:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block (2 levels) in save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:385:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:186:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:382:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block in save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `rollback_active_record_state!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:308:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:42:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:34:in `create'
     # ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:265:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `load'
     # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `<main>'

  9) OracleEnhancedAdapter custom methods for create, update and destroy should rollback record when exception is raised in after_destroy callback
     Failure/Error:
       all_timestamp_attributes.each do |column|
         if respond_to?(column) && respond_to?("#{column}=") && self.send(column).nil?
           write_attribute(column.to_s, current_time)
         end

     NameError:
       undefined local variable or method `all_timestamp_attributes' for #<TestEmployee:0x00555803a16188>
       Did you mean?  clear_timestamp_attributes
     # /home/yahonda/git/rails/activemodel/lib/active_model/attribute_methods.rb:432:in `method_missing'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:110:in `block in _create_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:138:in `run_callbacks'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:105:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:549:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:104:in `run_callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:817:in `_run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:125:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:44:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:35:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block (2 levels) in save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:385:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:186:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:382:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block in save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `rollback_active_record_state!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:308:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:42:in `save'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:34:in `create'
     # ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:279:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `load'
     # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `<main>'

  10) OracleEnhancedAdapter custom methods for create, update and destroy should set timestamps when creating record
      Failure/Error:
        all_timestamp_attributes.each do |column|
          if respond_to?(column) && respond_to?("#{column}=") && self.send(column).nil?
            write_attribute(column.to_s, current_time)
          end

      NameError:
        undefined local variable or method `all_timestamp_attributes' for #<TestEmployee:0x005558038ae458>
        Did you mean?  clear_timestamp_attributes
      # /home/yahonda/git/rails/activemodel/lib/active_model/attribute_methods.rb:432:in `method_missing'
      # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:110:in `block in _create_record'
      # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:138:in `run_callbacks'
      # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:105:in `_create_record'
      # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:549:in `create_or_update'
      # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `block in create_or_update'
      # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:104:in `run_callbacks'
      # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:817:in `_run_save_callbacks'
      # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `create_or_update'
      # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:125:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:44:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:35:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block (2 levels) in save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:385:in `block in with_transaction_returning_status'
      # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `block in transaction'
      # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:186:in `within_new_transaction'
      # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `transaction'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:382:in `with_transaction_returning_status'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block in save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `rollback_active_record_state!'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:308:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:42:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:34:in `create'
      # ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:295:in `block (2 levels) in <top (required)>'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
      # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `load'
      # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `<main>'

  11) OracleEnhancedAdapter custom methods for create, update and destroy should set timestamps when updating record
      Failure/Error:
        all_timestamp_attributes.each do |column|
          if respond_to?(column) && respond_to?("#{column}=") && self.send(column).nil?
            write_attribute(column.to_s, current_time)
          end

      NameError:
        undefined local variable or method `all_timestamp_attributes' for #<TestEmployee:0x00555803243cd0>
        Did you mean?  clear_timestamp_attributes
      # /home/yahonda/git/rails/activemodel/lib/active_model/attribute_methods.rb:432:in `method_missing'
      # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:110:in `block in _create_record'
      # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:138:in `run_callbacks'
      # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:105:in `_create_record'
      # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:549:in `create_or_update'
      # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `block in create_or_update'
      # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:104:in `run_callbacks'
      # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:817:in `_run_save_callbacks'
      # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `create_or_update'
      # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:125:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:44:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:35:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block (2 levels) in save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:385:in `block in with_transaction_returning_status'
      # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `block in transaction'
      # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:186:in `within_new_transaction'
      # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `transaction'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:382:in `with_transaction_returning_status'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block in save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `rollback_active_record_state!'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:308:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:42:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:34:in `create'
      # ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:305:in `block (2 levels) in <top (required)>'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
      # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `load'
      # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `<main>'

  12) OracleEnhancedAdapter custom methods for create, update and destroy should log create record
      Failure/Error:
        all_timestamp_attributes.each do |column|
          if respond_to?(column) && respond_to?("#{column}=") && self.send(column).nil?
            write_attribute(column.to_s, current_time)
          end

      NameError:
        undefined local variable or method `all_timestamp_attributes' for #<TestEmployee:0x00555802ec9d70>
        Did you mean?  clear_timestamp_attributes
      # /home/yahonda/git/rails/activemodel/lib/active_model/attribute_methods.rb:432:in `method_missing'
      # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:110:in `block in _create_record'
      # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:138:in `run_callbacks'
      # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:105:in `_create_record'
      # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:549:in `create_or_update'
      # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `block in create_or_update'
      # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:104:in `run_callbacks'
      # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:817:in `_run_save_callbacks'
      # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `create_or_update'
      # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:125:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:44:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:35:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block (2 levels) in save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:385:in `block in with_transaction_returning_status'
      # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `block in transaction'
      # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:186:in `within_new_transaction'
      # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `transaction'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:382:in `with_transaction_returning_status'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block in save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `rollback_active_record_state!'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:308:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:42:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:34:in `create'
      # ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:321:in `block (2 levels) in <top (required)>'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
      # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `load'
      # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `<main>'

  13) OracleEnhancedAdapter custom methods for create, update and destroy should log update record
      Failure/Error:
        all_timestamp_attributes.each do |column|
          if respond_to?(column) && respond_to?("#{column}=") && self.send(column).nil?
            write_attribute(column.to_s, current_time)
          end

      NameError:
        undefined local variable or method `all_timestamp_attributes' for #<TestEmployee:0x00555803c48a28>
        Did you mean?  clear_timestamp_attributes
      # /home/yahonda/git/rails/activemodel/lib/active_model/attribute_methods.rb:432:in `method_missing'
      # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:110:in `block in _create_record'
      # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:138:in `run_callbacks'
      # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:105:in `_create_record'
      # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:549:in `create_or_update'
      # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `block in create_or_update'
      # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:104:in `run_callbacks'
      # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:817:in `_run_save_callbacks'
      # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `create_or_update'
      # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:125:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:44:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:35:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block (2 levels) in save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:385:in `block in with_transaction_returning_status'
      # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `block in transaction'
      # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:186:in `within_new_transaction'
      # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `transaction'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:382:in `with_transaction_returning_status'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block in save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `rollback_active_record_state!'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:308:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:42:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:34:in `create'
      # ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:332:in `block (2 levels) in <top (required)>'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
      # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `load'
      # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `<main>'

  14) OracleEnhancedAdapter custom methods for create, update and destroy should log delete record
      Failure/Error:
        all_timestamp_attributes.each do |column|
          if respond_to?(column) && respond_to?("#{column}=") && self.send(column).nil?
            write_attribute(column.to_s, current_time)
          end

      NameError:
        undefined local variable or method `all_timestamp_attributes' for #<TestEmployee:0x00555803a943d0>
        Did you mean?  clear_timestamp_attributes
      # /home/yahonda/git/rails/activemodel/lib/active_model/attribute_methods.rb:432:in `method_missing'
      # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:110:in `block in _create_record'
      # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:138:in `run_callbacks'
      # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:105:in `_create_record'
      # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:549:in `create_or_update'
      # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `block in create_or_update'
      # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:104:in `run_callbacks'
      # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:817:in `_run_save_callbacks'
      # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `create_or_update'
      # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:125:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:44:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:35:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block (2 levels) in save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:385:in `block in with_transaction_returning_status'
      # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `block in transaction'
      # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:186:in `within_new_transaction'
      # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `transaction'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:382:in `with_transaction_returning_status'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block in save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `rollback_active_record_state!'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:308:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:42:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:34:in `create'
      # ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:344:in `block (2 levels) in <top (required)>'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
      # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `load'
      # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `<main>'

  15) OracleEnhancedAdapter custom methods for create, update and destroy should validate existing record before update
      Failure/Error:
        all_timestamp_attributes.each do |column|
          if respond_to?(column) && respond_to?("#{column}=") && self.send(column).nil?
            write_attribute(column.to_s, current_time)
          end

      NameError:
        undefined local variable or method `all_timestamp_attributes' for #<TestEmployee:0x00555802f1bb48>
        Did you mean?  clear_timestamp_attributes
      # /home/yahonda/git/rails/activemodel/lib/active_model/attribute_methods.rb:432:in `method_missing'
      # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:110:in `block in _create_record'
      # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:138:in `run_callbacks'
      # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:105:in `_create_record'
      # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:549:in `create_or_update'
      # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `block in create_or_update'
      # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:104:in `run_callbacks'
      # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:817:in `_run_save_callbacks'
      # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:287:in `create_or_update'
      # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:125:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:44:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:35:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block (2 levels) in save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:385:in `block in with_transaction_returning_status'
      # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `block in transaction'
      # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:186:in `within_new_transaction'
      # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:227:in `transaction'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:382:in `with_transaction_returning_status'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `block in save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `rollback_active_record_state!'
      # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:308:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:42:in `save'
      # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:34:in `create'
      # ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:365:in `block (2 levels) in <top (required)>'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
      # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
      # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `load'
      # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `<main>'

Finished in 2.01 seconds (files took 1.81 seconds to load)
16 examples, 15 failures

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:161 # OracleEnhancedAdapter custom methods for create, update and destroy should create record
rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:176 # OracleEnhancedAdapter custom methods for create, update and destroy should rollback record when exception is raised in after_create callback
rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:192 # OracleEnhancedAdapter custom methods for create, update and destroy should update record
rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:206 # OracleEnhancedAdapter custom methods for create, update and destroy should rollback record when exception is raised in after_update callback
rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:225 # OracleEnhancedAdapter custom methods for create, update and destroy should not update record if nothing is changed and partial writes are enabled
rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:238 # OracleEnhancedAdapter custom methods for create, update and destroy should update record if nothing is changed and partial writes are disabled
rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:251 # OracleEnhancedAdapter custom methods for create, update and destroy should delete record
rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:264 # OracleEnhancedAdapter custom methods for create, update and destroy should delete record and set destroyed flag
rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:275 # OracleEnhancedAdapter custom methods for create, update and destroy should rollback record when exception is raised in after_destroy callback
rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:294 # OracleEnhancedAdapter custom methods for create, update and destroy should set timestamps when creating record
rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:304 # OracleEnhancedAdapter custom methods for create, update and destroy should set timestamps when updating record
rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:319 # OracleEnhancedAdapter custom methods for create, update and destroy should log create record
rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:330 # OracleEnhancedAdapter custom methods for create, update and destroy should log update record
rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:343 # OracleEnhancedAdapter custom methods for create, update and destroy should log delete record
rspec ./spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:364 # OracleEnhancedAdapter custom methods for create, update and destroy should validate existing record before update
```