### PR TITLE
Remove a duplicated specs

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
@@ -495,43 +495,4 @@ describe "OracleEnhancedAdapter schema dump" do
     end
   end
 
-  describe "table comments" do
-    before(:each) do
-      schema_define do
-        create_table :test_table_comments, comment: "this is a \"table comment\"!", force: true do |t|
-          t.string :blah
-        end
-      end
-    end
-
-    after(:each) do
-      schema_define do
-        drop_table :test_table_comments
-      end
-    end
-
-    it "should dump table comments" do
-      expect(standard_dump).to match(/comment: "this is a \\"table comment\\"!"/)
-    end
-  end
-
-  describe "column comments" do
-    before(:each) do
-      schema_define do
-        create_table :test_column_comments, force: true do |t|
-          t.string :blah, comment: "this is a \"column comment\"!"
-        end
-      end
-    end
-
-    after(:each) do
-      schema_define do
-        drop_table :test_column_comments
-      end
-    end
-
-    it "should dump column comments" do
-      expect(standard_dump).to match(/comment: "this is a \\"column comment\\"!"/)
-    end
-  end
 end


### PR DESCRIPTION
It seems that [oracle_enhanced_schema_dump_spec.rb#L458-L496](https://github.com/rsim/oracle-enhanced/blob/8dda26422a352310311382b611b78ce021cd6479/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb#L458-L496) and [oracle_enhanced_schema_dump_spec.rb#L498-L536](https://github.com/rsim/oracle-enhanced/blob/8dda26422a352310311382b611b78ce021cd6479/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb#L498-L536) are the same.
