### PR TITLE
Oracle Database 12.2 or higher version required for version 2

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -223,6 +223,10 @@ module ActiveRecord
 
       def initialize(connection, logger = nil, config = {}) # :nodoc:
         super(connection, logger, config)
+        if @connection.database_version.to_s < [12, 2].to_s
+          raise "Your version of Oracle Database (#{@connection.database_version.first}.#{@connection.database_version.second}) is too old.
+          Active Record Oracle enhanced adapter 2 supports Oracle Database 12.2 or higher"
+        end
         @statements = StatementPool.new(self.class.type_cast_config_to_integer(config[:statement_limit]))
         @enable_dbms_output = false
       end


### PR DESCRIPTION
This test will fail at Travis CI test which running Oracle 11gR1 XE. Will update travis changes later.