### PR TITLE
Suppress `add_index_options` method `DEPRECATION WARNING: Passing def…

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -161,7 +161,7 @@ module ActiveRecord
           if index_name.to_s.length > max_index_length
             raise ArgumentError, "Index name '#{index_name}' on table '#{table_name}' is too long; the limit is #{max_index_length} characters"
           end
-          if index_name_exists?(table_name, index_name, false)
+          if table_exists?(table_name) && index_name_exists?(table_name, index_name)
             raise ArgumentError, "Index name '#{index_name}' on table '#{table_name}' already exists"
           end
 


### PR DESCRIPTION
…ault to #index_name_exists? is deprecated without replacement.`

This pull request suppresses this deprecation warning:

```ruby
DEPRECATION WARNING: Passing default to #index_name_exists? is deprecated without replacement. (called from add_index_options at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:164)
```
Refer https://github.com/rails/rails/pull/26930
https://github.com/rsim/oracle-enhanced/pull/1175