### PR TITLE
Rename `ActiveRecord::OracleEnhanced::Type` to `ActiveRecord::Type::OracleEnhanced`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -79,7 +79,7 @@ module ActiveRecord
         def sql_for_insert(sql, pk, id_value, sequence_name, binds)
           unless id_value || pk == false || pk.nil? ||  pk.is_a?(Array)
             sql = "#{sql} RETURNING #{quote_column_name(pk)} INTO :returning_id"
-            (binds = binds.dup) << ActiveRecord::Relation::QueryAttribute.new("returning_id", nil, ActiveRecord::OracleEnhanced::Type::Integer.new)
+            (binds = binds.dup) << ActiveRecord::Relation::QueryAttribute.new("returning_id", nil, Type::OracleEnhanced::Integer.new)
           end
           super
         end

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -359,7 +359,7 @@ module ActiveRecord
               @raw_statement.setClob(position, value)
             when Java::OracleSql::NCLOB
               @raw_statement.setClob(position, value)
-            when ActiveRecord::OracleEnhanced::Type::Raw
+            when Type::OracleEnhanced::Raw
               @raw_statement.setString(position, OracleEnhanced::Quoting.encode_raw(value))
             when String
               @raw_statement.setString(position, value)

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_quoting.rb
@@ -10,11 +10,11 @@ module ActiveRecord
             blob = Java::OracleSql::BLOB.createTemporary(@connection.raw_connection, false, Java::OracleSql::BLOB::DURATION_SESSION)
             blob.setBytes(1, value.to_s.to_java_bytes)
             blob
-          when ActiveRecord::OracleEnhanced::Type::Text::Data
+          when Type::OracleEnhanced::Text::Data
             clob = Java::OracleSql::CLOB.createTemporary(@connection.raw_connection, false, Java::OracleSql::CLOB::DURATION_SESSION)
             clob.setString(1, value.to_s)
             clob
-          when ActiveRecord::OracleEnhanced::Type::NationalCharacterText::Data
+          when Type::OracleEnhanced::NationalCharacterText::Data
             clob = Java::OracleSql::NCLOB.createTemporary(@connection.raw_connection, false, Java::OracleSql::NCLOB::DURATION_SESSION)
             clob.setString(1, value.to_s)
             clob

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -136,7 +136,7 @@ module ActiveRecord
 
           def bind_param(position, value)
             case value
-            when ActiveRecord::OracleEnhanced::Type::Raw
+            when Type::OracleEnhanced::Raw
               @raw_cursor.bind_param(position, OracleEnhanced::Quoting.encode_raw(value))
             when ActiveModel::Type::Decimal
               @raw_cursor.bind_param(position, BigDecimal.new(value.to_s))

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_quoting.rb
@@ -12,13 +12,13 @@ module ActiveRecord
             ora_value = bind_type.new(@connection.raw_oci_connection, lob_value)
             ora_value.size = 0 if value == ""
             ora_value
-          when ActiveRecord::OracleEnhanced::Type::Text::Data
+          when Type::OracleEnhanced::Text::Data
             lob_value = value.to_s == "" ? " " : value.to_s
             bind_type = OCI8::CLOB
             ora_value = bind_type.new(@connection.raw_oci_connection, lob_value)
             ora_value.size = 0 if value.to_s == ""
             ora_value
-          when ActiveRecord::OracleEnhanced::Type::NationalCharacterText::Data
+          when Type::OracleEnhanced::NationalCharacterText::Data
             lob_value = value.to_s == "" ? " " : value.to_s
             bind_type = OCI8::NCLOB
             ora_value = bind_type.new(@connection.raw_oci_connection, lob_value)

--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -93,13 +93,13 @@ module ActiveRecord
 
         def _quote(value) #:nodoc:
           case value
-          when ActiveRecord::OracleEnhanced::Type::NationalCharacterString::Data then
+          when Type::OracleEnhanced::NationalCharacterString::Data then
             "N".dup << "'#{quote_string(value.to_s)}'"
           when ActiveModel::Type::Binary::Data then
             "empty_blob()"
-          when ActiveRecord::OracleEnhanced::Type::Text::Data then
+          when Type::OracleEnhanced::Text::Data then
             "empty_clob()"
-          when ActiveRecord::OracleEnhanced::Type::NationalCharacterText::Data then
+          when Type::OracleEnhanced::NationalCharacterText::Data then
             "empty_nclob()"
           else
             super
@@ -128,14 +128,14 @@ module ActiveRecord
 
         def _type_cast(value)
           case value
-          when ActiveRecord::OracleEnhanced::Type::TimestampTz::Data, ActiveRecord::OracleEnhanced::Type::TimestampLtz::Data
+          when Type::OracleEnhanced::TimestampTz::Data, Type::OracleEnhanced::TimestampLtz::Data
             if value.acts_like?(:time)
               zone_conversion_method = ActiveRecord::Base.default_timezone == :utc ? :getutc : :getlocal
               value.respond_to?(zone_conversion_method) ? value.send(zone_conversion_method) : value
             else
               value
             end
-          when ActiveRecord::OracleEnhanced::Type::NationalCharacterString::Data
+          when Type::OracleEnhanced::NationalCharacterString::Data
             value.to_s
           else
             super

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -186,7 +186,7 @@ module ActiveRecord #:nodoc:
           end
 
           def bind_string(name, value)
-            ActiveRecord::Relation::QueryAttribute.new(name, value, ActiveRecord::OracleEnhanced::Type::String.new)
+            ActiveRecord::Relation::QueryAttribute.new(name, value, Type::OracleEnhanced::String.new)
           end
       end
     end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -47,16 +47,16 @@ require "active_record/connection_adapters/oracle_enhanced/dbms_output"
 require "active_record/connection_adapters/oracle_enhanced/type_metadata"
 require "active_record/connection_adapters/oracle_enhanced/structure_dump"
 
-require "active_record/oracle_enhanced/type/raw"
-require "active_record/oracle_enhanced/type/integer"
-require "active_record/oracle_enhanced/type/string"
-require "active_record/oracle_enhanced/type/national_character_string"
-require "active_record/oracle_enhanced/type/text"
-require "active_record/oracle_enhanced/type/national_character_text"
-require "active_record/oracle_enhanced/type/boolean"
-require "active_record/oracle_enhanced/type/json"
-require "active_record/oracle_enhanced/type/timestamptz"
-require "active_record/oracle_enhanced/type/timestampltz"
+require "active_record/type/oracle_enhanced/raw"
+require "active_record/type/oracle_enhanced/integer"
+require "active_record/type/oracle_enhanced/string"
+require "active_record/type/oracle_enhanced/national_character_string"
+require "active_record/type/oracle_enhanced/text"
+require "active_record/type/oracle_enhanced/national_character_text"
+require "active_record/type/oracle_enhanced/boolean"
+require "active_record/type/oracle_enhanced/json"
+require "active_record/type/oracle_enhanced/timestamptz"
+require "active_record/type/oracle_enhanced/timestampltz"
 
 require "digest/sha1"
 
@@ -492,7 +492,7 @@ module ActiveRecord
           value = attributes[col.name]
           # changed sequence of next two lines - should check if value is nil before converting to yaml
           next if value.blank?
-          if klass.attribute_types[col.name].is_a? ActiveRecord::Type::Serialized
+          if klass.attribute_types[col.name].is_a? Type::Serialized
             value = klass.attribute_types[col.name].serialize(value)
           end
           uncached do
@@ -790,14 +790,14 @@ module ActiveRecord
         def initialize_type_map(m = type_map)
           super
           # oracle
-          register_class_with_precision m, %r(WITH TIME ZONE)i,       ActiveRecord::OracleEnhanced::Type::TimestampTz
-          register_class_with_precision m, %r(WITH LOCAL TIME ZONE)i, ActiveRecord::OracleEnhanced::Type::TimestampLtz
-          register_class_with_limit m, %r(raw)i,            ActiveRecord::OracleEnhanced::Type::Raw
-          register_class_with_limit m, %r(char)i,           ActiveRecord::OracleEnhanced::Type::String
-          register_class_with_limit m, %r(clob)i,           ActiveRecord::OracleEnhanced::Type::Text
-          register_class_with_limit m, %r(nclob)i,           ActiveRecord::OracleEnhanced::Type::NationalCharacterText
+          register_class_with_precision m, %r(WITH TIME ZONE)i,       Type::OracleEnhanced::TimestampTz
+          register_class_with_precision m, %r(WITH LOCAL TIME ZONE)i, Type::OracleEnhanced::TimestampLtz
+          register_class_with_limit m, %r(raw)i,            Type::OracleEnhanced::Raw
+          register_class_with_limit m, %r(char)i,           Type::OracleEnhanced::String
+          register_class_with_limit m, %r(clob)i,           Type::OracleEnhanced::Text
+          register_class_with_limit m, %r(nclob)i,           Type::OracleEnhanced::NationalCharacterText
 
-          m.register_type "NCHAR", ActiveRecord::OracleEnhanced::Type::NationalCharacterString.new
+          m.register_type "NCHAR", Type::OracleEnhanced::NationalCharacterString.new
           m.alias_type %r(NVARCHAR2)i,    "NCHAR"
 
           m.register_type(%r(NUMBER)i) do |sql_type|
@@ -805,7 +805,7 @@ module ActiveRecord
             precision = extract_precision(sql_type)
             limit = extract_limit(sql_type)
             if scale == 0
-              ActiveRecord::OracleEnhanced::Type::Integer.new(precision: precision, limit: limit)
+              Type::OracleEnhanced::Integer.new(precision: precision, limit: limit)
             else
               Type::Decimal.new(precision: precision, scale: scale)
             end
@@ -813,7 +813,7 @@ module ActiveRecord
 
           if OracleEnhancedAdapter.emulate_booleans
             if OracleEnhancedAdapter.emulate_booleans_from_strings
-              m.register_type %r(^VARCHAR2\(1\))i, ActiveRecord::OracleEnhanced::Type::Boolean.new
+              m.register_type %r(^VARCHAR2\(1\))i, Type::OracleEnhanced::Boolean.new
             else
               m.register_type %r(^NUMBER\(1\))i, Type::Boolean.new
             end
@@ -857,11 +857,11 @@ module ActiveRecord
 
         # create bind object for type String
         def bind_string(name, value)
-          ActiveRecord::Relation::QueryAttribute.new(name, value, ActiveRecord::OracleEnhanced::Type::String.new)
+          ActiveRecord::Relation::QueryAttribute.new(name, value, Type::OracleEnhanced::String.new)
         end
 
-        ActiveRecord::Type.register(:boolean, ActiveRecord::OracleEnhanced::Type::Boolean, adapter: :oracleenhanced)
-        ActiveRecord::Type.register(:json, ActiveRecord::OracleEnhanced::Type::Json, adapter: :oracleenhanced)
+        ActiveRecord::Type.register(:boolean, Type::OracleEnhanced::Boolean, adapter: :oracleenhanced)
+        ActiveRecord::Type.register(:json, Type::OracleEnhanced::Json, adapter: :oracleenhanced)
     end
   end
 end

--- a/lib/active_record/type/oracle_enhanced/boolean.rb
+++ b/lib/active_record/type/oracle_enhanced/boolean.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module ActiveRecord
-  module OracleEnhanced
-    module Type
+  module Type
+    module OracleEnhanced
       class Boolean < ActiveModel::Type::Boolean # :nodoc:
         private
 

--- a/lib/active_record/type/oracle_enhanced/integer.rb
+++ b/lib/active_record/type/oracle_enhanced/integer.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module ActiveRecord
-  module OracleEnhanced
-    module Type
+  module Type
+    module OracleEnhanced
       class Integer < ActiveModel::Type::Integer # :nodoc:
         private
 

--- a/lib/active_record/type/oracle_enhanced/json.rb
+++ b/lib/active_record/type/oracle_enhanced/json.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module ActiveRecord
-  module OracleEnhanced
-    module Type
+  module Type
+    module OracleEnhanced
       class Json < ActiveRecord::Type::Json
       end
     end

--- a/lib/active_record/type/oracle_enhanced/national_character_string.rb
+++ b/lib/active_record/type/oracle_enhanced/national_character_string.rb
@@ -3,9 +3,9 @@
 require "active_model/type/string"
 
 module ActiveRecord
-  module OracleEnhanced
-    module Type
-      class NationalCharacterString < ActiveRecord::OracleEnhanced::Type::String # :nodoc:
+  module Type
+    module OracleEnhanced
+      class NationalCharacterString < ActiveRecord::Type::OracleEnhanced::String # :nodoc:
         def serialize(value)
           return unless value
           Data.new(super)

--- a/lib/active_record/type/oracle_enhanced/national_character_text.rb
+++ b/lib/active_record/type/oracle_enhanced/national_character_text.rb
@@ -3,9 +3,13 @@
 require "active_model/type/string"
 
 module ActiveRecord
-  module OracleEnhanced
-    module Type
-      class Text < ActiveRecord::Type::Text # :nodoc:
+  module Type
+    module OracleEnhanced
+      class NationalCharacterText < ActiveRecord::Type::Text # :nodoc:
+        def type
+          :ntext
+        end
+
         def changed_in_place?(raw_old_value, new_value)
           #TODO: Needs to find a way not to cast here.
           raw_old_value = cast(raw_old_value)

--- a/lib/active_record/type/oracle_enhanced/raw.rb
+++ b/lib/active_record/type/oracle_enhanced/raw.rb
@@ -3,8 +3,8 @@
 require "active_model/type/string"
 
 module ActiveRecord
-  module OracleEnhanced
-    module Type
+  module Type
+    module OracleEnhanced
       class Raw < ActiveModel::Type::String # :nodoc:
         def type
           :raw

--- a/lib/active_record/type/oracle_enhanced/string.rb
+++ b/lib/active_record/type/oracle_enhanced/string.rb
@@ -3,8 +3,8 @@
 require "active_model/type/string"
 
 module ActiveRecord
-  module OracleEnhanced
-    module Type
+  module Type
+    module OracleEnhanced
       class String < ActiveModel::Type::String # :nodoc:
         def changed?(old_value, new_value, _new_value_before_type_cast)
           if old_value.nil?

--- a/lib/active_record/type/oracle_enhanced/text.rb
+++ b/lib/active_record/type/oracle_enhanced/text.rb
@@ -3,13 +3,9 @@
 require "active_model/type/string"
 
 module ActiveRecord
-  module OracleEnhanced
-    module Type
-      class NationalCharacterText < ActiveRecord::Type::Text # :nodoc:
-        def type
-          :ntext
-        end
-
+  module Type
+    module OracleEnhanced
+      class Text < ActiveRecord::Type::Text # :nodoc:
         def changed_in_place?(raw_old_value, new_value)
           #TODO: Needs to find a way not to cast here.
           raw_old_value = cast(raw_old_value)

--- a/lib/active_record/type/oracle_enhanced/timestampltz.rb
+++ b/lib/active_record/type/oracle_enhanced/timestampltz.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module ActiveRecord
-  module OracleEnhanced
-    module Type
-      class TimestampTz < ActiveRecord::Type::DateTime
+  module Type
+    module OracleEnhanced
+      class TimestampLtz < ActiveRecord::Type::DateTime
         def type
-          :timestamptz
+          :timestampltz
         end
 
         class Data < DelegateClass(::Time) # :nodoc:

--- a/lib/active_record/type/oracle_enhanced/timestamptz.rb
+++ b/lib/active_record/type/oracle_enhanced/timestamptz.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module ActiveRecord
-  module OracleEnhanced
-    module Type
-      class TimestampLtz < ActiveRecord::Type::DateTime
+  module Type
+    module OracleEnhanced
+      class TimestampTz < ActiveRecord::Type::DateTime
         def type
-          :timestampltz
+          :timestamptz
         end
 
         class Data < DelegateClass(::Time) # :nodoc:

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -261,7 +261,7 @@ describe "OracleEnhancedAdapter" do
     end
 
     it "should clear older cursors when statement limit is reached" do
-      binds = [ActiveRecord::Relation::QueryAttribute.new("id", 1, ActiveRecord::OracleEnhanced::Type::Integer.new)]
+      binds = [ActiveRecord::Relation::QueryAttribute.new("id", 1, ActiveRecord::Type::OracleEnhanced::Integer.new)]
       # free statement pool from dictionary selections  to ensure next selects will increase statement pool
       @statements.clear
       expect {
@@ -273,7 +273,7 @@ describe "OracleEnhancedAdapter" do
 
     it "should cache UPDATE statements with bind variables" do
       expect {
-        binds = [ActiveRecord::Relation::QueryAttribute.new("id", 1, ActiveRecord::OracleEnhanced::Type::Integer.new)]
+        binds = [ActiveRecord::Relation::QueryAttribute.new("id", 1, ActiveRecord::Type::OracleEnhanced::Integer.new)]
         @conn.exec_update("UPDATE test_posts SET id = :id", "SQL", binds)
       }.to change(@statements, :length).by(+1)
     end
@@ -312,7 +312,7 @@ describe "OracleEnhancedAdapter" do
     end
 
     it "should explain query with binds" do
-      binds = [ActiveRecord::Relation::QueryAttribute.new("id", 1, ActiveRecord::OracleEnhanced::Type::Integer.new)]
+      binds = [ActiveRecord::Relation::QueryAttribute.new("id", 1, ActiveRecord::Type::OracleEnhanced::Integer.new)]
       explain = TestPost.where(id: binds).explain
       expect(explain).to include("Cost")
       expect(explain).to include("INDEX UNIQUE SCAN").or include("TABLE ACCESS FULL")


### PR DESCRIPTION
Rename `ActiveRecord::OracleEnhanced::Type` to `ActiveRecord::Type::OracleEnhanced`
and use relative path to keep the same structure with Rails and make code shorter.

Except for specs, which would get this error:

```ruby
     Failure/Error: binds = [ActiveRecord::Relation::QueryAttribute.new("id", 1, Type::OracleEnhanced::Integer.new)]

     NameError:
       uninitialized constant Type
```