### PR TITLE
Use conventional fixture load

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -217,6 +217,13 @@ module ActiveRecord
           end
         end
 
+        # fallback to non bulk fixture insert
+        def insert_fixtures(fixtures, table_name)
+          fixtures.each do |fixture|
+            insert_fixture(fixture, table_name)
+          end
+        end
+
         # Oracle Database does not support this feature
         # Refer https://community.oracle.com/ideas/13845 and consider to vote
         # if you need this feature.


### PR DESCRIPTION
rails/rails#29504 implements bulk insert for fixture load.
Oracle database needs another syntax.
In the mean time, this commit just falls back to conventional fixture load.

Refer rails/arel#482

This pull request addressses `ORA-00933` error.
```sql
$ ARCONN=oracle bin/test test/cases/aggregations_test.rb:126
Using oracle
Run options: --seed 3549

# Running:

E

Error:
AggregationsTest#test_do_not_run_the_converter_when_nil_was_set:
ActiveRecord::StatementInvalid: OCIError: ORA-00933: SQL command not properly ended: INSERT INTO "CUSTOMERS" ("ID", "NAME", "BALANCE", "ADDRESS_STREET", "ADDRESS_CITY", "ADDRESS_COUNTRY", "GPS_LOCATION") VALUES (1, 'David', 50, 'Funny Street', 'Scary Town', 'Loony Land', '35.544623640962634x-105.9309951055148'), (2, 'Zaphod', 62, 'Avenue Road', 'Hamlet Town', 'Nation Land', NULL), (3, 'Barney Gumble', 1, 'Quiet Road', 'Peaceful Town', 'Tranquil Land', NULL)
    stmt.c:243:in oci8lib_240.so
    /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/ruby-oci8-2.2.4.1/lib/oci8/cursor.rb:130:in `exec'
    /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/ruby-oci8-2.2.4.1/lib/oci8/oci8.rb:277:in `exec_internal'
    /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/ruby-oci8-2.2.4.1/lib/oci8/oci8.rb:268:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:429:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:90:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `block in execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:580:in `block (2 levels) in log'
    /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/2.4.0/monitor.rb:214:in `mon_synchronize'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:579:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:571:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:989:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:359:in `insert_fixtures'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:570:in `block (4 levels) in create_fixtures'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:569:in `each'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:569:in `block (3 levels) in create_fixtures'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:558:in `each'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:558:in `block (2 levels) in create_fixtures'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:226:in `block in transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:194:in `block in within_new_transaction'
    /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/2.4.0/monitor.rb:214:in `mon_synchronize'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:191:in `within_new_transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:226:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:556:in `block in create_fixtures'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:418:in `disable_referential_integrity'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:541:in `create_fixtures'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:1038:in `load_fixtures'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:975:in `setup_fixtures'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:867:in `before_setup'


bin/test test/cases/aggregations_test.rb:126



Finished in 0.281626s, 3.5508 runs/s, 0.0000 assertions/s.

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```

`