### PR TITLE
Remove `OracleEnhanced::Column#returning_id?`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   module ConnectionAdapters #:nodoc:
     module OracleEnhanced
       class Column < ActiveRecord::ConnectionAdapters::Column
-        attr_reader :table_name, :virtual_column_data_default, :returning_id #:nodoc:
+        attr_reader :table_name, :virtual_column_data_default #:nodoc:
 
         def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, virtual = false, returning_id = nil, comment = nil) #:nodoc:
           @virtual = virtual
@@ -20,10 +20,6 @@ module ActiveRecord
 
         def virtual?
           @virtual
-        end
-
-        def returning_id?
-          @returning_id
         end
 
       private


### PR DESCRIPTION
Remove `ActiveRecord::ConnectionAdapter::OracleEnhanced::Column#returning_id?`
It has not been called since #795