### PR TITLE
Remove deprecated `name` argument from `#tables`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -571,20 +571,11 @@ module ActiveRecord
         select_value("SELECT LOWER(default_tablespace) FROM user_users WHERE username = SYS_CONTEXT('userenv', 'current_schema')")
       end
 
-      def tables(name = nil) #:nodoc:
-        ActiveSupport::Deprecation.warn(<<-MSG.squish)
-          #tables currently returns both tables and views.
-          This behavior is deprecated and will be changed with Rails 5.1 to only return tables.
-          Use #data_sources instead.
-        MSG
-
-        if name
-          ActiveSupport::Deprecation.warn(<<-MSG.squish)
-            Passing arguments to #tables is deprecated without replacement.
-          MSG
-        end
-
-        data_sources
+      def tables #:nodoc:
+        select_values(<<-SQL, "SCHEMA")
+          SELECT DECODE(table_name, UPPER(table_name), LOWER(table_name), table_name)
+          FROM all_tables WHERE owner = SYS_CONTEXT('userenv', 'current_schema') AND secondary = 'N'
+        SQL
       end
 
       def data_sources


### PR DESCRIPTION
refer rails/rails#27503
https://github.com/rails/rails/commit/d5be101dd02

This pull request removes the deprecate warning

```ruby
$ bundle exec rspec ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:366
==> Loading config from ENV or use default
==> Running specs with MRI version 2.5.0
... snip ...
==> Effective ActiveRecord version 5.1.0.alpha
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb"=>[366]}}
DEPRECATION WARNING: #tables currently returns both tables and views. This behavior is deprecated and will be changed with Rails 5.1 to only return tables. Use #data_sources instead. (called from block (3 levels) in <top (required)> at /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:375)
... snip ...
.

Finished in 0.37907 seconds (files took 0.926 seconds to load)
1 example, 0 failures

Coverage report generated for RSpec to /home/yahonda/git/oracle-enhanced/coverage. 1037 / 2242 LOC (46.25%) covered.
$