### PR TITLE
Support `timestamptz` and `timestampltz` for migrations

### DIFF
--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -52,6 +52,8 @@ This adapter is superset of original ActiveRecord Oracle adapter.
     "lib/active_record/oracle_enhanced/type/raw.rb",
     "lib/active_record/oracle_enhanced/type/string.rb",
     "lib/active_record/oracle_enhanced/type/text.rb",
+    "lib/active_record/oracle_enhanced/type/timestamp.rb",
+    "lib/active_record/oracle_enhanced/type/timestampltz.rb",
     "lib/activerecord-oracle_enhanced-adapter.rb",
     "spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb",
     "spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb",

--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -119,7 +119,7 @@ module ActiveRecord
 
         def _type_cast(value)
           case value
-          when ActiveRecord::OracleEnhanced::Type::TimestampTz::Data
+          when ActiveRecord::OracleEnhanced::Type::TimestampTz::Data, ActiveRecord::OracleEnhanced::Type::TimestampLtz::Data
             if value.acts_like?(:time)
               zone_conversion_method = ActiveRecord::Base.default_timezone == :utc ? :getutc : :getlocal
               value.respond_to?(zone_conversion_method) ? value.send(zone_conversion_method) : value

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -8,7 +8,9 @@ module ActiveRecord
         end
 
         [
-          :raw
+          :raw,
+          :timestamptz,
+          :timestampltz
         ].each do |column_type|
           module_eval <<-CODE, __FILE__, __LINE__ + 1
             def #{column_type}(*args, **options)

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -342,6 +342,8 @@ module ActiveRecord
         decimal: { name: "DECIMAL" },
         datetime: { name: "TIMESTAMP" },
         timestamp: { name: "TIMESTAMP" },
+        timestamptz: { name: "TIMESTAMP WITH TIME ZONE" },
+        timestampltz: { name: "TIMESTAMP WITH LOCAL TIME ZONE" },
         time: { name: "TIMESTAMP" },
         date: { name: "DATE" },
         binary: { name: "BLOB" },
@@ -941,7 +943,8 @@ module ActiveRecord
         def initialize_type_map(m)
           super
           # oracle
-          register_class_with_precision m, %r(ZONE)i,  ActiveRecord::OracleEnhanced::Type::TimestampTz
+          register_class_with_precision m, %r(WITH TIME ZONE)i,       ActiveRecord::OracleEnhanced::Type::TimestampTz
+          register_class_with_precision m, %r(WITH LOCAL TIME ZONE)i, ActiveRecord::OracleEnhanced::Type::TimestampLtz
           register_class_with_limit m, %r(raw)i,            ActiveRecord::OracleEnhanced::Type::Raw
           register_class_with_limit m, %r(char)i,           ActiveRecord::OracleEnhanced::Type::String
           register_class_with_limit m, %r(clob)i,           ActiveRecord::OracleEnhanced::Type::Text
@@ -1118,3 +1121,6 @@ ActiveRecord::Type.register(:json, ActiveRecord::OracleEnhanced::Type::Json, ada
 
 # Add Type:TimestampTz
 require "active_record/oracle_enhanced/type/timestamptz"
+
+# Add Type:TimestampLtz
+require "active_record/oracle_enhanced/type/timestampltz"

--- a/lib/active_record/oracle_enhanced/type/timestampltz.rb
+++ b/lib/active_record/oracle_enhanced/type/timestampltz.rb
@@ -1,0 +1,23 @@
+module ActiveRecord
+  module OracleEnhanced
+    module Type
+      class TimestampLtz < ActiveRecord::Type::DateTime
+        def type
+          :timestampltz
+        end
+
+        class Data < DelegateClass(::Time) # :nodoc:
+        end
+
+        def serialize(value)
+          case value = super
+          when ::Time
+            Data.new(value)
+          else
+            value
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -433,44 +433,39 @@ describe "OracleEnhancedAdapter boolean support when emulate_booleans_from_strin
 end
 
 describe "OracleEnhancedAdapter timestamp with timezone support" do
+  include SchemaSpecHelper
+
   before(:all) do
     ActiveRecord::Base.default_timezone = :local
     ActiveRecord::Base.establish_connection(CONNECTION_WITH_TIMEZONE_PARAMS)
     @conn = ActiveRecord::Base.connection
-    @conn.execute <<-SQL
-      CREATE TABLE test_employees (
-        employee_id   NUMBER(6,0) PRIMARY KEY,
-        first_name    VARCHAR2(20),
-        last_name     VARCHAR2(25),
-        email         VARCHAR2(25),
-        phone_number  VARCHAR2(20),
-        hire_date     DATE,
-        job_id        NUMBER(6,0),
-        salary        NUMBER(8,2),
-        commission_pct  NUMBER(2,2),
-        manager_id    NUMBER(6,0),
-        department_id NUMBER(4,0),
-        created_at    TIMESTAMP,
-        created_at_tz   TIMESTAMP WITH TIME ZONE,
-        created_at_ltz  TIMESTAMP WITH LOCAL TIME ZONE
-      )
-    SQL
-    @conn.execute <<-SQL
-      CREATE SEQUENCE test_employees_seq  MINVALUE 1
-        INCREMENT BY 1 CACHE 20 NOORDER NOCYCLE
-    SQL
+    schema_define do
+      create_table :test_employees, force: true do |t|
+        t.string        :first_name,  limit: 20
+        t.string        :last_name,  limit: 25
+        t.string        :email, limit: 25
+        t.string        :phone_number, limit: 20
+        t.date          :hire_date
+        t.decimal       :job_id, scale: 0, precision: 6
+        t.decimal       :salary, scale: 2, precision: 8
+        t.decimal       :commission_pct, scale: 2, precision: 2
+        t.decimal       :manager_id, scale: 0, precision: 6
+        t.decimal       :department_id, scale: 0, precision: 4
+        t.timestamp     :created_at
+        t.timestamptz   :created_at_tz
+        t.timestampltz  :created_at_ltz
+      end
+    end
   end
 
   after(:all) do
-    @conn.execute "DROP TABLE test_employees"
-    @conn.execute "DROP SEQUENCE test_employees_seq"
+    @conn.drop_table :test_employees, if_exists: true
     ActiveRecord::Base.default_timezone = :utc
   end
 
   describe "/ TIMESTAMP WITH TIME ZONE values from ActiveRecord model" do
     before(:all) do
       class ::TestEmployee < ActiveRecord::Base
-        self.primary_key = "employee_id"
       end
     end
 


### PR DESCRIPTION
  ```ruby
  create_table :posts, force: true do |t|
    t.timestamptz   :updated_at_tz
    t.timestampltz  :updated_at_ltz
  end
  ```

  * `timestamptz` type is mapped to `TIMESTAMP WITH TIME ZONE` sql type.
  * `timestampltz` type is mapped to `TIMESTAMP WITH LOCAL TIME ZONE` sql type.