### PR TITLE
Bump ruby versions to 2.4.2, 2.3.5 and 2.2.8 at Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ install:
 
 language: ruby
 rvm:
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.2.8
+  - 2.3.5
+  - 2.4.2
   - ruby-head
   - jruby-9.1.13.0
   - jruby-head


### PR DESCRIPTION
https://github.com/rvm/rvm/pull/4159 needs merged.

Refer them for the fix included in the each release:
https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-4-2-released/
https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-3-5-released/
https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-2-8-released/
