### PR TITLE
Let `ActiveRecord::ConnectionAdapters::OracleEnhanced::TypeMetadata` handle `virtual` type

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column.rb
@@ -4,32 +4,14 @@ module ActiveRecord
   module ConnectionAdapters #:nodoc:
     module OracleEnhanced
       class Column < ActiveRecord::ConnectionAdapters::Column
-        attr_reader :virtual_column_data_default #:nodoc:
+        delegate :virtual, to: :sql_type_metadata, allow_nil: true
 
-        def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, virtual = false, comment = nil) #:nodoc:
-          @virtual = virtual
-          @virtual_column_data_default = default.inspect if virtual
-          if virtual
-            default_value = nil
-          else
-            default_value = self.class.extract_value_from_default(default)
-          end
-          super(name, default_value, sql_type_metadata, null, table_name, comment: comment)
+        def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, comment = nil) #:nodoc:
+          super(name, default, sql_type_metadata, null, table_name, comment: comment)
         end
 
         def virtual?
-          @virtual
-        end
-
-      private
-
-        def self.extract_value_from_default(default)
-          case default
-          when String
-            default.gsub(/''/, "'")
-            else
-            default
-          end
+          virtual
         end
       end
     end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -482,19 +482,20 @@ module ActiveRecord
               field["data_default"] = false if (field["data_default"] == "N" && OracleEnhancedAdapter.emulate_booleans_from_strings)
             end
 
-            type_metadata = fetch_type_metadata(field["sql_type"])
+            type_metadata = fetch_type_metadata(field["sql_type"], is_virtual)
+            default_value = extract_value_from_default(field["data_default"])
+            default_value = nil if is_virtual
             OracleEnhanced::Column.new(oracle_downcase(field["name"]),
-                             field["data_default"],
+                             default_value,
                              type_metadata,
                              field["nullable"] == "Y",
                              table_name,
-                             is_virtual,
                              field["column_comment"]
                       )
           end
 
-          def fetch_type_metadata(sql_type)
-            OracleEnhanced::TypeMetadata.new(super(sql_type))
+          def fetch_type_metadata(sql_type, virtual = nil)
+            OracleEnhanced::TypeMetadata.new(super(sql_type), virtual: virtual)
           end
 
           def tablespace_for(obj_type, tablespace_option, table_name = nil, column_name = nil)

--- a/lib/active_record/connection_adapters/oracle_enhanced/type_metadata.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/type_metadata.rb
@@ -3,9 +3,13 @@
 module ActiveRecord
   module ConnectionAdapters #:nodoc:
     module OracleEnhanced
-      class TypeMetadata < DelegateClass(SqlTypeMetadata) # :nodoc:
-        def initialize(type_metadata)
+      class TypeMetadata < DelegateClass(ActiveRecord::ConnectionAdapters::SqlTypeMetadata) # :nodoc:
+        attr_reader :virtual
+
+        def initialize(type_metadata, virtual: nil)
           super(type_metadata)
+          @type_metadata = type_metadata
+          @virtual = virtual
         end
       end
     end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -838,6 +838,15 @@ module ActiveRecord
           end
         end
 
+        def extract_value_from_default(default)
+          case default
+          when String
+            default.gsub("''", "'")
+          else
+            default
+          end
+        end
+
         def extract_limit(sql_type) #:nodoc:
           case sql_type
           when /^bigint/i

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -341,7 +341,7 @@ describe "OracleEnhancedConnection" do
     it "should execute prepared statement with decimal bind parameter " do
       cursor = @conn.prepare("INSERT INTO test_employees VALUES(:1)")
       type_metadata = ActiveRecord::ConnectionAdapters::SqlTypeMetadata.new(sql_type: "NUMBER", type: :decimal, limit: 10, precision: nil, scale: 2)
-      column = ActiveRecord::ConnectionAdapters::OracleEnhanced::Column.new("age", nil, type_metadata, false, "test_employees", false, nil)
+      column = ActiveRecord::ConnectionAdapters::OracleEnhanced::Column.new("age", nil, type_metadata, false, "test_employees", nil)
       expect(column.type).to eq(:decimal)
       # Here 1.5 expects that this value has been type casted already
       # it should use bind_params in the long term.


### PR DESCRIPTION
There have been some refactoring `ActiveRecord::ConnectionAdapters::OracleEnhanced::Column` made. Now refactoring for  `virtual` type support remains.

This pull request is work in progress one. The main problem so far is `fetch_type_metadata` does not return ` ActiveRecord::ConnectionAdapters::OracleEnhanced::TypeMetadata` including `virtual` then it cannot handle `virtual` which used to be inside `ActiveRecord::ConnectionAdapters::OracleEnhanced::Column`.