### PR TITLE
index_name_exists? at schema statements spec is not necessary

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -1239,7 +1239,6 @@ end
       @conn.instance_variable_set :@would_execute_sql, @would_execute_sql = ""
       class <<@conn
         def execute(sql, name = nil); @would_execute_sql << sql << ";\n"; end
-        def index_name_exists?(table_name, index_name, default); default; end
       end
     end
 


### PR DESCRIPTION
It suppresses the following warning message:
```
oracle_enhanced_schema_statements_spec.rb:1242: warning: method redefined; discarding old index_name_exists?
```