### PR TITLE
Some platforms do not support `OCI8.properties[:tcp_keepalive_time]`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -330,7 +330,10 @@ module ActiveRecord
           database
         end
         OCI8.properties[:tcp_keepalive] = true
-        OCI8.properties[:tcp_keepalive_time] = 600
+        begin
+          OCI8.properties[:tcp_keepalive_time] = 600
+        rescue NotImplementedError
+        end
         conn = OCI8.new username, password, connection_string, privilege
         conn.autocommit = true
         conn.non_blocking = true if async


### PR DESCRIPTION
Refer "Hanging After a Long Period of Inactivity"
http://www.rubydoc.info/github/kubo/ruby-oci8/file/docs/hanging-after-inactivity.md

Follow up for #1353. 