### PR TITLE
Use `supports_foreign_keys_in_create?`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -23,7 +23,7 @@ module ActiveRecord
             statements = o.columns.map { |c| accept c }
             statements << accept(o.primary_keys) if o.primary_keys
 
-            if supports_foreign_keys?
+            if supports_foreign_keys_in_create?
               statements.concat(o.foreign_keys.map { |to_table, options| foreign_key_in_create(o.name, to_table, options) })
             end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -288,6 +288,10 @@ module ActiveRecord
         true
       end
 
+      def supports_foreign_keys_in_create?
+        supports_foreign_keys?
+      end
+
       def supports_views?
         true
       end


### PR DESCRIPTION
Refer rails/rails#24743

This pull request addresses this error.

```ruby
$ bundle exec rake test_oracle
... snip ...
Using oracle
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb:26:in `visit_TableDefinition': undefined method `supports_foreign_keys?' for #<ActiveRecord::ConnectionAdapters::OracleEnhanced::SchemaCreation:0x0055ba30c6cf88> (NoMethodError)
Did you mean?  supports_foreign_keys_in_create?
        from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:14:in `accept'
        from /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:76:in `create_table'
        from /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:851:in `block in method_missing'
        from /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:820:in `block in say_with_time'
        from /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/2.4.0/benchmark.rb:293:in `measure'
        from /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:820:in `say_with_time'
        from /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:840:in `method_missing'
        from /home/yahonda/git/rails/activerecord/test/schema/schema.rb:9:in `block in <top (required)>'
        from /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:48:in `instance_eval'
        from /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:48:in `define'
        from /home/yahonda/git/rails/activerecord/lib/active_record/schema.rb:44:in `define'
        from /home/yahonda/git/rails/activerecord/test/schema/schema.rb:1:in `<top (required)>'
        from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:286:in `load'
        from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:286:in `block in load'
        from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:258:in `load_dependency'
        from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:286:in `load'
        from /home/yahonda/git/rails/activerecord/test/cases/helper.rb:140:in `load_schema'
        from /home/yahonda/git/rails/activerecord/test/cases/helper.rb:149:in `<top (required)>'
        from /home/yahonda/git/rails/activerecord/test/cases/comment_test.rb:1:in `require'
        from /home/yahonda/git/rails/activerecord/test/cases/comment_test.rb:1:in `<top (required)>'
        from /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/rake_test_loader.rb:15:in `require'
        from /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/rake_test_loader.rb:15:in `block in <main>'
        from /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/rake_test_loader.rb:4:in `select'
        from /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/rake_test_loader.rb:4:in `<main>'
rake aborted!
$
```