### PR TITLE
Address change_column `ArgumentError: wrong number of arguments`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -293,13 +293,12 @@ module ActiveRecord
           if type.to_sym == :virtual
             type = options[:type]
           end
-          change_column_sql = "ALTER TABLE #{quote_table_name(table_name)} MODIFY #{quote_column_name(column_name)} "
-          change_column_sql << "#{type_to_sql(type, options)}" if type
 
-          add_column_options!(change_column_sql, options.merge(type: type, column_name: column_name, table_name: table_name))
-
-          change_column_sql << tablespace_for((type_to_sql(type).downcase.to_sym), nil, options[:table_name], options[:column_name]) if type
-
+          td = create_table_definition(table_name)
+          cd = td.new_column_definition(column.name, type, options)
+          change_column_stmt = schema_creation.accept cd
+          change_column_stmt << tablespace_for((type_to_sql(type).downcase.to_sym), nil, options[:table_name], options[:column_name]) if type
+          change_column_sql = "ALTER TABLE #{quote_table_name(table_name)} MODIFY #{change_column_stmt}"
           execute(change_column_sql)
 
           change_column_comment(table_name, column_name, options[:comment]) if options.key?(:comment)

--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -264,30 +264,6 @@ module ActiveRecord #:nodoc:
         s.join
       end
 
-      def add_column_options!(sql, options) #:nodoc:
-        type = options[:type] || ((column = options[:column]) && column.type)
-        type = type && type.to_sym
-        # handle case of defaults for CLOB columns, which would otherwise get "quoted" incorrectly
-        if options_include_default?(options)
-          if type == :text
-            sql << " DEFAULT #{quote(options[:default])}"
-          else
-            # from abstract adapter
-            sql << " DEFAULT #{quote(options[:default], options[:column])}"
-          end
-        end
-        # must explicitly add NULL or NOT NULL to allow change_column to work on migrations
-        if options[:null] == false
-          sql << " NOT NULL"
-        elsif options[:null] == true
-          sql << " NULL" unless type == :primary_key
-        end
-        # add AS expression for virtual columns
-        if options[:as].present?
-          sql << " AS (#{options[:as]})"
-        end
-      end
-
       def execute_structure_dump(string)
         string.split(STATEMENT_TOKEN).each do |ddl|
           execute(ddl) unless ddl.blank?


### PR DESCRIPTION
This pull request fixes #1171 

It also removes duplicate `add_column_options!` method from `ActiveRecord::ConnectionAdapters::OracleEnhancedStructureDump`

It addresses these 7 errors:

```ruby
$ ARCONN=oracle bundle exec ruby -w -Itest test/cases/migration/change_schema_test.rb -n test_keeping_default_and_notnull_constraints_on_change
... snip ...
Run options: -n test_keeping_default_and_notnull_constraints_on_change --seed 31972

# Running:

E

Finished in 0.592900s, 1.6866 runs/s, 11.8064 assertions/s.

  1) Error:
ActiveRecord::Migration::ChangeSchemaTest#test_keeping_default_and_notnull_constraints_on_change:
ArgumentError: wrong number of arguments (given 2, expected 1)
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:9:in `quote'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb:276:in `add_column_options!'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:299:in `change_column'
    test/cases/migration/change_schema_test.rb:324:in `test_keeping_default_and_notnull_constraints_on_change'

1 runs, 7 assertions, 0 failures, 1 errors, 0 skips
$
```

```ruby
$ ARCONN=oracle bundle exec ruby -w -Itest test/cases/migration/columns_test.rb -n /test_change_column/
... snip ...
Run options: -n /test_change_column/ --seed 5924

# Running:

E...EEEEE

Finished in 1.326772s, 6.7834 runs/s, 8.2908 assertions/s.

  1) Error:
ActiveRecord::Migration::ColumnsTest#test_change_column:
ArgumentError: wrong number of arguments (given 2, expected 1)
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:9:in `quote'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb:276:in `add_column_options!'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:299:in `change_column'
    /home/yahonda/git/rails/activerecord/test/cases/migration/helper.rb:36:in `change_column'
    test/cases/migration/columns_test.rb:204:in `test_change_column'


  2) Error:
ActiveRecord::Migration::ColumnsTest#test_change_column_nullability:
ArgumentError: wrong number of arguments (given 2, expected 1)
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:9:in `quote'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb:276:in `add_column_options!'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:299:in `change_column'
    /home/yahonda/git/rails/activerecord/test/cases/migration/helper.rb:36:in `change_column'
    test/cases/migration/columns_test.rb:173:in `test_change_column_nullability'


  3) Error:
ActiveRecord::Migration::ColumnsTest#test_change_column_with_custom_index_name:
ArgumentError: wrong number of arguments (given 2, expected 1)
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:9:in `quote'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb:276:in `add_column_options!'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:299:in `change_column'
    /home/yahonda/git/rails/activerecord/test/cases/migration/helper.rb:36:in `change_column'
    test/cases/migration/columns_test.rb:242:in `test_change_column_with_custom_index_name'


  4) Error:
ActiveRecord::Migration::ColumnsTest#test_change_column_with_long_index_name:
ArgumentError: wrong number of arguments (given 2, expected 1)
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:9:in `quote'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb:276:in `add_column_options!'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:299:in `change_column'
    /home/yahonda/git/rails/activerecord/test/cases/migration/helper.rb:36:in `change_column'
    test/cases/migration/columns_test.rb:253:in `test_change_column_with_long_index_name'


  5) Error:
ActiveRecord::Migration::ColumnsTest#test_change_column_with_new_default:
ArgumentError: wrong number of arguments (given 2, expected 1)
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:9:in `quote'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb:276:in `add_column_options!'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:299:in `change_column'
    /home/yahonda/git/rails/activerecord/test/cases/migration/helper.rb:36:in `change_column'
    test/cases/migration/columns_test.rb:232:in `test_change_column_with_new_default'


  6) Error:
ActiveRecord::Migration::ColumnsTest#test_change_column_with_nil_default:
ArgumentError: wrong number of arguments (given 2, expected 1)
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:9:in `quote'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb:276:in `add_column_options!'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:299:in `change_column'
    /home/yahonda/git/rails/activerecord/test/cases/migration/helper.rb:36:in `change_column'
    test/cases/migration/columns_test.rb:222:in `test_change_column_with_nil_default'

9 runs, 11 assertions, 0 failures, 6 errors, 0 skips
$
```
