### PR TITLE
Use `drop_table` if_exists: true` to avoid rescue nil

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -150,8 +150,8 @@ describe "OracleEnhancedAdapter schema dump" do
     end
     after(:all) do
       schema_define do
-        drop_table :test_comments rescue nil
-        drop_table :test_posts rescue nil
+        drop_table :test_comments, if_exists: true
+        drop_table :test_posts, if_exists: true
       end
     end
 
@@ -505,7 +505,7 @@ describe "OracleEnhancedAdapter schema dump" do
 
     after do
       schema_define do
-        drop_table :test_comments rescue nil
+        drop_table :test_comments, if_exists: true
       end
 
       drop_test_posts_table

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -615,8 +615,8 @@ end
       Object.send(:remove_const, "TestPost")
       Object.send(:remove_const, "TestComment")
       schema_define do
-        drop_table :test_comments rescue nil
-        drop_table :test_posts rescue nil
+        drop_table :test_comments, if_exists: true
+        drop_table :test_posts, if_exists: true
       end
       ActiveRecord::Base.table_name_prefix = ""
       ActiveRecord::Base.table_name_suffix = ""
@@ -762,7 +762,7 @@ end
     after do
       Object.send(:remove_const, "TestPost")
       schema_define do
-        drop_table :test_posts rescue nil
+        drop_table :test_posts, if_exists: true
       end
     end
   end
@@ -808,7 +808,7 @@ end
     after do
       Object.send(:remove_const, "TestPost")
       schema_define do
-        drop_table :test_posts rescue nil
+        drop_table :test_posts, if_exists: true
       end
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[:index] = nil
     end
@@ -833,8 +833,8 @@ end
       Object.send(:remove_const, "TestPost")
       Object.send(:remove_const, "TestComment")
       schema_define do
-        drop_table :test_comments rescue nil
-        drop_table :test_posts rescue nil
+        drop_table :test_comments, if_exists: true
+        drop_table :test_posts, if_exists: true
       end
       ActiveRecord::Base.clear_cache!
     end
@@ -918,9 +918,9 @@ end
 
     after(:each) do
       schema_define do
-        drop_table "test_Mixed_Comments" rescue nil
-        drop_table :test_comments rescue nil
-        drop_table :test_posts rescue nil
+        drop_table "test_Mixed_Comments", if_exists: true
+        drop_table :test_comments, if_exists: true
+        drop_table :test_posts, if_exists: true
       end
     end
 
@@ -1298,7 +1298,7 @@ end
 
     describe "creating a table with a tablespace defaults set" do
       after(:each) do
-        @conn.drop_table :tablespace_tests rescue nil
+        @conn.drop_table :tablespace_tests, if_exists: true
         ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces.delete(:table)
       end
       it "should use correct tablespace" do
@@ -1312,7 +1312,7 @@ end
 
     describe "creating an index-organized table" do
       after(:each) do
-        @conn.drop_table :tablespace_tests rescue nil
+        @conn.drop_table :tablespace_tests, if_exists: true
         ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces.delete(:table)
       end
       it "should use correct tablespace" do

--- a/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
@@ -246,7 +246,7 @@ describe "OracleEnhancedAdapter structure dump" do
   end
   describe "temporary tables" do
     after(:all) do
-      @conn.drop_table :test_comments rescue nil
+      @conn.drop_table :test_comments, if_exists: true
     end
     it "should dump correctly" do
       @conn.create_table :test_comments, temporary: true, id: false do |t|

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -328,8 +328,8 @@ describe "OracleEnhancedAdapter" do
     after(:each) do
       ActiveRecord::Schema.define do
         suppress_messages do
-          drop_table "warehouse-things" rescue nil
-          drop_table "CamelCase" rescue nil
+          drop_table "warehouse-things", if_exists: true
+          drop_table "CamelCase", if_exists: true
         end
       end
       Object.send(:remove_const, "WarehouseThing") rescue nil
@@ -370,7 +370,7 @@ describe "OracleEnhancedAdapter" do
       @conn = ActiveRecord::Base.connection
       @db_link = "db_link"
       @sys_conn = ActiveRecord::Base.oracle_enhanced_connection(SYSTEM_CONNECTION_PARAMS)
-      @sys_conn.drop_table :test_posts rescue nil
+      @sys_conn.drop_table :test_posts, if_exists: true
       @sys_conn.create_table :test_posts do |t|
         t.string      :title
         # cannot update LOBs over database link
@@ -393,7 +393,7 @@ describe "OracleEnhancedAdapter" do
       @conn.execute "DROP SYNONYM test_posts"
       @conn.execute "DROP SYNONYM test_posts_seq"
       @conn.execute "DROP DATABASE LINK #{@db_link}" rescue nil
-      @sys_conn.drop_table :test_posts rescue nil
+      @sys_conn.drop_table :test_posts, if_exists: true
       Object.send(:remove_const, "TestPost") rescue nil
       ActiveRecord::Base.clear_cache!
     end
@@ -441,7 +441,7 @@ describe "OracleEnhancedAdapter" do
     end
 
     after(:each) do
-      @conn.drop_table :foos rescue nil
+      @conn.drop_table :foos, if_exists: true
     end
     it "should create ok" do
       @conn.create_table :foos, temporary: true, id: false do |t|
@@ -506,7 +506,7 @@ describe "OracleEnhancedAdapter" do
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(statement_limit: 3))
       @conn = ActiveRecord::Base.connection
       schema_define do
-        drop_table :test_posts rescue nil
+        drop_table :test_posts, if_exists: true
         create_table :test_posts
       end
       class ::TestPost < ActiveRecord::Base
@@ -559,7 +559,7 @@ describe "OracleEnhancedAdapter" do
     before(:all) do
       @conn = ActiveRecord::Base.connection
       schema_define do
-        drop_table :test_posts rescue nil
+        drop_table :test_posts, if_exists: true
         create_table :test_posts
       end
       class ::TestPost < ActiveRecord::Base


### PR DESCRIPTION
Actually current Oracle database does not support `drop table if exists`
sql statement like MySQL and PostgreSQL.
If you are interested in this feature implemented by Oracle database
itself please visit https://community.oracle.com/ideas/5212

Oracle enhanced adapter does not raise exceptions when `if_exists` set
to true.