### PR TITLE
rubocop 0.48.1

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -636,7 +636,7 @@ describe "OracleEnhancedAdapter" do
       @conn = ActiveRecord::Base.connection
       schema_define do
         create_table :test_employees, force: true do |t|
-          t.string  :first_name, limit: 20
+          t.string :first_name, limit: 20
         end
       end
     end


### PR DESCRIPTION
```ruby
$ rubocop -a
Inspecting 48 files
..............C.................................

Offenses:

spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:639:19: C: [Corrected] Put one space between the method name and the first argument.
          t.string  :first_name, limit: 20
                  ^^

48 files inspected, 1 offense detected, 1 offense corrected
$
```