### PR TITLE
Remove `guess_date_or_time` which has not been called

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column.rb
@@ -50,11 +50,6 @@ module ActiveRecord
             default
           end
         end
-
-        def guess_date_or_time(value)
-          value.respond_to?(:hour) && ((value.hour == 0) && (value.min == 0) && (value.sec == 0)) ?
-            Date.new(value.year, value.month, value.day) : value
-        end
       end
     end
   end


### PR DESCRIPTION
since Oracle enhanced adapter 1.7

Refer #811