### PR TITLE
Eliminate a redundant empty lines in schema.rb generated by SchemaDumper

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -72,8 +72,10 @@ module ActiveRecord #:nodoc:
                   # unrecognized index type
                   statement_parts = ["# unrecognized index #{index.name.inspect} with type #{index.type.inspect}"]
                 end
-                "  " + statement_parts.join(", ")
-              end
+                "  " + statement_parts.join(", ") unless statement_parts.empty?
+              end.compact
+
+              return if add_index_statements.empty?
 
               stream.puts add_index_statements.sort.join("\n")
               stream.puts

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
@@ -493,4 +493,29 @@ describe "OracleEnhancedAdapter schema dump" do
     end
   end
 
+  describe "schema.rb format" do
+    before do
+      create_test_posts_table
+
+      schema_define do
+        create_table :test_comments, force: true do |t|
+          t.string :title
+        end
+
+        add_index :test_comments, :title
+      end
+    end
+
+    it "should be only one blank line between create_table methods in schema dump" do
+      expect(standard_dump).to match(/end\n\n  create_table/)
+    end
+
+    after do
+      schema_define do
+        drop_table :test_comments rescue nil
+      end
+
+      drop_test_posts_table
+    end
+  end
 end


### PR DESCRIPTION
This PR will eliminates unnecessary blank lines from schema.rb as follows.

## Before

```ruby
# This file is auto-generated from the current state of the database. Instead
# of editing this file, please use the migrations feature of Active Record to
# incrementally modify your database, and then regenerate this schema definition.
#
# Note that this schema.rb definition is the authoritative source for your
# database schema. If you need to create the application database on another
# system, you should be using db:schema:load, not running all the migrations
# from scratch. The latter is a flawed and unsustainable approach (the more migrations
# you'll amass, the slower it'll run and the greater likelihood for issues).
#
# It's strongly recommended that you check this file into your version control system.

ActiveRecord::Schema.define(version: 0) do

  create_table "test_comments", force: :cascade do |t|
    t.string "title"
    t.index ["title"], name: "index_test_comments_on_title"
  end



  create_table "test_posts", force: :cascade do |t|
    t.string "title"
    t.datetime "created_at", precision: 6
    t.datetime "updated_at", precision: 6
    t.index ["title"], name: "index_test_posts_on_title"
  end



end
```

## After

```ruby
# This file is auto-generated from the current state of the database. Instead
# of editing this file, please use the migrations feature of Active Record to
# incrementally modify your database, and then regenerate this schema definition.
#
# Note that this schema.rb definition is the authoritative source for your
# database schema. If you need to create the application database on another
# system, you should be using db:schema:load, not running all the migrations
# from scratch. The latter is a flawed and unsustainable approach (the more migrations
# you'll amass, the slower it'll run and the greater likelihood for issues).
#
# It's strongly recommended that you check this file into your version control system.

ActiveRecord::Schema.define(version: 0) do

  create_table "test_comments", force: :cascade do |t|
    t.string "title"
    t.index ["title"], name: "index_test_comments_on_title"
  end

  create_table "test_posts", force: :cascade do |t|
    t.string "title"
    t.datetime "created_at", precision: 6
    t.datetime "updated_at", precision: 6
    t.index ["title"], name: "index_test_posts_on_title"
  end

end
```
Also, the diff of schema.rb will be beautiful when it migrated from a Rails 5.0 application.
