### PR TITLE
Restore :raw type migration support

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -6,6 +6,16 @@ module ActiveRecord
           # This is a placeholder for future :auto_increment support
           super
         end
+
+        [
+          :raw
+        ].each do |column_type|
+          module_eval <<-CODE, __FILE__, __LINE__ + 1
+            def #{column_type}(*args, **options)
+              args.each { |name| column(name, :#{column_type}, options) }
+            end
+          CODE
+        end
       end
 
       class ReferenceDefinition < ActiveRecord::ConnectionAdapters::ReferenceDefinition # :nodoc:

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -1133,33 +1133,29 @@ describe "OracleEnhancedAdapter handling of BLOB columns" do
 end
 
 describe "OracleEnhancedAdapter handling of RAW columns" do
+  include SchemaSpecHelper
+
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    @conn = ActiveRecord::Base.connection
-    @conn.execute <<-SQL
-      CREATE TABLE test_employees (
-        employee_id   NUMBER(6,0) PRIMARY KEY,
-        first_name    VARCHAR2(20),
-        last_name     VARCHAR2(25),
-        binary_data   RAW(1024)
-      )
-    SQL
-    @conn.execute <<-SQL
-      CREATE SEQUENCE test_employees_seq  MINVALUE 1
-        INCREMENT BY 1 CACHE 20 NOORDER NOCYCLE
-    SQL
+    schema_define do
+      create_table :test_employees, force: true do |t|
+        t.string    :first_name,    limit: 20
+        t.string    :last_name,     limit: 25
+        t.raw       :binary_data,   limit: 1024
+      end
+    end
     @binary_data = "\0\1\2\3\4\5\6\7\8\9" * 100
     @binary_data2 = "\1\2\3\4\5\6\7\8\9\0" * 100
   end
 
   after(:all) do
-    @conn.execute "DROP TABLE test_employees"
-    @conn.execute "DROP SEQUENCE test_employees_seq"
+    schema_define do
+      drop_table :test_employees
+    end
   end
 
   before(:each) do
     class ::TestEmployee < ActiveRecord::Base
-      self.primary_key = "employee_id"
     end
   end
 


### PR DESCRIPTION
This pull request supports `:raw` type migration support.

### Environment:
Rails master branch
Oracle enhanced master branch
Oracle Database 12.1.0.2 Enterprise Edition
ruby 2.5.0dev (2017-02-13 trunk 57613) [x86_64-linux]


#### Steps to reproduce:

```ruby
begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
  raise e
end

gemfile(true) do
  source "https://rubygems.org"
  gem "rails", github: "rails/rails", branch: "master"
  gem "arel", github: "rails/arel", branch: "master"
  gem "activerecord-oracle_enhanced-adapter",  github: "rsim/oracle-enhanced", branch: "master"
  gem "ruby-oci8"
  gem "minitest"
  gem "byebug"
end

require "active_record"
require "minitest/autorun"
require "logger"
require "active_record/connection_adapters/oracle_enhanced_adapter"
require "byebug"

# Ensure backward compatibility with Minitest 4
Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)

# Set Oracle enhanced adapter specific connection parameters
DATABASE_NAME = ENV["DATABASE_NAME"] || "orcl"
DATABASE_HOST = ENV["DATABASE_HOST"]
DATABASE_PORT = ENV["DATABASE_PORT"]
DATABASE_USER = ENV["DATABASE_USER"] || "oracle_enhanced"
DATABASE_PASSWORD = ENV["DATABASE_PASSWORD"] || "oracle_enhanced"
DATABASE_SYS_PASSWORD = ENV["DATABASE_SYS_PASSWORD"] || "admin"

CONNECTION_PARAMS = {
  adapter: "oracle_enhanced",
  database: DATABASE_NAME,
  host: DATABASE_HOST,
  port: DATABASE_PORT,
  username: DATABASE_USER,
  password: DATABASE_PASSWORD
}

ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)

ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.raw :original_data
  end
end

class Post < ActiveRecord::Base
end


class BugTest < Minitest::Test
  def test_raw_type
    original_data_type = Post.columns_hash["original_data"].type
    assert_equal original_data_type, :raw
  end
end
```

### Current behavior:

```ruby
$ ruby rep.rb
Fetching git://github.com/rails/rails.git
Fetching git://github.com/rails/arel.git
Fetching gem metadata from https://rubygems.org/...........
Fetching version metadata from https://rubygems.org/..
Resolving dependencies...
Using rake 12.0.0
Using concurrent-ruby 1.0.4
Using i18n 0.8.0
Using minitest 5.10.1
Using thread_safe 0.3.5
Using builder 3.2.3
Using erubi 1.5.0
Using mini_portile2 2.1.0
Using rack 2.0.1
Using nio4r 2.0.0
Using websocket-extensions 0.1.2
Using mime-types-data 3.2016.0521
Using arel 8.0.0 from git://github.com/rails/arel.git (at master@d6af209)
Using ruby-plsql 0.6.0
Using bundler 1.14.4
Using byebug 9.0.6
Using method_source 0.8.2
Using thor 0.19.4
Using ruby-oci8 2.2.3
Using tzinfo 1.2.2
Using nokogiri 1.7.0.1
Using rack-test 0.6.3
Using sprockets 3.7.1
Using websocket-driver 0.6.5
Using mime-types 3.1
Using activesupport 5.1.0.alpha from git://github.com/rails/rails.git (at master@1c968b4)
Using loofah 2.0.3
Using mail 2.6.4
Using rails-dom-testing 2.0.2
Using globalid 0.3.7
Using activemodel 5.1.0.alpha from git://github.com/rails/rails.git (at master@1c968b4)
Using rails-html-sanitizer 1.0.3
Using activejob 5.1.0.alpha from git://github.com/rails/rails.git (at master@1c968b4)
Using activerecord 5.1.0.alpha from git://github.com/rails/rails.git (at master@1c968b4)
Using actionview 5.1.0.alpha from git://github.com/rails/rails.git (at master@1c968b4)
Using activerecord-oracle_enhanced-adapter 1.8.0.alpha from git://github.com/rsim/oracle-enhanced.git (at /home/yahonda/git/oracle-enhanced@95557c1)
Using actionpack 5.1.0.alpha from git://github.com/rails/rails.git (at master@1c968b4)
Using actioncable 5.1.0.alpha from git://github.com/rails/rails.git (at master@1c968b4)
Using actionmailer 5.1.0.alpha from git://github.com/rails/rails.git (at master@1c968b4)
Using railties 5.1.0.alpha from git://github.com/rails/rails.git (at master@1c968b4)
Using sprockets-rails 3.2.0
Using rails 5.1.0.alpha from git://github.com/rails/rails.git (at master@1c968b4)
-- create_table(:posts, {:force=>true})
rep.rb:50:in `block (2 levels) in <main>': undefined method `raw' for #<ActiveRecord::ConnectionAdapters::OracleEnhanced::TableDefinition:0x0055bce74b2108> (NoMethodError)
        from /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:69:in `create_table'
        from /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/bundler/gems/rails-1c968b484bff/activerecord/lib/active_record/migration.rb:851:in `block in method_missing'
        from /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/bundler/gems/rails-1c968b484bff/activerecord/lib/active_record/migration.rb:820:in `block in say_with_time'
        from /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/2.5.0/benchmark.rb:293:in `measure'
        from /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/bundler/gems/rails-1c968b484bff/activerecord/lib/active_record/migration.rb:820:in `say_with_time'
        from /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/bundler/gems/rails-1c968b484bff/activerecord/lib/active_record/migration.rb:840:in `method_missing'
        from rep.rb:49:in `block in <main>'
        from /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/bundler/gems/rails-1c968b484bff/activerecord/lib/active_record/schema.rb:48:in `instance_eval'
        from /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/bundler/gems/rails-1c968b484bff/activerecord/lib/active_record/schema.rb:48:in `define'
        from /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/bundler/gems/rails-1c968b484bff/activerecord/lib/active_record/schema.rb:44:in `define'
        from rep.rb:48:in `<main>'
$
```