### PR TITLE
Remove add_runtime_dependency with arel

### DIFF
--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -23,6 +23,5 @@ This adapter is superset of original ActiveRecord Oracle adapter.
   s.summary = "Oracle enhanced adapter for ActiveRecord"
   s.test_files = Dir["spec/**/*"]
   s.add_runtime_dependency("activerecord", ["~> 5.2.0.alpha"])
-  s.add_runtime_dependency("arel", ["~> 8.0"])
   s.add_runtime_dependency("ruby-plsql", [">= 0.6.0"])
 end


### PR DESCRIPTION
Oracle enhanced adapter depends on ActiveRecord.
ActiveRecord depends on Arel which is described in activerecord/activerecord.gemspec

Related with https://github.com/rails/rails/commit/089ca520e32e8cd9ebe1075f491d7856683e6cde