### PR TITLE
Address `CommentTest#test_change_table_comment_to_nil` failure

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -319,7 +319,11 @@ module ActiveRecord
 
         def change_table_comment(table_name, comment)
           clear_cache!
-          execute "COMMENT ON TABLE #{quote_table_name(table_name)} IS #{quote(comment)}"
+          if comment.nil?
+            execute "COMMENT ON TABLE #{quote_table_name(table_name)} IS ''"
+          else
+            execute "COMMENT ON TABLE #{quote_table_name(table_name)} IS #{quote(comment)}"
+          end
         end
 
         def change_column_comment(table_name, column_name, comment) #:nodoc:


### PR DESCRIPTION
This pull request addresses this error.

```ruby
$ ARCONN=oracle bin/test test/cases/comment_test.rb:152
Using oracle
Run options: --seed 49367

E

Finished in 0.155438s, 6.4334 runs/s, 0.0000 assertions/s.

  1) Error:
CommentTest#test_change_table_comment_to_nil:
ActiveRecord::StatementInvalid: OCIError: ORA-01780: string literal required: COMMENT ON TABLE "COMMENTEDS" IS NULL
    stmt.c:243:in oci8lib_250.so
    /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/ruby-oci8-2.2.4.1/lib/oci8/cursor.rb:130:in `exec'
    /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/ruby-oci8-2.2.4.1/lib/oci8/oci8.rb:277:in `exec_internal'
    /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/ruby-oci8-2.2.4.1/lib/oci8/oci8.rb:268:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:442:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:97:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:13:in `block in execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:556:in `block (2 levels) in log'
    /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/2.5.0/monitor.rb:228:in `mon_synchronize'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:555:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:546:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/dbms_output.rb:36:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:13:in `execute'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:322:in `change_table_comment'
    /home/yahonda/git/rails/activerecord/test/cases/comment_test.rb:152:in `test_change_table_comment_to_nil'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```