### PR TITLE
Replace `pending` with `skip` not to execute the spec 

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -577,7 +577,7 @@ describe "OracleEnhancedAdapter" do
     end
 
     it "should explain query with binds" do
-      pending "Pending until further investigation made for #908 JRuby and #1386 for CRuby"
+      skip "Skip until further investigation made for #908 JRuby and #1386 for CRuby"
       pk = TestPost.columns_hash[TestPost.primary_key]
       sub = Arel::Nodes::BindParam.new.to_sql
       binds = [ActiveRecord::Relation::QueryAttribute.new(pk, 1, ActiveRecord::Type::Integer.new)]


### PR DESCRIPTION
To avoid unnecessary stack trace. Here are differences between `pending` and `skip` of rspec.

https://relishapp.com/rspec/rspec-core/v/3-4/docs/pending-and-skipped-examples

> An example can either be marked as skipped, in which is it not executed, or pending in which it is executed but failure will not cause a failure of the entire suite.


* Without this pull request - using `skip`
```ruby
$ bundle exec rspec ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:579
==> Loading config from ENV or use default
==> Running specs with MRI version 2.4.1
==> Effective ActiveRecord version 5.2.0.alpha
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb"=>[579]}}
*

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) OracleEnhancedAdapter explain should explain query with binds
     # Skip until further investigation made for #908 JRuby and #1386 for CRuby
     # ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:579


Finished in 0.80707 seconds (files took 1.15 seconds to load)
1 example, 0 failures, 1 pending

Coverage report generated for RSpec to /home/yahonda/git/oracle-enhanced/coverage. 939 / 2243 LOC (41.86%) covered.
```

* Without this pull request - using `pending`
```ruby
$ bundle exec rspec ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:579
==> Loading config from ENV or use default
==> Running specs with MRI version 2.4.1
==> Effective ActiveRecord version 5.2.0.alpha
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb"=>[579]}}
*

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) OracleEnhancedAdapter explain should explain query with binds
     # Pending until further investigation made for #908 JRuby and #1386 for CRuby
     Failure/Error: sub = Arel::Nodes::BindParam.new.to_sql

     ArgumentError:
       wrong number of arguments (given 0, expected 1)
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/bundler/gems/arel-62dfe907f38d/lib/arel/nodes/bind_param.rb:7:in `initialize'
     # ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:582:in `new'
     # ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:582:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:254:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:254:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:500:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:457:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:457:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:500:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:623:in `map'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:589:in `run'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:590:in `block in run'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:590:in `map'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/example_group.rb:590:in `run'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:118:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:118:in `map'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:118:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/configuration.rb:1894:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:113:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/reporter.rb:79:in `report'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:112:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rspec-core-3.6.0/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.1/bin/rspec:22:in `load'
     # /home/yahonda/.rbenv/versions/2.4.1/bin/rspec:22:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/cli/exec.rb:74:in `load'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/cli/exec.rb:74:in `kernel_load'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/cli/exec.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/cli.rb:365:in `exec'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/vendor/thor/lib/thor.rb:369:in `dispatch'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/cli.rb:22:in `dispatch'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/vendor/thor/lib/thor/base.rb:444:in `start'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/cli.rb:13:in `start'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/exe/bundle:30:in `block in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/lib/bundler/friendly_errors.rb:121:in `with_friendly_errors'
     # /home/yahonda/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.3/exe/bundle:22:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.4.1/bin/bundle:22:in `load'
     # /home/yahonda/.rbenv/versions/2.4.1/bin/bundle:22:in `<main>'

Finished in 1.23 seconds (files took 0.96991 seconds to load)
1 example, 0 failures, 1 pending

Coverage report generated for RSpec to /home/yahonda/git/oracle-enhanced/coverage. 960 / 2243 LOC (42.8%) covered.
$
```
