### PR TITLE
`release_savepoint` is not supported by Oracle

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -197,6 +197,7 @@ module ActiveRecord
 
         def release_savepoint(name = current_savepoint_name) #:nodoc:
           # there is no RELEASE SAVEPOINT statement in Oracle
+          raise NotImplementedError
         end
 
         # Returns default sequence name for table.


### PR DESCRIPTION
Better to raise `NotImplementedError` rather than do nothing