### PR TITLE
Enable frozen string literal

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,6 +74,10 @@ Layout/SpaceBeforeFirstArg:
 Style/MethodDefParentheses:
   Enabled: true
 
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: always
+
 # Use `foo {}` not `foo{}`.
 Layout/SpaceBeforeBlockBraces:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source "https://rubygems.org"
 
 git_source(:github) do |repo_name|

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 source "https://rubygems.org"
 
 git_source(:github) do |repo_name|

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "rubygems"
 require "bundler"
 require "bundler/gem_tasks"

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rubygems"
 require "bundler"
 require "bundler/gem_tasks"

--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 version = File.read(File.expand_path("../VERSION", __FILE__)).strip
 
 Gem::Specification.new do |s|

--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 version = File.read(File.expand_path("../VERSION", __FILE__)).strip
 
 Gem::Specification.new do |s|

--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 begin
   require "bundler/inline"
 rescue LoadError => e

--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 begin
   require "bundler/inline"
 rescue LoadError => e

--- a/guides/bug_report_templates/active_record_gem_spec.rb
+++ b/guides/bug_report_templates/active_record_gem_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 begin
   require "bundler/inline"
 rescue LoadError => e

--- a/guides/bug_report_templates/active_record_gem_spec.rb
+++ b/guides/bug_report_templates/active_record_gem_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 begin
   require "bundler/inline"
 rescue LoadError => e

--- a/lib/active_record/connection_adapters/emulation/oracle_adapter.rb
+++ b/lib/active_record/connection_adapters/emulation/oracle_adapter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ActiveRecord::ConnectionAdapters::OracleAdapter < ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter #:nodoc:
   def adapter_name
     "Oracle"

--- a/lib/active_record/connection_adapters/emulation/oracle_adapter.rb
+++ b/lib/active_record/connection_adapters/emulation/oracle_adapter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ActiveRecord::ConnectionAdapters::OracleAdapter < ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter #:nodoc:
   def adapter_name
     "Oracle"

--- a/lib/active_record/connection_adapters/oracle_enhanced/column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveRecord
   module ConnectionAdapters #:nodoc:
     class OracleEnhancedColumn < Column

--- a/lib/active_record/connection_adapters/oracle_enhanced/column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module ActiveRecord
   module ConnectionAdapters #:nodoc:
     class OracleEnhancedColumn < Column

--- a/lib/active_record/connection_adapters/oracle_enhanced/column_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column_dumper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module ActiveRecord #:nodoc:
   module ConnectionAdapters #:nodoc:
     module OracleEnhanced #:nodoc:

--- a/lib/active_record/connection_adapters/oracle_enhanced/column_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column_dumper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveRecord #:nodoc:
   module ConnectionAdapters #:nodoc:
     module OracleEnhanced #:nodoc:

--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module ActiveRecord
   module ConnectionAdapters
     # interface independent methods

--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveRecord
   module ConnectionAdapters
     # interface independent methods

--- a/lib/active_record/connection_adapters/oracle_enhanced/context_index.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/context_index.rb
@@ -87,7 +87,7 @@ module ActiveRecord
             create_index_column_trigger(table_name, index_name, options[:index_column], options[:index_column_trigger_on])
           end
 
-          sql = "CREATE INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)}"
+          sql = "CREATE INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)}".dup
           sql << " (#{quoted_column_name})"
           sql << " INDEXTYPE IS CTXSYS.CONTEXT"
           parameters = []
@@ -155,7 +155,7 @@ module ActiveRecord
             CREATE OR REPLACE PROCEDURE #{quote_table_name(procedure_name)}
               (p_rowid IN	      ROWID,
               p_clob	IN OUT NOCOPY CLOB) IS
-              -- add_context_index_parameters #{(column_names + select_queries).inspect}#{!options.empty? ? ', ' << options.inspect[1..-2] : ''}
+              -- add_context_index_parameters #{(column_names + select_queries).inspect}#{!options.empty? ? ', '.dup << options.inspect[1..-2] : ''}
               #{
               selected_columns.map do |cols|
                 cols.map do |col|
