### PR TITLE
Address `ORA-32794: cannot drop a system-generated sequence`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -5,7 +5,8 @@ module ActiveRecord #:nodoc:
       STATEMENT_TOKEN = "\n\n/\n\n"
 
       def structure_dump #:nodoc:
-        structure = select_values("SELECT sequence_name FROM all_sequences where sequence_owner = SYS_CONTEXT('userenv', 'session_user') ORDER BY 1").map do |seq|
+        structure = select_values("SELECT sequence_name FROM all_sequences
+                                  where sequence_owner = SYS_CONTEXT('userenv', 'session_user') and sequence_name not like 'ISEQ$$%' ORDER BY 1").map do |seq|
           "CREATE SEQUENCE \"#{seq}\""
         end
         select_values("SELECT table_name FROM all_tables t
@@ -219,7 +220,8 @@ module ActiveRecord #:nodoc:
       end
 
       def structure_drop #:nodoc:
-        statements = select_values("SELECT sequence_name FROM all_sequences where sequence_owner = SYS_CONTEXT('userenv', 'session_user') ORDER BY 1").map do |seq|
+        statements = select_values("SELECT sequence_name FROM all_sequences
+                                   where sequence_owner = SYS_CONTEXT('userenv', 'session_user') and sequence_name not like 'ISEQ$$%' ORDER BY 1").map do |seq|
           "DROP SEQUENCE \"#{seq}\""
         end
         select_values("SELECT table_name from all_tables t


### PR DESCRIPTION
Each Identity datatype creates a sequence named "ISEC$$_nnnnn", which depends on the table. This sequence cannot be dropped separately and it will be dropped once the base table dropped.

Example with SQL statements:

```sql
SQL> CREATE TABLE "TEST_POSTS" ("ID" NUMBER(38) GENERATED BY DEFAULT AS IDENTITY PRIMARY KEY, "SUBJECT" VARCHAR2(255));

Table created.

SQL> select object_name,object_type from user_objects;

OBJECT_NAME                    OBJECT_TYPE
------------------------------ -----------------------
SYS_C00208553                  INDEX
ISEQ$$_447502                  SEQUENCE
TEST_POSTS                     TABLE

SQL> drop sequence ISEQ$$_447502;
drop sequence ISEQ$$_447502
              *
ERROR at line 1:
ORA-32794: cannot drop a system-generated sequence

SQL> drop table "TEST_POSTS";

Table dropped.

SQL>  select object_name,object_type from user_objects;

no rows selected

SQL>
```