### PR TITLE
Suppress `warning: assigned but unused variable - post`

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -1267,7 +1267,7 @@ describe "OracleEnhancedAdapter attribute API support for JSON type" do
   end
 
   it "should support IS JSON" do
-    post = TestPost.create!(title: { "publish" => true, "foo" => "bar" })
+    TestPost.create!(title: { "publish" => true, "foo" => "bar" })
     count_json = TestPost.where("title is json")
     expect(count_json.size).to eq 1
     count_non_json = TestPost.where("title is not json")


### PR DESCRIPTION
This PR suppresses the following warning.

```sh
$ bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
==> Loading config from ENV or use default
==> Running specs with MRI version 2.4.1

(snip)

==> Effective ActiveRecord version 5.2.0.alpha
/home/vagrant/src/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1270: warning: assigned but unused variable - post
..................................................................**

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) OracleEnhancedAdapter attribute API support for JSON type should support attribute api for JSON
     # Not supported in this database version
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1259

  2) OracleEnhancedAdapter attribute API support for JSON type should support IS JSON
     # Not supported in this database version
     # ./spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb:1269


Finished in 2.65 seconds (files took 0.513 seconds to load)
68 examples, 0 failures, 2 pending
```