### PR TITLE
Skip `explain query with binds` for both CRuby and JRuby

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -577,7 +577,7 @@ describe "OracleEnhancedAdapter" do
     end
 
     it "should explain query with binds" do
-      pending "Pending until further investigation made for #908" if RUBY_ENGINE == "jruby"
+      pending "Pending until further investigation made for #908 JRuby and #1386 for CRuby"
       pk = TestPost.columns_hash[TestPost.primary_key]
       sub = Arel::Nodes::BindParam.new.to_sql
       binds = [ActiveRecord::Relation::QueryAttribute.new(pk, 1, ActiveRecord::Type::Integer.new)]


### PR DESCRIPTION
Looks like this needs fixed at spec, not library code itself.
Refer #908 #1386