### PR TITLE
Remove a spec covered by Active Record

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -1027,14 +1027,6 @@ end
       expect(TestPost.columns_hash["title"].null).to be_truthy
     end
 
-    it "should change column with comment" do
-      schema_define do
-        change_column :test_posts, :title, :string, comment: "hello comment"
-      end
-      TestPost.reset_column_information
-      expect(TestPost.columns_hash["title"].comment).to eq "hello comment"
-    end
-
     it "should add column" do
       schema_define do
         add_column :test_posts, :body, :string


### PR DESCRIPTION
This spec is covered [here](https://github.com/rails/rails/blob/28934172042505156f7c60ac2534dd92f32170d9/activerecord/test/cases/comment_test.rb#L80-L88).

Fixes https://github.com/rsim/oracle-enhanced/pull/1156#issuecomment-278036280.