### PR TITLE
Suppress `warning: assigned but unused variable - poolable_connection_factory`

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
@@ -201,7 +201,7 @@ describe "OracleEnhancedConnection" do
             connection_pool = GenericObjectPool.new(nil)
             uri = "jdbc:oracle:thin:@#{DATABASE_HOST && "#{DATABASE_HOST}:"}#{DATABASE_PORT && "#{DATABASE_PORT}:"}#{DATABASE_NAME}"
             connection_factory = DriverManagerConnectionFactory.new(uri, DATABASE_USER, DATABASE_PASSWORD)
-            poolable_connection_factory = PoolableConnectionFactory.new(connection_factory, connection_pool, nil, nil, false, true)
+            PoolableConnectionFactory.new(connection_factory, connection_pool, nil, nil, false, true)
             @data_source = PoolingDataSource.new(connection_pool)
             @data_source.access_to_underlying_connection_allowed = true
           end


### PR DESCRIPTION
This PR suppresses the following warning.

```sh
$ bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
==> Loading config from ENV or use default
==> Running specs with MRI version 2.4.1

(snip)

==> Effective ActiveRecord version 5.2.0.alpha
/home/vagrant/src/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb:204: warning: assigned but unused variable - poolable_connection_factory
.................................

Finished in 1.4 seconds (files took 0.50948 seconds to load)
33 examples, 0 failures
```