### PR TITLE
CI against JRuby 9.1.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ rvm:
   - 2.3.4
   - 2.4.1
   - ruby-head
-  - jruby-9.1.8.0
+  - jruby-9.1.9.0
   - jruby-head
 
 matrix:


### PR DESCRIPTION
JRuby 9.1.9.0 has been released.

http://jruby.org/2017/05/16/jruby-9-1-9-0