### PR TITLE
Rename `OracleEnhanced::Connection#oracle_downcase` to `_oracle_downc…

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -18,17 +18,6 @@ module ActiveRecord
 
         attr_reader :raw_connection
 
-        # Oracle column names by default are case-insensitive, but treated as upcase;
-        # for neatness, we'll downcase within Rails. EXCEPT that folks CAN quote
-        # their column names when creating Oracle tables, which makes then case-sensitive.
-        # I don't know anybody who does this, but we'll handle the theoretical case of a
-        # camelCase column name. I imagine other dbs handle this different, since there's a
-        # unit test that's currently failing test_oci.
-        def oracle_downcase(column_name)
-          return nil if column_name.nil?
-          column_name =~ /[a-z]/ ? column_name : column_name.downcase
-        end
-
         # Used always by JDBC connection as well by OCI connection when describing tables over database link
         def describe(name)
           name = name.to_s
@@ -80,6 +69,24 @@ module ActiveRecord
         end
 
         private
+
+          # Oracle column names by default are case-insensitive, but treated as upcase;
+          # for neatness, we'll downcase within Rails. EXCEPT that folks CAN quote
+          # their column names when creating Oracle tables, which makes then case-sensitive.
+          # I don't know anybody who does this, but we'll handle the theoretical case of a
+          # camelCase column name. I imagine other dbs handle this different, since there's a
+          # unit test that's currently failing test_oci.
+          #
+          # `_oracle_downcase` is expected to be called only from
+          # `ActiveRecord::ConnectionAdapters::OracleEnhanced::OCIConnection`
+          # or `ActiveRecord::ConnectionAdapters::OracleEnhanced::JDBCConnection`.
+          # Other method should call `ActiveRecord:: ConnectionAdapters::OracleEnhanced::Quoting#oracle_downcase`
+          # since this is kind of quoting, not connection.
+          # To avoid it is called from anywhere else, added _ at the beginning of the method name.
+          def _oracle_downcase(column_name)
+            return nil if column_name.nil?
+            column_name =~ /[a-z]/ ? column_name : column_name.downcase
+          end
 
           # _select_one and _select_value methods are expected to be called
           # only from `ActiveRecord::ConnectionAdapters::OracleEnhanced::Connection#describe`

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -462,7 +462,7 @@ module ActiveRecord
           column_count = metadata.getColumnCount
 
           cols_types_index = (1..column_count).map do |i|
-            col_name = oracle_downcase(metadata.getColumnName(i))
+            col_name = _oracle_downcase(metadata.getColumnName(i))
             next if col_name == "raw_rnum_"
             column_hash[col_name] = nil
             [col_name, metadata.getColumnTypeName(i).to_sym, i]

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -186,7 +186,7 @@ module ActiveRecord
           cols = []
           # Ignore raw_rnum_ which is used to simulate LIMIT and OFFSET
           cursor.get_col_names.each do |col_name|
-            col_name = oracle_downcase(col_name)
+            col_name = _oracle_downcase(col_name)
             cols << col_name unless col_name == "raw_rnum_"
           end
           # Reuse the same hash for all rows

--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -145,7 +145,8 @@ module ActiveRecord
         private
 
           def oracle_downcase(column_name)
-            @connection.oracle_downcase(column_name)
+            return nil if column_name.nil?
+            column_name =~ /[a-z]/ ? column_name : column_name.downcase
           end
       end
     end


### PR DESCRIPTION
Rename `OracleEnhanced::Connection#oracle_downcase` to `_oracle_downcase`

`_oracle_downcase` is expected to be called only from `ActiveRecord::ConnectionAdapters::OracleEnhanced::OCIConnection` or `ActiveRecord::ConnectionAdapters::OracleEnhanced::JDBCConnection`.

Other method should call `ActiveRecord:: ConnectionAdapters::OracleEnhanced::Quoting#oracle_downcase`
since this is kind of quoting, not connection.
To avoid it is called from anywhere else, added _ at the beginning of the method name.