### PR TITLE
Include VERSION file in gem

### DIFF
--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -15,7 +15,7 @@ This adapter is superset of original ActiveRecord Oracle adapter.
   s.extra_rdoc_files = [
     "README.md"
   ]
-  s.files = Dir["History.md", "License.txt", "README.md", "lib/**/*"]
+  s.files = Dir["History.md", "License.txt", "README.md", "VERSION", "lib/**/*"]
   s.homepage = "http://github.com/rsim/oracle-enhanced"
   s.require_paths = ["lib"]
   s.summary = "Oracle enhanced adapter for ActiveRecord"


### PR DESCRIPTION
There was a mistake in #1296.

[`ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter::VERSION`](https://github.com/rsim/oracle-enhanced/blob/78dacb3f461809b307c319a486f41c69b2a83d11/lib/active_record/connection_adapters/oracle_enhanced/version.rb) depends on the VERSION file, but it did not include that file in gem.

This problem can be confirmed from the build result of rsim/ruby-plsql#127.

https://travis-ci.org/rsim/ruby-plsql/jobs/224701029

```sh
  1) ActiveRecord connection should connect to test database
     Failure/Error: ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
     Errno::ENOENT:
       No such file or directory @ rb_sysopen - /home/travis/.rvm/gems/ruby-2.4.1/gems/activerecord-oracle_enhanced-adapter-1.8.0.rc2/VERSION
     # /home/travis/.rvm/gems/ruby-2.4.1/gems/activerecord-oracle_enhanced-adapter-1.8.0.rc2/lib/active_record/connection_adapters/oracle_enhanced/version.rb:1:in `read'
     # /home/travis/.rvm/gems/ruby-2.4.1/gems/activerecord-oracle_enhanced-adapter-1.8.0.rc2/lib/active_record/connection_adapters/oracle_enhanced/version.rb:1:in `<top (required)>'
     # /home/travis/.rvm/gems/ruby-2.4.1/gems/activesupport-5.1.0.rc2/lib/active_support/dependencies.rb:292:in `require'
     # /home/travis/.rvm/gems/ruby-2.4.1/gems/activesupport-5.1.0.rc2/lib/active_support/dependencies.rb:292:in `block in require'
     # /home/travis/.rvm/gems/ruby-2.4.1/gems/activesupport-5.1.0.rc2/lib/active_support/dependencies.rb:258:in `load_dependency'
     # /home/travis/.rvm/gems/ruby-2.4.1/gems/activesupport-5.1.0.rc2/lib/active_support/dependencies.rb:292:in `require'
     # /home/travis/.rvm/gems/ruby-2.4.1/gems/activerecord-oracle_enhanced-adapter-1.8.0.rc2/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1079:in `<top (required)>'
     # /home/travis/.rvm/gems/ruby-2.4.1/gems/activesupport-5.1.0.rc2/lib/active_support/dependencies.rb:292:in `require'
     # /home/travis/.rvm/gems/ruby-2.4.1/gems/activesupport-5.1.0.rc2/lib/active_support/dependencies.rb:292:in `block in require'
     # /home/travis/.rvm/gems/ruby-2.4.1/gems/activesupport-5.1.0.rc2/lib/active_support/dependencies.rb:258:in `load_dependency'
     # /home/travis/.rvm/gems/ruby-2.4.1/gems/activesupport-5.1.0.rc2/lib/active_support/dependencies.rb:292:in `require'
     # /home/travis/.rvm/gems/ruby-2.4.1/gems/activerecord-5.1.0.rc2/lib/active_record/connection_adapters/connection_specification.rb:186:in `spec'
     # /home/travis/.rvm/gems/ruby-2.4.1/gems/activerecord-5.1.0.rc2/lib/active_record/connection_adapters/abstract/connection_pool.rb:878:in `establish_connection'
     # /home/travis/.rvm/gems/ruby-2.4.1/gems/activerecord-5.1.0.rc2/lib/active_record/connection_handling.rb:58:in `establish_connection'
     # ./spec/plsql/schema_spec.rb:189:in `block (2 levels) in <top (required)>'
```

This fix is also required for the `release18` branch.
