### PR TITLE
Fix to return nil if column comment is blank at table creation

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -80,7 +80,7 @@ module ActiveRecord
           if supports_comments? && !supports_comments_in_create?
             change_table_comment(table_name, comment) if comment
             td.columns.each do |column|
-              change_column_comment(table_name, column.name, column.comment) if column.comment
+              change_column_comment(table_name, column.name, column.comment) if column.comment.present?
             end
           end
           td.indexes.each { |c, o| add_index table_name, c, o }


### PR DESCRIPTION
This PR will fix to return nil if a value of column comment is blank at table creation.

It's a code snippet from testing code.

```ruby
schema_define do
  create_table :test_employees do |t|
    t.string :first_name, comment: " "
  end
end

class ::TestEmployee < ActiveRecord::Base; end

expect(TestEmployee.columns_hash["first_name"].comment).to be_nil
```

And, This PR fixes the following failure when running AR tests of rails/rails.

## CommentTest#test_blank_columns_created_in_block

https://github.com/rails/rails/blob/28934172042505156f7c60ac2534dd92f32170d9/activerecord/test/cases/comment_test.rb#L51-L57

```sh
vagrant@rails-dev-box:~/src/rails/activerecord$ ARCONN=oracle bundle exec ruby -w -Itest:lib test/cases/comment_test.rb -n test_blank_columns_created_in_block
Ignoring jruby-launcher-1.1.1-java because its extensions are not built.  Try: gem pristine jruby-launcher --version 1.1.1
/home/vagrant/src/rails/activesupport/lib/active_support/core_ext/enumerable.rb:20: warning: method redefined; discarding old sum
Using oracle

(snip)

Run options: -n test_blank_columns_created_in_block --seed 26525

# Running:

F

Finished in 0.198379s, 5.0409 runs/s, 10.0817 assertions/s.

  1) Failure:
CommentTest#test_blank_columns_created_in_block [test/cases/comment_test.rb:55]:
Expected " " to be nil.

1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
vagrant@rails-dev-box:~/src/rails/activerecord$ vi ../../oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
```

I confirmed that these tests passed with Oracle 11g and MRI 2.4.0.

Thanks.
