### PR TITLE
Restore calling `OCIConnection#bind_returning_param`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -111,7 +111,7 @@ module ActiveRecord
               if sql =~ /:returning_id/
                 # it currently expects that returning_id comes last part of binds
                 returning_id_index = binds.size
-                cursor.bind_returning_param(returning_id_index, Integer) if ORACLE_ENHANCED_CONNECTION == :jdbc
+                cursor.bind_returning_param(returning_id_index, Integer)
               end
 
               cached = true


### PR DESCRIPTION
This method call was removed at https://github.com/rsim/oracle-enhanced/commit/35c4aa10a6a96a014f42e560c0f3486c45a1b015 then restored for JRuby only at ac0297d3c1634d35342aea263c92af2506c1df48

Considered the original implementation at https://github.com/rsim/oracle-enhanced/commit/d4128fa41e169f41c5afa52a770e3dc98c9b418e , it should be called on both JRuby and CRuby