### PR TITLE
Using bind variables for dictionary access

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -538,7 +538,7 @@ module ActiveRecord
           table_owner, table_name = default_owner, real_name
         end
 
-        select_values(<<-SQL, "SCHEMA", [bind_string('owner', table_owner), bind_string('table_name',table_name )]).any?
+        select_values(<<-SQL, "SCHEMA", [bind_string("owner", table_owner), bind_string("table_name",table_name)]).any?
           SELECT owner, table_name
           FROM all_tables
           WHERE owner = :owner
@@ -575,7 +575,7 @@ module ActiveRecord
         (owner, table_name, db_link) = @connection.describe(table_name)
         default_tablespace_name = default_tablespace
 
-        result = select_all(<<-SQL.strip.gsub(/\s+/, " "), 'indexes', [bind_string('owner', owner), bind_string('owner', owner)])
+        result = select_all(<<-SQL.strip.gsub(/\s+/, " "), "indexes", [bind_string("owner", owner), bind_string("owner", owner)])
             SELECT LOWER(i.table_name) AS table_name, LOWER(i.index_name) AS index_name, i.uniqueness,
               i.index_type, i.ityp_owner, i.ityp_name, i.parameters,
               LOWER(i.tablespace_name) AS tablespace_name,
@@ -604,7 +604,7 @@ module ActiveRecord
             statement_parameters = nil
             if row["index_type"] == "DOMAIN" && row["ityp_owner"] == "CTXSYS" && row["ityp_name"] == "CONTEXT"
               procedure_name = default_datastore_procedure(row["index_name"])
-              source = select_values(<<-SQL, 'procedure', [bind_string('owner', owner), bind_string('procedure_name', procedure_name.upcase)]).join
+              source = select_values(<<-SQL, 'procedure', [bind_string("owner", owner), bind_string("procedure_name", procedure_name.upcase)]).join
                   SELECT text
                   FROM all_source#{db_link}
                   WHERE owner = :owner
@@ -662,7 +662,7 @@ module ActiveRecord
             AND table_name = :table_name
             AND status = 'ENABLED'
         SQL
-        select_value(pkt_sql, "Primary Key Trigger", [bind_string('owner', owner), bind_string('trigger_name', trigger_name), bind_string('owner', owner), bind_string('table_name', desc_table_name)]) ? true : false
+        select_value(pkt_sql, "Primary Key Trigger", [bind_string("owner", owner), bind_string("trigger_name", trigger_name), bind_string("owner", owner), bind_string("table_name", desc_table_name)]) ? true : false
       end
 
       def columns(table_name, name = nil) #:nodoc:
@@ -693,7 +693,7 @@ module ActiveRecord
         SQL
 
         # added deletion of ignored columns
-        select_all(table_cols, name, [bind_string('owner', owner), bind_string('table_name', desc_table_name)]).to_a.map do |row|
+        select_all(table_cols, name, [bind_string("owner", owner), bind_string("table_name", desc_table_name)]).to_a.map do |row|
           limit, scale = row["limit"], row["scale"]
           if limit || scale
             row["sql_type"] += "(#{(limit || 38).to_i}" + ((scale = scale.to_i) > 0 ? ",#{scale})" : ")")
@@ -747,7 +747,7 @@ module ActiveRecord
       def pk_and_sequence_for(table_name, owner = nil, desc_table_name = nil, db_link = nil) #:nodoc:
         (owner, desc_table_name, db_link) = @connection.describe(table_name) unless owner
 
-        seqs = select_values(<<-SQL.strip.gsub(/\s+/, " "), "Sequence" , [bind_string('owner', owner), bind_string('sequence_name', default_sequence_name(desc_table_name).upcase)])
+        seqs = select_values(<<-SQL.strip.gsub(/\s+/, " "), "Sequence", [bind_string("owner", owner), bind_string("sequence_name", default_sequence_name(desc_table_name).upcase)])
           select us.sequence_name
           from all_sequences#{db_link} us
           where us.sequence_owner = :owner
@@ -755,7 +755,7 @@ module ActiveRecord
         SQL
 
         # changed back from user_constraints to all_constraints for consistency
