### PR TITLE
Modularize `OracleEnhanced::Connection` class

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   module ConnectionAdapters
     # interface independent methods
     module OracleEnhanced
-      class Connection #:nodoc:
+      module Connection #:nodoc:
         def self.create(config)
           case ORACLE_ENHANCED_CONNECTION
           when :oci
@@ -94,10 +94,6 @@ module ActiveRecord
         end
       end
 
-      # Returns array with major and minor version of database (e.g. [12, 1])
-      def database_version
-        raise NoMethodError, "Not implemented for this raw driver"
-      end
       class ConnectionException < StandardError #:nodoc:
       end
     end

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -51,7 +51,9 @@ module ActiveRecord
   module ConnectionAdapters
     # JDBC database interface for JRuby
     module OracleEnhanced
-      class JDBCConnection < OracleEnhanced::Connection #:nodoc:
+      class JDBCConnection #:nodoc:
+        include OracleEnhanced::Connection
+
         attr_accessor :active
         alias :active? :active
 
@@ -324,7 +326,7 @@ module ActiveRecord
         end
 
         def database_version
-          @database_version ||= (md = raw_connection.getMetaData) && [md.getDatabaseMajorVersion, md.getDatabaseMinorVersion]
+          (md = raw_connection.getMetaData) && [md.getDatabaseMajorVersion, md.getDatabaseMinorVersion]
         end
 
         class Cursor

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -26,7 +26,9 @@ module ActiveRecord
   module ConnectionAdapters
     # OCI database interface for MRI
     module OracleEnhanced
-      class OCIConnection < OracleEnhanced::Connection #:nodoc:
+      class OCIConnection
+        include OracleEnhanced::Connection #:nodoc:
+
         def initialize(config)
           @raw_connection = OCI8EnhancedAutoRecover.new(config, OracleEnhancedOCIFactory)
           # default schema owner
@@ -267,7 +269,7 @@ module ActiveRecord
         end
 
         def database_version
-          @database_version ||= (version = raw_connection.oracle_server_version) && [version.major, version.minor]
+          (version = raw_connection.oracle_server_version) && [version.major, version.minor]
         end
 
       private


### PR DESCRIPTION
Modularize `ActiveRecord::ConnectionAdapters::OracleEnhanced::Connection` class

`OracleEnhanced::Connection` class itself does not create connections by itself.
It mainly just handles if ruby runtime is CRuby or JRuby then
creates `OracleEnhanced::OCIConnection` or `OracleEnhanced::JDBCConnection` instances.

Also, there is almost unnecessary to create `Connection#database_version`.
Just let each `OracleEnhanced::OCIConnection` and `OracleEnhanced::JDBCConnection`
class includes `OracleEnhanced::Connection` module and implement
their own `database_version` methods.