### PR TITLE
Introduce module `DatabaseLimits`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_limits.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_limits.rb
@@ -1,0 +1,50 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module OracleEnhanced
+      module DatabaseLimits
+        # maximum length of Oracle identifiers
+        IDENTIFIER_MAX_LENGTH = 30
+
+        def table_alias_length #:nodoc:
+          IDENTIFIER_MAX_LENGTH
+        end
+
+        # the maximum length of a table name
+        def table_name_length
+          IDENTIFIER_MAX_LENGTH
+        end
+
+        # the maximum length of a column name
+        def column_name_length
+          IDENTIFIER_MAX_LENGTH
+        end
+
+        # Returns the maximum allowed length for an index name. This
+        # limit is enforced by rails and Is less than or equal to
+        # <tt>index_name_length</tt>. The gap between
+        # <tt>index_name_length</tt> is to allow internal rails
+        # opreations to use prefixes in temporary opreations.
+        def allowed_index_name_length
+          index_name_length
+        end
+
+        # the maximum length of an index name
+        # supported by this database
+        def index_name_length
+          IDENTIFIER_MAX_LENGTH
+        end
+
+        # the maximum length of a sequence name
+        def sequence_name_length
+          IDENTIFIER_MAX_LENGTH
+        end
+
+        # To avoid ORA-01795: maximum number of expressions in a list is 1000
+        # tell ActiveRecord to limit us to 1000 ids at a time
+        def in_clause_length
+          1000
+        end
+      end
+    end
+  end
+end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -38,6 +38,7 @@ require "active_record/connection_adapters/oracle_enhanced/column_dumper"
 require "active_record/connection_adapters/oracle_enhanced/context_index"
 require "active_record/connection_adapters/oracle_enhanced/column"
 require "active_record/connection_adapters/oracle_enhanced/quoting"
+require "active_record/connection_adapters/oracle_enhanced/database_limits"
 
 require "digest/sha1"
 
@@ -165,6 +166,7 @@ module ActiveRecord
       include ActiveRecord::ConnectionAdapters::OracleEnhanced::ColumnDumper
       include ActiveRecord::ConnectionAdapters::OracleEnhanced::ContextIndex
       include ActiveRecord::ConnectionAdapters::OracleEnhanced::Quoting
+      include ActiveRecord::ConnectionAdapters::OracleEnhanced::DatabaseLimits
 
       def schema_creation
         OracleEnhanced::SchemaCreation.new self
@@ -359,49 +361,6 @@ module ActiveRecord
 
       def native_database_types #:nodoc:
         emulate_booleans_from_strings ? NATIVE_DATABASE_TYPES_BOOLEAN_STRINGS : NATIVE_DATABASE_TYPES
-      end
-
-      # maximum length of Oracle identifiers
-      IDENTIFIER_MAX_LENGTH = 30
-
-      def table_alias_length #:nodoc:
-        IDENTIFIER_MAX_LENGTH
-      end
-
-      # the maximum length of a table name
-      def table_name_length
-        IDENTIFIER_MAX_LENGTH
-      end
-
-      # the maximum length of a column name
-      def column_name_length
-        IDENTIFIER_MAX_LENGTH
-      end
-
-      # Returns the maximum allowed length for an index name. This
-      # limit is enforced by rails and Is less than or equal to
-      # <tt>index_name_length</tt>. The gap between
-      # <tt>index_name_length</tt> is to allow internal rails
-      # opreations to use prefixes in temporary opreations.
-      def allowed_index_name_length
-        index_name_length
-      end
-
-      # the maximum length of an index name
-      # supported by this database
-      def index_name_length
-        IDENTIFIER_MAX_LENGTH
-      end
-
-      # the maximum length of a sequence name
-      def sequence_name_length
-        IDENTIFIER_MAX_LENGTH
-      end
-
-      # To avoid ORA-01795: maximum number of expressions in a list is 1000
-      # tell ActiveRecord to limit us to 1000 ids at a time
-      def in_clause_length
-        1000
       end
 
       # CONNECTION MANAGEMENT ====================================


### PR DESCRIPTION
To prepare longer identifier support in `nextval` branch.

Quoting module has implicit length information for
`NONQUOTED_OBJECT_NAME` and `NONQUOTED_DATABASE_LINK`, which will be addressed in another commit.