### PR TITLE
Change the position of table comment in schema dump

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -103,11 +103,6 @@ module ActiveRecord #:nodoc:
               # addition to make temporary option work
               tbl.print ", temporary: true" if @connection.temporary_table?(table)
 
-              table_comments = @connection.table_comment(table)
-              unless table_comments.blank?
-                tbl.print ", comment: #{table_comments.inspect}"
-              end
-
               case pk
               when String
                 tbl.print ", primary_key: #{pk.inspect}" unless pk == "id"
@@ -125,6 +120,12 @@ module ActiveRecord #:nodoc:
               end
 
               tbl.print ", force: :cascade"
+
+              table_comments = @connection.table_comment(table)
+              unless table_comments.blank?
+                tbl.print ", comment: #{table_comments.inspect}"
+              end
+
               tbl.puts " do |t|"
 
               # then dump all non-primary key columns


### PR DESCRIPTION
This PR changes the position of the table comment option backward in schema dump.

The following schema dump code is the value of `output` variable when running [this test](https://github.com/rails/rails/blob/e04de27b2fb0dffdf54316c42bc9669023877d51/activerecord/test/cases/comment_test.rb#L110).

## Before (Oracle Enhanced)

The `comment` option of `create_table` is forward.

```ruby
ActiveRecord::Schema.define(version: 0) do

  create_table "commenteds", comment: "A table with comment", force: :cascade do |t|
    t.string  "name",                   comment: "Comment should help clarify the column purpose"
    t.string  "obvious"
    t.string  "content",                comment: "Whoa, content describes itself!"
    t.integer "rating",  precision: 38, comment: "I am running out of imagination"
  end

  add_index "commenteds", ["name"], name: "index_commenteds_on_name"
  add_index "commenteds", ["obvious"], name: "idx_obvious"

end
```

## After (Oracle Enhanced)

The `comment` option of `create_table` is backward.

```ruby
ActiveRecord::Schema.define(version: 0) do

  create_table "commenteds", force: :cascade, comment: "A table with comment" do |t|
    t.string  "name",                   comment: "Comment should help clarify the column purpose"
    t.string  "obvious"
    t.string  "content",                comment: "Whoa, content describes itself!"
    t.integer "rating",  precision: 38, comment: "I am running out of imagination"
  end

  add_index "commenteds", ["name"], name: "index_commenteds_on_name"
  add_index "commenteds", ["obvious"], name: "idx_obvious"

end
```

This change is to make it consistent with schema dump by MySQL and PostgreSQL.

## MySQL

The `comment` option of `create_table` is backward.

```ruby
ActiveRecord::Schema.define(version: 0) do

  create_table "commenteds", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", comment: "A table with comment" do |t|
    t.string "name", comment: "Comment should help clarify the column purpose"
    t.string "obvious"
    t.string "content", comment: "Whoa, content describes itself!"
    t.integer "rating", comment: "I am running out of imagination"
    t.index ["name"], name: "index_commenteds_on_name", using: :btree, comment: "\"Very important\" index that powers all the performance.\nAnd it's fun!"
    t.index ["obvious"], name: "idx_obvious", using: :btree, comment: "We need to see obvious comments"
  end

end
```

## PostgreSQL

The `comment` option of `create_table` is backward.

```ruby
ActiveRecord::Schema.define(version: 0) do

  # These are extensions that must be enabled in order to support this database
  enable_extension "plpgsql"
  enable_extension "uuid-ossp"
  enable_extension "pgcrypto"
  enable_extension "ltree"
  enable_extension "hstore"

  create_table "commenteds", force: :cascade, comment: "A table with comment" do |t|
    t.string "name", comment: "Comment should help clarify the column purpose"
    t.string "obvious"
    t.string "content", comment: "Whoa, content describes itself!"
    t.integer "rating", comment: "I am running out of imagination"
    t.index ["name"], name: "index_commenteds_on_name", using: :btree, comment: "\"Very important\" index that powers all the performance.\nAnd it's fun!"
    t.index ["obvious"], name: "idx_obvious", using: :btree, comment: "We need to see obvious comments"
  end

end
```

And, This PR fixes the following 1 assertion failure when running AR tests of rails/rails.

https://github.com/rails/rails/blob/e04de27b2fb0dffdf54316c42bc9669023877d51/activerecord/test/cases/comment_test.rb#L110

Thanks.
