### PR TITLE
Remove `lengths`, `where`, `using` from `IndexDefinition`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -41,11 +41,11 @@ module ActiveRecord
       class IndexDefinition < ActiveRecord::ConnectionAdapters::IndexDefinition
         attr_accessor :parameters, :statement_parameters, :tablespace
 
-        def initialize(table, name, unique, columns, lengths, orders, where, type, using, parameters, statement_parameters, tablespace)
+        def initialize(table, name, unique, columns, orders, type, parameters, statement_parameters, tablespace)
           @parameters = parameters
           @statement_parameters = statement_parameters
           @tablespace = tablespace
-          super(table, name, unique, columns, lengths: lengths, orders: orders, where: where, type: type, using: using)
+          super(table, name, unique, columns, orders: orders, type: type)
         end
       end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -618,10 +618,7 @@ module ActiveRecord
               row["uniqueness"] == "UNIQUE",
               [],
               nil,
-              nil,
-              nil,
               row["index_type"] == "DOMAIN" ? "#{row['ityp_owner']}.#{row['ityp_name']}" : nil,
-              nil,
               row["parameters"],
               statement_parameters,
               row["tablespace_name"] == default_tablespace_name ? nil : row["tablespace_name"])


### PR DESCRIPTION
Remove `lengths`, `where`, `using` from `OracleEnhanced::IndexDefinition`
because Oracle database does not support these options for indexes.

Meaning of each option from MySQL and PostgreSQL point of view:

- lengths

https://dev.mysql.com/doc/refman/5.7/en/create-index.html

> For string columns, indexes can be created that use only the leading part of column values, using col_name(length) syntax to specify an index prefix length:

- `where`

https://www.postgresql.org/docs/10/static/sql-createindex.html

> predicate
> The constraint expression for a partial index.

- `using

https://dev.mysql.com/doc/refman/5.7/en/create-index.html

> index_type

> Some storage engines permit you to specify an index type when creating an index.

Note: `orders` is not used by Oracle enhanced adapter but Oracle database itself supports it.

- orders

https://docs.oracle.com/database/121/SQLRF/statements_5013.htm#SQLRF01209

> ASC | DESC

> Use ASC or DESC to indicate whether the index should be created in ascending or descending order. Indexes on character data are created in ascending or descending order of the character values in the database character set.