### PR TITLE
[ci skip] Create an issue template

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -1,0 +1,16 @@
+### Steps to reproduce
+Please refer https://github.com/rsim/oracle-enhanced/tree/master/guides/bug_report_templates
+to create an executable test case
+
+### Expected behavior
+Tell us what should happen
+
+### Actual behavior
+Tell us what happens instead
+
+### System configuration
+**Rails version**:
+
+**Ruby version**:
+
+**Oracle Database version**:


### PR DESCRIPTION
Referred the one from Rails repository https://github.com/rails/rails/blob/master/.github/issue_template.md and add necessary sections for Oracle enhanced adapter.

This time [ci skip] subject added to the commit message, not the subject of pull request. Will see how it goes.