### PR TITLE
Collapse a file specification in gemspec

### DIFF
--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -14,79 +14,11 @@ This adapter is superset of original ActiveRecord Oracle adapter.
   s.extra_rdoc_files = [
     "README.md"
   ]
-  s.files = [
-    ".rspec",
-    "Gemfile",
-    "History.md",
-    "License.txt",
-    "README.md",
-    "RUNNING_TESTS.md",
-    "Rakefile",
-    "VERSION",
-    "activerecord-oracle_enhanced-adapter.gemspec",
-    "lib/active_record/connection_adapters/emulation/oracle_adapter.rb",
-    "lib/active_record/connection_adapters/oracle_enhanced_adapter.rb",
-    "lib/active_record/connection_adapters/oracle_enhanced/column.rb",
-    "lib/active_record/connection_adapters/oracle_enhanced/column_dumper.rb",
-    "lib/active_record/connection_adapters/oracle_enhanced/connection.rb",
-    "lib/active_record/connection_adapters/oracle_enhanced/context_index.rb",
-    "lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb",
-    "lib/active_record/connection_adapters/oracle_enhanced/database_tasks.rb",
-    "lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb",
-    "lib/active_record/connection_adapters/oracle_enhanced/jdbc_quoting.rb",
-    "lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb",
-    "lib/active_record/connection_adapters/oracle_enhanced/oci_quoting.rb",
-    "lib/active_record/connection_adapters/oracle_enhanced/procedures.rb",
-    "lib/active_record/connection_adapters/oracle_enhanced/quoting.rb",
-    "lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb",
-    "lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb",
-    "lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb",
-    "lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb",
-    "lib/active_record/connection_adapters/oracle_enhanced/schema_statements_ext.rb",
-    "lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb",
-    "lib/active_record/connection_adapters/oracle_enhanced/version.rb",
-    "lib/active_record/oracle_enhanced/type/boolean.rb",
-    "lib/active_record/oracle_enhanced/type/integer.rb",
-    "lib/active_record/oracle_enhanced/type/json.rb",
-    "lib/active_record/oracle_enhanced/type/national_character_string.rb",
-    "lib/active_record/oracle_enhanced/type/raw.rb",
-    "lib/active_record/oracle_enhanced/type/string.rb",
-    "lib/active_record/oracle_enhanced/type/text.rb",
-    "lib/active_record/oracle_enhanced/type/timestamp.rb",
-    "lib/active_record/oracle_enhanced/type/timestampltz.rb",
-    "lib/activerecord-oracle_enhanced-adapter.rb",
-    "spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb",
-    "spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb",
-    "spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb",
-    "spec/active_record/connection_adapters/oracle_enhanced_database_tasks_spec.rb",
-    "spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb",
-    "spec/active_record/connection_adapters/oracle_enhanced_dbms_output_spec.rb",
-    "spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb",
-    "spec/active_record/connection_adapters/oracle_enhanced_emulate_oracle_adapter_spec.rb",
-    "spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb",
-    "spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb",
-    "spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb",
-    "spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb",
-    "spec/spec_helper.rb"
-  ]
+  s.files = Dir["History.md", "License.txt", "README.md", "lib/**/*"]
   s.homepage = "http://github.com/rsim/oracle-enhanced"
   s.require_paths = ["lib"]
   s.summary = "Oracle enhanced adapter for ActiveRecord"
-  s.test_files = [
-    "spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb",
-    "spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb",
-    "spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb",
-    "spec/active_record/connection_adapters/oracle_enhanced_database_tasks_spec.rb",
-    "spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb",
-    "spec/active_record/connection_adapters/oracle_enhanced_dbms_output_spec.rb",
-    "spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb",
-    "spec/active_record/connection_adapters/oracle_enhanced_emulate_oracle_adapter_spec.rb",
-    "spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb",
-    "spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb",
-    "spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb",
-    "spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb",
-    "spec/spec_helper.rb"
-  ]
+  s.test_files = Dir["spec/**/*"]
   s.add_runtime_dependency("activerecord", ["~> 5.2.0.alpha"])
   s.add_runtime_dependency("arel", ["~> 8.0"])
   s.add_runtime_dependency("ruby-plsql", [">= 0.6.0"])


### PR DESCRIPTION
It seemed that maintenance was complicated to write each file name in gemspec. As shown in the sample below, it doesn't seem to match the actual file structure.

```ruby
# File list of the following URL:
# https://github.com/rsim/oracle-enhanced/blob/f9c0f5e445a613f1996b0967b31e9ca33da6ca9f/activerecord-oracle_enhanced-adapter.gemspec#L17-L71
[
  ".rspec",
  "Gemfile",
  "History.md",
  "License.txt",
  "README.md",
  "RUNNING_TESTS.md",
  "Rakefile",
  "VERSION",
  "activerecord-oracle_enhanced-adapter.gemspec",
  "lib/active_record/connection_adapters/emulation/oracle_adapter.rb",
  "lib/active_record/connection_adapters/oracle_enhanced_adapter.rb",
  "lib/active_record/connection_adapters/oracle_enhanced/column.rb",
  "lib/active_record/connection_adapters/oracle_enhanced/column_dumper.rb",
  "lib/active_record/connection_adapters/oracle_enhanced/connection.rb",
  "lib/active_record/connection_adapters/oracle_enhanced/context_index.rb",
  "lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb",
  "lib/active_record/connection_adapters/oracle_enhanced/database_tasks.rb",
  "lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb",
  "lib/active_record/connection_adapters/oracle_enhanced/jdbc_quoting.rb",
  "lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb",
  "lib/active_record/connection_adapters/oracle_enhanced/oci_quoting.rb",
  "lib/active_record/connection_adapters/oracle_enhanced/procedures.rb",
  "lib/active_record/connection_adapters/oracle_enhanced/quoting.rb",
  "lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb",
  "lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb",
  "lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb",
  "lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb",
  "lib/active_record/connection_adapters/oracle_enhanced/schema_statements_ext.rb",
  "lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb",
  "lib/active_record/connection_adapters/oracle_enhanced/version.rb",
  "lib/active_record/oracle_enhanced/type/boolean.rb",
  "lib/active_record/oracle_enhanced/type/integer.rb",
  "lib/active_record/oracle_enhanced/type/json.rb",
  "lib/active_record/oracle_enhanced/type/national_character_string.rb",
  "lib/active_record/oracle_enhanced/type/raw.rb",
  "lib/active_record/oracle_enhanced/type/string.rb",
  "lib/active_record/oracle_enhanced/type/text.rb",
  "lib/active_record/oracle_enhanced/type/timestamp.rb",
  "lib/active_record/oracle_enhanced/type/timestampltz.rb",
  "lib/activerecord-oracle_enhanced-adapter.rb",
  "spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb",
  "spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb",
  "spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb",
  "spec/active_record/connection_adapters/oracle_enhanced_database_tasks_spec.rb",
  "spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb",
  "spec/active_record/connection_adapters/oracle_enhanced_dbms_output_spec.rb",
  "spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb",
  "spec/active_record/connection_adapters/oracle_enhanced_emulate_oracle_adapter_spec.rb",
  "spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb",
  "spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb",
  "spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb",
  "spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb",
  "spec/spec_helper.rb"
] - `git ls-files`.split($/)

# => ["lib/active_record/oracle_enhanced/type/timestamp.rb"] # This file does not exist.
```

In this PR, it refer to the configuration of the following Active Record.

https://github.com/rails/rails/blob/0d208e02f6b90fd3d61da60e58854b9fdd8eeb1d/activerecord/activerecord.gemspec#L18

It also changed the `s.test_files` to include spec files that are already specified.