### PR TITLE
Setting `disk_asynch_io` to `false` to address slow unit tests to release18 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: precise
 sudo: required
 cache: bundler
 

--- a/.travis/oracle/install.sh
+++ b/.travis/oracle/install.sh
@@ -21,6 +21,8 @@ test -d /var/lock/subsys || sudo mkdir /var/lock/subsys
 sudo dpkg -i "${ORACLE_DEB}"
 
 echo 'OS_AUTHENT_PREFIX=""' | sudo tee -a "$ORACLE_HOME/config/scripts/init.ora" > /dev/null
+echo 'disk_asynch_io=false' | sudo tee -a "$ORACLE_HOME/config/scripts/init.ora" > /dev/null
+
 sudo usermod -aG dba $USER
 
 ( echo ; echo ; echo travis ; echo travis ; echo n ) | sudo AWK='/usr/bin/awk' /etc/init.d/oracle-xe configure


### PR DESCRIPTION
backport #1413 to release18