### PR TITLE
Remove `OracleEnhancedAdapter.default_tablespaces[native_database_typ…

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -42,8 +42,7 @@ module ActiveRecord
           end
 
           def default_tablespace_for(type)
-            (ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[type] ||
-             ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[native_database_types[type][:name]]) rescue nil
+            OracleEnhancedAdapter.default_tablespaces[type]
           end
 
           def add_column_options!(sql, options)


### PR DESCRIPTION
Remove `OracleEnhancedAdapter.default_tablespaces[native_database_types[type][:name]]` from `default_tablespace_for`