### PR TITLE
Restore #1208 and #1209

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -919,10 +919,6 @@ module ActiveRecord
         select_value("SELECT temporary FROM all_tables WHERE table_name = '#{table_name.upcase}' and owner = SYS_CONTEXT('userenv', 'session_user')") == "Y"
       end
 
-      def valid_type?(type)
-        !native_database_types[type].nil?
-      end
-
       def combine_bind_parameters(
         from_clause: [],
         join_clause: [],

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -263,10 +263,6 @@ module ActiveRecord
         end
       end
 
-      def supports_migrations? #:nodoc:
-        true
-      end
-
       def supports_savepoints? #:nodoc:
         true
       end


### PR DESCRIPTION
Oracle enhanced adapter 1.8.0.beta1 has been out. We can restore #1208 and #1209 to master branch.