### PR TITLE
Rename `SchemaDumper#indexes` to `SchemaDumper#_indexes`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -54,7 +54,7 @@ module ActiveRecord #:nodoc:
             end
           end
 
-          def indexes(table, stream)
+          def _indexes(table, stream)
             if (indexes = @connection.indexes(table)).any?
               add_index_statements = indexes.map do |index|
                 case index.type
@@ -157,7 +157,7 @@ module ActiveRecord #:nodoc:
               tbl.puts "  end"
               tbl.puts
 
-              indexes(table, tbl)
+              _indexes(table, tbl)
 
               tbl.rewind
               stream.print tbl.read


### PR DESCRIPTION
It is just for context indexes. `ActiveRecord::SchemaDumper#indexes` is left just for indexes on materialized views which is not called from `ActiveRecord::SchemaDumper#tables`