### PR TITLE
Enable TCP keepalive for OCI connections 

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -12,7 +12,7 @@ rescue LoadError => e
 end
 
 # check ruby-oci8 version
-required_oci8_version = [2, 2, 0]
+required_oci8_version = [2, 2, 4]
 oci8_version_ints = OCI8::VERSION.scan(/\d+/).map { |s| s.to_i }
 if (oci8_version_ints <=> required_oci8_version) < 0
   raise LoadError, "ERROR: ruby-oci8 version #{OCI8::VERSION} is too old. Please install ruby-oci8 version #{required_oci8_version.join('.')} or later."

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -15,7 +15,11 @@ end
 required_oci8_version = [2, 2, 4]
 oci8_version_ints = OCI8::VERSION.scan(/\d+/).map { |s| s.to_i }
 if (oci8_version_ints <=> required_oci8_version) < 0
-  raise LoadError, "ERROR: ruby-oci8 version #{OCI8::VERSION} is too old. Please install ruby-oci8 version #{required_oci8_version.join('.')} or later."
+  $stderr.puts <<-EOS.strip_heredoc
+    "ERROR: ruby-oci8 version #{OCI8::VERSION} is too old. Please install ruby-oci8 version #{required_oci8_version.join('.')} or later."
+  EOS
+
+  exit!
 end
 
 module ActiveRecord

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -332,6 +332,11 @@ module ActiveRecord
           else
             database
           end
+          OCI8.properties[:tcp_keepalive] = true
+          begin
+            OCI8.properties[:tcp_keepalive_time] = 600
+          rescue NotImplementedError
+          end
           conn = OCI8.new username, password, connection_string, privilege
           conn.autocommit = true
           conn.non_blocking = true if async


### PR DESCRIPTION
Refer #1353 which was planned to support "nextval" branch. 
Since "nextval" plan has been cancelled, I think this feature can be available for 5.2.