### PR TITLE
Suppress `remove_index` method deprecation warning at remove_index

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -173,17 +173,6 @@ module ActiveRecord
         # Gives warning if index does not exist
         def remove_index(table_name, options = {}) #:nodoc:
           index_name = index_name_for_remove(table_name, options)
-          unless index_name_exists?(table_name, index_name, true)
-            # sometimes options can be String or Array with column names
-            options = {} unless options.is_a?(Hash)
-            if options.has_key? :name
-              options_without_column = options.dup
-              options_without_column.delete :column
-              index_name_without_column = index_name(table_name, options_without_column)
-              return index_name_without_column if index_name_exists?(table_name, index_name_without_column, false)
-            end
-            raise ArgumentError, "Index name '#{index_name}' on table '#{table_name}' does not exist"
-          end
           #TODO: It should execute only when index_type == "UNIQUE"
           execute "ALTER TABLE #{quote_table_name(table_name)} DROP CONSTRAINT #{quote_column_name(index_name)}" rescue nil
           execute "DROP INDEX #{quote_column_name(index_name)}"


### PR DESCRIPTION
`DEPRECATION WARNING: Passing default to #index_name_exists? is deprecated without replacement.`
Since `index_name_for_remove` method already checks index existence then no need to take care of it here.

Related with #1193