### PR TITLE
Made it able to change column with adding comment

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -308,6 +308,8 @@ module ActiveRecord
           change_column_sql << tablespace_for((type_to_sql(type).downcase.to_sym), nil, options[:table_name], options[:column_name]) if type
 
           execute(change_column_sql)
+
+          change_column_comment(table_name, column_name, options[:comment]) if options.key?(:comment)
         ensure
           clear_table_columns_cache(table_name)
         end

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -1027,6 +1027,14 @@ end
       expect(TestPost.columns_hash["title"].null).to be_truthy
     end
 
+    it "should change column with comment" do
+      schema_define do
+        change_column :test_posts, :title, :string, comment: "hello comment"
+      end
+      TestPost.reset_column_information
+      expect(TestPost.columns_hash["title"].comment).to eq "hello comment"
+    end
+
     it "should add column" do
       schema_define do
         add_column :test_posts, :body, :string


### PR DESCRIPTION
This PR will make it possible to change column with adding comment.

```ruby
schema_define do
  change_column :test_posts, :title, :string, comment: "hello comment"
end

TestPost.reset_column_information

expect(TestPost.columns_hash["title"].comment).to eq "hello comment"
```

And, this PR fixes the following 2 failures when running AR tests of rails/rails.

## 1. CommentTest#test_add_comment_to_column

https://github.com/rails/rails/blob/28934172042505156f7c60ac2534dd92f32170d9/activerecord/test/cases/comment_test.rb#L80-L88

```sh
vagrant@rails-dev-box:~/src/rails/activerecord$ ruby -v
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-linux]

vagrant@rails-dev-box:~/src/rails/activerecord$ ARCONN=oracle bundle exec ruby -w -Itest:lib test/cases/comment_test.rb -n test_add_comment_to_column
/home/vagrant/src/rails/activesupport/lib/active_support/core_ext/enumerable.rb:20: warning: method redefined; discarding old sum
Using oracle

(snip)

Run options: -n test_add_comment_to_column --seed 13585

# Running:

F

Finished in 0.233997s, 4.2736 runs/s, 8.5471 assertions/s.

  1) Failure:
CommentTest#test_add_comment_to_column [test/cases/comment_test.rb:87]:
--- expected
+++ actual
@@ -1 +1 @@
-"Whoa, content describes itself!"
+nil


1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```

## 2. CommentTest#test_remove_comment_from_column

https://github.com/rails/rails/blob/28934172042505156f7c60ac2534dd92f32170d9/activerecord/test/cases/comment_test.rb#L90-L98

```sh
vagrant@rails-dev-box:~/src/rails/activerecord$ ARCONN=oracle bundle exec ruby -w -Itest:lib test/cases/comment_test.rb -n test_remove_comment_from_column
/home/vagrant/src/rails/activesupport/lib/active_support/core_ext/enumerable.rb:20: warning: method redefined; discarding old sum
Using oracle

(snip)

Run options: -n test_remove_comment_from_column --seed 50950

# Running:

F

Finished in 0.244650s, 4.0875 runs/s, 8.1749 assertions/s.

  1) Failure:
CommentTest#test_remove_comment_from_column [test/cases/comment_test.rb:97]:
Expected "Question is: should you comment obviously named objects?" to be nil.

1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```

I confirmed that these tests passed with Oracle 11g and MRI 2.4.0.

Thanks.
