### PR TITLE
Use bundler 1.16.0.preX and update rubygems to the latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ before_install:
   - chmod +x .travis/setup_accounts.sh
 
 install:
-  - "gem install bundler"
+  - "travis_retry gem update --system"
+  - "travis_retry gem install bundler --pre --force"
   - .travis/oracle/download.sh
   - .travis/oracle/install.sh
   - .travis/setup_accounts.sh


### PR DESCRIPTION
```ruby
The latest bundler is 1.16.0.pre.3, but you are currently running 1.15.4.
To update, run `gem install bundler --pre`
```
`--force` option added to replace pre-installed bundler for ruby-head