### PR TITLE
Address `undefined method `tablespace' for #<ActiveRecord::Connection…

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -92,6 +92,7 @@ module ActiveRecord #:nodoc:
           end
 
           def index_parts(index)
+            return super unless @connection.respond_to?(:temporary_table?)
             index_parts = super
             index_parts << "tablespace: #{index.tablespace.inspect}" if index.tablespace
             index_parts


### PR DESCRIPTION
…Adapters::IndexDefinition`

This commit changes to call super method if this connection is not Oracle.

Addresses #1332