-        pks = select_values(<<-SQL.strip.gsub(/\s+/, " "), "Primary Key", [bind_string('owner', owner), bind_string('table_name', desc_table_name)])
+        pks = select_values(<<-SQL.strip.gsub(/\s+/, " "), "Primary Key", [bind_string("owner", owner), bind_string("table_name", desc_table_name)])
           SELECT cc.column_name
             FROM all_constraints#{db_link} c, all_cons_columns#{db_link} cc
            WHERE c.owner = :owner
@@ -789,7 +789,7 @@ module ActiveRecord
       def primary_keys(table_name) # :nodoc:
         (owner, desc_table_name, db_link) = @connection.describe(table_name) unless owner
 
-        pks = select_values(<<-SQL.strip_heredoc, "Primary Keys", [bind_string('owner', owner), bind_string('table_name', desc_table_name)])
+        pks = select_values(<<-SQL.strip_heredoc, "Primary Keys", [bind_string("owner", owner), bind_string("table_name", desc_table_name)])
           SELECT cc.column_name
             FROM all_constraints#{db_link} c, all_cons_columns#{db_link} cc
            WHERE c.owner = :owner
@@ -819,7 +819,7 @@ module ActiveRecord
       end
 
       def temporary_table?(table_name) #:nodoc:
-        select_value("SELECT temporary FROM all_tables WHERE table_name = :table_name and owner = SYS_CONTEXT('userenv', 'session_user')", 'temp tables', [bind_string('table_name', table_name.upcase)]) == "Y"
+        select_value("SELECT temporary FROM all_tables WHERE table_name = :table_name and owner = SYS_CONTEXT('userenv', 'session_user')", "temp tables", [bind_string("table_name", table_name.upcase)]) == "Y"
       end
 
       def combine_bind_parameters(
@@ -908,10 +908,11 @@ module ActiveRecord
         end
 
       private
-      # create bind object for type String
-      def bind_string(name, value)
-        ActiveRecord::Relation::QueryAttribute.new(name, value, ActiveRecord::OracleEnhanced::Type::String.new)
-      end
+
+        # create bind object for type String
+        def bind_string(name, value)
+          ActiveRecord::Relation::QueryAttribute.new(name, value, ActiveRecord::OracleEnhanced::Type::String.new)
+        end
     end
   end
 end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -538,7 +538,7 @@ module ActiveRecord
           table_owner, table_name = default_owner, real_name
         end
 
-        select_values(<<-SQL, "SCHEMA", [bind_string("owner", table_owner), bind_string("table_name",table_name)]).any?
+        select_values(<<-SQL, "SCHEMA", [bind_string("owner", table_owner), bind_string("table_name", table_name)]).any?
           SELECT owner, table_name
           FROM all_tables
           WHERE owner = :owner
@@ -604,7 +604,7 @@ module ActiveRecord
             statement_parameters = nil
             if row["index_type"] == "DOMAIN" && row["ityp_owner"] == "CTXSYS" && row["ityp_name"] == "CONTEXT"
               procedure_name = default_datastore_procedure(row["index_name"])
-              source = select_values(<<-SQL, 'procedure', [bind_string("owner", owner), bind_string("procedure_name", procedure_name.upcase)]).join
+              source = select_values(<<-SQL, "procedure", [bind_string("owner", owner), bind_string("procedure_name", procedure_name.upcase)]).join
                   SELECT text
                   FROM all_source#{db_link}
                   WHERE owner = :owner

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -537,11 +537,12 @@ module ActiveRecord
         else
           table_owner, table_name = default_owner, real_name
         end
-        select_values(<<-SQL, "SCHEMA").any?
+
+        select_values(<<-SQL, "SCHEMA", [bind_string('owner', table_owner), bind_string('table_name',table_name )]).any?
           SELECT owner, table_name
           FROM all_tables
-          WHERE owner = '#{table_owner}'
-          AND table_name = q'[#{table_name}]'
+          WHERE owner = :owner
+          AND table_name = :table_name
         SQL
       end
 
@@ -573,7 +574,8 @@ module ActiveRecord
       def indexes(table_name, name = nil) #:nodoc:
         (owner, table_name, db_link) = @connection.describe(table_name)
         default_tablespace_name = default_tablespace
-        result = select_all(<<-SQL.strip.gsub(/\s+/, " "))
+
+        result = select_all(<<-SQL.strip.gsub(/\s+/, " "), 'indexes', [bind_string('owner', owner), bind_string('owner', owner)])
             SELECT LOWER(i.table_name) AS table_name, LOWER(i.index_name) AS index_name, i.uniqueness,
               i.index_type, i.ityp_owner, i.ityp_name, i.parameters,
               LOWER(i.tablespace_name) AS tablespace_name,
@@ -585,8 +587,8 @@ module ActiveRecord
                 e.index_owner = i.owner AND e.column_position = c.column_position
               LEFT OUTER JOIN all_tab_cols#{db_link} atc ON i.table_name = atc.table_name AND
                 c.column_name = atc.column_name AND i.owner = atc.owner AND atc.hidden_column = 'NO'
-            WHERE i.owner = '#{owner}'
-               AND i.table_owner = '#{owner}'
+            WHERE i.owner = :owner
+               AND i.table_owner = :owner
                AND NOT EXISTS (SELECT uc.index_name FROM all_constraints uc
                 WHERE uc.index_name = i.index_name AND uc.owner = i.owner AND uc.constraint_type = 'P')
             ORDER BY i.index_name, c.column_position
@@ -602,11 +604,11 @@ module ActiveRecord
             statement_parameters = nil
             if row["index_type"] == "DOMAIN" && row["ityp_owner"] == "CTXSYS" && row["ityp_name"] == "CONTEXT"
               procedure_name = default_datastore_procedure(row["index_name"])
-              source = select_values(<<-SQL).join
+              source = select_values(<<-SQL, 'procedure', [bind_string('owner', owner), bind_string('procedure_name', procedure_name.upcase)]).join
                   SELECT text
                   FROM all_source#{db_link}
-                  WHERE owner = '#{owner}'
-                    AND name = '#{procedure_name.upcase}'
+                  WHERE owner = :owner
+                    AND name = :procedure_name
                   ORDER BY line
                 SQL
               if source =~ /-- add_context_index_parameters (.+)\n/
@@ -650,16 +652,17 @@ module ActiveRecord
         (owner, desc_table_name, db_link) = @connection.describe(table_name) unless owner
 
         trigger_name = default_trigger_name(table_name).upcase
+
         pkt_sql = <<-SQL
           SELECT trigger_name
           FROM all_triggers#{db_link}
-          WHERE owner = '#{owner}'
-            AND trigger_name = q'[#{trigger_name}]'
-            AND table_owner = '#{owner}'
-            AND table_name = q'[#{desc_table_name}]'
+          WHERE owner = :owner
+            AND trigger_name = :trigger_name
+            AND table_owner = :owner
+            AND table_name = :table_name
             AND status = 'ENABLED'
         SQL
-        select_value(pkt_sql, "Primary Key Trigger") ? true : false
+        select_value(pkt_sql, "Primary Key Trigger", [bind_string('owner', owner), bind_string('trigger_name', trigger_name), bind_string('owner', owner), bind_string('table_name', desc_table_name)]) ? true : false
       end
 
       def columns(table_name, name = nil) #:nodoc:
@@ -680,8 +683,8 @@ module ActiveRecord
                  DECODE(data_type, 'NUMBER', data_scale, NULL) AS scale,
                  comments.comments as column_comment
             FROM all_tab_cols#{db_link} cols, all_col_comments#{db_link} comments
-           WHERE cols.owner      = '#{owner}'
-             AND cols.table_name = #{quote(desc_table_name)}
+           WHERE cols.owner      = :owner
+             AND cols.table_name = :table_name
              AND cols.hidden_column = 'NO'
              AND cols.owner = comments.owner
              AND cols.table_name = comments.table_name
@@ -690,7 +693,7 @@ module ActiveRecord
         SQL
 
         # added deletion of ignored columns
-        select_all(table_cols, name).to_a.map do |row|
+        select_all(table_cols, name, [bind_string('owner', owner), bind_string('table_name', desc_table_name)]).to_a.map do |row|
           limit, scale = row["limit"], row["scale"]
           if limit || scale
             row["sql_type"] += "(#{(limit || 38).to_i}" + ((scale = scale.to_i) > 0 ? ",#{scale})" : ")")
@@ -744,19 +747,19 @@ module ActiveRecord
       def pk_and_sequence_for(table_name, owner = nil, desc_table_name = nil, db_link = nil) #:nodoc:
         (owner, desc_table_name, db_link) = @connection.describe(table_name) unless owner
 
-        seqs = select_values(<<-SQL.strip.gsub(/\s+/, " "), "Sequence")
+        seqs = select_values(<<-SQL.strip.gsub(/\s+/, " "), "Sequence" , [bind_string('owner', owner), bind_string('sequence_name', default_sequence_name(desc_table_name).upcase)])
           select us.sequence_name
           from all_sequences#{db_link} us
-          where us.sequence_owner = '#{owner}'
-          and us.sequence_name = upper(#{quote(default_sequence_name(desc_table_name))})
+          where us.sequence_owner = :owner
+          and us.sequence_name = :sequence_name
         SQL
 
         # changed back from user_constraints to all_constraints for consistency
-        pks = select_values(<<-SQL.strip.gsub(/\s+/, " "), "Primary Key")
+        pks = select_values(<<-SQL.strip.gsub(/\s+/, " "), "Primary Key", [bind_string('owner', owner), bind_string('table_name', desc_table_name)])
           SELECT cc.column_name
             FROM all_constraints#{db_link} c, all_cons_columns#{db_link} cc
-           WHERE c.owner = '#{owner}'
-             AND c.table_name = #{quote(desc_table_name)}
+           WHERE c.owner = :owner
+             AND c.table_name = :table_name
              AND c.constraint_type = 'P'
              AND cc.owner = c.owner
              AND cc.constraint_name = c.constraint_name
@@ -786,11 +789,11 @@ module ActiveRecord
       def primary_keys(table_name) # :nodoc:
         (owner, desc_table_name, db_link) = @connection.describe(table_name) unless owner
 
-        pks = select_values(<<-SQL.strip_heredoc, "Primary Keys")
+        pks = select_values(<<-SQL.strip_heredoc, "Primary Keys", [bind_string('owner', owner), bind_string('table_name', desc_table_name)])
           SELECT cc.column_name
             FROM all_constraints#{db_link} c, all_cons_columns#{db_link} cc
-           WHERE c.owner = '#{owner}'
-             AND c.table_name = '#{desc_table_name}'
+           WHERE c.owner = :owner
+             AND c.table_name = :table_name
              AND c.constraint_type = 'P'
              AND cc.owner = c.owner
              AND cc.constraint_name = c.constraint_name
@@ -816,7 +819,7 @@ module ActiveRecord
       end
 
       def temporary_table?(table_name) #:nodoc:
-        select_value("SELECT temporary FROM all_tables WHERE table_name = '#{table_name.upcase}' and owner = SYS_CONTEXT('userenv', 'session_user')") == "Y"
+        select_value("SELECT temporary FROM all_tables WHERE table_name = :table_name and owner = SYS_CONTEXT('userenv', 'session_user')", 'temp tables', [bind_string('table_name', table_name.upcase)]) == "Y"
       end
 
       def combine_bind_parameters(
@@ -903,6 +906,12 @@ module ActiveRecord
             super
           end
         end
+
+      private
+      # create bind object for type String
+      def bind_string(name, value)
+        ActiveRecord::Relation::QueryAttribute.new(name, value, ActiveRecord::OracleEnhanced::Type::String.new)
+      end
     end
   end
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -493,4 +493,60 @@ describe "OracleEnhancedAdapter" do
       expect(conn.data_sources).to include("synonym_comments")
     end
   end
+
+  describe "dictionary selects with bind variables" do
+    before(:all) do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+      @conn = ActiveRecord::Base.connection
+      schema_define do
+        drop_table :test_posts, if_exists: true
+        create_table :test_posts
+      end
+      class ::TestPost < ActiveRecord::Base
+      end
+    end
+
+    before(:each) do
+      @conn.clear_cache!
+    end
+
+    after(:all) do
+      schema_define do
+        drop_table :test_posts
+      end
+      Object.send(:remove_const, "TestPost")
+      ActiveRecord::Base.clear_cache!
+    end
+
+    it "should test table existence" do
+      expect(@conn.table_exists?("TEST_POSTS")).to eq true
+      expect(@conn.table_exists?("NOT_EXISTING")).to eq false
+    end
+
+    it "should return array from indexes" do
+      expect(@conn.indexes("TEST_POSTS").class).to eq Array
+    end
+
+    it "should not have primary key trigger" do
+      expect(@conn.has_primary_key_trigger?("TEST_POSTS")).to eq false
+    end
+
+    it "should return content from columns" do
+      expect(@conn.columns("TEST_POSTS").length).to be > 0
+    end
+
+    it "should return pk and sequence from pk_and_sequence_for" do
+      expect(@conn.pk_and_sequence_for("TEST_POSTS").length).to eq 2
+    end
+
+    it "should return pk from primary_keys" do
+      expect(@conn.primary_keys("TEST_POSTS")).to eq ["id"]
+    end
+
+    it "should return false from temporary_table?" do
+      expect(@conn.temporary_table?("TEST_POSTS")).to eq false
+    end
+
+  end
+
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -264,7 +264,8 @@ describe "OracleEnhancedAdapter" do
       pk = TestPost.columns_hash[TestPost.primary_key]
       sub = Arel::Nodes::BindParam.new(nil).to_sql
       binds = [ActiveRecord::Relation::QueryAttribute.new(pk, 1, ActiveRecord::Type::Integer.new)]
-
+      # free statement pool from dictionary selections  to ensure next selects will increase statement pool
+      @statements.clear
       expect {
         4.times do |i|
           @conn.exec_query("SELECT * FROM test_posts WHERE #{i}=#{i} AND id = #{sub}", "SQL", binds)

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -531,39 +531,39 @@ describe "OracleEnhancedAdapter" do
     it "should return array from indexes with bind usage" do
       expect(@conn.indexes("TEST_POSTS").class).to eq Array
       expect(@logger.logged(:debug).last).to match(/:owner/)
-      expect(@logger.logged(:debug).last).to match(/[["owner", "#{DATABASE_USER}"], ["owner", "#{DATABASE_USER}"]]/)
+      expect(@logger.logged(:debug).last).to match(/\[\["owner", "#{DATABASE_USER.upcase}"\], \["owner", "#{DATABASE_USER.upcase}"\]\]/)
     end
 
     it "should not have primary key trigger with bind usage" do
       expect(@conn.has_primary_key_trigger?("TEST_POSTS")).to eq false
       expect(@logger.logged(:debug).last).to match(/:owner/)
       expect(@logger.logged(:debug).last).to match(/:table_name/)
-      expect(@logger.logged(:debug).last).to match(/[["owner", "#{DATABASE_USER}"], ["trigger_name", "TEST_POSTS_PKT"], ["owner", "#{DATABASE_USER}"], ["table_name", "TEST_POSTS"]]/)
+      expect(@logger.logged(:debug).last).to match(/\[\["owner", "#{DATABASE_USER.upcase}"\], \["trigger_name", "TEST_POSTS_PKT"\], \["owner", "#{DATABASE_USER.upcase}"\], \["table_name", "TEST_POSTS"\]\]/)
     end
 
     it "should return content from columns with bind usage" do
       expect(@conn.columns("TEST_POSTS").length).to be > 0
       expect(@logger.logged(:debug).last).to match(/:owner/)
       expect(@logger.logged(:debug).last).to match(/:table_name/)
-      expect(@logger.logged(:debug).last).to match(/[["owner", "#{DATABASE_USER}"], ["table_name", "TEST_POSTS"]]/)
+      expect(@logger.logged(:debug).last).to match(/\[\["owner", "#{DATABASE_USER.upcase}"\], \["table_name", "TEST_POSTS"\]\]/)
     end
 
     it "should return pk and sequence from pk_and_sequence_for with bind usage" do
       expect(@conn.pk_and_sequence_for("TEST_POSTS").length).to eq 2
       expect(@logger.logged(:debug).last).to match(/:owner/)
-      expect(@logger.logged(:debug).last).to match(/[["owner", "#{DATABASE_USER}"], ["table_name", "TEST_POSTS"]]/)
+      expect(@logger.logged(:debug).last).to match(/\[\["owner", "#{DATABASE_USER.upcase}"\], \["table_name", "TEST_POSTS"\]\]/)
     end
 
     it "should return pk from primary_keys with bind usage" do
       expect(@conn.primary_keys("TEST_POSTS")).to eq ["id"]
       expect(@logger.logged(:debug).last).to match(/:owner/)
-      expect(@logger.logged(:debug).last).to match(/[["owner", "#{DATABASE_USER}"], ["table_name", "TEST_POSTS"]]/)
+      expect(@logger.logged(:debug).last).to match(/\[\["owner", "#{DATABASE_USER.upcase}"\], \["table_name", "TEST_POSTS"\]\]/)
     end
 
     it "should return false from temporary_table? with bind usage" do
       expect(@conn.temporary_table?("TEST_POSTS")).to eq false
       expect(@logger.logged(:debug).last).to match(/:table_name/)
-      expect(@logger.logged(:debug).last).to match(/[["table_name", "TEST_POSTS"]]/)
+      expect(@logger.logged(:debug).last).to match(/\[\["table_name", "TEST_POSTS"\]\]/)
     end
 
   end

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -508,6 +508,11 @@ describe "OracleEnhancedAdapter" do
 
     before(:each) do
       @conn.clear_cache!
+      set_logger
+    end
+
+    after(:each) do
+      clear_logger
     end
 
     after(:all) do
@@ -523,28 +528,42 @@ describe "OracleEnhancedAdapter" do
       expect(@conn.table_exists?("NOT_EXISTING")).to eq false
     end
 
-    it "should return array from indexes" do
+    it "should return array from indexes with bind usage" do
       expect(@conn.indexes("TEST_POSTS").class).to eq Array
+      expect(@logger.logged(:debug).last).to match(/:owner/im)
+      expect(@logger.logged(:debug).last).to match(/[["owner", "ORACLE_ENHANCED"], ["owner", "ORACLE_ENHANCED"]]/im)
     end
 
-    it "should not have primary key trigger" do
+    it "should not have primary key trigger with bind usage" do
       expect(@conn.has_primary_key_trigger?("TEST_POSTS")).to eq false
+      expect(@logger.logged(:debug).last).to match(/:owner/im)
+      expect(@logger.logged(:debug).last).to match(/:table_name/im)
+      expect(@logger.logged(:debug).last).to match(/[["owner", "ORACLE_ENHANCED"], ["trigger_name", "TEST_POSTS_PKT"], ["owner", "ORACLE_ENHANCED"], ["table_name", "TEST_POSTS"]]/im)
     end
 
-    it "should return content from columns" do
+    it "should return content from columns with bind usage" do
       expect(@conn.columns("TEST_POSTS").length).to be > 0
+      expect(@logger.logged(:debug).last).to match(/:owner/im)
+      expect(@logger.logged(:debug).last).to match(/:table_name/im)
+      expect(@logger.logged(:debug).last).to match(/[["owner", "ORACLE_ENHANCED"], ["table_name", "TEST_POSTS"]]/im)
     end
 
-    it "should return pk and sequence from pk_and_sequence_for" do
+    it "should return pk and sequence from pk_and_sequence_for with bind usage" do
       expect(@conn.pk_and_sequence_for("TEST_POSTS").length).to eq 2
+      expect(@logger.logged(:debug).last).to match(/:owner/im)
+      expect(@logger.logged(:debug).last).to match(/[["owner", "ORACLE_ENHANCED"], ["table_name", "TEST_POSTS"]]/im)
     end
 
-    it "should return pk from primary_keys" do
+    it "should return pk from primary_keys with bind usage" do
       expect(@conn.primary_keys("TEST_POSTS")).to eq ["id"]
+      expect(@logger.logged(:debug).last).to match(/:owner/im)
+      expect(@logger.logged(:debug).last).to match(/[["owner", "ORACLE_ENHANCED"], ["table_name", "TEST_POSTS"]]/im)
     end
 
-    it "should return false from temporary_table?" do
+    it "should return false from temporary_table? with bind usage" do
       expect(@conn.temporary_table?("TEST_POSTS")).to eq false
+      expect(@logger.logged(:debug).last).to match(/:table_name/im)
+      expect(@logger.logged(:debug).last).to match(/[["table_name", "TEST_POSTS"]]/im)
     end
 
   end

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -530,40 +530,40 @@ describe "OracleEnhancedAdapter" do
 
     it "should return array from indexes with bind usage" do
       expect(@conn.indexes("TEST_POSTS").class).to eq Array
-      expect(@logger.logged(:debug).last).to match(/:owner/im)
-      expect(@logger.logged(:debug).last).to match(/[["owner", "ORACLE_ENHANCED"], ["owner", "ORACLE_ENHANCED"]]/im)
+      expect(@logger.logged(:debug).last).to match(/:owner/)
+      expect(@logger.logged(:debug).last).to match(/[["owner", "#{DATABASE_USER}"], ["owner", "#{DATABASE_USER}"]]/)
     end
 
     it "should not have primary key trigger with bind usage" do
       expect(@conn.has_primary_key_trigger?("TEST_POSTS")).to eq false
-      expect(@logger.logged(:debug).last).to match(/:owner/im)
-      expect(@logger.logged(:debug).last).to match(/:table_name/im)
-      expect(@logger.logged(:debug).last).to match(/[["owner", "ORACLE_ENHANCED"], ["trigger_name", "TEST_POSTS_PKT"], ["owner", "ORACLE_ENHANCED"], ["table_name", "TEST_POSTS"]]/im)
+      expect(@logger.logged(:debug).last).to match(/:owner/)
+      expect(@logger.logged(:debug).last).to match(/:table_name/)
+      expect(@logger.logged(:debug).last).to match(/[["owner", "#{DATABASE_USER}"], ["trigger_name", "TEST_POSTS_PKT"], ["owner", "#{DATABASE_USER}"], ["table_name", "TEST_POSTS"]]/)
     end
 
     it "should return content from columns with bind usage" do
       expect(@conn.columns("TEST_POSTS").length).to be > 0
-      expect(@logger.logged(:debug).last).to match(/:owner/im)
-      expect(@logger.logged(:debug).last).to match(/:table_name/im)
-      expect(@logger.logged(:debug).last).to match(/[["owner", "ORACLE_ENHANCED"], ["table_name", "TEST_POSTS"]]/im)
+      expect(@logger.logged(:debug).last).to match(/:owner/)
+      expect(@logger.logged(:debug).last).to match(/:table_name/)
+      expect(@logger.logged(:debug).last).to match(/[["owner", "#{DATABASE_USER}"], ["table_name", "TEST_POSTS"]]/)
     end
 
     it "should return pk and sequence from pk_and_sequence_for with bind usage" do
       expect(@conn.pk_and_sequence_for("TEST_POSTS").length).to eq 2
-      expect(@logger.logged(:debug).last).to match(/:owner/im)
-      expect(@logger.logged(:debug).last).to match(/[["owner", "ORACLE_ENHANCED"], ["table_name", "TEST_POSTS"]]/im)
+      expect(@logger.logged(:debug).last).to match(/:owner/)
+      expect(@logger.logged(:debug).last).to match(/[["owner", "#{DATABASE_USER}"], ["table_name", "TEST_POSTS"]]/)
     end
 
     it "should return pk from primary_keys with bind usage" do
       expect(@conn.primary_keys("TEST_POSTS")).to eq ["id"]
-      expect(@logger.logged(:debug).last).to match(/:owner/im)
-      expect(@logger.logged(:debug).last).to match(/[["owner", "ORACLE_ENHANCED"], ["table_name", "TEST_POSTS"]]/im)
+      expect(@logger.logged(:debug).last).to match(/:owner/)
+      expect(@logger.logged(:debug).last).to match(/[["owner", "#{DATABASE_USER}"], ["table_name", "TEST_POSTS"]]/)
     end
 
     it "should return false from temporary_table? with bind usage" do
       expect(@conn.temporary_table?("TEST_POSTS")).to eq false
-      expect(@logger.logged(:debug).last).to match(/:table_name/im)
-      expect(@logger.logged(:debug).last).to match(/[["table_name", "TEST_POSTS"]]/im)
+      expect(@logger.logged(:debug).last).to match(/:table_name/)
+      expect(@logger.logged(:debug).last).to match(/[["table_name", "TEST_POSTS"]]/)
     end
 
   end


### PR DESCRIPTION
For larger database systems cursor_sharing has to be set to EXACT, there has been no way to run production with cursor_sharing=FORCE.
With cursor_sharing=EXACT and larger number of process starts statement execution of dictionary access SQLs without bind variables became an problem for database stability.