### PR TITLE
CI against JRuby 9.1.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ rvm:
   - 2.3.4
   - 2.4.1
   - ruby-head
-  - jruby-9.1.12.0
+  - jruby-9.1.13.0
   - jruby-head
 
 notifications:


### PR DESCRIPTION
JRuby 9.1.13.0 has been released and this version is available on Travis CI.
http://jruby.org/2017/09/06/jruby-9-1-13-0.html