### PR TITLE
Drop db_link support - remove #{db_link} from metadata queries

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -30,9 +30,7 @@ module ActiveRecord
       def describe(name)
         name = name.to_s
         if name.include?("@")
-          name, db_link = name.split("@")
-          default_owner = select_value("SELECT username FROM all_db_links WHERE db_link = '#{db_link.upcase}'")
-          db_link = "@#{db_link}"
+          raise ArgumentError "db link is not supported"
         else
           db_link = nil
           default_owner = @owner
@@ -45,31 +43,31 @@ module ActiveRecord
         end
         sql = <<-SQL
           SELECT owner, table_name, 'TABLE' name_type
-          FROM all_tables#{db_link}
+          FROM all_tables
           WHERE owner = '#{table_owner}'
             AND table_name = '#{table_name}'
           UNION ALL
           SELECT owner, view_name table_name, 'VIEW' name_type
-          FROM all_views#{db_link}
+          FROM all_views
           WHERE owner = '#{table_owner}'
             AND view_name = '#{table_name}'
           UNION ALL
           SELECT table_owner, DECODE(db_link, NULL, table_name, table_name||'@'||db_link), 'SYNONYM' name_type
-          FROM all_synonyms#{db_link}
+          FROM all_synonyms
           WHERE owner = '#{table_owner}'
             AND synonym_name = '#{table_name}'
           UNION ALL
           SELECT table_owner, DECODE(db_link, NULL, table_name, table_name||'@'||db_link), 'SYNONYM' name_type
-          FROM all_synonyms#{db_link}
+          FROM all_synonyms
           WHERE owner = 'PUBLIC'
             AND synonym_name = '#{real_name}'
         SQL
         if result = select_one(sql)
           case result["name_type"]
           when "SYNONYM"
