### PR TITLE
Handle `TIMESTAMP WITH TIMEZONE` separately from `TIMEZONE`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -119,7 +119,7 @@ module ActiveRecord
 
         def _type_cast(value)
           case value
-          when Date, Time
+          when ActiveRecord::OracleEnhanced::Type::TimestampTz::Data
             if value.acts_like?(:time)
               zone_conversion_method = ActiveRecord::Base.default_timezone == :utc ? :getutc : :getlocal
               value.respond_to?(zone_conversion_method) ? value.send(zone_conversion_method) : value

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -941,6 +941,7 @@ module ActiveRecord
         def initialize_type_map(m)
           super
           # oracle
+          register_class_with_precision m, %r(ZONE)i,  ActiveRecord::OracleEnhanced::Type::TimestampTz
           register_class_with_limit m, %r(raw)i,            ActiveRecord::OracleEnhanced::Type::Raw
           register_class_with_limit m, %r(char)i,           ActiveRecord::OracleEnhanced::Type::String
           register_class_with_limit m, %r(clob)i,           ActiveRecord::OracleEnhanced::Type::Text
@@ -1114,3 +1115,6 @@ ActiveRecord::Type.register(:boolean, ActiveRecord::OracleEnhanced::Type::Boolea
 # Add JSON attribute support
 require "active_record/oracle_enhanced/type/json"
 ActiveRecord::Type.register(:json, ActiveRecord::OracleEnhanced::Type::Json, adapter: :oracleenhanced)
+
+# Add Type:TimestampTz
+require "active_record/oracle_enhanced/type/timestamptz"

--- a/lib/active_record/oracle_enhanced/type/timestamptz.rb
+++ b/lib/active_record/oracle_enhanced/type/timestamptz.rb
@@ -1,0 +1,23 @@
+module ActiveRecord
+  module OracleEnhanced
+    module Type
+      class TimestampTz < ActiveRecord::Type::DateTime
+        def type
+          :timestamptz
+        end
+
+        class Data < DelegateClass(::Time) # :nodoc:
+        end
+
+        def serialize(value)
+          case value = super
+          when ::Time
+            Data.new(value)
+          else
+            value
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -511,7 +511,7 @@ describe "OracleEnhancedAdapter timestamp with timezone support" do
 
 end
 
-describe "OracleEnhancedAdapter date and timestamp with different NLS date formats" do
+xdescribe "OracleEnhancedAdapter date and timestamp with different NLS date formats" do
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
     @conn = ActiveRecord::Base.connection


### PR DESCRIPTION
Fixes #1206

rails/rails#27962 moves `TypeCastingTest` from sqlite3 specific one to generic then some tests are failing because `type_cast` and `quote` method both call `quoted_date` for `Date` and `Time` class objects in abstract adapter but Oracle enhanced adapter does not, using its own implementation.

This pull request lets generic `Date` and `Type` objects handled by abstract adapter implementation.
For non-generic data types including timezone `ActiveRecord::OracleEnhanced::Type::TimestampTz` type has been created and `TimestampTz` type is handled as it used to.

Oracle enhanced adapter now relies on `Time::DATE_FORMATS` defined in ActiveSupport by this change.
Therefore changing `NLS_DATE_FORMAT` and `NLS_TIMESTAMP_FORMAT` are not working and will not be supported.
