### PR TITLE
Remove incorrect prepend to `ActiveRecord::ColumnDumper`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/column_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column_dumper.rb
@@ -23,8 +23,4 @@ module ActiveRecord #:nodoc:
       end
     end
   end
-
-  module ColumnDumper #:nodoc:
-    prepend ConnectionAdapters::OracleEnhanced::ColumnDumper
-  end
 end


### PR DESCRIPTION
* `ActiveRecord::ColumnDumper` does not exist, it is harmless but should not exist.
* This module is included here:

https://github.com/rsim/oracle-enhanced/blob/master/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb#L166

```ruby
      include ActiveRecord::ConnectionAdapters::OracleEnhanced::ColumnDumper
```