### PR TITLE
Setting `disk_asynch_io` to `false` to address slow unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: precise
+dist: trusty
 sudo: required
 cache: bundler
 

--- a/.travis/oracle/install.sh
+++ b/.travis/oracle/install.sh
@@ -21,6 +21,8 @@ test -d /var/lock/subsys || sudo mkdir /var/lock/subsys
 sudo dpkg -i "${ORACLE_DEB}"
 
 echo 'OS_AUTHENT_PREFIX=""' | sudo tee -a "$ORACLE_HOME/config/scripts/init.ora" > /dev/null
+echo 'disk_asynch_io=false' | sudo tee -a "$ORACLE_HOME/config/scripts/init.ora" > /dev/null
+
 sudo usermod -aG dba $USER
 
 ( echo ; echo ; echo travis ; echo travis ; echo n ) | sudo AWK='/usr/bin/awk' /etc/init.d/oracle-xe configure


### PR DESCRIPTION
This pull request addresses #1397.
Open a support request with Travis CI and there is a solution provided to set disk_asynch_io=false'