### PR TITLE
Bump Ruby version to 2.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ language: ruby
 rvm:
   - 2.2.6
   - 2.3.3
-  - 2.4.0
+  - 2.4.1
   - ruby-head
   - jruby-9.1.8.0
   - jruby-head


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2017/03/22/ruby-2-4-1-released/