### PR TITLE
Suppress `DEPRECATION WARNING: Dangerous query method`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/context_index.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/context_index.rb
@@ -332,7 +332,7 @@ module ActiveRecord
             def contains(column, query, options = {})
               score_label = options[:label].to_i || 1
               where("CONTAINS(#{connection.quote_table_name(column)}, ?, #{score_label}) > 0", query).
-                order("SCORE(#{score_label}) DESC")
+                order(Arel.sql("SCORE(#{score_label}) DESC"))
             end
           end
       end


### PR DESCRIPTION
This pull request has been created for some more discussion in advance in case rails/rails/#27947 merged to master.

It is easy to suppress `DEPRECATION WARNING: Dangerous query method` by adding `Arel.sql` but I am not sure if it is a better way to implement it.