### PR TITLE
Remove `ids_in_list_limit` alias

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -401,7 +401,6 @@ module ActiveRecord
       def in_clause_length
         1000
       end
-      alias ids_in_list_limit in_clause_length
 
       # CONNECTION MANAGEMENT ====================================
       #


### PR DESCRIPTION
since it has been removed since Rails 3.1
https://github.com/rails/rails/commit/66c09372f3ef3d4ca2b99d44cf1859d585b9dcb3