### PR TITLE
Remove unsed `fk_name`

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -733,8 +733,6 @@ end
     end
 
     it "should query foreign_keys using bind variables" do
-      fk_name = "fk_rails_#{Digest::SHA256.hexdigest("test_comments_test_post_id_fk").first(10)}"
-
       schema_define do
         add_foreign_key :test_comments, :test_posts
       end


### PR DESCRIPTION
This pull request addresses the following warning below:

```ruby
$ bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb:735
==> Loading config from ENV or use default
==> Running specs with MRI version 2.4.2
==> Effective ActiveRecord version 5.2.0.alpha
/home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb:736: warning: assigned but unused variable - fk_name
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb"=>[735]}}
.

Finished in 0.46229 seconds (files took 0.91534 seconds to load)
1 example, 0 failures

Coverage report generated for RSpec to /home/yahonda/git/oracle-enhanced/coverage. 1076 / 2621 LOC (41.05%) covered.
$
```