### PR TITLE
Use `rubocop-0-49` channel to run rubocop 0.49

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,6 +1,7 @@
 engines:
   rubocop:
     enabled: true
+    channel: rubocop-0-49
 
 ratings:
   paths:


### PR DESCRIPTION
Refer https://github.com/codeclimate/codeclimate-rubocop/issues/99