### PR TITLE
Use Ubuntu 12.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: trusty
 sudo: required
 cache: bundler
 


### PR DESCRIPTION
CI for JRuby (jruby-9.1.8.0 and jruby-head) are slow,
taking 22 min to 24 min without this change.

This change improves CI for JRuby about 6 min to 7 min