### PR TITLE
Set `dist: precise` explicitly to workaround #1397

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: precise
 sudo: required
 
 env:


### PR DESCRIPTION
Backport #1398 to release17 branch.
