### PR TITLE
CI against JRuby 9.1.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ rvm:
   - 2.3.4
   - 2.4.1
   - ruby-head
-  - jruby-9.1.9.0
+  - jruby-9.1.10.0
   - jruby-head
 
 matrix:


### PR DESCRIPTION
http://jruby.org/2017/05/25/jruby-9-1-10-0.html

Backports #1348 to release18