### PR TITLE
Reduce tasks of release work

### DIFF
--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -1,6 +1,8 @@
+version = File.read(File.expand_path("../VERSION", __FILE__)).strip
+
 Gem::Specification.new do |s|
   s.name = "activerecord-oracle_enhanced-adapter"
-  s.version = "1.9.0.alpha"
+  s.version = version
 
   s.required_rubygems_version = ">= 1.8.11"
   s.required_ruby_version     = ">= 2.2.2"

--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -8,7 +8,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = ">= 2.2.2"
   s.license = "MIT"
   s.authors = ["Raimonds Simanovskis"]
-  s.date = "2017-03-22"
   s.description = 'Oracle "enhanced" ActiveRecord adapter contains useful additional methods for working with new and legacy Oracle databases.
 This adapter is superset of original ActiveRecord Oracle adapter.
 '


### PR DESCRIPTION
Follow up to https://github.com/rsim/oracle-enhanced/pull/1297#issuecomment-295083804.

This PR reduces 2 tasks in release work.

I made different commits on these in this PR.

## Commit 1. Do not write VERSION directly with gemspec

It will use the version written in the VERSION file.
As a result, the description of the version becomes unified management.

I often see this technique. For example Rails does.

## Commit 2. Omit specification of release date in gemspec

By not specifying `s.date`, the release date (i.e. ` gem push` date) will be displayed as rubygems.org release date. This makes it unnecessary to specify the release date for gemspec.

:warning: However, there are cautions in this. As far as I know, the date when `s.date` is not specified seems to be the date in UTC (not the local time zone). Since Oracle enhanced adapter describes the release date in `History.md`, there may be a difference from the date displayed on rubygems.org.

If it seems inconvenient for omitting `s.date`, I will revert this commit.

How do you think about this?