### PR TITLE
Arity change in insert method

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -84,7 +84,7 @@ module ActiveRecord
           super
         end
 
-        def insert(arel, name = nil, pk = nil, id_value = nil, sequence_name = nil, binds = [])
+        def insert(arel, name = nil, pk = nil, id_value = nil, sequence_name = nil)
           pk = nil if id_value
           super
         end


### PR DESCRIPTION
Refer: https://github.com/rails/rails/commit/213796f

This pull request addresses these failures:

```ruby
$ bundle exec rspec ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:218
==> Loading config from ENV or use default
==> Running specs with MRI version 2.4.1
==> Effective ActiveRecord version 5.2.0.alpha
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb"=>[218]}}
F

Failures:

  1) OracleEnhancedAdapter reserved words column quoting should create record
     Failure/Error: super

     ArgumentError:
       wrong number of arguments (given 6, expected 1..5)
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:140:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:19:in `insert'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:89:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:64:in `insert'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:595:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:180:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:77:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:220:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:342:in `block in _create_record'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:132:in `run_callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:827:in `_run_create_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:342:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:95:in `_create_record'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:569:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:338:in `block in create_or_update'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:98:in `run_callbacks'
     # /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:827:in `_run_save_callbacks'
     # /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:338:in `create_or_update'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:164:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:52:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:315:in `block in save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:386:in `block in with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:247:in `block in transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:230:in `block in within_new_transaction'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/2.4.0/monitor.rb:214:in `mon_synchronize'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:227:in `within_new_transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:247:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:212:in `transaction'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:383:in `with_transaction_returning_status'
     # /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:315:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:48:in `save!'
     # /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:53:in `create!'
     # ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:224:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:254:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:254:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:500:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:457:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:457:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:500:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:590:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:590:in `map'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:590:in `run'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:118:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:118:in `map'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:118:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/configuration.rb:1894:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:113:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/reporter.rb:79:in `report'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:112:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.1/bin/rspec:22:in `load'
     # /home/yahonda/.rbenv/versions/2.4.1/bin/rspec:22:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/cli/exec.rb:74:in `load'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/cli/exec.rb:74:in `kernel_load'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/cli/exec.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/cli.rb:365:in `exec'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/vendor/thor/lib/thor.rb:369:in `dispatch'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/cli.rb:22:in `dispatch'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/vendor/thor/lib/thor/base.rb:444:in `start'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/cli.rb:13:in `start'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/exe/bundle:30:in `block in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/friendly_errors.rb:121:in `with_friendly_errors'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/exe/bundle:22:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.1/bin/bundle:22:in `load'
     # /home/yahonda/.rbenv/versions/2.4.1/bin/bundle:22:in `<main>'

Finished in 0.40631 seconds (files took 0.77443 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:218 # OracleEnhancedAdapter reserved words column quoting should create record

Coverage report generated for RSpec to /home/yahonda/git/oracle-enhanced/coverage. 1007 / 2231 LOC (45.14%) covered.
$
```
