### PR TITLE
Use `ActiveSupport.on_load` to hook into `ActiveRecord::Base`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/lob.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/lob.rb
@@ -41,4 +41,6 @@ module ActiveRecord #:nodoc:
   end
 end
 
-ActiveRecord::Base.send(:include, ActiveRecord::ConnectionAdapters::OracleEnhanced::Lob)
+ActiveSupport.on_load(:active_record) do
+  ActiveRecord::Base.send(:include, ActiveRecord::ConnectionAdapters::OracleEnhanced::Lob)
+end


### PR DESCRIPTION
Refer https://github.com/rails/rails/issues/23589
and https://github.com/plataformatec/devise/commit/c2c74b0a39238e7d997486814a1c8f75fdaf276f

Follow up #1547