### PR TITLE
Suppress DEPRECATION WARNING at rename_index 

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -227,12 +227,7 @@ module ActiveRecord
         end
 
         def rename_index(table_name, old_name, new_name) #:nodoc:
-          unless index_name_exists?(table_name, old_name, true)
-            raise ArgumentError, "Index name '#{old_name}' on table '#{table_name}' does not exist"
-          end
-          if new_name.length > allowed_index_name_length
-            raise ArgumentError, "Index name '#{new_name}' on table '#{table_name}' is too long; the limit is #{allowed_index_name_length} characters"
-          end
+          validate_index_length!(table_name, new_name)
           execute "ALTER INDEX #{quote_column_name(old_name)} rename to #{quote_column_name(new_name)}"
         ensure
           self.all_schema_indexes = nil

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1000,7 +1000,7 @@ module ActiveRecord
           case @connection.error_code(exception)
           when 1
             RecordNotUnique.new(message)
-          when 942, 955
+          when 942, 955, 1418
             ActiveRecord::StatementInvalid.new(message)
           when 1400
             ActiveRecord::NotNullViolation.new(message)

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -550,7 +550,7 @@ describe "OracleEnhancedAdapter schema definition" do
   it "should raise error when current index name does not exist" do
     expect do
       @conn.rename_index("test_employees", "nonexist_index_name", "new_index_name")
-    end.to raise_error(ArgumentError)
+    end.to raise_error(ActiveRecord::StatementInvalid)
   end
 
   it "should rename index name with new one" do


### PR DESCRIPTION
This pull request suppresses the deprecation warning below.

```ruby
DEPRECATION WARNING: Passing default to #index_name_exists? is deprecated without replacement. (called from rename_index at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:241)
```