### PR TITLE
Remove `OCIConnection#returning_clause` and `JDBCConnection#returning…

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -278,10 +278,6 @@ module ActiveRecord
           s.close rescue nil
         end
 
-        def returning_clause(quoted_pk)
-          " RETURNING #{quoted_pk} INTO ?"
-        end
-
         # execute sql with RETURNING ... INTO :insert_id
         # and return :insert_id value
         def exec_with_returning(sql)

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -97,10 +97,6 @@ module ActiveRecord
           @raw_connection.exec(sql, *bindvars, &block)
         end
 
-        def returning_clause(quoted_pk)
-          " RETURNING #{quoted_pk} INTO :insert_id"
-        end
-
         # execute sql with RETURNING ... INTO :insert_id
         # and return :insert_id value
         def exec_with_returning(sql)


### PR DESCRIPTION
…_clause`

which have not been called since https://github.com/rsim/oracle-enhanced/commit/6b0f427ec0d81ab28cd2833aa95e1e6bcb42dda0
Refer #890