### PR TITLE
Drop JRuby 9.0.x support for Rails 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,14 +36,11 @@ rvm:
   - 2.3.3
   - 2.4.0
   - ruby-head
-  - jruby-9.0.4.0
-  - jruby-9.0.5.0
   - jruby-9.1.7.0
   - jruby-head
 
 matrix:
   allow_failures:
-    - rvm: jruby-9.0.5.0
     - rvm: ruby-head
     - rvm: jruby-head
 notifications:


### PR DESCRIPTION
Use JRuby 9.1.x or higher
Refer jruby/jruby#4453 and #1145