### PR TITLE
Remove `returning_id` instance variable

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column.rb
@@ -6,10 +6,9 @@ module ActiveRecord
       class Column < ActiveRecord::ConnectionAdapters::Column
         attr_reader :virtual_column_data_default #:nodoc:
 
-        def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, virtual = false, returning_id = nil, comment = nil) #:nodoc:
+        def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, virtual = false, comment = nil) #:nodoc:
           @virtual = virtual
           @virtual_column_data_default = default.inspect if virtual
-          @returning_id = returning_id
           if virtual
             default_value = nil
           else

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -489,7 +489,6 @@ module ActiveRecord
                              field["nullable"] == "Y",
                              table_name,
                              is_virtual,
-                             false,
                              field["column_comment"]
                       )
           end

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -341,7 +341,7 @@ describe "OracleEnhancedConnection" do
     it "should execute prepared statement with decimal bind parameter " do
       cursor = @conn.prepare("INSERT INTO test_employees VALUES(:1)")
       type_metadata = ActiveRecord::ConnectionAdapters::SqlTypeMetadata.new(sql_type: "NUMBER", type: :decimal, limit: 10, precision: nil, scale: 2)
-      column = ActiveRecord::ConnectionAdapters::OracleEnhanced::Column.new("age", nil, type_metadata, false, "test_employees", false, false, nil)
+      column = ActiveRecord::ConnectionAdapters::OracleEnhanced::Column.new("age", nil, type_metadata, false, "test_employees", false, nil)
       expect(column.type).to eq(:decimal)
       # Here 1.5 expects that this value has been type casted already
       # it should use bind_params in the long term.


### PR DESCRIPTION
Remove `returning_id` instance variable from `ActiveRecord::ConnectionAdapter::OracleEnhanced::Column`

Follow-up #1523