### PR TITLE
Always generate `debug.log` for unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Gemfile.lock
 /spec/spec_config.yaml
 ojdbc*.jar
 .byebug_history
+debug.log

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -191,4 +191,4 @@ DATABASE_NON_DEFAULT_TABLESPACE = config["database"]["non_default_tablespace"] |
 # which will be used to set session time zone
 ENV["TZ"] ||= config["timezone"] || "Europe/Riga"
 
-# ActiveRecord::Base.logger = Logger.new(STDOUT)
+ActiveRecord::Base.logger = ActiveSupport::Logger.new("debug.log", 0, 100 * 1024 * 1024)


### PR DESCRIPTION
debug.log file will be rotated on each 100MB
Refer https://github.com/rails/rails/commit/64391cd520cd8aee2c8b9ba1b95e4aae4512a6a0