### PR TITLE
Arel::Nodes::BindParam#initialize introduced

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -524,7 +524,7 @@ describe "OracleEnhancedAdapter" do
 
     it "should clear older cursors when statement limit is reached" do
       pk = TestPost.columns_hash[TestPost.primary_key]
-      sub = Arel::Nodes::BindParam.new.to_sql
+      sub = Arel::Nodes::BindParam.new(nil).to_sql
       binds = [ActiveRecord::Relation::QueryAttribute.new(pk, 1, ActiveRecord::Type::Integer.new)]
 
       expect {
@@ -537,7 +537,7 @@ describe "OracleEnhancedAdapter" do
     it "should cache UPDATE statements with bind variables" do
       expect {
         pk = TestPost.columns_hash[TestPost.primary_key]
-        sub = Arel::Nodes::BindParam.new.to_sql
+        sub = Arel::Nodes::BindParam.new(nil).to_sql
         binds = [ActiveRecord::Relation::QueryAttribute.new(pk, 1, ActiveRecord::Type::Integer.new)]
         @conn.exec_update("UPDATE test_posts SET id = #{sub}", "SQL", binds)
       }.to change(@statements, :length).by(+1)


### PR DESCRIPTION
Refer https://github.com/rails/arel/commit/db1bb4e9a728a437d16f8bdb48c3b772c3e4edb0

This pull request addresses these two failures:

```ruby
$ bundle exec rspec ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:525
==> Loading config from ENV or use default
==> Running specs with MRI version 2.5.0
/home/yahonda/git/rails/activesupport/lib/active_support/core_ext/hash/keys.rb:14: warning: method redefined; discarding old transform_keys
/home/yahonda/git/rails/activesupport/lib/active_support/core_ext/hash/keys.rb:25: warning: method redefined; discarding old transform_keys!
==> Effective ActiveRecord version 5.2.0.alpha
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb"=>[525]}}
F

Failures:

  1) OracleEnhancedAdapter with statement pool should clear older cursors when statement limit is reached
     Failure/Error: sub = Arel::Nodes::BindParam.new.to_sql

     ArgumentError:
       wrong number of arguments (given 0, expected 1)
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/bundler/gems/arel-bfb770dbcc84/lib/arel/nodes/bind_param.rb:7:in `initialize'
     # ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:527:in `new'
     # ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:527:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:254:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:254:in `block in run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:500:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:457:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:457:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:500:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:590:in `block in run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:590:in `map'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:590:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:118:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:118:in `map'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:118:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/configuration.rb:1894:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:113:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/reporter.rb:79:in `report'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:112:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/bin/rspec:23:in `load'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/bin/rspec:23:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.15.3/lib/bundler/cli/exec.rb:74:in `load'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.15.3/lib/bundler/cli/exec.rb:74:in `kernel_load'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.15.3/lib/bundler/cli/exec.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.15.3/lib/bundler/cli.rb:365:in `exec'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.15.3/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.15.3/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.15.3/lib/bundler/vendor/thor/lib/thor.rb:369:in `dispatch'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.15.3/lib/bundler/cli.rb:22:in `dispatch'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.15.3/lib/bundler/vendor/thor/lib/thor/base.rb:444:in `start'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.15.3/lib/bundler/cli.rb:13:in `start'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.15.3/exe/bundle:30:in `block in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.15.3/lib/bundler/friendly_errors.rb:121:in `with_friendly_errors'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.15.3/exe/bundle:22:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/bin/bundle:23:in `load'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/bin/bundle:23:in `<main>'

Finished in 0.41486 seconds (files took 0.79759 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:525 # OracleEnhancedAdapter with statement pool should clear older cursors when statement limit is reached

Coverage report generated for RSpec to /home/yahonda/git/oracle-enhanced/coverage. 964 / 2230 LOC (43.23%) covered.
```

```ruby
$ bundle exec rspec ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:537
==> Loading config from ENV or use default
==> Running specs with MRI version 2.5.0
/home/yahonda/git/rails/activesupport/lib/active_support/core_ext/hash/keys.rb:14: warning: method redefined; discarding old transform_keys
/home/yahonda/git/rails/activesupport/lib/active_support/core_ext/hash/keys.rb:25: warning: method redefined; discarding old transform_keys!
==> Effective ActiveRecord version 5.2.0.alpha
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb"=>[537]}}
F

Failures:

  1) OracleEnhancedAdapter with statement pool should cache UPDATE statements with bind variables
     Failure/Error: sub = Arel::Nodes::BindParam.new.to_sql

     ArgumentError:
       wrong number of arguments (given 0, expected 1)
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/bundler/gems/arel-bfb770dbcc84/lib/arel/nodes/bind_param.rb:7:in `initialize'
     # ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:540:in `new'
     # ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:540:in `block (4 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.6.0/lib/rspec/matchers/built_in/change.rb:347:in `perform_change'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.6.0/lib/rspec/matchers/built_in/change.rb:133:in `matches?'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.6.0/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.6.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.6.0/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.6.0/lib/rspec/expectations/expectation_target.rb:65:in `to'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-expectations-3.6.0/lib/rspec/expectations/expectation_target.rb:101:in `to'
     # ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:538:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:254:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:254:in `block in run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:500:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:457:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:457:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:500:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:590:in `block in run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:590:in `map'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:590:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:118:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:118:in `map'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:118:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/configuration.rb:1894:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:113:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/reporter.rb:79:in `report'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:112:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/rspec-core-3.6.0/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/bin/rspec:23:in `load'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/bin/rspec:23:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.15.3/lib/bundler/cli/exec.rb:74:in `load'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.15.3/lib/bundler/cli/exec.rb:74:in `kernel_load'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.15.3/lib/bundler/cli/exec.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.15.3/lib/bundler/cli.rb:365:in `exec'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.15.3/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.15.3/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.15.3/lib/bundler/vendor/thor/lib/thor.rb:369:in `dispatch'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.15.3/lib/bundler/cli.rb:22:in `dispatch'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.15.3/lib/bundler/vendor/thor/lib/thor/base.rb:444:in `start'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.15.3/lib/bundler/cli.rb:13:in `start'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.15.3/exe/bundle:30:in `block in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.15.3/lib/bundler/friendly_errors.rb:121:in `with_friendly_errors'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/bundler-1.15.3/exe/bundle:22:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/bin/bundle:23:in `load'
     # /home/yahonda/.rbenv/versions/2.5.0-dev/bin/bundle:23:in `<main>'

Finished in 0.41309 seconds (files took 0.91246 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:537 # OracleEnhancedAdapter with statement pool should cache UPDATE statements with bind variables

Coverage report generated for RSpec to /home/yahonda/git/oracle-enhanced/coverage. 965 / 2230 LOC (43.27%) covered.
$
```
