### PR TITLE
rubocop `AlignWith` has been renamed to `EnforcedStyleAlignWith`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -107,7 +107,7 @@ Style/UnneededPercentQ:
 # assignments, where it should be aligned with the LHS.
 Lint/EndAlignment:
   Enabled: true
-  AlignWith: variable
+  EnforcedStyleAlignWith: variable
 
 # Use my_method(my_arg) not my_method( my_arg ) or my_method my_arg.
 Lint/RequireParentheses:


### PR DESCRIPTION
```
$ rubocop -v
0.47.1
$ rubocop
Error: obsolete parameter AlignWith (for Lint/EndAlignment) found in
/home/yahonda/git/oracle-enhanced/.rubocop.yml
`AlignWith` has been renamed to `EnforcedStyleAlignWith`
```