### PR TITLE
Exclude `rails6` label  [skip ci]

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -8,6 +8,7 @@ daysUntilClose: 7
 exemptLabels:
   - pinned
   - security
+  - rails6
 # Label to use when marking as stale
 staleLabel: wontfix
 # Comment to post when marking as stale. Set to `false` to disable


### PR DESCRIPTION
Created #1505 whose target is next major version which will be released
as Rails 6, It will not be likely available within 90 days.

Created `rails6` label to handle it.