### PR TITLE
Workaround rails/arel#491 for Oracle Database 11gR2 or lower

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development do
   gem "rake"
 
   gem "activerecord",   github: "rails/rails", branch: "master"
-  gem "arel",   github: "rails/arel", branch: "master"
+  gem "arel",   github: "yahonda/arel", branch: "follow_up_add_bind_for_oracle_visitor"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do


### PR DESCRIPTION
This pull request implements a workaround for rails/arel#491 for Oracle Database 11gR2 or lower.
```ruby
 NoMethodError:
       undefined method `value_for_database' for #<Arel::Nodes::BindParam:0x000055852a3e64d0>
```

This commit will get reverted when rails/arel#491 is merged to master
or other fixes found.