### PR TITLE
Address explain with binds errors #908 #1386

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -312,13 +312,10 @@ describe "OracleEnhancedAdapter" do
     end
 
     it "should explain query with binds" do
-      skip "Skip until further investigation made for #908 JRuby and #1386 for CRuby"
-      pk = TestPost.columns_hash[TestPost.primary_key]
-      sub = Arel::Nodes::BindParam.new.to_sql
-      binds = [ActiveRecord::Relation::QueryAttribute.new(pk, 1, ActiveRecord::Type::Integer.new)]
-      explain = @conn.explain(TestPost.where(TestPost.arel_table[pk.name].eq(sub)), binds)
+      binds = [ActiveRecord::Relation::QueryAttribute.new("id", 1, ActiveRecord::OracleEnhanced::Type::Integer.new)]
+      explain = TestPost.where(id: binds).explain
       expect(explain).to include("Cost")
-      expect(explain).to include("INDEX UNIQUE SCAN")
+      expect(explain).to include("INDEX UNIQUE SCAN").or include("TABLE ACCESS FULL")
     end
   end
 


### PR DESCRIPTION
Address explain with binds errors #908 #1386

Also allow "TABLE ACCESS FULL" operation since Oracle may choose this
plan as follows.

```ruby
$ bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:318
==> Loading config from ENV or use default
==> Running specs with MRI version 2.4.2
==> Effective ActiveRecord version 5.2.0.alpha
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb"=>[318]}}
F

Failures:

  1) OracleEnhancedAdapter explain should explain query with binds
     Failure/Error: expect(explain).to include("INDEX UNIQUE SCAN")

       expected EXPLAIN for: SELECT "TEST_POSTS".* FROM "TEST_POSTS" WHERE "TEST_POSTS"."ID" IS NULL
       Plan hash value:...  1 - filter(NULL IS NOT NULL)

       Note
       -----
          - dynamic statistics used: dynamic sampling (level=2) to include "INDEX UNIQUE SCAN"
       Diff:
       @@ -1,2 +1,20 @@
       -INDEX UNIQUE SCAN
       +EXPLAIN for: SELECT "TEST_POSTS".* FROM "TEST_POSTS" WHERE "TEST_POSTS"."ID" IS NULL
       +Plan hash value: 3025710980
       +
       +---------------------------------------------------------------------------------
       +| Id  | Operation          | Name       | Rows  | Bytes | Cost (%CPU)| Time     |
       +---------------------------------------------------------------------------------
       +|   0 | SELECT STATEMENT   |            |     1 |    13 |     0   (0)|          |
       +|*  1 |  FILTER            |            |       |       |            |          |
       +|   2 |   TABLE ACCESS FULL| TEST_POSTS |     1 |    13 |     2   (0)| 00:00:01 |
       +---------------------------------------------------------------------------------
       +
       +Predicate Information (identified by operation id):
       +---------------------------------------------------
       +
       +   1 - filter(NULL IS NOT NULL)
       +
       +Note
       +-----
       +   - dynamic statistics used: dynamic sampling (level=2)
```