### PR TITLE
Drop db_link support - `describe` does not return db_link

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -32,7 +32,6 @@ module ActiveRecord
         if name.include?("@")
           raise ArgumentError "db link is not supported"
         else
-          db_link = nil
           default_owner = @owner
         end
         real_name = ActiveRecord::ConnectionAdapters::OracleEnhanced::Quoting.valid_table_name?(name) ? name.upcase : name

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -195,7 +195,7 @@ module ActiveRecord
               Passing default to #index_name_exists? is deprecated without replacement.
             MSG
           end
-          (owner, table_name, db_link) = @connection.describe(table_name)
+          (owner, table_name) = @connection.describe(table_name)
           result = select_value(<<-SQL)
             SELECT 1 FROM all_indexes i
             WHERE i.owner = '#{owner}'
@@ -301,7 +301,7 @@ module ActiveRecord
         end
 
         def table_comment(table_name) #:nodoc:
-          (owner, table_name, db_link) = @connection.describe(table_name)
+          (owner, table_name) = @connection.describe(table_name)
           select_value <<-SQL
             SELECT comments FROM all_tab_comments
             WHERE owner = '#{owner}'
@@ -311,7 +311,7 @@ module ActiveRecord
 
         def column_comment(table_name, column_name) #:nodoc:
           # TODO: it  does not exist in Abstract adapter
-          (owner, table_name, db_link) = @connection.describe(table_name)
+          (owner, table_name) = @connection.describe(table_name)
           select_value <<-SQL
             SELECT comments FROM all_col_comments
             WHERE owner = '#{owner}'
@@ -339,7 +339,7 @@ module ActiveRecord
 
         # get table foreign keys for schema dump
         def foreign_keys(table_name) #:nodoc:
-          (owner, desc_table_name, db_link) = @connection.describe(table_name)
+          (owner, desc_table_name) = @connection.describe(table_name)
 
           fk_info = select_all(<<-SQL, "Foreign Keys")
             SELECT r.table_name to_table

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -576,7 +576,7 @@ module ActiveRecord
       # This method selects all indexes at once, and caches them in a class variable.
       # Subsequent index calls get them from the variable, without going to the DB.
       def indexes(table_name, name = nil) #:nodoc:
-        (owner, table_name, db_link) = @connection.describe(table_name)
+        (owner, table_name) = @connection.describe(table_name)
         unless all_schema_indexes
           default_tablespace_name = default_tablespace
           result = select_all(<<-SQL.strip.gsub(/\s+/, " "))
@@ -674,7 +674,7 @@ module ActiveRecord
       def columns_without_cache(table_name, name = nil) #:nodoc:
         table_name = table_name.to_s
 
-        (owner, desc_table_name, db_link) = @connection.describe(table_name)
+        (owner, desc_table_name) = @connection.describe(table_name)
 
         # reset do_not_prefetch_primary_key cache for this table
         @@do_not_prefetch_primary_key[table_name] = nil
@@ -823,7 +823,7 @@ module ActiveRecord
       end
 
       def primary_keys(table_name) # :nodoc:
-        (owner, desc_table_name, db_link) = @connection.describe(table_name) unless owner
+        (owner, desc_table_name) = @connection.describe(table_name) unless owner
 
         pks = select_values(<<-SQL.strip_heredoc, "Primary Keys")
           SELECT cc.column_name


### PR DESCRIPTION
- Addresses these warnings:
```
lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:577: warning: assigned but unused variable - db_link
lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:692: warning: assigned but unused variable - db_link
lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:841: warning: assigned but unused variable - db_link
lib/active_record/connection_adapters/oracle_enhanced/connection.rb:35: warning: assigned but unused variable - db_link
lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:218: warning: assigned but unused variable - db_link
lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:324: warning: assigned but unused variable - db_link
lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:334: warning: assigned but unused variable - db_link
lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:362: warning: assigned but unused variable - db_link
```