### PR TITLE
Raise ActiveRecord::NotNullViolation when OCIError: ORA-01400

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -999,6 +999,8 @@ module ActiveRecord
             RecordNotUnique.new(message)
           when 942, 955
             ActiveRecord::StatementInvalid.new(message)
+          when 1400
+            ActiveRecord::NotNullViolation.new(message)
           when 2291
             InvalidForeignKey.new(message)
           when 12899


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/25451.

This PR will fix to raise `ActiveRecord::NotNullViolation` when `OCIError: ORA-01400`.

And, This PR fixes the following 4 failures when running AR tests of rails/rails.

## 1.ActiveRecord::Migration::ChangeSchemaTest#test_create_table_with_not_null_column

https://github.com/rails/rails/blob/efe121eab01d70c9da5747597d8ac6f526f2da4e/activerecord/test/cases/migration/change_schema_test.rb#L41-L49

```sh
vagrant@rails-dev-box:~/src/rails/activerecord$ ARCONN=oracle bundle exec ruby -w -Itest:lib test/cases/migration/change_schema_test.rb -n test_create_table_with_not_null_column

(snip)

Run options: -n test_create_table_with_not_null_column --seed 55458

# Running:

F

Finished in 0.058355s, 17.1366 runs/s, 17.1366 assertions/s.

  1) Failure:
ActiveRecord::Migration::ChangeSchemaTest#test_create_table_with_not_null_column [test/cases/migration/change_schema_test.rb:46]:
[ActiveRecord::NotNullViolation] exception expected, not
Class: <ActiveRecord::StatementInvalid>
Message: <"OCIError: ORA-01400: cannot insert NULL into (\"ARUNIT\".\"TESTINGS\".\"ID\"): insert into testings (foo) values (NULL)">
---Backtrace---
stmt.c:243:in oci8lib_240.so
/home/vagrant/.rvm/gems/ruby-2.4.0/gems/ruby-oci8-2.2.3/lib/oci8/cursor.rb:129:in `exec'
/home/vagrant/.rvm/gems/ruby-2.4.0/gems/ruby-oci8-2.2.3/lib/oci8/oci8.rb:276:in `exec_internal'
/home/vagrant/.rvm/gems/ruby-2.4.0/gems/ruby-oci8-2.2.3/lib/oci8/oci8.rb:267:in `exec'
/home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:443:in `exec'
/home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:90:in `exec'
/home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `block in execute'
/home/vagrant/src/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:605:in `block in log'
/home/vagrant/src/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/home/vagrant/src/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:598:in `log'
/home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1052:in `log'
/home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `execute'
test/cases/migration/change_schema_test.rb:47:in `block in test_create_table_with_not_null_column'
---------------

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
```

## 2.ActiveRecord::Migration::ChangeSchemaTest#test_add_column_not_null_with_default

https://github.com/rails/rails/blob/efe121eab01d70c9da5747597d8ac6f526f2da4e/activerecord/test/cases/migration/change_schema_test.rb#L242-L258

```sh
vagrant@rails-dev-box:~/src/rails/activerecord$ ARCONN=oracle bundle exec ruby -w -Itest:lib test/cases/migration/change_schema_test.rb -n test_add_column_not_null_with_default

(snip)

Run options: -n test_add_column_not_null_with_default --seed 14977

# Running:

F

Finished in 0.077817s, 12.8507 runs/s, 12.8507 assertions/s.

  1) Failure:
ActiveRecord::Migration::ChangeSchemaTest#test_add_column_not_null_with_default [test/cases/migration/change_schema_test.rb:255]:
[ActiveRecord::NotNullViolation] exception expected, not
Class: <ActiveRecord::StatementInvalid>
Message: <"OCIError: ORA-01400: cannot insert NULL into (\"ARUNIT\".\"TESTINGS\".\"BAR\"): insert into testings (\"ID\", \"FOO\", \"BAR\") valu
es (2, 'hello', NULL)">
---Backtrace---
stmt.c:243:in oci8lib_240.so
/home/vagrant/.rvm/gems/ruby-2.4.0/gems/ruby-oci8-2.2.3/lib/oci8/cursor.rb:129:in `exec'
/home/vagrant/.rvm/gems/ruby-2.4.0/gems/ruby-oci8-2.2.3/lib/oci8/oci8.rb:276:in `exec_internal'
/home/vagrant/.rvm/gems/ruby-2.4.0/gems/ruby-oci8-2.2.3/lib/oci8/oci8.rb:267:in `exec'
/home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:443:in `exec'
/home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:90:in `exec'
/home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `block in execute'
/home/vagrant/src/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:605:in `block in log'
/home/vagrant/src/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/home/vagrant/src/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:598:in `log'
/home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1052:in `log'
/home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `execute'
test/cases/migration/change_schema_test.rb:256:in `block in test_add_column_not_null_with_default'
---------------

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
```

