### PR TITLE
Respect database instance `cursor_sharing` value `exact` by default

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -150,8 +150,8 @@ module ActiveRecord
             # @raw_connection.setDefaultRowPrefetch(prefetch_rows) if prefetch_rows
           end
 
-          cursor_sharing = config[:cursor_sharing] || "force"
-          exec "alter session set cursor_sharing = #{cursor_sharing}"
+          cursor_sharing = config[:cursor_sharing]
+          exec "alter session set cursor_sharing = #{cursor_sharing}" if cursor_sharing
 
           # Initialize NLS parameters
           OracleEnhancedAdapter::DEFAULT_NLS_PARAMETERS.each do |key, default_value|

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -313,7 +313,7 @@ module ActiveRecord
           privilege = config[:privilege] && config[:privilege].to_sym
           async = config[:allow_concurrency]
           prefetch_rows = config[:prefetch_rows] || 100
-          cursor_sharing = config[:cursor_sharing] || "force"
+          cursor_sharing = config[:cursor_sharing]
           # get session time_zone from configuration or from TZ environment variable
           time_zone = config[:time_zone] || ENV["TZ"]
 
@@ -341,7 +341,7 @@ module ActiveRecord
           conn.autocommit = true
           conn.non_blocking = true if async
           conn.prefetch_rows = prefetch_rows
-          conn.exec "alter session set cursor_sharing = #{cursor_sharing}" rescue nil
+          conn.exec "alter session set cursor_sharing = #{cursor_sharing}" rescue nil if cursor_sharing
           if ActiveRecord::Base.default_timezone == :local
             conn.exec "alter session set time_zone = '#{time_zone}'" unless time_zone.blank?
           elsif ActiveRecord::Base.default_timezone == :utc

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -30,6 +30,17 @@ describe "OracleEnhancedAdapter establish connection" do
     ActiveRecord::Base.connection.reconnect!
     expect(ActiveRecord::Base.connection).to be_active
   end
+
+  it "should use database default cursor_sharing parameter value exact by default" do
+    # Use `SYSTEM_CONNECTION_PARAMS` to query v$parameter
+    conn = ActiveRecord::ConnectionAdapters::OracleEnhanced::Connection.create(SYSTEM_CONNECTION_PARAMS)
+    expect(conn.select_value("select value from v$parameter where name = 'cursor_sharing'")).to eq("EXACT")
+  end
+
+  it "should use modified cursor_sharing value force" do
+    conn = ActiveRecord::ConnectionAdapters::OracleEnhanced::Connection.create(SYSTEM_CONNECTION_PARAMS.merge(cursor_sharing: :force))
+    expect(conn.select_value("select value from v$parameter where name = 'cursor_sharing'")).to eq("FORCE")
+  end
 end
 
 describe "OracleEnhancedConnection" do


### PR DESCRIPTION
Oracle enhanced adapter has been changing `cursor_sharing` parameter value to `force`
to share cursors between sql statements whose literal values are different.

However, prepared statements for dictionary queries will be enabled Oracle enhanced adapter 5.2 by #1498 and #1502,
Ther will be no need to change `cursor_sharing` value to `exact` anymore.

If you want to keep the current behavior in Rails 5.2, they can set `cursor_sharing: :force` explicitly in the database.yml.

Refer #1501