### PR TITLE
Friendly "nextval" error when using Oracle 12.1 or lower

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -226,8 +226,12 @@ module ActiveRecord
       def initialize(connection, logger = nil, config = {}) # :nodoc:
         super(connection, logger, config)
         if @connection.database_version.to_s < [12, 2].to_s
-          raise "Your version of Oracle Database (#{@connection.database_version.first}.#{@connection.database_version.second}) is too old.
-          Active Record Oracle enhanced adapter 2 supports Oracle Database 12.2 or higher"
+          $stderr.puts <<-EOS.strip_heredoc
+            Your version of Oracle Database (#{@connection.database_version.first}.#{@connection.database_version.second}) is too old.
+            Active Record Oracle enhanced adapter 2 supports Oracle Database 12.2 or higher.
+          EOS
+
+          exit!
         end
         @statements = StatementPool.new(self.class.type_cast_config_to_integer(config[:statement_limit]))
         @enable_dbms_output = false


### PR DESCRIPTION
This PR will changing an error when using "nextval" with Oracle 12.1 or lower.

## Before

```console
% bundle exec rake
==> Loading config from ENV or use default
==> Running specs with MRI version 2.4.1
==> Effective ActiveRecord version 5.2.0.alpha
rake aborted!
Your version of Oracle Database (11.2) is too old.
          Active Record Oracle enhanced adapter 2 supports Oracle Database 12.2 or higher
/home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:229:in `initialize'
/home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:93:in `new'
/home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:93:in `oracle_enhanced_connection'
/home/vagrant/.rvm/gems/ruby-2.4.1/bundler/gems/rails-f19f4270d014/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:759:in `new_connection'
/home/vagrant/.rvm/gems/ruby-2.4.1/bundler/gems/rails-f19f4270d014/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:803:in `checkout_new_connection'
/home/vagrant/.rvm/gems/ruby-2.4.1/bundler/gems/rails-f19f4270d014/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:782:in `try_to_checkout_new_connection'
/home/vagrant/.rvm/gems/ruby-2.4.1/bundler/gems/rails-f19f4270d014/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:743:in `acquire_connection'
/home/vagrant/.rvm/gems/ruby-2.4.1/bundler/gems/rails-f19f4270d014/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:500:in `checkout'
/home/vagrant/.rvm/gems/ruby-2.4.1/bundler/gems/rails-f19f4270d014/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:374:in `connection'
/home/vagrant/.rvm/gems/ruby-2.4.1/bundler/gems/rails-f19f4270d014/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:931:in `retrieve_connection'
/home/vagrant/.rvm/gems/ruby-2.4.1/bundler/gems/rails-f19f4270d014/activerecord/lib/active_record/connection_handling.rb:116:in `retrieve_connection'
/home/vagrant/.rvm/gems/ruby-2.4.1/bundler/gems/rails-f19f4270d014/activerecord/lib/active_record/connection_handling.rb:88:in `connection'
/home/vagrant/src/oracle-enhanced/Rakefile:22:in `block in <top (required)>'
/home/vagrant/.rvm/gems/ruby-2.4.1@global/gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
/home/vagrant/.rvm/gems/ruby-2.4.1/gems/bundler-1.14.6/lib/bundler/cli/exec.rb:74:in `load'
/home/vagrant/.rvm/gems/ruby-2.4.1/gems/bundler-1.14.6/lib/bundler/cli/exec.rb:74:in `kernel_load'
/home/vagrant/.rvm/gems/ruby-2.4.1/gems/bundler-1.14.6/lib/bundler/cli/exec.rb:27:in `run'
/home/vagrant/.rvm/gems/ruby-2.4.1/gems/bundler-1.14.6/lib/bundler/cli.rb:335:in `exec'
/home/vagrant/.rvm/gems/ruby-2.4.1/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/home/vagrant/.rvm/gems/ruby-2.4.1/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/home/vagrant/.rvm/gems/ruby-2.4.1/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
/home/vagrant/.rvm/gems/ruby-2.4.1/gems/bundler-1.14.6/lib/bundler/cli.rb:20:in `dispatch'
/home/vagrant/.rvm/gems/ruby-2.4.1/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
/home/vagrant/.rvm/gems/ruby-2.4.1/gems/bundler-1.14.6/lib/bundler/cli.rb:11:in `start'
/home/vagrant/.rvm/gems/ruby-2.4.1/gems/bundler-1.14.6/exe/bundle:32:in `block in <top (required)>'
/home/vagrant/.rvm/gems/ruby-2.4.1/gems/bundler-1.14.6/lib/bundler/friendly_errors.rb:121:in `with_friendly_errors'
/home/vagrant/.rvm/gems/ruby-2.4.1/gems/bundler-1.14.6/exe/bundle:24:in `<top (required)>'
/home/vagrant/.rvm/gems/ruby-2.4.1/bin/bundle:22:in `load'
/home/vagrant/.rvm/gems/ruby-2.4.1/bin/bundle:22:in `<main>'
/home/vagrant/.rvm/gems/ruby-2.4.1/bin/ruby_executable_hooks:15:in `eval'
/home/vagrant/.rvm/gems/ruby-2.4.1/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => default => spec => clear
(See full trace by running task with --trace)
Coverage report generated for RSpec to /home/vagrant/src/oracle-enhanced/coverage. 583 / 1757 LOC (33.18%) covered.
```

## After

```console
% bundle exec rake
==> Loading config from ENV or use default
==> Running specs with MRI version 2.4.1
==> Effective ActiveRecord version 5.2.0.alpha
Your version of Oracle Database (11.2) is too old.
Active Record Oracle enhanced adapter 2 supports Oracle Database 12.2 or higher.
```

This PR got an idea from rails/rails#28939. Thank you.