-            describe("#{result['owner'] && "#{result['owner']}."}#{result['table_name']}#{db_link}")
+            describe("#{result['owner'] && "#{result['owner']}."}#{result['table_name']}")
           else
-            db_link ? [result["owner"], result["table_name"], db_link] : [result["owner"], result["table_name"]]
+            [result["owner"], result["table_name"]]
           end
         else
           raise OracleEnhancedConnectionException, %Q{"DESC #{name}" failed; does it exist?}

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -33,7 +33,6 @@ module ActiveRecord #:nodoc:
                 next if ignored? syn.name
                 table_name = syn.table_name
                 table_name = "#{syn.table_owner}.#{table_name}" if syn.table_owner
-                table_name = "#{table_name}@#{syn.db_link}" if syn.db_link
                 stream.print "  add_synonym #{syn.name.inspect}, #{table_name.inspect}, force: true"
                 stream.puts
               end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -197,7 +197,7 @@ module ActiveRecord
           end
           (owner, table_name, db_link) = @connection.describe(table_name)
           result = select_value(<<-SQL)
-            SELECT 1 FROM all_indexes#{db_link} i
+            SELECT 1 FROM all_indexes i
             WHERE i.owner = '#{owner}'
                AND i.table_owner = '#{owner}'
                AND i.table_name = '#{table_name}'
@@ -303,7 +303,7 @@ module ActiveRecord
         def table_comment(table_name) #:nodoc:
           (owner, table_name, db_link) = @connection.describe(table_name)
           select_value <<-SQL
-            SELECT comments FROM all_tab_comments#{db_link}
+            SELECT comments FROM all_tab_comments
             WHERE owner = '#{owner}'
               AND table_name = '#{table_name}'
           SQL
@@ -313,7 +313,7 @@ module ActiveRecord
           # TODO: it  does not exist in Abstract adapter
           (owner, table_name, db_link) = @connection.describe(table_name)
           select_value <<-SQL
-            SELECT comments FROM all_col_comments#{db_link}
+            SELECT comments FROM all_col_comments
             WHERE owner = '#{owner}'
               AND table_name = '#{table_name}'
               AND column_name = '#{column_name.upcase}'
@@ -347,8 +347,8 @@ module ActiveRecord
                   ,cc.column_name
                   ,c.constraint_name name
                   ,c.delete_rule
-              FROM all_constraints#{db_link} c, all_cons_columns#{db_link} cc,
-                   all_constraints#{db_link} r, all_cons_columns#{db_link} rc
+              FROM all_constraints c, all_cons_columns cc,
+                   all_constraints r, all_cons_columns rc
              WHERE c.owner = '#{owner}'
                AND c.table_name = q'[#{desc_table_name}]'
                AND c.constraint_type = 'R'

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -585,11 +585,11 @@ module ActiveRecord
               LOWER(i.tablespace_name) AS tablespace_name,
               LOWER(c.column_name) AS column_name, e.column_expression,
               atc.virtual_column
-            FROM all_indexes#{db_link} i
-              JOIN all_ind_columns#{db_link} c ON c.index_name = i.index_name AND c.index_owner = i.owner
-              LEFT OUTER JOIN all_ind_expressions#{db_link} e ON e.index_name = i.index_name AND
+            FROM all_indexes i
+              JOIN all_ind_columns c ON c.index_name = i.index_name AND c.index_owner = i.owner
+              LEFT OUTER JOIN all_ind_expressions e ON e.index_name = i.index_name AND
                 e.index_owner = i.owner AND e.column_position = c.column_position
-              LEFT OUTER JOIN all_tab_cols#{db_link} atc ON i.table_name = atc.table_name AND
+              LEFT OUTER JOIN all_tab_cols atc ON i.table_name = atc.table_name AND
                 c.column_name = atc.column_name AND i.owner = atc.owner AND atc.hidden_column = 'NO'
             WHERE i.owner = '#{owner}'
                AND i.table_owner = '#{owner}'
@@ -610,7 +610,7 @@ module ActiveRecord
                 procedure_name = default_datastore_procedure(row["index_name"])
                 source = select_values(<<-SQL).join
                   SELECT text
-                  FROM all_source#{db_link}
+                  FROM all_source
                   WHERE owner = '#{owner}'
                     AND name = '#{procedure_name.upcase}'
                   ORDER BY line
@@ -691,7 +691,7 @@ module ActiveRecord
                                     NULL) AS limit,
                  DECODE(data_type, 'NUMBER', data_scale, NULL) AS scale,
                  comments.comments as column_comment
-            FROM all_tab_cols#{db_link} cols, all_col_comments#{db_link} comments
+            FROM all_tab_cols cols, all_col_comments comments
            WHERE cols.owner      = '#{owner}'
              AND cols.table_name = #{quote(desc_table_name)}
              AND cols.hidden_column = 'NO'
@@ -785,7 +785,7 @@ module ActiveRecord
 
         seqs = select_values(<<-SQL.strip.gsub(/\s+/, " "), "Sequence")
           select us.sequence_name
-          from all_sequences#{db_link} us
+          from all_sequences us
           where us.sequence_owner = '#{owner}'
           and us.sequence_name = upper(#{quote(default_sequence_name(desc_table_name))})
         SQL
@@ -793,7 +793,7 @@ module ActiveRecord
         # changed back from user_constraints to all_constraints for consistency
         pks = select_values(<<-SQL.strip.gsub(/\s+/, " "), "Primary Key")
           SELECT cc.column_name
-            FROM all_constraints#{db_link} c, all_cons_columns#{db_link} cc
+            FROM all_constraints c, all_cons_columns cc
            WHERE c.owner = '#{owner}'
              AND c.table_name = #{quote(desc_table_name)}
              AND c.constraint_type = 'P'
@@ -827,7 +827,7 @@ module ActiveRecord
 
         pks = select_values(<<-SQL.strip_heredoc, "Primary Keys")
           SELECT cc.column_name
-            FROM all_constraints#{db_link} c, all_cons_columns#{db_link} cc
+            FROM all_constraints c, all_cons_columns cc
            WHERE c.owner = '#{owner}'
              AND c.table_name = '#{desc_table_name}'
              AND c.constraint_type = 'P'

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -359,55 +359,6 @@ describe "OracleEnhancedAdapter" do
     end
   end
 
-  describe "access table over database link" do
-    before(:all) do
-      @conn = ActiveRecord::Base.connection
-      @db_link = "db_link"
-      @sys_conn = ActiveRecord::Base.oracle_enhanced_connection(SYSTEM_CONNECTION_PARAMS)
-      @sys_conn.drop_table :test_posts rescue nil
-      @sys_conn.create_table :test_posts do |t|
-        t.string      :title
-        # cannot update LOBs over database link
-        t.string      :body
-        t.timestamps null: true
-      end
-      @db_link_username = SYSTEM_CONNECTION_PARAMS[:username]
-      @db_link_password = SYSTEM_CONNECTION_PARAMS[:password]
-      @db_link_database = SYSTEM_CONNECTION_PARAMS[:database]
-      @conn.execute "DROP DATABASE LINK #{@db_link}" rescue nil
-      @conn.execute "CREATE DATABASE LINK #{@db_link} CONNECT TO #{@db_link_username} IDENTIFIED BY \"#{@db_link_password}\" USING '#{@db_link_database}'"
-      @conn.execute "CREATE OR REPLACE SYNONYM test_posts FOR test_posts@#{@db_link}"
-      @conn.execute "CREATE OR REPLACE SYNONYM test_posts_seq FOR test_posts_seq@#{@db_link}"
-      class ::TestPost < ActiveRecord::Base
-      end
-      TestPost.table_name = "test_posts"
-    end
-
-    after(:all) do
-      @conn.execute "DROP SYNONYM test_posts"
-      @conn.execute "DROP SYNONYM test_posts_seq"
-      @conn.execute "DROP DATABASE LINK #{@db_link}" rescue nil
-      @sys_conn.drop_table :test_posts rescue nil
-      Object.send(:remove_const, "TestPost") rescue nil
-      ActiveRecord::Base.clear_cache!
-    end
-
-    it "should verify database link" do
-      @conn.select_value("select * from dual@#{@db_link}") == "X"
-    end
-
-    it "should get column names" do
-      expect(TestPost.column_names).to eq(["id", "title", "body", "created_at", "updated_at"])
-    end
-
-    it "should create record" do
-      p = TestPost.create(title: "Title", body: "Body")
-      expect(p.id).not_to be_nil
-      expect(TestPost.find(p.id)).not_to be_nil
-    end
-
-  end
-
   describe "session information" do
     before(:all) do
       @conn = ActiveRecord::Base.connection

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
@@ -250,7 +250,7 @@ describe "OracleEnhancedAdapter schema dump" do
       expect(standard_dump).to match(/add_synonym "test_synonym", "schema_name.table_name", force: true/)
     end
 
-    it "should include synonym to other database table in schema dump" do
+    xit "should include synonym to other database table in schema dump" do
       schema_define do
         add_synonym :test_synonym, "table_name@link_name", force: true
       end


### PR DESCRIPTION
This commit mainly removes #{db_link} from metadata queries.
There are code remaining about db_link, other commits are coming.