### PR TITLE
Add sequence with settings to structure dump

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -5,8 +5,8 @@ module ActiveRecord #:nodoc:
       STATEMENT_TOKEN = "\n\n/\n\n"
 
       def structure_dump #:nodoc:
-        structure = select_values("SELECT sequence_name FROM all_sequences where sequence_owner = SYS_CONTEXT('userenv', 'session_user') ORDER BY 1").map do |seq|
-          "CREATE SEQUENCE \"#{seq}\""
+        structure = select("SELECT sequence_name, min_value, max_value, increment_by, order_flag, cycle_flag FROM all_sequences where sequence_owner = SYS_CONTEXT('userenv', 'session_user') ORDER BY 1").map do |result|
+          "CREATE SEQUENCE #{quote_table_name(result["sequence_name"])} MINVALUE #{result["min_value"]} MAXVALUE #{result["max_value"]} INCREMENT BY #{result["increment_by"]} #{result["order_flag"] == 'Y' ? "ORDER" : "NOORDER"} #{result["cycle_flag"] == 'Y' ? "CYCLE" : "NOCYCLE"}"
         end
         select_values("SELECT table_name FROM all_tables t
                     WHERE owner = SYS_CONTEXT('userenv', 'current_schema') AND secondary = 'N'

--- a/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
@@ -243,6 +243,38 @@ describe "OracleEnhancedAdapter structure dump" do
     end
   end
 
+  describe "sequences" do
+    let(:sequence_name) { "test_sequence_a" }
+    before(:each) do
+      @conn.execute sql
+    end
+    after(:each) do
+      @conn.execute "drop SEQUENCE \"#{sequence_name}\""
+    end
+    subject do
+      ActiveRecord::Base.connection.structure_dump
+    end
+    context "default sequence" do
+      let(:sql) { "CREATE SEQUENCE \"#{sequence_name}\"" }
+      it { is_expected.to_not match(%r{CREATE SEQUENCE \"#{sequence_name}" MAXVALUE \d+ MINVALUE \d+ NOORDER NOCYCLE}) }
+    end
+    context "noorder" do
+      let(:sql) { "CREATE SEQUENCE \"#{sequence_name}\" NOORDER" }
+      it { is_expected.to include("NOORDER") }
+      it { is_expected.to_not include(" ORDER") }
+    end
+    context "order" do
+      let(:sql) { "CREATE SEQUENCE \"#{sequence_name}\" ORDER" }
+      it { is_expected.to include(" ORDER") }
+      it { is_expected.to_not include("NOORDER") }
+    end
+    context "min max values" do
+      let(:sql) { "CREATE SEQUENCE \"#{sequence_name}\" MINVALUE 7 MAXVALUE 444" }
+      it { is_expected.to include("MINVALUE 7") }
+      it { is_expected.to include("MAXVALUE 444") }
+    end
+  end
+
   describe "database structure dump extensions" do
     before(:all) do
       @conn.execute <<-SQL


### PR DESCRIPTION
Add min and max values, order and cycle flags.

These are sometimes needed when sequence is not solely used for id generation for example.

order flag is quite useful also sometimes for id generation.