### PR TITLE
Remove @@do_not_prefetch_primary_key class variable

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -114,7 +114,6 @@ describe "OracleEnhancedAdapter schema dump" do
 
     after(:each) do
       drop_test_posts_table
-      @conn.clear_prefetch_primary_key
     end
 
     it "should include primary key trigger in schema dump" do

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -181,7 +181,6 @@ describe "OracleEnhancedAdapter schema definition" do
         drop_table :test_employees, (seq_name ? { sequence_name: seq_name } : {})
       end
       Object.send(:remove_const, "TestEmployee")
-      @conn.clear_prefetch_primary_key
       ActiveRecord::Base.clear_cache!
     end
 


### PR DESCRIPTION
The goal is to remove class variables from Oracle enhanced adapter