### PR TITLE
Refactor ColumnDumper to support consistent Virtual column with Rails

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/column_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column_dumper.rb
@@ -2,69 +2,21 @@ module ActiveRecord #:nodoc:
   module ConnectionAdapters #:nodoc:
     module OracleEnhanced #:nodoc:
       module ColumnDumper #:nodoc:
-        def column_spec(column)
-          spec = Hash[prepare_column_options(column).map { |k, v| [k, "#{k}: #{v}"] }]
-          spec[:name] = column.name.inspect
-          if column.virtual?
-            spec[:type] = "virtual"
-          else
-            spec[:type] = schema_type(column).to_s
-          end
-          spec
-        end
-
         def prepare_column_options(column)
-          spec = {}
+          spec = super
 
-          if limit = schema_limit(column)
-            spec[:limit] = limit
+          if supports_virtual_columns? && column.virtual?
+            spec[:as] = column.virtual_column_data_default
+            spec = { type: schema_type(column).inspect }.merge!(spec) unless column.type == :decimal
           end
-
-          if precision = schema_precision(column)
-            spec[:precision] = precision
-          end
-
-          if scale = schema_scale(column)
-            spec[:scale] = scale
-          end
-
-          if virtual_as = schema_virtual_as(column)
-            spec[:as] = virtual_as
-          end
-
-          if virtual_type = schema_virtual_type(column)
-            spec[:virtual_type] = virtual_type
-          end
-
-          default = schema_default(column) if column.has_default?
-          spec[:default] = default unless default.nil?
-
-          spec[:null] = "false" unless column.null
-
-          spec[:comment] = column.comment.inspect if column.comment.present?
 
           spec
-        end
-
-        def migration_keys
-          # TODO `& column_specs.map(&:keys).flatten` should be exetuted here
-          [:name, :limit, :precision, :scale, :default, :null, :as, :virtual_type, :comment]
         end
 
         private
 
           def default_primary_key?(column)
             schema_type(column) == :integer
-          end
-
-          def schema_virtual_as(column)
-            column.virtual_column_data_default if column.virtual?
-          end
-
-          def schema_virtual_type(column)
-            unless column.type == :decimal
-              column.type.inspect if column.virtual?
-            end
           end
       end
     end

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
@@ -384,12 +384,12 @@ describe "OracleEnhancedAdapter schema dump" do
     end
 
     it "should dump correctly" do
