### PR TITLE
Remove unused `require "digest/sha1"`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -58,8 +58,6 @@ require "active_record/type/oracle_enhanced/json"
 require "active_record/type/oracle_enhanced/timestamptz"
 require "active_record/type/oracle_enhanced/timestampltz"
 
-require "digest/sha1"
-
 ActiveRecord::Base.class_eval do
   class_attribute :custom_create_method, :custom_update_method, :custom_delete_method
 end


### PR DESCRIPTION
it was added for `index_name` at e10bd49ecbaa0fb0dc0e87e6b0f6e0c7d9283354

Now `index_name` method has been migrated to `schema_statements.rb`