### PR TITLE
Remove `value_to_boolean` which has been removed from Rails

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column.rb
@@ -40,18 +40,6 @@ module ActiveRecord
           @object_type
         end
 
-        # convert something to a boolean
-        # added y as boolean value
-        def self.value_to_boolean(value) #:nodoc:
-          if value == true || value == false
-            value
-          elsif value.is_a?(String) && value.blank?
-            nil
-          else
-            %w(true t 1 y +).include?(value.to_s.downcase)
-          end
-        end
-
         # convert Time or DateTime value to Date for :date columns
         def self.string_to_date(string) #:nodoc:
           return string.to_date if string.is_a?(Time) || string.is_a?(DateTime)


### PR DESCRIPTION
Remove `value_to_boolean` which has been removed from Rails since 4.2

Refer https://github.com/rails/rails/commit/8f387995054d9ce79522da8ef65fba28c6ea0785