### PR TITLE
Push `valid_type?` up to abstract adapter

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -919,10 +919,6 @@ module ActiveRecord
         select_value("SELECT temporary FROM all_tables WHERE table_name = '#{table_name.upcase}' and owner = SYS_CONTEXT('userenv', 'session_user')") == "Y"
       end
 
-      def valid_type?(type)
-        !native_database_types[type].nil?
-      end
-
       def combine_bind_parameters(
         from_clause: [],
         join_clause: [],


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/28176.

It becomes the same implementation as the super class, it was removed.