### PR TITLE
`remove_prefix_and_suffix` handles dollar sign by `Regexp#escape`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -169,7 +169,9 @@ module ActiveRecord #:nodoc:
           end
 
           def remove_prefix_and_suffix(table)
-            table.gsub(/^(#{@options[:table_name_prefix].to_s.gsub('$', '\$')})(.+)(#{@options[:table_name_suffix].to_s.gsub('$', '\$')})$/,  "\\2")
+            prefix = Regexp.escape(@options[:table_name_prefix].to_s)
+            suffix = Regexp.escape(@options[:table_name_suffix].to_s)
+            table.sub(/\A(?:#{prefix})(.+)(?:#{suffix})\z/, "\\1")
           end
 
           def oracle_enhanced_adapter?


### PR DESCRIPTION
Implemented at Oracle enhanced locally first for rails/rails#30044 Thanks @kamipo 