### PR TITLE
Revert "`release_savepoint` is not supported by Oracle"

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -197,7 +197,6 @@ module ActiveRecord
 
         def release_savepoint(name = current_savepoint_name) #:nodoc:
           # there is no RELEASE SAVEPOINT statement in Oracle
-          raise NotImplementedError
         end
 
         # Returns default sequence name for table.


### PR DESCRIPTION
This reverts commit 55bf70964e41292eeb922f616cd5e9a515babc2c.

It caused these errors:
```ruby
  1) Error:
ActiveRecord::AdapterTest#test_update_prepared_statement:
NotImplementedError: NotImplementedError
    /opt/circleci/.rvm/gems/ruby-2.4.0/bundler/gems/oracle-enhanced-e72b434901ce/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:200:in `release_savepoint'
    /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:117:in `commit'
    /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:174:in `commit_transaction'
    /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:199:in `within_new_transaction'
    /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:225:in `transaction'
    /home/ubuntu/rails/activerecord/lib/active_record/transactions.rb:210:in `transaction'
    /home/ubuntu/rails/activerecord/lib/active_record/transactions.rb:381:in `with_transaction_returning_status'
    /home/ubuntu/rails/activerecord/lib/active_record/transactions.rb:308:in `block in save'
    /home/ubuntu/rails/activerecord/lib/active_record/transactions.rb:323:in `rollback_active_record_state!'
    /home/ubuntu/rails/activerecord/lib/active_record/transactions.rb:307:in `save'
    /home/ubuntu/rails/activerecord/lib/active_record/suppressor.rb:42:in `save'
    /home/ubuntu/rails/activerecord/lib/active_record/persistence.rb:34:in `create'
    /home/ubuntu/rails/activerecord/test/cases/adapter_test.rb:18:in `test_update_prepared_statement'
```