### PR TITLE
`initialize_schema_migrations_table` method has been removed

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
@@ -108,13 +108,13 @@ describe "OracleEnhancedAdapter schema dump" do
 
     it "should not include schema_migrations table with prefix in schema dump" do
       ActiveRecord::Base.table_name_prefix = "xxx_"
-      @conn.initialize_schema_migrations_table
+      ActiveRecord::SchemaMigration.create_table
       expect(standard_dump).not_to match(/schema_migrations/)
     end
 
     it "should not include schema_migrations table with suffix in schema dump" do
       ActiveRecord::Base.table_name_suffix = "_xxx"
-      @conn.initialize_schema_migrations_table
+      ActiveRecord::SchemaMigration.create_table
       expect(standard_dump).not_to match(/schema_migrations/)
     end
 


### PR DESCRIPTION
Refer rails/rails#27718

This pull request addresses these two failures:

```ruby
$ bundle exec rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
==> Loading config from ENV or use default
==> Running specs with MRI version 2.4.0
... snip ...
==> Effective ActiveRecord version 5.1.0.alpha
... snip ...

Failures:

  1) OracleEnhancedAdapter schema dump table prefixes and suffixes should not include schema_migrations table with prefix in schema dump
     Failure/Error: @conn.initialize_schema_migrations_table

     NoMethodError:
       undefined method `initialize_schema_migrations_table' for #<ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter:0x0055b8f6bad808>
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:111:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `load'
     # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.13.7/lib/bundler/cli/exec.rb:74:in `load'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.13.7/lib/bundler/cli/exec.rb:74:in `kernel_load'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.13.7/lib/bundler/cli/exec.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.13.7/lib/bundler/cli.rb:332:in `exec'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.13.7/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.13.7/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.13.7/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.13.7/lib/bundler/cli.rb:20:in `dispatch'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.13.7/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.13.7/lib/bundler/cli.rb:11:in `start'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.13.7/exe/bundle:34:in `block in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.13.7/lib/bundler/friendly_errors.rb:100:in `with_friendly_errors'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.13.7/exe/bundle:26:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/bin/bundle:22:in `load'
     # /home/yahonda/.rbenv/versions/2.4.0/bin/bundle:22:in `<main>'

  2) OracleEnhancedAdapter schema dump table prefixes and suffixes should not include schema_migrations table with suffix in schema dump
     Failure/Error: @conn.initialize_schema_migrations_table

     NoMethodError:
       undefined method `initialize_schema_migrations_table' for #<ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter:0x0055b8f6bad808>
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:117:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `load'
     # /home/yahonda/.rbenv/versions/2.4.0/bin/rspec:22:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.13.7/lib/bundler/cli/exec.rb:74:in `load'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.13.7/lib/bundler/cli/exec.rb:74:in `kernel_load'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.13.7/lib/bundler/cli/exec.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.13.7/lib/bundler/cli.rb:332:in `exec'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.13.7/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.13.7/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.13.7/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.13.7/lib/bundler/cli.rb:20:in `dispatch'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.13.7/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.13.7/lib/bundler/cli.rb:11:in `start'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.13.7/exe/bundle:34:in `block in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.13.7/lib/bundler/friendly_errors.rb:100:in `with_friendly_errors'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.13.7/exe/bundle:26:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/bin/bundle:22:in `load'
     # /home/yahonda/.rbenv/versions/2.4.0/bin/bundle:22:in `<main>'

Finished in 25.89 seconds (files took 1.14 seconds to load)
39 examples, 2 failures

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:109 # OracleEnhancedAdapter schema dump table prefixes and suffixes should not include schema_migrations table with prefix in schema dump
rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:115 # OracleEnhancedAdapter schema dump table prefixes and suffixes should not include schema_migrations table with suffix in schema dump
```