### PR TITLE
Prefer to place a table options before `force: :cascade`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -126,14 +126,12 @@ module ActiveRecord #:nodoc:
                 tbl.print ", id: false"
               end
 
-              tbl.print ", force: :cascade"
-
               table_options = @connection.table_options(table)
               if table_options.present?
                 tbl.print ", #{format_options(table_options)}"
               end
 
-              tbl.puts " do |t|"
+              tbl.puts ", force: :cascade do |t|"
 
               # then dump all non-primary key columns
               columns.each do |column|

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -461,7 +461,7 @@ describe "OracleEnhancedAdapter schema dump" do
 
     it "should dump table comments" do
       output = dump_table_schema "test_table_comments"
-      expect(output).to match(/comment: "this is a \\"table comment\\"!"/)
+      expect(output).to match(/create_table "test_table_comments", comment: "this is a \\"table comment\\"!", force: :cascade do \|t\|$/)
     end
   end
 


### PR DESCRIPTION
Oracle enhanced adapter implements table comments options
Refer rails/rails#28005 and #1439