### PR TITLE
Deprecate passing `default` to `index_name_exists?`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -220,7 +220,12 @@ module ActiveRecord
         # as there's no way to determine the correct answer in that case.
         #
         # Will always query database and not index cache.
-        def index_name_exists?(table_name, index_name, default)
+        def index_name_exists?(table_name, index_name, default = nil)
+          unless default.nil?
+            ActiveSupport::Deprecation.warn(<<-MSG.squish)
+              Passing default to #index_name_exists? is deprecated without replacement.
+            MSG
+          end
           (owner, table_name, db_link) = @connection.describe(table_name)
           result = select_value(<<-SQL)
             SELECT 1 FROM all_indexes#{db_link} i


### PR DESCRIPTION
Refer rails/rails#26930

This pull request addresses these 1 failure and 5 errors.

```ruby
$ ARCONN=oracle bundle exec ruby -w -Itest test/cases/migration/index_test.rb
... snip ...
# Running:

..EE.....E...FE..

Finished in 97.620479s, 0.1741 runs/s, 0.2663 assertions/s.

  1) Error:
ActiveRecord::Migration::IndexTest#test_add_index_does_not_accept_too_long_index_names:
ArgumentError: wrong number of arguments (given 2, expected 3)
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:223:in `index_name_exists?'
    test/cases/migration/index_test.rb:78:in `test_add_index_does_not_accept_too_long_index_names'


  2) Error:
ActiveRecord::Migration::IndexTest#test_add_index_works_with_long_index_names:
ArgumentError: wrong number of arguments (given 2, expected 3)
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:223:in `index_name_exists?'
    test/cases/migration/index_test.rb:66:in `test_add_index_works_with_long_index_names'


  3) Error:
ActiveRecord::Migration::IndexTest#test_internal_index_with_name_matching_database_limit:
ArgumentError: wrong number of arguments (given 2, expected 3)
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:223:in `index_name_exists?'
    test/cases/migration/index_test.rb:86:in `test_internal_index_with_name_matching_database_limit'


  4) Failure:
ActiveRecord::Migration::IndexTest#test_rename_index [test/cases/migration/index_test.rb:34]:
Expected a deprecation warning within the block but received none


  5) Error:
ActiveRecord::Migration::IndexTest#test_rename_index_too_long:
ArgumentError: wrong number of arguments (given 2, expected 3)
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:223:in `index_name_exists?'
    test/cases/migration/index_test.rb:49:in `test_rename_index_too_long'

17 runs, 26 assertions, 1 failures, 4 errors, 0 skips
$
```

```ruby
$ ARCONN=oracle bundle exec ruby -w -Itest test/cases/migration/compatibility_test.rb -n test_migration_does_remove_unnamed_index
... snip ...

  1) Error:
ActiveRecord::Migration::CompatibilityTest#test_migration_does_remove_unnamed_index:
StandardError: An error has occurred, all later migrations canceled:

wrong number of arguments (given 2, expected 3)
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:223:in `index_name_exists?'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:851:in `block in method_missing'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:820:in `block in say_with_time'
    /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/2.5.0/benchmark.rb:293:in `measure'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:820:in `say_with_time'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:840:in `method_missing'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration/compatibility.rb:148:in `index_name_for_remove'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration/compatibility.rb:139:in `remove_index'
    test/cases/migration/compatibility_test.rb:49:in `migrate'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:1215:in `block in execute_migration_in_transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:1285:in `ddl_transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:1214:in `execute_migration_in_transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:1186:in `block in migrate_without_lock'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:1185:in `each'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:1185:in `migrate_without_lock'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:1135:in `migrate'
    test/cases/migration/compatibility_test.rb:54:in `test_migration_does_remove_unnamed_index'

1 runs, 1 assertions, 0 failures, 1 errors, 0 skips
$
```