### PR TITLE
Add spec for #1149 `TypeError: can't cast Java::JavaSql::Timestamp`

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -744,4 +744,31 @@ describe "OracleEnhancedAdapter" do
       expect(serialized_column.save!).to eq(true)
     end
   end
+
+  describe "quoting" do
+    before(:all) do
+      schema_define do
+        create_table :test_logs, force: true do |t|
+          t.timestamp :send_time
+        end
+      end
+      class TestLog < ActiveRecord::Base
+        validates_uniqueness_of :send_time
+      end
+    end
+
+    after(:all) do
+      schema_define do
+        drop_table :test_logs
+      end
+      Object.send(:remove_const, "TestLog")
+      ActiveRecord::Base.clear_cache! if ActiveRecord::Base.respond_to?(:"clear_cache!")
+    end
+
+    it "should create records including Time"  do
+      TestLog.create! send_time: Time.now + 1.seconds
+      TestLog.create! send_time: Time.now + 2.seconds
+      expect(TestLog.count).to eq 2
+    end
+  end
 end


### PR DESCRIPTION
Added this spec to avoid future regressions reported in #1149.