### PR TITLE
Fix typos by https://github.com/client9/misspell

### DIFF
--- a/History.md
+++ b/History.md
@@ -526,7 +526,7 @@
  * Address undefined method `cast_type' [#805]
  * Better fix to support "Relation#count does not support finder options anymore in Rails [#788, #787]
  * ActiveRecord::Calculations#count no longer accepts an options hash argument #754
- * Supress WARNINGs using `raise_error` without specific errors [#724]
+ * Suppress WARNINGs using `raise_error` without specific errors [#724]
  * Use RSpec 3 [#707]
  * Update "OracleEnhancedAdapter boolean type detection based on string column types and names" [#873]
  * Update "OracleEnhancedAdapter integer type detection based on column names" [#871]
@@ -813,7 +813,7 @@
  * Update README to support assignment methods [#365]
  * Remove add_limit_offset! method [#369]
  * Update Gemfile to use `bundle config --local` [#370]
- * `describe` does not try super when no datbase link and ORA-4043 returned [#375]
+ * `describe` does not try super when no database link and ORA-4043 returned [#375]
  * Support `remove_columns` [#377]
  * Dump views in alphabetical order and add `FORCE` option [#378]
 
@@ -1198,10 +1198,10 @@
 * Forked from original activerecord-oracle-adapter-1.0.0.9216
 * Renamed oracle adapter to oracle_enhanced adapter
   * Added "enhanced" to method and class definitions so that oracle_enhanced and original oracle adapter
-    could be used simultaniously
+    could be used simultaneously
   * Added Rails rake tasks as a copy from original oracle tasks
 * Enhancements:
-  * Improved perfomance of schema dump methods when used on large data dictionaries
+  * Improved performance of schema dump methods when used on large data dictionaries
   * Added LOB writing callback for sessions stored in database
   * Added emulate_dates_by_column_name option
   * Added emulate_integers_by_column_name option

--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ Post.contains(:all_text, "aaa within title")
 Post.contains(:all_text, "bbb within comment_author")
 ```
 
-Please note that `index_column` must be a real column in your database and it's value will be overriden every time your `index_column_trigger_on` columns are changed. So, _do not use columns with real data as `index_column`_.
+Please note that `index_column` must be a real column in your database and it's value will be overridden every time your `index_column_trigger_on` columns are changed. So, _do not use columns with real data as `index_column`_.
 
 Index column can be created as:
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
@@ -412,9 +412,9 @@ describe "OracleEnhancedConnection" do
     if defined?(OCI8)
       context "OCI8 adapter" do
 
-        it "should not fallback to SELECT-based logic when querying non-existant table information" do
+        it "should not fallback to SELECT-based logic when querying non-existent table information" do
           expect(@conn).not_to receive(:select_one)
-          @conn.describe("non_existant") rescue ActiveRecord::ConnectionAdapters::OracleEnhancedConnectionException
+          @conn.describe("non_existent") rescue ActiveRecord::ConnectionAdapters::OracleEnhancedConnectionException
         end
 
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
@@ -225,7 +225,7 @@ describe "OracleEnhancedAdapter schema dump" do
     end
 
     it "should include foreign keys following all tables" do
-      # if foreign keys preceed declaration of all tables
+      # if foreign keys precede declaration of all tables
       # it can cause problems when using db:test rake tasks
       schema_define do
         add_foreign_key :test_comments, :test_posts

--- a/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
@@ -243,7 +243,7 @@ describe "OracleEnhancedAdapter structure dump" do
     end
   end
 
-  describe "database stucture dump extentions" do
+  describe "database structure dump extensions" do
     before(:all) do
       @conn.execute <<-SQL
         CREATE TABLE nvarchartable (


### PR DESCRIPTION
```ruby
$ misspell -w *
History.md:529:3: corrected "Supress" to "Suppress"
History.md:816:41: corrected "datbase" to "database"
History.md:1201:18: corrected "simultaniously" to "simultaneously"
History.md:1204:13: corrected "perfomance" to "performance"
spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb:415:72: corrected "existant" to "existent"
spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb:417:30: corrected "existant" to "existent"
README.md:473:94: corrected "overriden" to "overridden"
spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb:228:24: corrected "preceed" to "precede"
spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb:246:21: corrected "stucture" to "structure"
spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb:246:35: corrected "extentions" to "extensions"
$
```