### PR TITLE
Add synonyms in data_sources

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -527,7 +527,7 @@ module ActiveRecord
       end
 
       def data_sources
-        super
+        super | synonyms.map(&:name)
       end
 
       def table_exists?(table_name)

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -729,4 +729,29 @@ describe "OracleEnhancedAdapter" do
       expect(TestLog.count).to eq 2
     end
   end
+
+  describe "synonym_names" do
+    before(:all) do
+      schema_define do
+        create_table :test_comments, force: true do |t|
+          t.string :comment
+        end
+        add_synonym :synonym_comments, :test_comments
+      end
+    end
+
+    after(:all) do
+      schema_define do
+        drop_table :test_comments
+        remove_synonym :synonym_comments
+      end
+      ActiveRecord::Base.clear_cache! if ActiveRecord::Base.respond_to?(:"clear_cache!")
+    end
+
+    it "includes synonyms in data_source" do
+      conn = ActiveRecord::Base.connection
+      expect(conn).to be_data_source_exist("synonym_comments")
+      expect(conn.data_sources).to include("synonym_comments")
+    end
+  end
 end


### PR DESCRIPTION
I'm wondering why `data_sources` does not returns synonyms.
Current `data_sources` and `data_source_exist?` causes different behavior.

```ruby
conn.data_source_exist?('my_synonym') # => true
conn.data_sources.include?('my_synonym') # => false
```

I think synonyms are available as data source for AR models, so it is reasonable that `data_sources` includes synonyms.
Are there any reason to not treat synonyms as `data_sources` ?
