### PR TITLE
Get db user default tablespace and do not rely on USERS

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_schema_statements_spec.rb
@@ -759,13 +759,15 @@ end
         create_table :test_posts, force: true
       end
 
+      default_tablespace = @conn.default_tablespace
+
       index_name = @conn.select_value(
         "SELECT index_name FROM all_constraints
             WHERE table_name = 'TEST_POSTS'
             AND constraint_type = 'P'
             AND owner = SYS_CONTEXT('userenv', 'current_schema')")
 
-      expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_indexes WHERE index_name = '#{index_name}'")).to eq("USERS")
+      expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_indexes WHERE index_name = '#{index_name}'").downcase).to eq(default_tablespace)
     end
 
     it "should use non default tablespace for primary key" do


### PR DESCRIPTION
If user's default tablespace is not USERS specs does not pass. This asks default tablespace and then asserts it was used to create index.

I am not sure why `def default_tablespace` downcases tablespace name. Now when it does it like that I had to downcase tablespace name used to index also.