## 3.ActiveRecord::Migration::ChangeSchemaTest#test_add_column_not_null_without_default

https://github.com/rails/rails/blob/efe121eab01d70c9da5747597d8ac6f526f2da4e/activerecord/test/cases/migration/change_schema_test.rb#L230-L239

```sh
vagrant@rails-dev-box:~/src/rails/activerecord$ ARCONN=oracle bundle exec ruby -w -Itest:lib test/cases/migration/change_schema_test.rb -n test_add_column_not_null_without_default

(snip)

Run options: -n test_add_column_not_null_without_default --seed 44017

# Running:

F

Finished in 0.070769s, 14.1305 runs/s, 14.1305 assertions/s.

  1) Failure:
ActiveRecord::Migration::ChangeSchemaTest#test_add_column_not_null_without_default [test/cases/migration/change_schema_test.rb:236]:
[ActiveRecord::NotNullViolation] exception expected, not
Class: <ActiveRecord::StatementInvalid>
Message: <"OCIError: ORA-01400: cannot insert NULL into (\"ARUNIT\".\"TESTINGS\".\"ID\"): insert into testings (foo, bar) values ('hello', NULL)">
---Backtrace---
stmt.c:243:in oci8lib_240.so
/home/vagrant/.rvm/gems/ruby-2.4.0/gems/ruby-oci8-2.2.3/lib/oci8/cursor.rb:129:in `exec'
/home/vagrant/.rvm/gems/ruby-2.4.0/gems/ruby-oci8-2.2.3/lib/oci8/oci8.rb:276:in `exec_internal'
/home/vagrant/.rvm/gems/ruby-2.4.0/gems/ruby-oci8-2.2.3/lib/oci8/oci8.rb:267:in `exec'
/home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:443:in `exec'
/home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:90:in `exec'
/home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `block in execute'
/home/vagrant/src/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:605:in `block in log'
/home/vagrant/src/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/home/vagrant/src/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:598:in `log'
/home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1052:in `log'
/home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `execute'
test/cases/migration/change_schema_test.rb:237:in `block in test_add_column_not_null_without_default'
---------------

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
```


## 4.ActiveRecord::AdapterTest#test_not_null_violations_are_translated_to_specific_exception

https://github.com/rails/rails/blob/efe121eab01d70c9da5747597d8ac6f526f2da4e/activerecord/test/cases/adapter_test.rb#L178-L184

```sh
vagrant@rails-dev-box:~/src/rails/activerecord$ ARCONN=oracle bundle exec ruby -w -Itest:lib test/cases/adapter_test.rb -n test_not_null_violations_are_translated_to_specific_exception

(snip)

Run options: -n test_not_null_violations_are_translated_to_specific_exception --seed 59222

# Running:

F

Finished in 0.408885s, 2.4457 runs/s, 2.4457 assertions/s.

  1) Failure:
ActiveRecord::AdapterTest#test_not_null_violations_are_translated_to_specific_exception [test/cases/adapter_test.rb:179]:
[ActiveRecord::NotNullViolation] exception expected, not
Class: <ActiveRecord::StatementInvalid>
Message: <"OCIError: ORA-01400: cannot insert NULL into (\"ARUNIT\".\"POSTS\".\"TITLE\"): INSERT INTO \"POSTS\" (\"ID\") VALUES (:a1)">
---Backtrace---
stmt.c:243:in oci8lib_240.so
/home/vagrant/.rvm/gems/ruby-2.4.0/gems/ruby-oci8-2.2.3/lib/oci8/cursor.rb:129:in `exec'
/home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:166:in `exec_update'
/home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:120:in `block in exec_insert'
/home/vagrant/src/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:605:in `block in log'
/home/vagrant/src/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/home/vagrant/src/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:598:in `log'
/home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1050:in `log'
/home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:99:in `exec_insert'

(snip)

/home/vagrant/src/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:225:in `block in tran
saction'
/home/vagrant/src/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:186:in `within_new_transaction'
/home/vagrant/src/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:225:in `transaction'
/home/vagrant/src/rails/activerecord/lib/active_record/transactions.rb:210:in `transaction'
/home/vagrant/src/rails/activerecord/lib/active_record/transactions.rb:381:in `with_transaction_returning_status'
/home/vagrant/src/rails/activerecord/lib/active_record/transactions.rb:308:in `block in save'
/home/vagrant/src/rails/activerecord/lib/active_record/transactions.rb:323:in `rollback_active_record_state!'
/home/vagrant/src/rails/activerecord/lib/active_record/transactions.rb:307:in `save'
/home/vagrant/src/rails/activerecord/lib/active_record/suppressor.rb:42:in `save'
/home/vagrant/src/rails/activerecord/lib/active_record/persistence.rb:34:in `create'
test/cases/adapter_test.rb:180:in `block in test_not_null_violations_are_translated_to_specific_exception'
---------------

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
```

I confirmed that these tests passed with Oracle 11g and MRI 2.4.0.

Thanks.
