### PR TITLE
Deprecate `supports_primary_key?`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -272,10 +272,6 @@ module ActiveRecord
         true
       end
 
-      def supports_primary_key? #:nodoc:
-        true
-      end
-
       def supports_savepoints? #:nodoc:
         true
       end


### PR DESCRIPTION
Refer rails/rails#27977

This pull request addresses this failure:

```ruby
$ ARCONN=oracle bundle exec ruby -w -Itest test/cases/primary_keys_test.rb -n test_deprecate_supports_primary_key
... snip ...
Using oracle
... snip ...
Run options: -n test_deprecate_supports_primary_key --seed 39161

# Running:

F

Finished in 0.501226s, 1.9951 runs/s, 1.9951 assertions/s.

  1) Failure:
PrimaryKeysTest#test_deprecate_supports_primary_key [test/cases/primary_keys_test.rb:145]:
Expected a deprecation warning within the block but received none

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```