### PR TITLE
`Model.table_comment` syntax is not supported anymore

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -46,11 +46,6 @@ end
 
 module ActiveRecord
   class Base
-    # Get table comment from schema definition.
-    def self.table_comment
-      connection.table_comment(self.table_name)
-    end
-
     def self.lob_columns
       columns.select do |column|
         column.respond_to?(:lob?) && column.lob?

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -348,7 +348,6 @@ describe "OracleEnhancedAdapter schema definition" do
       class ::TestEmployee < ActiveRecord::Base; end
 
       expect(@conn.table_comment("test_employees")).to eq(table_comment)
-      expect(TestEmployee.table_comment).to eq(table_comment)
     end
 
     it "should create table with columns comment" do
@@ -372,7 +371,6 @@ describe "OracleEnhancedAdapter schema definition" do
       class ::TestEmployee < ActiveRecord::Base; end
 
       expect(@conn.table_comment(TestEmployee.table_name)).to eq(table_comment)
-      expect(TestEmployee.table_comment).to eq(table_comment)
       [:first_name, :last_name].each do |attr|
         expect(@conn.column_comment(TestEmployee.table_name, attr.to_s)).to eq(column_comments[attr])
       end


### PR DESCRIPTION
Use Rails `table_comment(table_name)` syntax.