### PR TITLE
Make `type_map` to private because it is only used in the connection adapter

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -901,7 +901,7 @@ module ActiveRecord
 
       protected
 
-        def initialize_type_map(m)
+        def initialize_type_map(m = type_map)
           super
           # oracle
           register_class_with_precision m, %r(WITH TIME ZONE)i,       ActiveRecord::OracleEnhanced::Type::TimestampTz


### PR DESCRIPTION
Follow up of rails/rails#29869.