### PR TITLE
Fixes drop_table causing exception on schema load

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -72,7 +72,7 @@ module ActiveRecord
           create_sequence = create_sequence || td.create_sequence
 
           if options[:force] && data_source_exists?(table_name)
-            drop_table(table_name, options)
+            drop_table(table_name, options.merge({ if_exists: true }))
           end
 
           execute schema_creation.accept td

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -72,7 +72,7 @@ module ActiveRecord
           create_sequence = create_sequence || td.create_sequence
 
           if options[:force] && data_source_exists?(table_name)
-            drop_table(table_name, options.merge({ if_exists: true }))
+            drop_table(table_name, options.merge(if_exists: true))
           end
 
           execute schema_creation.accept td


### PR DESCRIPTION
## What Changed
* Turn on `if_exists` for the `drop_table` flag in the `create_table` method.

## Why

The command `rake db:schema:load` was raising the following error when it tried to drop a table that did not exist.

```
ActiveRecord::StatementInvalid: NativeException: java.sql.SQLSyntaxErrorException: ORA-00942: table or view does not exist
: DROP TABLE "<TABLE_NAME>" CASCADE CONSTRAINTS
```

This change utilizes the `if_exists` option for the `drop_table` method to prevent raising of this error when schema load goes through the process of dropping tables.

## Note
It would be amazing if this could be deployed to 1.8 and 1.7 since I require 1.7 for use with my Rails 5.0 application.