### PR TITLE
CI against JRuby 9.1.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,6 @@ rvm:
   - 2.2.7
   - 2.3.4
   - 2.4.1
-  - jruby-9.1.12.0
+  - jruby-9.1.13.0
 notifications:
     email: false


### PR DESCRIPTION
This PR backports #1471 to release17 branch.