### PR TITLE
Make `OracleEnhanced::Connection#describe` private

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -494,6 +494,11 @@ module ActiveRecord
           end
         end
 
+        # To allow private method called from `JDBCConnection`
+        def describe(name)
+          super
+        end
+
         # Return NativeException / java.sql.SQLException error code
         def error_code(exception)
           case exception


### PR DESCRIPTION
which is only called from its subclasses of `OracleEnhanced::Connection`

`describe` method may be appropriate to move to `OracleEnhanced::SchemaStatements`
which has `table_exists?` or similar methods.

but I'd like to postpone this decision. Just make it private now.