### PR TITLE
Suppress `WARNING: Using `expect { }.not_to raise_error(...)` risks false positives`

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
@@ -125,7 +125,7 @@ if ActiveRecord::Base.method_defined?(:changed?)
       class << oci_conn
          def write_lob(lob, value, is_binary = false); raise "don't do this'"; end
       end
-      expect { @employee.save! }.not_to raise_exception(RuntimeError, "don't do this'")
+      expect { @employee.save! }.not_to raise_error
       class << oci_conn
         remove_method :write_lob
       end


### PR DESCRIPTION
This PR suppresses the following warning.

```sh
% bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb:128

(snip)

WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass, message)` risks false positives, since literally any other error would cause 
the expectation to pass, including those raised by Ruby (e.g. NoMethodError, NameError and ArgumentError), meaning the code you are intending to t
est may not even get reached. Instead consider using `expect {}.not_to raise_error` or `expect { }.to raise_error(DifferentSpecificErrorClas
s)`. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /home/
vagrant/src/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb:128:in `block (2 levels) in <top (required)>'.
.

Finished in 0.15775 seconds (files took 0.51207 seconds to load)
1 example, 0 failures
```