### PR TITLE
Remove redundant requires

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1010,14 +1010,8 @@ module ActiveRecord
   end
 end
 
-# Implementation of standard schema definition statements and extensions for schema definition
-require "active_record/connection_adapters/oracle_enhanced/schema_statements"
-
 # Extensions for schema definition
 require "active_record/connection_adapters/oracle_enhanced/schema_definitions"
-
-# Extensions for context index definition
-require "active_record/connection_adapters/oracle_enhanced/context_index"
 
 # Patches and enhancements for schema dumper
 require "active_record/connection_adapters/oracle_enhanced/schema_dumper"
@@ -1031,14 +1025,8 @@ module ActiveRecord
   autoload :OracleEnhancedProcedures, "active_record/connection_adapters/oracle_enhanced/procedures"
 end
 
-# Patches and enhancements for column dumper
-require "active_record/connection_adapters/oracle_enhanced/column_dumper"
-
 # Moved SchemaCreation class
 require "active_record/connection_adapters/oracle_enhanced/schema_creation"
-
-# Moved DatabaseStetements
-require "active_record/connection_adapters/oracle_enhanced/database_statements"
 
 # Add Type:Raw
 require "active_record/oracle_enhanced/type/raw"


### PR DESCRIPTION
```
$ grep require lib/active_record/connection_adapters/oracle_enhanced_adapter.rb | sort | uniq -c |grep 2
      2 require "active_record/connection_adapters/oracle_enhanced/column_dumper"
      2 require "active_record/connection_adapters/oracle_enhanced/context_index"
      2 require "active_record/connection_adapters/oracle_enhanced/database_statements"
      2 require "active_record/connection_adapters/oracle_enhanced/schema_statements"
```