-      expect(standard_dump).to match(/t\.virtual "full_name",(\s*)limit: 512,(\s*)as: "\\"FIRST_NAME\\"\|\|', '\|\|\\"LAST_NAME\\"",(\s*)type: :string/)
-      expect(standard_dump).to match(/t\.virtual "short_name",(\s*)limit: 300,(\s*)as:(.*),(\s*)type: :string/)
-      expect(standard_dump).to match(/t\.virtual "full_name_length",(\s*)precision: 38,(\s*)as:(.*),(\s*)type: :integer/)
+      expect(standard_dump).to match(/t\.virtual "full_name",(\s*)type: :string,(\s*)limit: 512,(\s*)as: "\\"FIRST_NAME\\"\|\|', '\|\|\\"LAST_NAME\\""/)
+      expect(standard_dump).to match(/t\.virtual "short_name",(\s*)type: :string,(\s*)limit: 300,(\s*)as:(.*)/)
+      expect(standard_dump).to match(/t\.virtual "full_name_length",(\s*)type: :integer,(\s*)precision: 38,(\s*)as:(.*)/)
       expect(standard_dump).to match(/t\.virtual "name_ratio",(\s*)as:(.*)\"$/) # no :type
-      expect(standard_dump).to match(/t\.virtual "abbrev_name",(\s*)limit: 100,(\s*)as:(.*),(\s*)type: :string/)
-      expect(standard_dump).to match(/t\.virtual "field_with_leading_space",(\s*)limit: 300,(\s*)as: "' '\|\|\\"FIRST_NAME\\"\|\|' '",(\s*)type: :string/)
+      expect(standard_dump).to match(/t\.virtual "abbrev_name",(\s*)type: :string,(\s*)limit: 100,(\s*)as:(.*)/)
+      expect(standard_dump).to match(/t\.virtual "field_with_leading_space",(\s*)type: :string,(\s*)limit: 300,(\s*)as: "' '\|\|\\"FIRST_NAME\\"\|\|' '"/)
     end
 
     context "with column cache" do


### PR DESCRIPTION
This pull request addresses these 3 failures:

```ruby
$ ARCONN=oracle bundle exec ruby -w -Itest test/cases/schema_dumper_test.rb -n /no_line_up/

... snip ...

Finished in 21.899343s, 0.0913 runs/s, 0.5480 assertions/s.

  1) Failure:
SchemaDumperTest#test_arguments_no_line_up [test/cases/schema_dumper_test.rb:100]:
Failed assertion, no message given.


  2) Failure:
SchemaDumperTest#test_types_no_line_up [test/cases/schema_dumper_test.rb:94]:
Failed assertion, no message given.

2 runs, 12 assertions, 2 failures, 0 errors, 0 skips
```

```ruby
$ ARCONN=oracle bundle exec ruby -w -Itest test/cases/migration_test.rb -n test_deprecate_migration_keys

... snip ...



# Running:

F

Finished in 0.005173s, 193.2977 runs/s, 193.2977 assertions/s.

  1) Failure:
CopyMigrationsTest#test_deprecate_migration_keys [test/cases/migration_test.rb:1143]:
Expected a deprecation warning within the block but received none

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```

Refer these changes at Rails:
* rails/rails#26756
* rails/rails#22589
* https://github.com/rails/rails/commit/df84e986721
* rails/rails#27884

This commit introduces Virtual column schema dumper format change. `:type` attribute shown next to column name.

Align changes has been introduced by https://github.com/rails/rails/commit/df84e986721 .

* Before this commit:

```ruby
ActiveRecord::Schema.define(version: 0) do

  create_table "test_names", force: :cascade do |t|
    t.string  "first_name"
    t.string  "last_name"
    t.virtual "full_name",                limit: 512,                as: "\"FIRST_NAME\"||', '||\"LAST_NAME\"",                              type: :string
    t.virtual "short_name",               limit: 300,                as: "COALESCE(\"FIRST_NAME\",\"LAST_NAME\")",                           type: :string
    t.virtual "abbrev_name",              limit: 100,                as: "SUBSTR(\"FIRST_NAME\",1,50)||' '||SUBSTR(\"LAST_NAME\",1,1)||'.'", type: :string
    t.virtual "name_ratio",                                          as: "LENGTH(\"FIRST_NAME\")*10/LENGTH(\"LAST_NAME\")*10"
    t.virtual "full_name_length",                     precision: 38, as: "LENGTH(\"FIRST_NAME\"||', '||\"LAST_NAME\")",                      type: :integer
    t.virtual "field_with_leading_space", limit: 300,                as: "' '||\"FIRST_NAME\"||' '",                                         type: :string
  end

end
```

* After this commit:
```
ActiveRecord::Schema.define(version: 0) do

  create_table "test_names", force: :cascade do |t|
    t.string "first_name"
    t.string "last_name"
    t.virtual "full_name", type: :string, limit: 512, as: "\"FIRST_NAME\"||', '||\"LAST_NAME\""
    t.virtual "short_name", type: :string, limit: 300, as: "COALESCE(\"FIRST_NAME\",\"LAST_NAME\")"
    t.virtual "abbrev_name", type: :string, limit: 100, as: "SUBSTR(\"FIRST_NAME\",1,50)||' '||SUBSTR(\"LAST_NAME\",1,1)||'.'"
    t.virtual "name_ratio", as: "LENGTH(\"FIRST_NAME\")*10/LENGTH(\"LAST_NAME\")*10"
    t.virtual "full_name_length", type: :integer, precision: 38, as: "LENGTH(\"FIRST_NAME\"||', '||\"LAST_NAME\")"
    t.virtual "field_with_leading_space", type: :string, limit: 300, as: "' '||\"FIRST_NAME\"||' '"
  end

end
```