### PR TITLE
Add missing `timestamptz.rb` to gemspec at release18 branch

### DIFF
--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -52,6 +52,7 @@ This adapter is superset of original ActiveRecord Oracle adapter.
     "lib/active_record/oracle_enhanced/type/raw.rb",
     "lib/active_record/oracle_enhanced/type/string.rb",
     "lib/active_record/oracle_enhanced/type/text.rb",
+    "lib/active_record/oracle_enhanced/type/timestamptz.rb",
     "lib/activerecord-oracle_enhanced-adapter.rb",
     "spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb",
     "spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb",


### PR DESCRIPTION
Follows up #1268