### PR TITLE
Remove `OracleEnhanced::Connection#select_values`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -92,13 +92,6 @@ module ActiveRecord
             result.values.first
           end
         end
-
-        # Returns an array of the values of the first column in a select:
-        #   select_values("SELECT id FROM companies LIMIT 3") => [1,2,3]
-        def select_values(arel, name = nil, binds = [])
-          result = select(arel, name = nil)
-          result.map { |r| r.values.first }
-        end
       end
 
       # Returns array with major and minor version of database (e.g. [12, 1])


### PR DESCRIPTION
Remove `ActiveRecord ConnectionAdapters::OracleEnhanced::Connection#select_values`
to use `ActiveRecord::ConnectionAdapters::DatabaseStatements#select_values`.

As of right now, other similar methods are kept as they are.

- `ActiveRecord ConnectionAdapters::OracleEnhanced::Connection#select_one`
- `ActiveRecord ConnectionAdapters::OracleEnhanced::Connection#select_value` (without trailing `s`)

One of the reasons is when it is called
from `ActiveRecord::ConnectionAdapters::OracleEnhanced::Connection` class object as follows,
it is unable to call `ActiveRecord::ConnectionAdapters::DatabaseStatements#select_value` as super.

i.e.
```ruby
  it "should use database default cursor_sharing parameter value exact by default" do
    # Use `SYSTEM_CONNECTION_PARAMS` to query v$parameter
    conn = ActiveRecord::ConnectionAdapters::OracleEnhanced::Connection.create(SYSTEM_CONNECTION_PARAMS)
    expect(conn.select_value("select value from v$parameter where name = 'cursor_sharing'")).to eq("EXACT")
  end
```