### PR TITLE
Suppress `WARNING: Using the `raise_error` matcher without providing a specific error`

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -1107,7 +1107,7 @@ end
             t.virtual :field2
           end
         end
-      }.to raise_error
+      }.to raise_error(RuntimeError, "No virtual column definition found.")
     end
   end
 


### PR DESCRIPTION
This PR suppresses the following warning.

```sh
% be rspec spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1103

(snip)

WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match wh
en Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the metho
d you are intending to call. Actual error raised was #<RuntimeError: No virtual column definition found.>. Instead consider providing a specif
ic error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing
`. Called from /home/vagrant/src/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1103:in `bloc
k (3 levels) in <top (required)>'.
.

Finished in 0.0453 seconds (files took 0.52483 seconds to load)
1 example, 0 failures
```
