### PR TITLE
Fail fast by removing ruby-head and jruby-head from allow_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,5 @@ rvm:
   - jruby-9.1.9.0
   - jruby-head
 
-matrix:
-  allow_failures:
-    - rvm: ruby-head
-    - rvm: jruby-head
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_install:
   - chmod +x .travis/setup_accounts.sh
 
 install:
+  - "gem install bundler"
   - .travis/oracle/download.sh
   - .travis/oracle/install.sh
   - .travis/setup_accounts.sh


### PR DESCRIPTION
#1279 was opened while Oracle enhanced adapter was tested with jruby-head but no actions taken until JRuby 9.1.9.0 has been released.

This change may be too much but I think it is worth to try it. 