### PR TITLE
Fix the BINARY_FLOAT column type returns nil in JRuby

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -521,6 +521,8 @@ module ActiveRecord
           else
             BigDecimal.new(d.stringValue)
           end
+        when :BINARY_FLOAT
+          rset.getFloat(i)
         when :VARCHAR2, :CHAR, :LONG, :NVARCHAR2, :NCHAR
           rset.getString(i)
         when :DATE

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -1401,9 +1401,14 @@ describe "OracleEnhancedAdapter handling of BINARY_FLOAT columns" do
       CREATE SEQUENCE test2_employees_seq  MINVALUE 1
         INCREMENT BY 1 START WITH 10040 CACHE 20 NOORDER NOCYCLE
     SQL
+
+    class ::Test2Employee < ActiveRecord::Base
+    end
   end
 
   after(:all) do
+    Object.send(:remove_const, "Test2Employee")
+
     @conn.execute "DROP TABLE test2_employees"
     @conn.execute "DROP SEQUENCE test2_employees_seq"
   end
@@ -1412,5 +1417,13 @@ describe "OracleEnhancedAdapter handling of BINARY_FLOAT columns" do
     columns = @conn.columns('test2_employees')
     column = columns.detect{|c| c.name == "hourly_rate"}
     expect(column.type).to eq(:float)
+  end
+
+  it "should BINARY_FLOAT column type returns an approximate value" do
+    employee = Test2Employee.create(hourly_rate: 4.4)
+
+    employee.reload
+
+    expect(employee.hourly_rate).to eq(4.400000095367432)
   end
 end


### PR DESCRIPTION
This PR backports #1254 to release17 branch.