@@ -172,7 +172,7 @@ module ActiveRecord
                 #{
                 (column_names.map do |col|
                   col = col.to_s
-                  "DBMS_LOB.WRITEAPPEND(p_clob, #{col.length + 2}, '<#{col}>');\n" <<
+                  "DBMS_LOB.WRITEAPPEND(p_clob, #{col.length + 2}, '<#{col}>');\n".dup <<
                   "IF LENGTH(r1.#{col}) > 0 THEN\n" <<
                   "DBMS_LOB.WRITEAPPEND(p_clob, LENGTH(r1.#{col}), r1.#{col});\n" <<
                   "END IF;\n" <<
@@ -190,7 +190,7 @@ module ActiveRecord
                   "END LOOP;\n" <<
                   (cols.map do |col|
                     col = col.to_s
-                    "DBMS_LOB.WRITEAPPEND(p_clob, #{col.length + 2}, '<#{col}>');\n" <<
+                    "DBMS_LOB.WRITEAPPEND(p_clob, #{col.length + 2}, '<#{col}>');\n".dup <<
                     "IF LENGTH(l_#{col}) > 0 THEN\n" <<
                     "DBMS_LOB.WRITEAPPEND(p_clob, LENGTH(l_#{col}), l_#{col});\n" <<
                     "END IF;\n" <<
@@ -227,7 +227,7 @@ module ActiveRecord
 
           def create_storage_preference(storage_name, tablespace)
             drop_ctx_preference(storage_name)
-            sql = "BEGIN\nCTX_DDL.CREATE_PREFERENCE('#{storage_name}', 'BASIC_STORAGE');\n"
+            sql = "BEGIN\nCTX_DDL.CREATE_PREFERENCE('#{storage_name}', 'BASIC_STORAGE');\n".dup
             ["I_TABLE_CLAUSE", "K_TABLE_CLAUSE", "R_TABLE_CLAUSE",
             "N_TABLE_CLAUSE", "I_INDEX_CLAUSE", "P_TABLE_CLAUSE"].each do |clause|
               default_clause = case clause
@@ -243,7 +243,7 @@ module ActiveRecord
 
           def create_lexer_preference(lexer_name, lexer_type, options)
             drop_ctx_preference(lexer_name)
-            sql = "BEGIN\nCTX_DDL.CREATE_PREFERENCE('#{lexer_name}', '#{lexer_type}');\n"
+            sql = "BEGIN\nCTX_DDL.CREATE_PREFERENCE('#{lexer_name}', '#{lexer_type}');\n".dup
             options.each do |key, value|
               plsql_value = case value
                             when String; "'#{value}'"
@@ -260,7 +260,7 @@ module ActiveRecord
 
           def create_wordlist_preference(wordlist_name, wordlist_type, options)
             drop_ctx_preference(wordlist_name)
-            sql = "BEGIN\nCTX_DDL.CREATE_PREFERENCE('#{wordlist_name}', '#{wordlist_type}');\n"
+            sql = "BEGIN\nCTX_DDL.CREATE_PREFERENCE('#{wordlist_name}', '#{wordlist_type}');\n".dup
             options.each do |key, value|
               plsql_value = case value
                             when String; "'#{value}'"

--- a/lib/active_record/connection_adapters/oracle_enhanced/context_index.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/context_index.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced

--- a/lib/active_record/connection_adapters/oracle_enhanced/context_index.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/context_index.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_limits.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_limits.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_limits.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_limits.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_tasks.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_tasks.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "active_record/base"
 
 module ActiveRecord

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_tasks.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_tasks.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_record/base"
 
 module ActiveRecord

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 begin
   require "java"
   require "jruby"

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 begin
   require "java"
   require "jruby"

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_quoting.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_quoting.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "delegate"
 
 begin

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "delegate"
 
 begin

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_quoting.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_quoting.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced

--- a/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_support"
 
 module ActiveRecord #:nodoc:

--- a/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "active_support"
 
 module ActiveRecord #:nodoc:

--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -89,7 +89,7 @@ module ActiveRecord
         def _quote(value) #:nodoc:
           case value
           when ActiveRecord::OracleEnhanced::Type::NationalCharacterString::Data then
-            "N" << "'#{quote_string(value.to_s)}'"
+            "N".dup << "'#{quote_string(value.to_s)}'"
           when ActiveModel::Type::Binary::Data then
             "empty_blob()"
           when ActiveRecord::OracleEnhanced::Type::Text::Data then

--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced

--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -17,7 +17,7 @@ module ActiveRecord
           end
 
           def visit_TableDefinition(o)
-            create_sql = "CREATE#{' GLOBAL TEMPORARY' if o.temporary} TABLE #{quote_table_name(o.name)} "
+            create_sql = "CREATE#{' GLOBAL TEMPORARY' if o.temporary} TABLE #{quote_table_name(o.name)} ".dup
             statements = o.columns.map { |c| accept c }
             statements << accept(o.primary_keys) if o.primary_keys
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module ActiveRecord #:nodoc:
   module ConnectionAdapters #:nodoc:
     module OracleEnhanced #:nodoc:

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveRecord #:nodoc:
   module ConnectionAdapters #:nodoc:
     module OracleEnhanced #:nodoc:

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -119,7 +119,7 @@ module ActiveRecord
           sm_table = quote_table_name(ActiveRecord::SchemaMigration.table_name)
 
           if supports_multi_insert?
-            versions.inject("INSERT ALL\n") { |sql, version|
+            versions.inject("INSERT ALL\n".dup) { |sql, version|
               sql << "INTO #{sm_table} (version) VALUES (#{quote(version)})\n"
             } << "SELECT * FROM DUAL\n"
           else
@@ -436,7 +436,7 @@ module ActiveRecord
         private
 
           def tablespace_for(obj_type, tablespace_option, table_name = nil, column_name = nil)
-            tablespace_sql = ""
+            tablespace_sql = "".dup
             if tablespace = (tablespace_option || default_tablespace_for(obj_type))
               if [:blob, :clob].include?(obj_type.to_sym)
                 tablespace_sql << " LOB (#{quote_column_name(column_name)}) STORE AS #{column_name.to_s[0..10]}_#{table_name.to_s[0..14]}_ls (TABLESPACE #{tablespace})"

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "digest/sha1"
 
 module ActiveRecord

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "digest/sha1"
 
 module ActiveRecord

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements_ext.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements_ext.rb
@@ -32,7 +32,7 @@ module ActiveRecord
         #   add_synonym :employees, "hr.employees@dblink", :force => true
         #
         def add_synonym(name, table_name, options = {})
-          sql = "CREATE"
+          sql = "CREATE".dup
           if options[:force] == true
             sql << " OR REPLACE"
           end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements_ext.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements_ext.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements_ext.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements_ext.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced

--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveRecord #:nodoc:
   module ConnectionAdapters #:nodoc:
     module OracleEnhancedStructureDump #:nodoc:

--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module ActiveRecord #:nodoc:
   module ConnectionAdapters #:nodoc:
     module OracleEnhancedStructureDump #:nodoc:

--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -16,7 +16,7 @@ module ActiveRecord #:nodoc:
                       AND NOT EXISTS (SELECT mvl.log_table FROM all_mview_logs mvl WHERE mvl.log_owner = t.owner AND mvl.log_table = t.table_name)
                     ORDER BY 1").each do |table_name|
           virtual_columns = virtual_columns_for(table_name)
-          ddl = "CREATE#{ ' GLOBAL TEMPORARY' if temporary_table?(table_name)} TABLE \"#{table_name}\" (\n"
+          ddl = "CREATE#{ ' GLOBAL TEMPORARY' if temporary_table?(table_name)} TABLE \"#{table_name}\" (\n".dup
           cols = select_all("
             SELECT column_name, data_type, data_length, char_used, char_length, data_precision, data_scale, data_default, nullable
             FROM all_tab_columns
@@ -44,7 +44,7 @@ module ActiveRecord #:nodoc:
       end
 
       def structure_dump_column(column) #:nodoc:
-        col = "\"#{column['column_name']}\" #{column['data_type']}"
+        col = "\"#{column['column_name']}\" #{column['data_type']}".dup
         if (column["data_type"] == "NUMBER") && !column["data_precision"].nil?
           col << "(#{column['data_precision'].to_i}"
           col << ",#{column['data_scale'].to_i}" if !column["data_scale"].nil?
@@ -60,7 +60,7 @@ module ActiveRecord #:nodoc:
 
       def structure_dump_virtual_column(column, data_default) #:nodoc:
         data_default = data_default.gsub(/"/, "")
-        col = "\"#{column['column_name']}\" #{column['data_type']}"
+        col = "\"#{column['column_name']}\" #{column['data_type']}".dup
         if (column["data_type"] == "NUMBER") && !column["data_precision"].nil?
           col << "(#{column['data_precision'].to_i}"
           col << ",#{column['data_scale'].to_i}" if !column["data_scale"].nil?
@@ -132,7 +132,7 @@ module ActiveRecord #:nodoc:
         fks = select_all("SELECT table_name FROM all_tables WHERE owner = SYS_CONTEXT('userenv', 'current_schema') ORDER BY 1").map do |table|
           if respond_to?(:foreign_keys) && (foreign_keys = foreign_keys(table["table_name"])).any?
             foreign_keys.map do |fk|
-              sql = "ALTER TABLE #{quote_table_name(fk.from_table)} ADD CONSTRAINT #{quote_column_name(fk.options[:name])} "
+              sql = "ALTER TABLE #{quote_table_name(fk.from_table)} ADD CONSTRAINT #{quote_column_name(fk.options[:name])} ".dup
               sql << "#{foreign_key_definition(fk.to_table, fk.options)}"
             end
           end
@@ -189,7 +189,7 @@ module ActiveRecord #:nodoc:
                     WHERE type IN ('PROCEDURE', 'PACKAGE', 'PACKAGE BODY', 'FUNCTION', 'TRIGGER', 'TYPE')
                       AND name NOT LIKE 'BIN$%'
                       AND owner = SYS_CONTEXT('userenv', 'current_schema') ORDER BY type").each do |source|
-          ddl = "CREATE OR REPLACE   \n"
+          ddl = "CREATE OR REPLACE   \n".dup
           select_all("
                   SELECT text
                     FROM all_source

--- a/lib/active_record/connection_adapters/oracle_enhanced/version.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/version.rb
@@ -1,2 +1,3 @@
 # frozen_string_literal: true
+
 ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter::VERSION = File.read(File.expand_path("../../../../../VERSION", __FILE__)).chomp

--- a/lib/active_record/connection_adapters/oracle_enhanced/version.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/version.rb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter::VERSION = File.read(File.expand_path("../../../../../VERSION", __FILE__)).chomp

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # oracle_enhanced_adapter.rb -- ActiveRecord adapter for Oracle 8i, 9i, 10g, 11g
 #
 # Authors or original oracle_adapter: Graham Jenkins, Michael Schoen

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # oracle_enhanced_adapter.rb -- ActiveRecord adapter for Oracle 8i, 9i, 10g, 11g
 #
 # Authors or original oracle_adapter: Graham Jenkins, Michael Schoen

--- a/lib/active_record/oracle_enhanced/type/boolean.rb
+++ b/lib/active_record/oracle_enhanced/type/boolean.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module ActiveRecord
   module OracleEnhanced
     module Type

--- a/lib/active_record/oracle_enhanced/type/boolean.rb
+++ b/lib/active_record/oracle_enhanced/type/boolean.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveRecord
   module OracleEnhanced
     module Type

--- a/lib/active_record/oracle_enhanced/type/integer.rb
+++ b/lib/active_record/oracle_enhanced/type/integer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module ActiveRecord
   module OracleEnhanced
     module Type

--- a/lib/active_record/oracle_enhanced/type/integer.rb
+++ b/lib/active_record/oracle_enhanced/type/integer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveRecord
   module OracleEnhanced
     module Type

--- a/lib/active_record/oracle_enhanced/type/json.rb
+++ b/lib/active_record/oracle_enhanced/type/json.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module ActiveRecord
   module OracleEnhanced
     module Type

--- a/lib/active_record/oracle_enhanced/type/json.rb
+++ b/lib/active_record/oracle_enhanced/type/json.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveRecord
   module OracleEnhanced
     module Type

--- a/lib/active_record/oracle_enhanced/type/national_character_string.rb
+++ b/lib/active_record/oracle_enhanced/type/national_character_string.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_model/type/string"
 
 module ActiveRecord

--- a/lib/active_record/oracle_enhanced/type/national_character_string.rb
+++ b/lib/active_record/oracle_enhanced/type/national_character_string.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "active_model/type/string"
 
 module ActiveRecord

--- a/lib/active_record/oracle_enhanced/type/raw.rb
+++ b/lib/active_record/oracle_enhanced/type/raw.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_model/type/string"
 
 module ActiveRecord

--- a/lib/active_record/oracle_enhanced/type/raw.rb
+++ b/lib/active_record/oracle_enhanced/type/raw.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "active_model/type/string"
 
 module ActiveRecord

--- a/lib/active_record/oracle_enhanced/type/string.rb
+++ b/lib/active_record/oracle_enhanced/type/string.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_model/type/string"
 
 module ActiveRecord

--- a/lib/active_record/oracle_enhanced/type/string.rb
+++ b/lib/active_record/oracle_enhanced/type/string.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "active_model/type/string"
 
 module ActiveRecord

--- a/lib/active_record/oracle_enhanced/type/text.rb
+++ b/lib/active_record/oracle_enhanced/type/text.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_model/type/string"
 
 module ActiveRecord

--- a/lib/active_record/oracle_enhanced/type/text.rb
+++ b/lib/active_record/oracle_enhanced/type/text.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "active_model/type/string"
 
 module ActiveRecord

--- a/lib/active_record/oracle_enhanced/type/timestampltz.rb
+++ b/lib/active_record/oracle_enhanced/type/timestampltz.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module ActiveRecord
   module OracleEnhanced
     module Type

--- a/lib/active_record/oracle_enhanced/type/timestampltz.rb
+++ b/lib/active_record/oracle_enhanced/type/timestampltz.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveRecord
   module OracleEnhanced
     module Type

--- a/lib/active_record/oracle_enhanced/type/timestamptz.rb
+++ b/lib/active_record/oracle_enhanced/type/timestamptz.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module ActiveRecord
   module OracleEnhanced
     module Type

--- a/lib/active_record/oracle_enhanced/type/timestamptz.rb
+++ b/lib/active_record/oracle_enhanced/type/timestamptz.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveRecord
   module OracleEnhanced
     module Type

--- a/lib/activerecord-oracle_enhanced-adapter.rb
+++ b/lib/activerecord-oracle_enhanced-adapter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 if defined?(Rails)
   module ActiveRecord
     module ConnectionAdapters

--- a/lib/activerecord-oracle_enhanced-adapter.rb
+++ b/lib/activerecord-oracle_enhanced-adapter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 if defined?(Rails)
   module ActiveRecord
     module ConnectionAdapters

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 describe "OracleEnhancedAdapter establish connection" do
 
   it "should connect to database" do

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe "OracleEnhancedAdapter establish connection" do
 
   it "should connect to database" do

--- a/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe "OracleEnhancedConnection" do
 
   describe "create connection" do

--- a/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 describe "OracleEnhancedConnection" do
 
   describe "create connection" do

--- a/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 describe "OracleEnhancedAdapter context index" do
   include SchemaSpecHelper
   include LoggerSpecHelper

--- a/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe "OracleEnhancedAdapter context index" do
   include SchemaSpecHelper
   include LoggerSpecHelper

--- a/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_context_index_spec.rb
@@ -426,7 +426,7 @@ describe "OracleEnhancedAdapter context index" do
             ], options
         end
         expect(standard_dump).to match(/add_context_index "posts", \[:title, :body, "SELECT comments.author AS comment_author, comments.body AS comment_body FROM comments WHERE comments.post_id = :id"\], #{
-          options.inspect[1..-2].gsub(/[{}]/) { |s| '\\' << s }}$/)
+          options.inspect[1..-2].gsub(/[{}]/) { |s| '\\'.dup << s }}$/)
         schema_define { remove_context_index :posts, name: "xxx_post_and_comments_i" }
       end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe "OracleEnhancedAdapter date type detection based on column names" do
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 describe "OracleEnhancedAdapter date type detection based on column names" do
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)

--- a/spec/active_record/connection_adapters/oracle_enhanced_database_tasks_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_database_tasks_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_record/connection_adapters/oracle_enhanced/database_tasks"
 require "stringio"
 require "tempfile"

--- a/spec/active_record/connection_adapters/oracle_enhanced_database_tasks_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_database_tasks_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "active_record/connection_adapters/oracle_enhanced/database_tasks"
 require "stringio"
 require "tempfile"

--- a/spec/active_record/connection_adapters/oracle_enhanced_dbms_output_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_dbms_output_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 describe "OracleEnhancedAdapter logging dbms_output from plsql" do
   include LoggerSpecHelper
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_dbms_output_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_dbms_output_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe "OracleEnhancedAdapter logging dbms_output from plsql" do
   include LoggerSpecHelper
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 describe "OracleEnhancedAdapter dirty object tracking" do
   include SchemaSpecHelper
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_dirty_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe "OracleEnhancedAdapter dirty object tracking" do
   include SchemaSpecHelper
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_emulate_oracle_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_emulate_oracle_adapter_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe "OracleEnhancedAdapter emulate OracleAdapter" do
 
   before(:all) do

--- a/spec/active_record/connection_adapters/oracle_enhanced_emulate_oracle_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_emulate_oracle_adapter_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 describe "OracleEnhancedAdapter emulate OracleAdapter" do
 
   before(:all) do

--- a/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "ruby-plsql"
 
 describe "OracleEnhancedAdapter custom methods for create, update and destroy" do

--- a/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_procedures_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "ruby-plsql"
 
 describe "OracleEnhancedAdapter custom methods for create, update and destroy" do

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe "OracleEnhancedAdapter schema dump" do
   include SchemaSpecHelper
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_dump_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 describe "OracleEnhancedAdapter schema dump" do
   include SchemaSpecHelper
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -1233,7 +1233,7 @@ end
     end
 
     before(:each) do
-      @conn.instance_variable_set :@would_execute_sql, @would_execute_sql = ""
+      @conn.instance_variable_set :@would_execute_sql, @would_execute_sql = "".dup
       class <<@conn
         def execute(sql, name = nil); @would_execute_sql << sql << ";\n"; end
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe "OracleEnhancedAdapter schema definition" do
   include SchemaSpecHelper
   include LoggerSpecHelper

--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 describe "OracleEnhancedAdapter schema definition" do
   include SchemaSpecHelper
   include LoggerSpecHelper

--- a/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 describe "OracleEnhancedAdapter structure dump" do
   include LoggerSpecHelper
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_structure_dump_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe "OracleEnhancedAdapter structure dump" do
   include LoggerSpecHelper
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "simplecov"
 SimpleCov.start
 require "rubygems"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "simplecov"
 SimpleCov.start
 require "rubygems"


### PR DESCRIPTION
## Summary

It seems that introduction of frozen string literal to Rails has started, so this PR applies it to Oracle enhanced adapter.

https://github.com/rails/rails/blob/472f39f781e5ebf5dcb19bb432572ba68dfcceca/.rubocop.yml#L83-L88

I also confirmed that the "`can not modify frozen String`" error does not occur in rails/activerecord tests.

## Other Information

The "`can not modify frozen String`" error is fixed by `String#dup`. I think that `String#dup` is preferable to `String.new` for the following reasons.

https://github.com/rails/rails/pull/29506#issuecomment-309672824

There are the following PR recently merged into RuboCop.

https://github.com/bbatsov/rubocop/pull/4586

It seems that `String#+@` is superior to `String#dup`, but this PR does not using it because support target can not be limited to Ruby 2.3 or higher.
