### PR TITLE
Add JSON attribute support

### DIFF
--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -47,6 +47,7 @@ This adapter is superset of original ActiveRecord Oracle adapter.
     "lib/active_record/connection_adapters/oracle_enhanced/version.rb",
     "lib/active_record/oracle_enhanced/type/boolean.rb",
     "lib/active_record/oracle_enhanced/type/integer.rb",
+    "lib/active_record/oracle_enhanced/type/json.rb",
     "lib/active_record/oracle_enhanced/type/national_character_string.rb",
     "lib/active_record/oracle_enhanced/type/raw.rb",
     "lib/active_record/oracle_enhanced/type/string.rb",

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -285,6 +285,32 @@ module ActiveRecord
         @connection.database_version.first >= 11
       end
 
+      def supports_json?
+        # No migration supported for :json type due to there is no `JSON` data type
+        # in Oracle Database itself.
+        #
+        # 1.Define :string or :text in migration
+        #
+        # create_table :test_posts, force: true do |t|
+        #   t.string  :title
+        #   t.text    :article
+        # end
+        #
+        # 2. Set :json attributes
+        #
+        # class TestPost < ActiveRecord::Base
+        #  attribute :title, :json
+        #  attribute :article, :json
+        # end
+        #
+        # 3. Add `is json` database constraints by running sql statements
+        #
+        # alter table test_posts add constraint test_posts_title_is_json check (title is json)
+        # alter table test_posts add constraint test_posts_article_is_json check (article is json)
+        #
+        @connection.database_version.first >= 12
+      end
+
       #:stopdoc:
       DEFAULT_NLS_PARAMETERS = {
         nls_calendar: nil,
@@ -1084,3 +1110,7 @@ require "active_record/oracle_enhanced/type/boolean"
 
 # To use :boolean type for Attribute API, each type needs registered explicitly.
 ActiveRecord::Type.register(:boolean, ActiveRecord::OracleEnhanced::Type::Boolean, adapter: :oracleenhanced)
+
+# Add JSON attribute support
+require "active_record/oracle_enhanced/type/json"
+ActiveRecord::Type.register(:json, ActiveRecord::OracleEnhanced::Type::Json, adapter: :oracleenhanced)

--- a/lib/active_record/oracle_enhanced/type/json.rb
+++ b/lib/active_record/oracle_enhanced/type/json.rb
@@ -1,0 +1,8 @@
+module ActiveRecord
+  module OracleEnhanced
+    module Type
+      class Json < ActiveRecord::Type::Internal::AbstractJson
+      end
+    end
+  end
+end

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -1346,3 +1346,58 @@ describe "OracleEnhancedAdapter handling of BINARY_FLOAT columns" do
     expect(column.type).to eq(:float)
   end
 end
+
+describe "OracleEnhancedAdapter attribute API support for JSON type" do
+
+  include SchemaSpecHelper
+
+  before(:each) do
+    @conn = ActiveRecord::Base.connection
+    @oracle12c_or_higher = !! @conn.select_value(
+      "select * from product_component_version where product like 'Oracle%' and to_number(substr(version,1,2)) >= 12")
+    skip "Not supported in this database version" unless @oracle12c_or_higher
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    schema_define do
+      create_table :test_posts, force: true do |t|
+        t.string  :title
+        t.text    :article
+      end
+    end
+    @conn.execute <<-SQL
+      alter table test_posts add constraint test_posts_title_is_json check (title is json)
+    SQL
+    @conn.execute <<-SQL
+      alter table test_posts add constraint test_posts_article_is_json check (article is json)
+    SQL
+
+    class TestPost < ActiveRecord::Base
+      attribute :title, :json
+      attribute :article, :json
+    end
+  end
+
+  after(:each) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    schema_define do
+      drop_table :test_posts, if_exists: true
+    end
+  end
+
+  it "should support attribute api for JSON" do
+    post = TestPost.create!(title: { "publish" => true, "foo" => "bar" }, article: { "bar" => "baz" })
+    post.reload
+    expect(post.title).to eq ({ "publish" => true, "foo" => "bar" })
+    expect(post.article).to eq ({ "bar" => "baz" })
+    post.title = ({ "publish" => false, "foo" => "bar2" })
+    post.save
+    expect(post.reload.title).to eq ({ "publish" => false, "foo" => "bar2" })
+  end
+
+  it "should support IS JSON" do
+    post = TestPost.create!(title: { "publish" => true, "foo" => "bar" })
+    count_json = TestPost.where("title is json")
+    expect(count_json.size).to eq 1
+    count_non_json = TestPost.where("title is not json")
+    expect(count_non_json.size).to eq 0
+  end
+end


### PR DESCRIPTION
This pull request adds JSON attribute support.

- Oracle Database 12c Release 1 or higher version is required

- ActiveRecord migration for json type is not supported
since there is no JSON data type in Oracle database

1. Define :string or :text in migration for columns for JSON
```ruby
  create_table :test_posts, force: true do |t|
    t.string  :title
    t.text    :article
  end
```

2. Set :json attributes

```ruby
  class TestPost < ActiveRecord::Base
    attribute :title, :json
    attribute :article, :json
  end
```

3. Add `is json` database constraints by running sql statements
```sql
  alter table test_posts add constraint test_posts_title_is_json check (title is json)
  alter table test_posts add constraint test_posts_article_is_json check (article is json)
```