### PR TITLE
Align the columns of db/structure.sql

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -28,7 +28,7 @@ module ActiveRecord #:nodoc:
               structure_dump_column(row)
             end
           end
-          ddl << cols.join(",\n ")
+          ddl << cols.map { |col| " #{col}" }.join(",\n")
           ddl << structure_dump_primary_key(table_name)
           ddl << "\n)"
           structure << ddl

--- a/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
@@ -147,7 +147,7 @@ describe "OracleEnhancedAdapter structure dump" do
         )
       SQL
       dump = ActiveRecord::Base.connection.structure_dump
-      expect(dump).to match(/CREATE TABLE \"BARS\" \(\n\"ID\" NUMBER\(38,0\) NOT NULL,\n \"SUPER\" RAW\(255\) GENERATED ALWAYS AS \(HEXTORAW\(TO_CHAR\(ID\)\)\) VIRTUAL/)
+      expect(dump).to match(/CREATE TABLE \"BARS\" \(\n \"ID\" NUMBER\(38,0\) NOT NULL,\n \"SUPER\" RAW\(255\) GENERATED ALWAYS AS \(HEXTORAW\(TO_CHAR\(ID\)\)\) VIRTUAL/)
     end
 
     it "should dump unique keys" do
@@ -198,7 +198,7 @@ describe "OracleEnhancedAdapter structure dump" do
         )
       SQL
       dump = ActiveRecord::Base.connection.structure_dump
-      expect(dump).to match(/CREATE TABLE \"BARS\" \(\n\"ID\" NUMBER\(38,0\) NOT NULL,\n \"SUPER\" RAW\(255\)/)
+      expect(dump).to match(/CREATE TABLE \"BARS\" \(\n \"ID\" NUMBER\(38,0\) NOT NULL,\n \"SUPER\" RAW\(255\)/)
     end
 
     it "should dump table comments" do


### PR DESCRIPTION
This PR will aligns columns of db/structure.sql generated by AR::ConnectionAdapters::OracleEnhancedStructureDump as follows.

## Before

The top column is not indented.

```sql
CREATE TABLE "TEST_POSTS" (
"ID" NUMBER(38,0) NOT NULL,
 "TITLE" VARCHAR2(255),
 "FOO" VARCHAR2(255),
 "FOO_ID" NUMBER(38,0),
 CONSTRAINT SYS_C00233872 PRIMARY KEY (ID)
)
```

## After

All columns are indented.

```sql
CREATE TABLE "TEST_POSTS" (
 "ID" NUMBER(38,0) NOT NULL,
 "TITLE" VARCHAR2(255),
 "FOO" VARCHAR2(255),
 "FOO_ID" NUMBER(38,0),
 CONSTRAINT SYS_C00233872 PRIMARY KEY (ID)
)
```
