### PR TITLE
Omit table comment option of schema.rb if it is blank

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -104,7 +104,7 @@ module ActiveRecord #:nodoc:
               tbl.print ", temporary: true" if @connection.temporary_table?(table)
 
               table_comments = @connection.table_comment(table)
-              unless table_comments.nil?
+              unless table_comments.blank?
                 tbl.print ", comment: #{table_comments.inspect}"
               end
 


### PR DESCRIPTION
This PR omits table comment option of schema.rb generated by `db:schema:dump` if it is blank.

The following is a sample code of schema.rb generated by `db:schema:dump`.

## Before

```ruby
ActiveRecord::Schema.define(version: 0) do

  create_table "blank_comments", comment: " ", force: :cascade do |t|
    t.string "space_comment"
    t.string "empty_comment"
    t.string "nil_comment"
    t.string "absent_comment"
  end

  add_index "blank_comments", ["absent_comment"], name: "i_bla_com_abs_com"
  add_index "blank_comments", ["empty_comment"], name: "i_blank_comments_empty_comment"
  add_index "blank_comments", ["nil_comment"], name: "i_blank_comments_nil_comment"
  add_index "blank_comments", ["space_comment"], name: "i_blank_comments_space_comment"

end
```

## After

```ruby
ActiveRecord::Schema.define(version: 0) do

  create_table "blank_comments", force: :cascade do |t|
    t.string "space_comment"
    t.string "empty_comment"
    t.string "nil_comment"
    t.string "absent_comment"
  end

  add_index "blank_comments", ["absent_comment"], name: "i_bla_com_abs_com"
  add_index "blank_comments", ["empty_comment"], name: "i_blank_comments_empty_comment"
  add_index "blank_comments", ["nil_comment"], name: "i_blank_comments_nil_comment"
  add_index "blank_comments", ["space_comment"], name: "i_blank_comments_space_comment"

end
```

And, This PR fixes the following failure when running AR tests of rails/rails.

## CommentTest#test_schema_dump_omits_blank_comments

https://github.com/rails/rails/blob/28934172042505156f7c60ac2534dd92f32170d9/activerecord/test/cases/comment_test.rb#L119-L136

```sh
$ ARCONN=oracle bundle exec ruby -w -Itest:lib test/cases/comment_test.rb -n test_schema_dump_omits_blank_comments

(snip)

Finished in 6.738563s, 0.1484 runs/s, 0.5936 assertions/s.

  1) Failure:
CommentTest#test_schema_dump_omits_blank_comments [test/cases/comment_test.rb:123]:
Expected /create_table "blank_comments",.+comment:/ to not match "# This file is auto-generated from the current state of the database. Instead\n# of editing this file, please use the migrations feature of Active Record to\n# incrementally modify your database, and then regenerate this schema definition.\n#\n# Note that this schema.rb definition is the authoritative source for your\n# database schema. If you need to create the application database on another\n# system, you should be using db:schema:load, not running all the migrations\n# from scratch. The latter is a flawed and unsustainable approach (the more migrations\n# you'll amass, the slower it'll run and the greater likelihood for issues).\n#\n# It's strongly recommended that you check this file into your version control system.\n\nActiveRecord::Schema.define(version: 0) do\n\n  create_table \"blank_comments\", comment: \" \", force: :cascade do |t|\n    t.string \"space_comment\"\n    t.string \"empty_comment\"\n    t.string \"nil_comment\"\n    t.string \"absent_comment\"\n  end\n\n  add_index \"blank_comments\", [\"absent_comment\"], name: \"i_bla_com_abs_com\"\n  add_index \"blank_comments\", [\"empty_comment\"], name: \"i_blank_comments_empty_comment\"\n  add_index \"blank_comments\", [\"nil_comment\"], name: \"i_blank_comments_nil_comment\"\n  add_index \"blank_comments\", [\"space_comment\"], name: \"i_blank_comments_space_comment\"\n\nend\n".

1 runs, 4 assertions, 1 failures, 0 errors, 0 skips
```

I confirmed that these tests passed with Oracle 11g and MRI 2.4.0.

Thanks.
