### PR TITLE
Remove `OracleEnhancedAdapter.cache_columns` 

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -111,7 +111,6 @@ module ActiveRecord
         rescue ActiveRecord::StatementInvalid => e
           raise e unless options[:if_exists]
         ensure
-          clear_table_columns_cache(table_name)
           self.all_schema_indexes = nil
         end
 
@@ -274,8 +273,6 @@ module ActiveRecord
           execute add_column_sql
           create_sequence_and_trigger(table_name, options) if type && type.to_sym == :primary_key
           change_column_comment(table_name, column_name, options[:comment]) if options.key?(:comment)
-        ensure
-          clear_table_columns_cache(table_name)
         end
 
         def aliased_types(name, fallback)
@@ -285,8 +282,6 @@ module ActiveRecord
         def change_column_default(table_name, column_name, default_or_changes) #:nodoc:
           default = extract_new_default_value(default_or_changes)
           execute "ALTER TABLE #{quote_table_name(table_name)} MODIFY #{quote_column_name(column_name)} DEFAULT #{quote(default)}"
-        ensure
-          clear_table_columns_cache(table_name)
         end
 
         def change_column_null(table_name, column_name, null, default = nil) #:nodoc:
@@ -319,22 +314,17 @@ module ActiveRecord
           execute(change_column_sql)
 
           change_column_comment(table_name, column_name, options[:comment]) if options.key?(:comment)
-        ensure
-          clear_table_columns_cache(table_name)
         end
 
         def rename_column(table_name, column_name, new_column_name) #:nodoc:
           execute "ALTER TABLE #{quote_table_name(table_name)} RENAME COLUMN #{quote_column_name(column_name)} to #{quote_column_name(new_column_name)}"
           self.all_schema_indexes = nil
           rename_column_indexes(table_name, column_name, new_column_name)
-        ensure
-          clear_table_columns_cache(table_name)
         end
 
         def remove_column(table_name, column_name, type = nil, options = {}) #:nodoc:
           execute "ALTER TABLE #{quote_table_name(table_name)} DROP COLUMN #{quote_column_name(column_name)} CASCADE CONSTRAINTS"
         ensure
-          clear_table_columns_cache(table_name)
           self.all_schema_indexes = nil
         end
 

--- a/lib/activerecord-oracle_enhanced-adapter.rb
+++ b/lib/activerecord-oracle_enhanced-adapter.rb
@@ -10,12 +10,6 @@ if defined?(Rails)
 
         ActiveSupport.on_load(:active_record) do
           require "active_record/connection_adapters/oracle_enhanced_adapter"
-
-          # Cache column descriptions between requests in test and production environments
-          if Rails.env.test? || Rails.env.production?
-            ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.cache_columns = true
-          end
-
         end
       end
     end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -381,13 +381,10 @@ describe "OracleEnhancedAdapter schema dump" do
 
     context "with column cache" do
       before(:all) do
-        @old_cache = ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.cache_columns
-        ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.cache_columns = true
       end
       after(:all) do
-        ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.cache_columns = @old_cache
       end
-      it "should not change column defaults after several dumps" do
+      xit "should not change column defaults after several dumps" do
         col = TestName.columns.detect { |c| c.name == "full_name" }
         expect(col).not_to be_nil
         expect(col.virtual_column_data_default).not_to match(/:as/)

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -23,7 +23,7 @@ describe "OracleEnhancedAdapter schema definition" do
     end
 
     it "creates a sequence when adding a column with create_sequence = true" do
-      _, sequence_name = ActiveRecord::Base.connection.pk_and_sequence_for_without_cache(:keyboards)
+      _, sequence_name = ActiveRecord::Base.connection.pk_and_sequence_for(:keyboards)
 
       expect(sequence_name).to eq(Keyboard.sequence_name)
     end
@@ -1008,14 +1008,12 @@ end
     include LoggerSpecHelper
 
     before(:all) do
-      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.cache_columns = true
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces.delete(:clob)
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces.delete(:nclob)
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces.delete(:blob)
     end
 
     after(:all) do
-      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.cache_columns = nil
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces.delete(:clob)
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces.delete(:nclob)
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces.delete(:blob)

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -46,14 +46,12 @@ describe "OracleEnhancedAdapter" do
       Object.send(:remove_const, "TestEmployee2")
       @conn.drop_table :test_employees, if_exists: true
       @conn.drop_table :test_employees_without_pk, if_exists: true
-      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.cache_columns = nil
       ActiveRecord::Base.clear_cache!
     end
 
     before(:each) do
       set_logger
       @conn = ActiveRecord::Base.connection
-      @conn.clear_columns_cache
     end
 
     after(:each) do
@@ -63,7 +61,6 @@ describe "OracleEnhancedAdapter" do
     describe "without column caching" do
 
       before(:each) do
-        ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.cache_columns = false
       end
 
       it "should identify virtual columns as such" do
@@ -105,10 +102,9 @@ describe "OracleEnhancedAdapter" do
 
     end
 
-    describe "with column caching" do
+    xdescribe "with column caching" do
 
       before(:each) do
-        ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.cache_columns = true
       end
 
       it "should get columns from database at first time" do
@@ -116,7 +112,7 @@ describe "OracleEnhancedAdapter" do
         expect(@logger.logged(:debug).last).to match(/select .* from all_tab_cols/im)
       end
 
-      it "should get columns from cache at second time" do
+      xit "should get columns from cache at second time" do
         TestEmployee.connection.columns("test_employees")
         @logger.clear(:debug)
         expect(TestEmployee.connection.columns("test_employees").map(&:name)).to eq(@column_names)
@@ -128,14 +124,14 @@ describe "OracleEnhancedAdapter" do
         expect(@logger.logged(:debug).last).to match(/select .* from all_constraints/im)
       end
 
-      it "should get primary key from cache at first time" do
+      xit "should get primary key from cache at first time" do
         expect(TestEmployee.connection.pk_and_sequence_for("test_employees")).to eq(["id", "test_employees_seq"])
         @logger.clear(:debug)
         expect(TestEmployee.connection.pk_and_sequence_for("test_employees")).to eq(["id", "test_employees_seq"])
         expect(@logger.logged(:debug).last).to be_blank
       end
 
-      it "should store primary key as nil in cache at first time for table without primary key" do
+      xit "should store primary key as nil in cache at first time for table without primary key" do
         expect(TestEmployee.connection.pk_and_sequence_for("test_employees_without_pk")).to eq(nil)
         @logger.clear(:debug)
         expect(TestEmployee.connection.pk_and_sequence_for("test_employees_without_pk")).to eq(nil)


### PR DESCRIPTION
Remove `OracleEnhancedAdapter.cache_columns` to use Rails `db:schema:cache:dump`

Oracle enhanced adapter had implemented its own `cache_columns`,
which can be replaced by Rails `db:schema:cache:dump` feature.

```ruby
$ rails -T
...
rails db:schema:cache:dump               # Creates a db/schema_cache.yml file
```

* Removed `ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.cache_columns`
* Removed `columns_without_cache` and `pk_and_sequence_for_without_cache` methods
* Skip specs for column caching