### PR TITLE
Address `OCIException: OCI8 was already closed` at specs for JSON

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -1364,7 +1364,7 @@ describe "OracleEnhancedAdapter attribute API support for JSON type" do
 
   include SchemaSpecHelper
 
-  before(:each) do
+  before(:all) do
     @conn = ActiveRecord::Base.connection
     @oracle12c_or_higher = !! @conn.select_value(
       "select * from product_component_version where product like 'Oracle%' and to_number(substr(version,1,2)) >= 12")
@@ -1375,25 +1375,25 @@ describe "OracleEnhancedAdapter attribute API support for JSON type" do
         t.string  :title
         t.text    :article
       end
+      execute "alter table test_posts add constraint test_posts_title_is_json check (title is json)"
+      execute "alter table test_posts add constraint test_posts_article_is_json check (article is json)"
     end
-    @conn.execute <<-SQL
-      alter table test_posts add constraint test_posts_title_is_json check (title is json)
-    SQL
-    @conn.execute <<-SQL
-      alter table test_posts add constraint test_posts_article_is_json check (article is json)
-    SQL
 
-    class TestPost < ActiveRecord::Base
+    class ::TestPost < ActiveRecord::Base
       attribute :title, :json
       attribute :article, :json
     end
   end
 
-  after(:each) do
+  after(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
     schema_define do
       drop_table :test_posts, if_exists: true
     end
+  end
+
+  before(:each) do
+    TestPost.delete_all
   end
 
   it "should support attribute api for JSON" do


### PR DESCRIPTION
This pull request addresses these failures.

```ruby
$ bundle exec rake spec
... snip ...
Failures:

  1) OracleEnhancedAdapter attribute API support for JSON type should support attribute api for JSON
     Failure/Error: @connection.exec(sql, *bindvars, &block)

     ActiveRecord::StatementInvalid:
       OCIException: OCI8 was already closed.:       alter table test_posts add constraint test_posts_title_is_json check (title is json)
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-0ffd0c8787bd/lib/oci8/cursor.rb:28:in `__initialize'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-0ffd0c8787bd/lib/oci8/cursor.rb:28:in `initialize'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-0ffd0c8787bd/lib/oci8/oci8.rb:176:in `new'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-0ffd0c8787bd/lib/oci8/oci8.rb:176:in `parse_internal'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-0ffd0c8787bd/lib/oci8/oci8.rb:169:in `parse'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-0ffd0c8787bd/lib/oci8/oci8.rb:276:in `exec_internal'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-0ffd0c8787bd/lib/oci8/oci8.rb:268:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:429:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:90:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `block in execute'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:580:in `block (2 levels) in log'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/2.4.0/monitor.rb:214:in `mon_synchronize'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:579:in `block in log'
     # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:571:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1036:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `execute'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1379:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:350:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:507:in `block in run_owned_hooks_for'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:506:in `each'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:506:in `run_owned_hooks_for'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:593:in `block in run_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:592:in `reverse_each'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:592:in `run_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:462:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:490:in `run_before_example'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:253:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<main>'
     # ------------------
     # --- Caused by: ---
     # OCIException:
     #   OCI8 was already closed.
     #   /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-0ffd0c8787bd/lib/oci8/cursor.rb:28:in `__initialize'

  2) OracleEnhancedAdapter attribute API support for JSON type should support IS JSON
     Failure/Error: @connection.exec(sql, *bindvars, &block)

     ActiveRecord::StatementInvalid:
       OCIException: OCI8 was already closed.:       alter table test_posts add constraint test_posts_title_is_json check (title is json)
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-0ffd0c8787bd/lib/oci8/cursor.rb:28:in `__initialize'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-0ffd0c8787bd/lib/oci8/cursor.rb:28:in `initialize'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-0ffd0c8787bd/lib/oci8/oci8.rb:176:in `new'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-0ffd0c8787bd/lib/oci8/oci8.rb:176:in `parse_internal'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-0ffd0c8787bd/lib/oci8/oci8.rb:169:in `parse'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-0ffd0c8787bd/lib/oci8/oci8.rb:276:in `exec_internal'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-0ffd0c8787bd/lib/oci8/oci8.rb:268:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:429:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:90:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `block in execute'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:580:in `block (2 levels) in log'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/2.4.0/monitor.rb:214:in `mon_synchronize'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:579:in `block in log'
     # /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:571:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1036:in `log'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `execute'
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1379:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:350:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:507:in `block in run_owned_hooks_for'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:506:in `each'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:506:in `run_owned_hooks_for'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:593:in `block in run_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:592:in `reverse_each'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:592:in `run_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:462:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:490:in `run_before_example'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:253:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<main>'
     # ------------------
     # --- Caused by: ---
     # OCIException:
     #   OCI8 was already closed.
     #   /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bundler/gems/ruby-oci8-0ffd0c8787bd/lib/oci8/cursor.rb:28:in `__initialize'

Finished in 1 minute 25.64 seconds (files took 0.91177 seconds to load)
365 examples, 2 failures, 2 pending

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1399 # OracleEnhancedAdapter attribute API support for JSON type should support attribute api for JSON
rspec ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1409 # OracleEnhancedAdapter attribute API support for JSON type should support IS JSON

Coverage report generated for RSpec to /home/yahonda/git/oracle-enhanced/coverage. 4934 / 5203 LOC (94.83%) covered.
/home/yahonda/.rbenv/versions/2.4.0/bin/ruby -I/home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib:/home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-support-3.5.0/lib /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb failed
Coverage report generated for RSpec to /home/yahonda/git/oracle-enhanced/coverage. 634 / 1757 LOC (36.08%) covered.
$
```
