### PR TITLE
Suppress unused and not initialized warnings

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
@@ -78,6 +78,10 @@ describe "OracleEnhancedAdapter context index" do
       ActiveRecord::Base.clear_cache!
     end
 
+    before(:each) do
+      @post = nil
+    end
+
     after(:each) do
       @post.destroy if @post
     end

--- a/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
@@ -112,6 +112,8 @@ if ActiveRecord::Base.method_defined?(:changed?)
     end
 
     it "should not update unchanged CLOBs" do
+      @conn = nil
+      @connection = nil
       @employee = TestEmployee.create!(
           comments: "initial"
       )

--- a/spec/active_record/connection_adapters/oracle_enhanced_emulate_oracle_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_emulate_oracle_adapter_spec.rb
@@ -1,6 +1,7 @@
 describe "OracleEnhancedAdapter emulate OracleAdapter" do
 
   before(:all) do
+    @old_oracle_adapter = nil
     if defined?(ActiveRecord::ConnectionAdapters::OracleAdapter)
       @old_oracle_adapter = ActiveRecord::ConnectionAdapters::OracleAdapter
       ActiveRecord::ConnectionAdapters.send(:remove_const, :OracleAdapter)

--- a/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
@@ -210,7 +210,6 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
       hire_date: @today,
       description: "description"
     )
-    empl_id = @employee.id
     @employee.reload
     @employee.first_name = "Second"
     expect {

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -214,7 +214,7 @@ describe "OracleEnhancedAdapter schema definition" do
       it "should not generate NoMethodError for :returning_id:Symbol" do
         set_logger
         @conn.reconnect! unless @conn.active?
-        insert_id = @conn.insert("INSERT INTO test_employees (first_name) VALUES ('Yasuo')", nil, "id")
+        @conn.insert("INSERT INTO test_employees (first_name) VALUES ('Yasuo')", nil, "id")
         expect(@logger.output(:error)).not_to match(/^Could not log "sql.active_record" event. NoMethodError: undefined method `name' for :returning_id:Symbol/)
         clear_logger
       end


### PR DESCRIPTION
This pull request suppresses following warnings.

```ruby
  oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb:122: warning: instance variable @conn not initialized
  oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb:122: warning: instance variable @connection not initialized
  oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb:213: warning: assigned but unused variable - empl_id
  oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:217: warning: assigned but unused variable - insert_id
  oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb:82: warning: instance variable @post not initialized
  oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_emulate_oracle_adapter_spec.rb:17: warning: instance variable @old_oracle_adapter not initialized
```