### PR TITLE
Hard code `empty_blob()` or `empty_clob()` based on types

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -89,9 +89,9 @@ module ActiveRecord
           when ActiveRecord::OracleEnhanced::Type::NationalCharacterString::Data then
             "N" << "'#{quote_string(value.to_s)}'"
           when ActiveModel::Type::Binary::Data then
-            "empty_#{ type_to_sql(column.type.to_sym).downcase rescue 'blob' }()"
+            "empty_blob()"
           when ActiveRecord::OracleEnhanced::Type::Text::Data then
-            "empty_#{ type_to_sql(column.type.to_sym).downcase rescue 'clob' }()"
+            "empty_clob()"
           else
             super
           end


### PR DESCRIPTION
Since this method does not know `column` it always get rescued.