### PR TITLE
Fix deprecated warnings in Ruby 2.4.0+

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -239,12 +239,12 @@ module ActiveRecord
 
       def typecast_result_value(value, get_lob_value)
         case value
-        when Fixnum, Bignum
+        when Integer
           value
         when String
           value
         when Float, BigDecimal
-          # return Fixnum or Bignum if value is integer (to avoid issues with _before_type_cast values for id attributes)
+          # return Integer if value is integer (to avoid issues with _before_type_cast values for id attributes)
           value == (v_to_i = value.to_i) ? v_to_i : value
         when OraNumber
           # change OraNumber value (returned in early versions of ruby-oci8 2.0.x) to BigDecimal

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -254,11 +254,11 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
     column.type_cast_from_database(1.0).class.should == BigDecimal
   end
 
-  it "should return Fixnum value from NUMBER column if column name contains 'id' and emulate_integers_by_column_name is true" do
+  it "should return Integer value from NUMBER column if column name contains 'id' and emulate_integers_by_column_name is true" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = true
     columns = @conn.columns('test2_employees')
     column = columns.detect{|c| c.name == "job_id"}
-    column.type_cast_from_database(1.0).class.should == Fixnum
+    column.type_cast_from_database(1.0).class.should == Integer
   end
 
   describe "/ NUMBER values from ActiveRecord model" do
@@ -291,16 +291,16 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
       @employee2.job_id.class.should == BigDecimal
     end
 
-    it "should return Fixnum value from NUMBER column if column name contains 'id' and emulate_integers_by_column_name is true" do
+    it "should return Integer value from NUMBER column if column name contains 'id' and emulate_integers_by_column_name is true" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = true
       create_employee2
-      @employee2.job_id.class.should == Fixnum
+      @employee2.job_id.class.should == Integer
     end
 
-    it "should return Fixnum value from NUMBER column with integer value using _before_type_cast method" do
+    it "should return Integer value from NUMBER column with integer value using _before_type_cast method" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = true
       create_employee2
-      @employee2.job_id_before_type_cast.class.should == Fixnum
+      @employee2.job_id_before_type_cast.class.should == Integer
     end
 
     it "should return BigDecimal value from NUMBER column if column name does not contain 'id' and emulate_integers_by_column_name is true" do
@@ -309,11 +309,11 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
       @employee2.salary.class.should == BigDecimal
     end
 
-    it "should return Fixnum value from NUMBER column if column specified in set_integer_columns" do
+    it "should return Integer value from NUMBER column if column specified in set_integer_columns" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = false
       Test2Employee.set_integer_columns :job_id
       create_employee2
-      @employee2.job_id.class.should == Fixnum
+      @employee2.job_id.class.should == Integer
     end
 
     it "should return Boolean value from NUMBER(1) column if emulate booleans is used" do
@@ -322,17 +322,17 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
       @employee2.is_manager.class.should == TrueClass
     end
 
-    it "should return Fixnum value from NUMBER(1) column if emulate booleans is not used" do
+    it "should return Integer value from NUMBER(1) column if emulate booleans is not used" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans = false
       create_employee2
-      @employee2.is_manager.class.should == Fixnum
+      @employee2.is_manager.class.should == Integer
     end
 
-    it "should return Fixnum value from NUMBER(1) column if column specified in set_integer_columns" do
+    it "should return Integer value from NUMBER(1) column if column specified in set_integer_columns" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans = true
       Test2Employee.set_integer_columns :is_manager
       create_employee2
-      @employee2.is_manager.class.should == Fixnum
+      @employee2.is_manager.class.should == Integer
     end
 
   end

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -258,7 +258,7 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = true
     columns = @conn.columns('test2_employees')
     column = columns.detect{|c| c.name == "job_id"}
-    column.type_cast_from_database(1.0).class.should == Integer
+    expect(column.type_cast_from_database(1.0)).to be_a(Integer)
   end
 
   describe "/ NUMBER values from ActiveRecord model" do
@@ -294,13 +294,13 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
     it "should return Integer value from NUMBER column if column name contains 'id' and emulate_integers_by_column_name is true" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = true
       create_employee2
-      @employee2.job_id.class.should == Integer
+      expect(@employee2.job_id).to be_a(Integer)
     end
 
     it "should return Integer value from NUMBER column with integer value using _before_type_cast method" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = true
       create_employee2
-      @employee2.job_id_before_type_cast.class.should == Integer
+      expect(@employee2.job_id_before_type_cast).to be_a(Integer)
     end
 
     it "should return BigDecimal value from NUMBER column if column name does not contain 'id' and emulate_integers_by_column_name is true" do
@@ -313,7 +313,7 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_integers_by_column_name = false
       Test2Employee.set_integer_columns :job_id
       create_employee2
-      @employee2.job_id.class.should == Integer
+      expect(@employee2.job_id).to be_a(Integer)
     end
 
     it "should return Boolean value from NUMBER(1) column if emulate booleans is used" do
@@ -325,14 +325,14 @@ describe "OracleEnhancedAdapter integer type detection based on column names" do
     it "should return Integer value from NUMBER(1) column if emulate booleans is not used" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans = false
       create_employee2
-      @employee2.is_manager.class.should == Integer
+      expect(@employee2.is_manager).to be_a(Integer)
     end
 
     it "should return Integer value from NUMBER(1) column if column specified in set_integer_columns" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans = true
       Test2Employee.set_integer_columns :is_manager
       create_employee2
-      @employee2.is_manager.class.should == Integer
+      expect(@employee2.is_manager).to be_a(Integer)
     end
 
   end


### PR DESCRIPTION
This PR fixes #1234.

Backport of #1048.

:warning: This PR includes backport #1055 because it fixes the following error in `release16` branch.

```sh
% bundle exec rake spec
rake aborted!
NoMethodError: undefined method `last_comment' for #<Rake::Application:0x00000002c18570>
/home/vagrant/.rvm/gems/ruby-2.4.0/gems/rspec-core-2.99.2/lib/rspec/core/rake_task.rb:143:in `initialize'
/home/vagrant/src/oracle-enhanced/Rakefile:30:in `new'
/home/vagrant/src/oracle-enhanced/Rakefile:30:in `<top (required)>'
/home/vagrant/.rvm/gems/ruby-2.4.0@global/gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
```

As additional Information, This PR is only a change of `OracleEnhancedOCIConnection`, and the following `OracleEnhancedJDBCConnection` is not changed.

https://github.com/rsim/oracle-enhanced/blob/release16/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb#L435
