### PR TITLE
set `open_cursor` value to `1200` 

### DIFF
--- a/.travis/setup_accounts.sh
+++ b/.travis/setup_accounts.sh
@@ -4,6 +4,7 @@ set -ev
 
 "$ORACLE_HOME/bin/sqlplus" -L -S / AS SYSDBA <<SQL
 @@spec/support/alter_system_user_password.sql
+@@spec/support/alter_system_set_open_cursors.sql
 @@spec/support/create_oracle_enhanced_users.sql
 exit
 SQL

--- a/spec/support/alter_system_set_open_cursors.sql
+++ b/spec/support/alter_system_set_open_cursors.sql
@@ -1,0 +1,1 @@
+alter system set open_cursors = 1200 scope = both;


### PR DESCRIPTION
set `open_cursor` value to `1200` which is larger than the default `:statement_limit` value `1000`