### PR TITLE
Check presence of CLOB/BLOB keywords in the class name rather than checking for exact class while converting lob to ruby

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -567,14 +567,15 @@ module ActiveRecord
       private
 
       def lob_to_ruby_value(val)
-        case val
-        when ::Java::OracleSql::CLOB
+        klass_name = val.class.name
+
+        if klass_name.include?('CLOB')
           if val.isEmptyLob
             nil
           else
             val.getSubString(1, val.length)
           end
-        when ::Java::OracleSql::BLOB
+        elsif klass_name.include?('BLOB')
           if val.isEmptyLob
             nil
           else


### PR DESCRIPTION
In Weblogic 12c, the class name for CLOB is `Java::WeblogicJdbcWrapper::Clob_oracle_sql_CLOB`. Matching exact class can make it unstable. 