### PR TITLE
`current_database` returns the expected database name

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -547,6 +547,8 @@ module ActiveRecord
 
       # Current database name
       def current_database
+        select_value("SELECT SYS_CONTEXT('userenv', 'con_name') FROM dual")
+      rescue ActiveRecord::StatementInvalid
         select_value("SELECT SYS_CONTEXT('userenv', 'db_name') FROM dual")
       end
 


### PR DESCRIPTION
This pull request addresses #1131.

In 12c, it returns `CDB_NAME`.

https://docs.oracle.com/database/121/SQLRF/functions199.htm#SQLRF06117

```
Parameter
CDB_NAME

Return Value
If queried while connected to a CDB, returns the current container name.
Otherwise, returns the name of the database as specified in the DB_NAME initialization parameter.
```

CDB_NAME parameter does not exist 11gR2 or lower, it gets `ActiveRecord::StatementInvalid ORA-02003`
then executes the old 'DB_NAME'.