### PR TITLE
Use Abstract `select_rows(arel, name = nil, binds = [])`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -76,12 +76,6 @@ module ActiveRecord
           select_values("SELECT * FROM TABLE(DBMS_XPLAN.DISPLAY)", "EXPLAIN").join("\n")
         end
 
-        # Returns an array of arrays containing the field values.
-        # Order is the same as that returned by #columns.
-        def select_rows(sql, name = nil, binds = [])
-          exec_query(sql, name, binds).rows
-        end
-
         # New method in ActiveRecord 3.1
         # Will add RETURNING clause in case of trigger generated primary keys
         def sql_for_insert(sql, pk, id_value, sequence_name, binds)


### PR DESCRIPTION
Refer rails/rails#25522

This pull request addresses (about) 166 errors like this:

```ruby
$ ARCONN=oracle bundle exec ruby -Itest test/cases/autosave_association_test.rb -n test_should_destroy_habtm_as_part_of_the_save_transaction_if_they_were_marked_for_destruction
Using oracle
... snip ...
Run options: -n test_should_destroy_habtm_as_part_of_the_save_transaction_if_they_were_marked_for_destruction --seed 31131

# Running:

E

Finished in 0.549146s, 1.8210 runs/s, 3.6420 assertions/s.

  1) Error:
TestDestroyAsPartOfAutosaveAssociation#test_should_destroy_habtm_as_part_of_the_save_transaction_if_they_were_marked_for_destruction:
ActiveRecord::StatementInvalid: TypeError: no implicit conversion of Parrot::ActiveRecord_Relation into String: #<Parrot::ActiveRecord_Relation:0x0055e62d142eb8>
    /home/yahonda/git/rails/activerecord/test/cases/test_case.rb:132:in `match?'
    /home/yahonda/git/rails/activerecord/test/cases/test_case.rb:132:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/fanout.rb:127:in `finish'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/fanout.rb:46:in `block in finish'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/fanout.rb:46:in `each'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/fanout.rb:46:in `finish'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:42:in `finish_with_state'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:27:in `ensure in instrument'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:27:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:587:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1044:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:22:in `exec_query'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:82:in `select_rows'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:54:in `select_value'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation/finder_methods.rb:326:in `exists?'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:239:in `empty?'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/has_many_association.rb:46:in `empty?'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_proxy.rb:861:in `empty?'
    test/cases/autosave_association_test.rb:1012:in `test_should_destroy_habtm_as_part_of_the_save_transaction_if_they_were_marked_for_destruction'

1 runs, 2 assertions, 0 failures, 1 errors, 0 skips
$
```
