### PR TITLE
Use `ActiveRecord::SchemaMigration.table_name`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -114,7 +114,7 @@ module ActiveRecord
         end
 
         def insert_versions_sql(versions) # :nodoc:
-          sm_table = quote_table_name(ActiveRecord::Migrator.schema_migrations_table_name)
+          sm_table = quote_table_name(ActiveRecord::SchemaMigration.table_name)
 
           if supports_multi_insert?
             versions.inject("INSERT ALL\n") { |sql, version|

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
@@ -74,7 +74,7 @@ describe "OracleEnhancedAdapter schema dump" do
   describe "table prefixes and suffixes" do
     after(:each) do
       drop_test_posts_table
-      @conn.drop_table(ActiveRecord::Migrator.schema_migrations_table_name) if @conn.table_exists?(ActiveRecord::Migrator.schema_migrations_table_name)
+      @conn.drop_table(ActiveRecord::SchemaMigration.table_name) if @conn.table_exists?(ActiveRecord::SchemaMigration.table_name)
       @conn.drop_table(ActiveRecord::InternalMetadata.table_name) if @conn.table_exists?(ActiveRecord::InternalMetadata.table_name)
       ActiveRecord::Base.table_name_prefix = ""
       ActiveRecord::Base.table_name_suffix = ""


### PR DESCRIPTION
refer rails/rails#28293

This pull request addresses these failures:

```ruby
$ bundle exec rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:83
==> Loading config from ENV or use default
==> Running specs with MRI version 2.5.0
/home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/bundler/gems/ruby-oci8-0ffd0c8787bd/lib/oci8/oci8.rb:627: warning: method redefined; discarding old initialize
/home/yahonda/git/rails/activesupport/lib/active_support/core_ext/enumerable.rb:20: warning: method redefined; discarding old sum
/home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/bundler/gems/ruby-plsql-5e5761cb8e4c/lib/plsql/variable.rb:87: warning: shadowing outer local variable - column
/home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/bundler/gems/ruby-plsql-5e5761cb8e4c/lib/plsql/table.rb:61: warning: assigned but unused variable - data_type_mod
/home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/bundler/gems/ruby-plsql-5e5761cb8e4c/lib/plsql/type.rb:70: warning: assigned but unused variable - data_type_mod
/home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/bundler/gems/ruby-plsql-5e5761cb8e4c/lib/plsql/oci_connection.rb:219: warning: assigned but unused variable - attr_length
/home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/bundler/gems/ruby-plsql-5e5761cb8e4c/lib/plsql/oci_connection.rb:238: warning: assigned but unused variable - attr_length
==> Effective ActiveRecord version 5.1.0.beta1
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb"=>[83]}}
F

Failures:

  1) OracleEnhancedAdapter schema dump table prefixes and suffixes should remove table prefix in schema dump
     Failure/Error: @conn.drop_table(ActiveRecord::Migrator.schema_migrations_table_name) if @conn.table_exists?(ActiveRecord::Migrator.schema_migrations_table_name)

     NoMethodError:
       undefined method `schema_migrations_table_name' for ActiveRecord::Migrator:Class
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:77:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:357:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:507:in `block in run_owned_hooks_for'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:506:in `each'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:506:in `run_owned_hooks_for'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:593:in `block in run_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:592:in `each'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:592:in `run_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:463:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:503:in `run_after_example'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:269:in `block in run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/bin/rspec:22:in `load'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/bin/rspec:22:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/cli/exec.rb:74:in `load'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/cli/exec.rb:74:in `kernel_load'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/cli/exec.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/cli.rb:335:in `exec'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/cli.rb:20:in `dispatch'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/cli.rb:11:in `start'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/exe/bundle:32:in `block in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/friendly_errors.rb:121:in `with_friendly_errors'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/exe/bundle:24:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/bin/bundle:22:in `load'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/bin/bundle:22:in `<main>'

Finished in 1.35 seconds (files took 0.69063 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:83 # OracleEnhancedAdapter schema dump table prefixes and suffixes should remove table prefix in schema dump

Coverage report generated for RSpec to /home/yahonda/git/oracle-enhanced/coverage. 1097 / 2060 LOC (53.25%) covered.
```

```ruby
$ bundle exec rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1339
==> Loading config from ENV or use default
==> Running specs with MRI version 2.5.0
/home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/bundler/gems/ruby-oci8-0ffd0c8787bd/lib/oci8/oci8.rb:627: warning: method redefined; discarding old initialize
/home/yahonda/git/rails/activesupport/lib/active_support/core_ext/enumerable.rb:20: warning: method redefined; discarding old sum
/home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/bundler/gems/ruby-plsql-5e5761cb8e4c/lib/plsql/variable.rb:87: warning: shadowing outer local variable - column
/home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/bundler/gems/ruby-plsql-5e5761cb8e4c/lib/plsql/table.rb:61: warning: assigned but unused variable - data_type_mod
/home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/bundler/gems/ruby-plsql-5e5761cb8e4c/lib/plsql/type.rb:70: warning: assigned but unused variable - data_type_mod
/home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/bundler/gems/ruby-plsql-5e5761cb8e4c/lib/plsql/oci_connection.rb:219: warning: assigned but unused variable - attr_length
/home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/bundler/gems/ruby-plsql-5e5761cb8e4c/lib/plsql/oci_connection.rb:238: warning: assigned but unused variable - attr_length
==> Effective ActiveRecord version 5.1.0.beta1
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb"=>[1339]}}
F

Failures:

  1) OracleEnhancedAdapter schema definition load schema multi insert is supported should loads the migration schema table from insert versions sql
     Failure/Error:
       expect {
         @conn.execute @conn.insert_versions_sql(versions)
       }.not_to raise_error

       expected no Exception, got #<NoMethodError: undefined method `schema_migrations_table_name' for ActiveRecord::Migrator:Class> with backtrace:
         # ./lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:117:in `insert_versions_sql'
         # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1343:in `block (5 levels) in <top (required)>'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.5.0/lib/rspec/matchers/built_in/raise_error.rb:52:in `matches?'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.5.0/lib/rspec/matchers/built_in/raise_error.rb:71:in `does_not_match?'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:78:in `does_not_match?'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:72:in `block in handle_matcher'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:70:in `handle_matcher'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/expectation_target.rb:78:in `not_to'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/expectation_target.rb:106:in `not_to'
         # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1342:in `block (4 levels) in <top (required)>'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/bin/rspec:22:in `load'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/bin/rspec:22:in `<top (required)>'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/cli/exec.rb:74:in `load'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/cli/exec.rb:74:in `kernel_load'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/cli/exec.rb:27:in `run'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/cli.rb:335:in `exec'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/cli.rb:20:in `dispatch'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/cli.rb:11:in `start'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/exe/bundle:32:in `block in <top (required)>'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/friendly_errors.rb:121:in `with_friendly_errors'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/exe/bundle:24:in `<top (required)>'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/bin/bundle:22:in `load'
         # /home/yahonda/.rbenv/versions/2.5.0-dev/bin/bundle:22:in `<main>'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-support-3.5.0/lib/rspec/support.rb:87:in `block in <module:Support>'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-support-3.5.0/lib/rspec/support.rb:96:in `notify_failure'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/fail_with.rb:27:in `fail_with'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:40:in `handle_failure'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:72:in `block in handle_matcher'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/handler.rb:70:in `handle_matcher'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/expectation_target.rb:78:in `not_to'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.5.0/lib/rspec/expectations/expectation_target.rb:106:in `not_to'
     # ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1342:in `block (4 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/bin/rspec:22:in `load'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/bin/rspec:22:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/cli/exec.rb:74:in `load'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/cli/exec.rb:74:in `kernel_load'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/cli/exec.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/cli.rb:335:in `exec'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/cli.rb:20:in `dispatch'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/cli.rb:11:in `start'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/exe/bundle:32:in `block in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/lib/bundler/friendly_errors.rb:121:in `with_friendly_errors'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.14.6/exe/bundle:24:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/bin/bundle:22:in `load'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/bin/bundle:22:in `<main>'

Finished in 0.30731 seconds (files took 1.18 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb:1339 # OracleEnhancedAdapter schema definition load schema multi insert is supported should loads the migration schema table from insert versions sql

Coverage report generated for RSpec to /home/yahonda/git/oracle-enhanced/coverage. 908 / 2592 LOC (35.03%) covered.
$
```
