### PR TITLE
Revert "Workaround rails/arel#491 for Oracle Database 11gR2 or lower"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development do
   gem "rake"
 
   gem "activerecord",   github: "rails/rails", branch: "master"
-  gem "arel",   github: "yahonda/arel", branch: "follow_up_add_bind_for_oracle_visitor"
+  gem "arel",   github: "rails/arel", branch: "master"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do


### PR DESCRIPTION
This reverts commit edf97598a844d530dd82446b74016197b66a5609.

rails/arel#491 has been merged to master branch. This workaround is not necessary anymore.