### PR TITLE
`columns` second argument does not exist in Abstract adapter

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -662,7 +662,7 @@ module ActiveRecord
         select_value(pkt_sql, "Primary Key Trigger", [bind_string("owner", owner), bind_string("trigger_name", trigger_name), bind_string("owner", owner), bind_string("table_name", desc_table_name)]) ? true : false
       end
 
-      def columns(table_name, name = nil) #:nodoc:
+      def columns(table_name) #:nodoc:
         table_name = table_name.to_s
 
         (owner, desc_table_name, db_link) = @connection.describe(table_name)
@@ -690,7 +690,7 @@ module ActiveRecord
         SQL
 
         # added deletion of ignored columns
-        select_all(table_cols, name, [bind_string("owner", owner), bind_string("table_name", desc_table_name)]).to_a.map do |row|
+        select_all(table_cols, nil, [bind_string("owner", owner), bind_string("table_name", desc_table_name)]).to_a.map do |row|
           limit, scale = row["limit"], row["scale"]
           if limit || scale
             row["sql_type"] += "(#{(limit || 38).to_i}" + ((scale = scale.to_i) > 0 ? ",#{scale})" : ")")


### PR DESCRIPTION
Refer https://github.com/rails/rails/pull/4850 and follow-up #1516