### PR TITLE
CI against JRuby 9.1.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ rvm:
   - 2.3.4
   - 2.4.1
   - ruby-head
-  - jruby-9.1.10.0
+  - jruby-9.1.12.0
   - jruby-head
 
 matrix:


### PR DESCRIPTION
This PR backports #1359 to release18 branch.
