### PR TITLE
Deprecate `supports_statement_cache?`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -57,10 +57,6 @@ module ActiveRecord
           end
         end
 
-        def supports_statement_cache?
-          true
-        end
-
         def supports_explain?
           true
         end


### PR DESCRIPTION
Follow up to rails/rails#28938.