### PR TITLE
Show correct bind value information in debug.log

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -261,24 +261,20 @@ describe "OracleEnhancedAdapter" do
     end
 
     it "should clear older cursors when statement limit is reached" do
-      pk = TestPost.columns_hash[TestPost.primary_key]
-      sub = Arel::Nodes::BindParam.new(nil).to_sql
-      binds = [ActiveRecord::Relation::QueryAttribute.new(pk, 1, ActiveRecord::Type::Integer.new)]
+      binds = [ActiveRecord::Relation::QueryAttribute.new("id", 1, ActiveRecord::OracleEnhanced::Type::Integer.new)]
       # free statement pool from dictionary selections  to ensure next selects will increase statement pool
       @statements.clear
       expect {
         4.times do |i|
-          @conn.exec_query("SELECT * FROM test_posts WHERE #{i}=#{i} AND id = #{sub}", "SQL", binds)
+          @conn.exec_query("SELECT * FROM test_posts WHERE #{i}=#{i} AND id = :id", "SQL", binds)
         end
       }.to change(@statements, :length).by(+3)
     end
 
     it "should cache UPDATE statements with bind variables" do
       expect {
-        pk = TestPost.columns_hash[TestPost.primary_key]
-        sub = Arel::Nodes::BindParam.new(nil).to_sql
-        binds = [ActiveRecord::Relation::QueryAttribute.new(pk, 1, ActiveRecord::Type::Integer.new)]
-        @conn.exec_update("UPDATE test_posts SET id = #{sub}", "SQL", binds)
+        binds = [ActiveRecord::Relation::QueryAttribute.new("id", 1, ActiveRecord::OracleEnhanced::Type::Integer.new)]
+        @conn.exec_update("UPDATE test_posts SET id = :id", "SQL", binds)
       }.to change(@statements, :length).by(+1)
     end
 


### PR DESCRIPTION
Use ` ActiveRecord::OracleEnhanced::Type::Integer` not `ActiveRecord::Type::Integer`

* Steps to reproduce
```ruby
$ bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:238
$ tail -f debug.log
```
* Without this commit:

```ruby
  SQL (3.8ms)  SELECT * FROM test_posts WHERE 0=0 AND id = :a1  [[#<ActiveRecord::ConnectionAdapters::OracleEnhanced::Column:0x0000564f63b3e9b8 @name="id", @table_name="test_posts", @sql_type_metadata=#<ActiveRecord::ConnectionAdapters::SqlTypeMetadata:0x0000564f63b3eb20 @sql_type="NUMBER(38)", @type=:integer, @limit=38, @precision=38, @scale=nil>, @null=false, @default=nil, @default_function=nil, @collation=nil, @comment=nil>, 1]]
  SQL (1.9ms)  SELECT * FROM test_posts WHERE 1=1 AND id = :a1  [[#<ActiveRecord::ConnectionAdapters::OracleEnhanced::Column:0x0000564f63b3e9b8 @name="id", @table_name="test_posts", @sql_type_metadata=#<ActiveRecord::ConnectionAdapters::SqlTypeMetadata:0x0000564f63b3eb20 @sql_type="NUMBER(38)", @type=:integer, @limit=38, @precision=38, @scale=nil>, @null=false, @default=nil, @default_function=nil, @collation=nil, @comment=nil>, 1]]
  SQL (1.6ms)  SELECT * FROM test_posts WHERE 2=2 AND id = :a1  [[#<ActiveRecord::ConnectionAdapters::OracleEnhanced::Column:0x0000564f63b3e9b8 @name="id", @table_name="test_posts", @sql_type_metadata=#<ActiveRecord::ConnectionAdapters::SqlTypeMetadata:0x0000564f63b3eb20 @sql_type="NUMBER(38)", @type=:integer, @limit=38, @precision=38, @scale=nil>, @null=false, @default=nil, @default_function=nil, @collation=nil, @comment=nil>, 1]]
  SQL (1.6ms)  SELECT * FROM test_posts WHERE 3=3 AND id = :a1  [[#<ActiveRecord::ConnectionAdapters::OracleEnhanced::Column:0x0000564f63b3e9b8 @name="id", @table_name="test_posts", @sql_type_metadata=#<ActiveRecord::ConnectionAdapters::SqlTypeMetadata:0x0000564f63b3eb20 @sql_type="NUMBER(38)", @type=:integer, @limit=38, @precision=38, @scale=nil>, @null=false, @default=nil, @default_function=nil, @collation=nil, @comment=nil>, 1]]
  SQL (3.7ms)  UPDATE test_posts SET id = :a1  [[#<ActiveRecord::ConnectionAdapters::OracleEnhanced::Column:0x0000564f63b3e9b8 @name="id", @table_name="test_posts", @sql_type_metadata=#<ActiveRecord::ConnectionAdapters::SqlTypeMetadata:0x0000564f63b3eb20 @sql_type="NUMBER(38)", @type=:integer, @limit=38, @precision=38, @scale=nil>, @null=false, @default=nil, @default_function=nil, @collation=nil, @comment=nil>, 1]]
```

* With this commit:

```ruby
  SQL (3.8ms)  SELECT * FROM test_posts WHERE 0=0 AND id = :id  [["id", 1]]
  SQL (1.8ms)  SELECT * FROM test_posts WHERE 1=1 AND id = :id  [["id", 1]]
  SQL (1.6ms)  SELECT * FROM test_posts WHERE 2=2 AND id = :id  [["id", 1]]
  SQL (1.8ms)  SELECT * FROM test_posts WHERE 3=3 AND id = :id  [["id", 1]]
  SQL (3.5ms)  UPDATE test_posts SET id = :id  [["id", 1]]
```

Also, this test introduces some hard code into specs:

- Hard code primary key column name "id"
- Hard code bind parameter name :id

This makes test code simpler and these look-ups are out of scope of these specs.