### PR TITLE
Deprecate `supports_migrations?` on connection adapters

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -263,10 +263,6 @@ module ActiveRecord
         end
       end
 
-      def supports_migrations? #:nodoc:
-        true
-      end
-
       def supports_savepoints? #:nodoc:
         true
       end


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/28172.