### PR TITLE
Change log format of "Primary Key Trigger" to one line

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -608,7 +608,7 @@ module ActiveRecord
 
         trigger_name = default_trigger_name(table_name).upcase
 
-        pkt_sql = <<-SQL
+        !!select_value(<<-SQL.strip.gsub(/\s+/, " "), "Primary Key Trigger", [bind_string("owner", owner), bind_string("trigger_name", trigger_name), bind_string("owner", owner), bind_string("table_name", desc_table_name)])
           SELECT trigger_name
           FROM all_triggers#{db_link}
           WHERE owner = :owner
@@ -617,7 +617,6 @@ module ActiveRecord
             AND table_name = :table_name
             AND status = 'ENABLED'
         SQL
-        select_value(pkt_sql, "Primary Key Trigger", [bind_string("owner", owner), bind_string("trigger_name", trigger_name), bind_string("owner", owner), bind_string("table_name", desc_table_name)]) ? true : false
       end
 
       def column_definitions(table_name)


### PR DESCRIPTION
Follow up for #1550.

## Before

The following is a "Primary Key Trigger" log output by multi line.

```console
  Primary Key Trigger (0.6ms)            SELECT trigger_name
      FROM all_triggers
      WHERE owner = :owner
       AND trigger_name = :trigger_name
       AND table_owner = :owner
       AND table_name = :table_name
       AND status = 'ENABLED'
  [["owner", "ORACLE_ENHANCED"], ["trigger_name", "POSTS_PKT"],
  ["owner", "ORACLE_ENHANCED"], ["table_name", "POSTS"]]
```

## After

The following is a "Primary Key Trigger" log output by single line.

```console
  Primary Key Trigger (0.3ms)            SELECT trigger_name FROM
  all_triggers WHERE owner = :owner AND trigger_name = :trigger_name AND
  table_owner = :owner AND table_name = :table_name AND status = 'ENABLED'
  [["owner", "ORACLE_ENHANCED"], ["trigger_name", "POSTS_PKT"],
  ["owner", "ORACLE_ENHANCED"], ["table_name", "POSTS"]]
```