### PR TITLE
`empty_insert_statement_value_not_supported` is not implemented

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -220,6 +220,13 @@ module ActiveRecord
             write_lobs(table_name, klass, fixture, klass.lob_columns)
           end
         end
+
+        # Oracle Database does not support this feature
+        # Refer https://community.oracle.com/ideas/13845 and consider to vote
+        # if you need this feature.
+        def empty_insert_statement_value
+          raise NotImplementedError
+        end
       end
     end
   end


### PR DESCRIPTION
`empty_insert_statement_value_not_supported` is not implemented by Oracle database

It would be better raise `NotImplementedError` than returning Abstract adapter implementation `DEFAULT VALUES`.

These two ActiveRecord unit tests currently get error `ActiveRecord::StatementInvalid: OCIError: ORA-00926: missing VALUES keyword`.


```ruby
$ ARCONN=oracle bundle exec ruby -w -Itest test/cases/primary_keys_test.rb -n test_create_without_primary_key_no_extra_query
... snip ...
E

Finished in 0.496107s, 2.0157 runs/s, 0.0000 assertions/s.

  1) Error:
PrimaryKeysTest#test_create_without_primary_key_no_extra_query:
ActiveRecord::StatementInvalid: OCIError: ORA-00926: missing VALUES keyword: INSERT INTO "DASHBOARDS" DEFAULT VALUES
    stmt.c:243:in oci8lib_240.so
    /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/ruby-oci8-2.2.3/lib/oci8/cursor.rb:129:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:166:in `exec_update'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:120:in `block in exec_insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:608:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:601:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1048:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:99:in `exec_insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:123:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:17:in `insert'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:91:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:61:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:578:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:178:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:78:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:296:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:340:in `block in _create_record'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:131:in `run_callbacks'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:825:in `_run_create_callbacks'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:340:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:95:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:555:in `create_or_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:336:in `block in create_or_update'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `run_callbacks'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:825:in `_run_save_callbacks'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:336:in `create_or_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:154:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:50:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:43:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:313:in `block in save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:384:in `block in with_transaction_returning_status'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:225:in `block in transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:186:in `within_new_transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:225:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:210:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:381:in `with_transaction_returning_status'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:313:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:46:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:51:in `create!'
    test/cases/primary_keys_test.rb:189:in `test_create_without_primary_key_no_extra_query'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```

```ruby
$ ARCONN=oracle bundle exec ruby -w -Itest test/cases/dup_test.rb -n test_dup_without_primary_key
... snip ...
# Running:

E

Finished in 0.562839s, 1.7767 runs/s, 0.0000 assertions/s.

  1) Error:
ActiveRecord::DupTest#test_dup_without_primary_key:
ActiveRecord::StatementInvalid: OCIError: ORA-00926: missing VALUES keyword: INSERT INTO "PARROTS_PIRATES" DEFAULT VALUES
    stmt.c:243:in oci8lib_240.so
    /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/ruby-oci8-2.2.3/lib/oci8/cursor.rb:129:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:166:in `exec_update'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:120:in `block in exec_insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:608:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:601:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1048:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:99:in `exec_insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:123:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:17:in `insert'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:91:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:61:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:578:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:178:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:78:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:296:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:340:in `block in _create_record'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:131:in `run_callbacks'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:825:in `_run_create_callbacks'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:340:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:95:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:555:in `create_or_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:336:in `block in create_or_update'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `run_callbacks'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:825:in `_run_save_callbacks'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:336:in `create_or_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:154:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:50:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:43:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:313:in `block in save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:384:in `block in with_transaction_returning_status'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:225:in `block in transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:186:in `within_new_transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:225:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:210:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:381:in `with_transaction_returning_status'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:313:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:46:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:51:in `create!'
    test/cases/dup_test.rb:150:in `test_dup_without_primary_key'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
``` 

### With this commit:

```ruby
  1) Error:
PrimaryKeysTest#test_create_without_primary_key_no_extra_query:
NotImplementedError: NotImplementedError
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:228:in `empty_insert_statement_value'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:56:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:578:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:178:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:78:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:296:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:340:in `block in _create_record'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:131:in `run_callbacks'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:825:in `_run_create_callbacks'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:340:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:95:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:555:in `create_or_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:336:in `block in create_or_update'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `run_callbacks'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:825:in `_run_save_callbacks'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:336:in `create_or_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:154:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:50:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:43:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:313:in `block in save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:384:in `block in with_transaction_returning_status'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:225:in `block in transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:186:in `within_new_transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:225:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:210:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:381:in `with_transaction_returning_status'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:313:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:46:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:51:in `create!'
    test/cases/primary_keys_test.rb:189:in `test_create_without_primary_key_no_extra_query'

1 runs, 0 assertions, 0 failures, 1 errors, 
```

```ruby
  1) Error:
ActiveRecord::DupTest#test_dup_without_primary_key:
NotImplementedError: NotImplementedError
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:228:in `empty_insert_statement_value'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:56:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:578:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:178:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:78:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:296:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:340:in `block in _create_record'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:131:in `run_callbacks'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:825:in `_run_create_callbacks'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:340:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:95:in `_create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:555:in `create_or_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:336:in `block in create_or_update'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `run_callbacks'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:825:in `_run_save_callbacks'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:336:in `create_or_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:154:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:50:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:43:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:313:in `block in save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:384:in `block in with_transaction_returning_status'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:225:in `block in transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:186:in `within_new_transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:225:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:210:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:381:in `with_transaction_returning_status'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:313:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:46:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:51:in `create!'
    test/cases/dup_test.rb:150:in `test_dup_without_primary_key'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```