### PR TITLE
Remove `OCIConnection#typecast_result_value` handling `OraNumber`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -247,9 +247,6 @@ module ActiveRecord
           when Float, BigDecimal
             # return Integer if value is integer (to avoid issues with _before_type_cast values for id attributes)
             value == (v_to_i = value.to_i) ? v_to_i : value
-          when OraNumber
-            # change OraNumber value (returned in early versions of ruby-oci8 2.0.x) to BigDecimal
-            value == (v_to_i = value.to_i) ? v_to_i : BigDecimal.new(value.to_s)
           when OCI8::LOB
             if get_lob_value
               data = value.read || ""     # if value.read returns nil, then we have an empty_clob() i.e. an empty string


### PR DESCRIPTION
since ruby-oci8 2.0.4 returns BigDecimal.

Refer:
https://github.com/rsim/oracle-enhanced/commit/ce42b6ee9022bd0d723416440f7b447a6abe7d71
https://github.com/kubo/ruby-oci8/commit/76eb8f7b80e58e0f72a7c7d0bcdc9ecf475858f8