### PR TITLE
Remove `string_to_date` which has been removed from Rails 4.2

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column.rb
@@ -40,12 +40,6 @@ module ActiveRecord
           @object_type
         end
 
-        # convert Time or DateTime value to Date for :date columns
-        def self.string_to_date(string) #:nodoc:
-          return string.to_date if string.is_a?(Time) || string.is_a?(DateTime)
-          super
-        end
-
         # convert Date value to Time for :datetime columns
         def self.string_to_time(string) #:nodoc:
           return string.to_time if string.is_a?(Date)


### PR DESCRIPTION
Refer https://github.com/rails/rails/commit/e2d19d60182b017bb092a018564d329c4f52b6a3
https://github.com/rails/rails/commit/8f387995054d9ce79522da8ef65fba28c6ea0785