### PR TITLE
Set `dist: precise` explicitly to workaround #1397

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: precise
 sudo: required
 cache: bundler
 


### PR DESCRIPTION
It cannot be a permanent fix since Ubuntu Presice is already EOL.
https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming