### PR TITLE
Address `MigrationTest#test_create_table_with_query_from_relation` error

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -37,7 +37,7 @@ module ActiveRecord
               end
             end
             add_table_options!(create_sql, table_options(o))
-            create_sql << " AS #{@conn.to_sql(o.as)}" if o.as
+            create_sql << " AS #{to_sql(o.as)}" if o.as
             create_sql
           end
 


### PR DESCRIPTION
Address `MigrationTest#test_create_table_with_query_from_relation` error and suppress `DEPRECATION WARNING: Delegating ast to arel is deprecated
and will be removed in Rails 6.0. `

### Steps to reproduce:

```ruby
$ ARCONN=oracle bin/test test/cases/migration_test.rb:518
Using oracle
Run options: --seed 37268

# Running:

DEPRECATION WARNING: Delegating ast to arel is deprecated and will be removed in Rails 6.0. (called from visit_TableDefinition at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb:40)
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:23:in `to_sql_and_binds'
  /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:13:in `to_sql'
  /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb:40:in `visit_TableDefinition'
  /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:16:in `accept'
  /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:78:in `create_table'
  /home/yahonda/git/rails/activerecord/test/cases/migration_test.rb:518:in `test_create_table_with_query_from_relation'
  /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/minitest-5.10.3/lib/minitest/test.rb:107:in `block (3 levels) in run'
  /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/minitest-5.10.3/lib/minitest/test.rb:204:in `capture_exceptions'
  /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/minitest-5.10.3/lib/minitest/test.rb:104:in `block (2 levels) in run'
  /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/minitest-5.10.3/lib/minitest/test.rb:255:in `time_it'
  /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/minitest-5.10.3/lib/minitest/test.rb:103:in `block in run'
  /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/minitest-5.10.3/lib/minitest.rb:350:in `on_signal'
  /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/minitest-5.10.3/lib/minitest/test.rb:275:in `with_info_handler'
  /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/minitest-5.10.3/lib/minitest/test.rb:102:in `run'
  /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/minitest-5.10.3/lib/minitest.rb:839:in `run_one_method'
  /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/minitest-5.10.3/lib/minitest.rb:324:in `run_one_method'
  /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/minitest-5.10.3/lib/minitest.rb:311:in `block (2 levels) in run'
  /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/minitest-5.10.3/lib/minitest.rb:310:in `each'
  /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/minitest-5.10.3/lib/minitest.rb:310:in `block in run'
  /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/minitest-5.10.3/lib/minitest.rb:350:in `on_signal'
  /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/minitest-5.10.3/lib/minitest.rb:337:in `with_info_handler'
  /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/minitest-5.10.3/lib/minitest.rb:309:in `run'
  /home/yahonda/git/rails/railties/lib/rails/test_unit/line_filtering.rb:10:in `run'
  /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/minitest-5.10.3/lib/minitest.rb:159:in `block in __run'
  /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/minitest-5.10.3/lib/minitest.rb:159:in `map'
  /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/minitest-5.10.3/lib/minitest.rb:159:in `__run'
  /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/minitest-5.10.3/lib/minitest.rb:136:in `run'
  /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/minitest-5.10.3/lib/minitest.rb:63:in `block in autorun'
E

Finished in 0.863417s, 1.1582 runs/s, 0.0000 assertions/s.

  1) Error:
MigrationTest#test_create_table_with_query_from_relation:
ActiveRecord::StatementInvalid: OCIError: ORA-01027: bind variables not allowed for data definition operations: CREATE TABLE "TABLE_FROM_QUERY_TESTINGS"  AS SELECT "PEOPLE"."ID" FROM "PEOPLE" WHERE "PEOPLE"."ID" = :a1
    stmt.c:243:in oci8lib_250.so
    /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/ruby-oci8-2.2.4.1/lib/oci8/cursor.rb:130:in `exec'
    /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/ruby-oci8-2.2.4.1/lib/oci8/oci8.rb:277:in `exec_internal'
    /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/ruby-oci8-2.2.4.1/lib/oci8/oci8.rb:268:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:442:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:97:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:13:in `block in execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:558:in `block (2 levels) in log'
    /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/2.5.0/monitor.rb:226:in `mon_synchronize'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:557:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:548:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/dbms_output.rb:36:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:13:in `execute'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:78:in `create_table'
    /home/yahonda/git/rails/activerecord/test/cases/migration_test.rb:518:in `test_create_table_with_query_from_relation'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```