### PR TITLE
Move methods for synonyms out of `SchemaStatementsExt`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -235,6 +235,32 @@ module ActiveRecord
           self.all_schema_indexes = nil
         end
 
+        # Add synonym to existing table or view or sequence. Can be used to create local synonym to
+        # remote table in other schema or in other database
+        # Examples:
+        #
+        #   add_synonym :posts, "blog.posts"
+        #   add_synonym :posts_seq, "blog.posts_seq"
+        #   add_synonym :employees, "hr.employees@dblink", :force => true
+        #
+        def add_synonym(name, table_name, options = {})
+          sql = "CREATE".dup
+          if options[:force] == true
+            sql << " OR REPLACE"
+          end
+          sql << " SYNONYM #{quote_table_name(name)} FOR #{quote_table_name(table_name)}"
+          execute sql
+        end
+
+        # Remove existing synonym to table or view or sequence
+        # Example:
+        #
+        #   remove_synonym :posts, "blog.posts"
+        #
+        def remove_synonym(name)
+          execute "DROP SYNONYM #{quote_table_name(name)}"
+        end
+
         def add_reference(table_name, *args)
           ActiveRecord::ConnectionAdapters::OracleEnhanced::ReferenceDefinition.new(*args).add_to(update_table_definition(table_name, self))
         end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements_ext.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements_ext.rb
@@ -22,40 +22,6 @@ module ActiveRecord
           # call the same private method that is used for create_table :primary_key_trigger => true
           create_primary_key_trigger(table_name, options)
         end
-
-        # Add synonym to existing table or view or sequence. Can be used to create local synonym to
-        # remote table in other schema or in other database
-        # Examples:
-        #
-        #   add_synonym :posts, "blog.posts"
-        #   add_synonym :posts_seq, "blog.posts_seq"
-        #   add_synonym :employees, "hr.employees@dblink", :force => true
-        #
-        def add_synonym(name, table_name, options = {})
-          sql = "CREATE".dup
-          if options[:force] == true
-            sql << " OR REPLACE"
-          end
-          sql << " SYNONYM #{quote_table_name(name)} FOR #{quote_table_name(table_name)}"
-          execute sql
-        end
-
-        # Remove existing synonym to table or view or sequence
-        # Example:
-        #
-        #   remove_synonym :posts, "blog.posts"
-        #
-        def remove_synonym(name)
-          execute "DROP SYNONYM #{quote_table_name(name)}"
-        end
-
-        # get synonyms for schema dump
-        def synonyms #:nodoc:
-          select_all("SELECT synonym_name, table_owner, table_name, db_link FROM all_synonyms where owner = SYS_CONTEXT('userenv', 'session_user')").collect do |row|
-            OracleEnhanced::SynonymDefinition.new(oracle_downcase(row["synonym_name"]),
-              oracle_downcase(row["table_owner"]), oracle_downcase(row["table_name"]), oracle_downcase(row["db_link"]))
-          end
-        end
       end
     end
   end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -569,6 +569,15 @@ module ActiveRecord
         select_values("SELECT LOWER(mview_name) FROM all_mviews WHERE owner = SYS_CONTEXT('userenv', 'current_schema')")
       end
 
+      # get synonyms for schema dump
+      def synonyms
+        select_all("SELECT synonym_name, table_owner, table_name, db_link
+                   FROM all_synonyms where owner = SYS_CONTEXT('userenv', 'session_user')").collect do |row|
+          OracleEnhanced::SynonymDefinition.new(oracle_downcase(row["synonym_name"]),
+          oracle_downcase(row["table_owner"]), oracle_downcase(row["table_name"]), oracle_downcase(row["db_link"]))
+        end
+      end
+
       cattr_accessor :all_schema_indexes #:nodoc:
 
       # This method selects all indexes at once, and caches them in a class variable.


### PR DESCRIPTION
This pull request moves methods for synonyms out of `SchemaStatementsExt` 