### PR TITLE
These methods are private in `AbstractAdapter` or `PostgreSQLAdapter`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -774,7 +774,7 @@ module ActiveRecord
         select_value("SELECT temporary FROM all_tables WHERE table_name = :table_name and owner = SYS_CONTEXT('userenv', 'session_user')", "temp tables", [bind_string("table_name", table_name.upcase)]) == "Y"
       end
 
-      protected
+      private
 
         def initialize_type_map(m = type_map)
           super
@@ -843,8 +843,6 @@ module ActiveRecord
             super
           end
         end
-
-      private
 
         # create bind object for type String
         def bind_string(name, value)


### PR DESCRIPTION
```ruby
`initialize_type_map(m = type_map)`
`extract_value_from_default(default)`
`extract_limit(sql_type)`
`translate_exception(exception, message)`
```