### PR TITLE
Remove a duplicate spec testing `Model.distinct.count`

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -177,35 +177,6 @@ describe "OracleEnhancedAdapter" do
 
   end
 
-  describe "without composite_primary_keys" do
-
-    before(:all) do
-      @conn = ActiveRecord::Base.connection
-      @conn.execute "DROP TABLE test_employees" rescue nil
-      @conn.execute <<-SQL
-        CREATE TABLE test_employees (
-          employee_id   NUMBER PRIMARY KEY,
-          name          VARCHAR2(50)
-        )
-      SQL
-      Object.send(:remove_const, "CompositePrimaryKeys") if defined?(CompositePrimaryKeys)
-      class ::TestEmployee < ActiveRecord::Base
-        self.primary_key = :employee_id
-      end
-    end
-
-    after(:all) do
-      Object.send(:remove_const, "TestEmployee")
-      @conn.execute "DROP TABLE test_employees"
-      ActiveRecord::Base.clear_cache!
-    end
-
-    it "should execute correct SQL COUNT DISTINCT statement" do
-      expect { TestEmployee.distinct.count(:employee_id) }.not_to raise_error
-    end
-
-  end
-
   describe "reserved words column quoting" do
 
     before(:all) do


### PR DESCRIPTION
It is tested at `CalculationsTest#test_apply_distinct_in_count`

```ruby
$ ARCONN=oracle bundle exec ruby -w -Itest test/cases/calculations_test.rb -n test_apply_distinct_in_count
/home/yahonda/git/rails/activesupport/lib/active_support/core_ext/enumerable.rb:20: warning: method redefined; discarding old sum
Using oracle
Run options: -n test_apply_distinct_in_count --seed 13824

# Running:

.

Finished in 0.664032s, 1.5060 runs/s, 7.5298 assertions/s.

1 runs, 5 assertions, 0 failures, 0 errors, 0 skips
$
```
