### PR TITLE
data_sources returns tables and views

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -7,7 +7,7 @@ module ActiveRecord #:nodoc:
           def tables(stream)
             return super unless @connection.respond_to?(:materialized_views)
             # do not include materialized views in schema dump - they should be created separately after schema creation
-            sorted_tables = (@connection.data_sources - @connection.materialized_views).sort
+            sorted_tables = (@connection.tables - @connection.materialized_views).sort
             sorted_tables.each do |tbl|
               # add table prefix or suffix for schema_migrations
               next if ignored? tbl

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -386,7 +386,7 @@ module ActiveRecord
               FROM all_constraints#{db_link} c, all_cons_columns#{db_link} cc,
                    all_constraints#{db_link} r, all_cons_columns#{db_link} rc
              WHERE c.owner = '#{owner}'
-               AND c.table_name = '#{desc_table_name}'
+               AND c.table_name = q'[#{desc_table_name}]'
                AND c.constraint_type = 'R'
                AND cc.owner = c.owner
                AND cc.constraint_name = c.constraint_name

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -579,9 +579,7 @@ module ActiveRecord
       end
 
       def data_sources
-        select_values(
-        "SELECT DECODE(table_name, UPPER(table_name), LOWER(table_name), table_name) FROM all_tables WHERE owner = SYS_CONTEXT('userenv', 'current_schema') AND secondary = 'N'",
-        "SCHEMA")
+        super
       end
 
       def table_exists?(table_name)

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -713,9 +713,9 @@ module ActiveRecord
           SELECT trigger_name
           FROM all_triggers#{db_link}
           WHERE owner = '#{owner}'
-            AND trigger_name = '#{trigger_name}'
+            AND trigger_name = q'[#{trigger_name}]'
             AND table_owner = '#{owner}'
-            AND table_name = '#{desc_table_name}'
+            AND table_name = q'[#{desc_table_name}]'
             AND status = 'ENABLED'
         SQL
         select_value(pkt_sql, "Primary Key Trigger") ? true : false


### PR DESCRIPTION
Refer rails/rails#21715

Since https://github.com/rsim/oracle-enhanced/pull/1192/commits/eca49387edc1eff82af7db5cce092bab7b8d20c4 caused these two regressions other two commit address these error and failure.


```ruby
 35) Error:
ViewWithPrimaryKeyTest#test_does_not_dump_view_as_table:
ActiveRecord::StatementInvalid: OCIError: ORA-00911: invalid character:           SELECT trigger_name
          FROM all_triggers
          WHERE owner = 'ARUNIT'
            AND trigger_name = 'EBOOKS'_PKT'
            AND table_owner = 'ARUNIT'
            AND table_name = 'ebooks''
            AND status = 'ENABLED'

    stmt.c:243:in oci8lib_230.so
    /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.3/lib/oci8/cursor.rb:126:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:162:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:39:in `block in exec_query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:611:in `block (2 levels) in log'
    /home/yahonda/.rbenv/versions/2.3.3/lib/ruby/2.3.0/monitor.rb:214:in `mon_synchronize'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:610:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:602:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1055:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:22:in `exec_query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:361:in `select'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:42:in `select_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:97:in `select_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:68:in `select_rows'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:54:in `select_value'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:721:in `has_primary_key_trigger?'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb:32:in `primary_key_trigger'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb:18:in `block in tables'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb:11:in `each'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb:11:in `tables'
    /home/yahonda/git/rails/activerecord/lib/active_record/schema_dumper.rb:37:in `dump'
    /home/yahonda/git/rails/activerecord/lib/active_record/schema_dumper.rb:21:in `dump'
    /home/yahonda/git/rails/activerecord/test/support/schema_dumping_helper.rb:6:in `dump_table_schema'
    /home/yahonda/git/rails/activerecord/test/cases/view_test.rb:75:in `test_does_not_dump_view_as_table'
````

```ruby
 36) Failure:
ViewWithoutPrimaryKeyTest#test_does_not_dump_view_as_table [/home/yahonda/git/rails/activerecord/test/cases/view_test.rb:152]:
Expected /create_table "paperbacks"/ to not match "# This file is auto-generated from the current state of the database. Instead\n# of editing this file, please use the migrations feature of Active Record to\n# incrementally modify your database, and then regenerate this schema definition.\n#\n# Note that this schema.rb definition is the authoritative source for your\n# database schema. If you need to create the application database on another\n# system, you should be using db:schema:load, not running all the migrations\n# from scratch. The latter is a flawed and unsustainable approach (the more migrations\n# you'll amass, the slower it'll run and the greater likelihood for issues).\n#\n# It's strongly recommended that you check this file into your version control system.\n\nActiveRecord::Schema.define(version: 0) do\n\n  create_table \"paperbacks\", id: false, force: :cascade do |t|\n    t.string \"name\"\n    t.integer \"status\", precision: 38\n  end\n\nend\n".
```
