### PR TITLE
Let abstract adapter type cast Date, DateTime and Time for JRuby

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_quoting.rb
@@ -12,10 +12,6 @@ module ActiveRecord
             clob = Java::OracleSql::CLOB.createTemporary(@connection.raw_connection, false, Java::OracleSql::CLOB::DURATION_SESSION)
             clob.setString(1, value.to_s)
             clob
-          when Date, DateTime
-            Java::oracle.sql.DATE.new(value.strftime("%Y-%m-%d %H:%M:%S"))
-          when Time
-            Java::java.sql.Timestamp.new(value.year - 1900, value.month - 1, value.day, value.hour, value.min, value.sec, value.usec * 1000)
           else
             super
           end


### PR DESCRIPTION
Refer #1267 for CRuby

This pull request addresses these 3 failures:

```ruby
$ ARCONN=oracle bundle exec ruby -w -Itest test/cases/quoting_test.rb
Using oracle
Run options: --seed 31792

# Running:

..........................F....F....F

Finished in 2.771868s, 13.3484 runs/s, 17.3168 assertions/s.

  1) Failure:
ActiveRecord::ConnectionAdapters::TypeCastingTest#test_type_cast_date [test/cases/quoting_test.rb:165]:
--- expected
+++ actual
@@ -1 +1 @@
-"2017-03-30"
+#<Java::OracleSql::DATE:0xXXXXXX>



  2) Failure:
ActiveRecord::ConnectionAdapters::TypeCastingTest#test_type_cast_time [test/cases/quoting_test.rb:171]:
--- expected
+++ actual
@@ -1 +1 @@
-"2017-03-30 20:30:08.614795"
+#<Java::JavaSql::Timestamp:0xXXXXXX>



  3) Failure:
ActiveRecord::ConnectionAdapters::QuoteARBaseTest#test_type_cast_ar_object [test/cases/quoting_test.rb:247]:
--- expected
+++ actual
@@ -1 +1 @@
-"2017-02-14 12:34:56.789000"
+#<Java::JavaSql::Timestamp:0xXXXXXX>


37 runs, 48 assertions, 3 failures, 0 errors, 0 skips
$
```