### PR TITLE
Add JRuby 9.0.4.0 and allow JRuby 9.0.5.0 failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,12 +36,14 @@ rvm:
   - 2.3.3
   - 2.4.0
   - ruby-head
+  - jruby-9.0.4.0
   - jruby-9.0.5.0
   - jruby-9.1.7.0
   - jruby-head
 
 matrix:
   allow_failures:
+    - rvm: jruby-9.0.5.0
     - rvm: ruby-head
     - rvm: jruby-head
 notifications:


### PR DESCRIPTION
Test with Ruby 9.0.4.0 until #1145 is resolved.