### PR TITLE
Use new method name for active record dirty checks

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
@@ -146,7 +146,7 @@ module ActiveRecord #:nodoc:
 
               timestamp_attributes_for_update_in_model.each do |column|
                 column = column.to_s
-                next if attribute_changed?(column)
+                next if will_save_change_to_attribute?(column)
                 write_attribute(column, current_time)
               end
             end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -75,7 +75,7 @@ module ActiveRecord
 
       def record_changed_lobs
         @changed_lob_columns = self.class.lob_columns.select do |col|
-          self.attribute_changed?(col.name) && !self.class.readonly_attributes.to_a.include?(col.name)
+          self.will_save_change_to_attribute?(col.name) && !self.class.readonly_attributes.to_a.include?(col.name)
         end
       end
   end


### PR DESCRIPTION
This removes deprecation warning inserted in https://github.com/rails/rails/commit/16ae3db5a5c6a08383b974ae6c96faac5b4a3c81

Deprecation warnings are now removed but smees like new methods are more recommendable.

This was problem when doublesaving like described by dhh: https://github.com/rails/rails/commit/16ae3db5a5c6a08383b974ae6c96faac5b4a3c81#commitcomment-20192607

Methods listed
https://github.com/rails/rails/pull/25337#issuecomment-225166796