### PR TITLE
Add these errors to be recognized as `ActiveRecord::StatementInvalid`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -672,7 +672,7 @@ module ActiveRecord
           case @connection.error_code(exception)
           when 1
             RecordNotUnique.new(message)
-          when 942, 955, 1418
+          when 900, 904, 942, 955, 1418, 17008
             ActiveRecord::StatementInvalid.new(message)
           when 1400
             ActiveRecord::NotNullViolation.new(message)


### PR DESCRIPTION
ORA-00900 "invalid SQL statement"
ORA-00904 "invalid identifier"
ORA-17008 "Closed Connection"

ORA-17008 is likely reported only with JRuby and JDBC driver.

This pull request addresses these 3 failures when tested with JRuby.

```ruby
$ ARCONN=oracle bin/test test/cases/migration/columns_test.rb:84
... snip ...
Using oracle
Run options: --seed 6074

# Running:

F

Finished in 1.606378s, 0.6225 runs/s, 0.6225 assertions/s.

  1) Failure:
ActiveRecord::Migration::ColumnsTest#test_rename_nonexistent_column [/home/yahonda/git/rails/activerecord/test/cases/migration/columns_test.rb:84]:
[ActiveRecord::StatementInvalid] exception expected, not
Class: <NativeException>
Message: <"java.sql.SQLSyntaxErrorException: ORA-00904: \"NONEXISTENT\": invalid identifier\n">
---Backtrace---
oracle/jdbc/driver/T4CTTIoer11.java:494:in `processError'
oracle/jdbc/driver/T4CTTIoer11.java:446:in `processError'
oracle/jdbc/driver/T4C8Oall.java:1054:in `processError'
oracle/jdbc/driver/T4CTTIfun.java:623:in `receive'
oracle/jdbc/driver/T4CTTIfun.java:252:in `doRPC'
oracle/jdbc/driver/T4C8Oall.java:612:in `doOALL'
oracle/jdbc/driver/T4CPreparedStatement.java:226:in `doOall8'
oracle/jdbc/driver/T4CPreparedStatement.java:59:in `doOall8'
oracle/jdbc/driver/T4CPreparedStatement.java:910:in `executeForRows'
oracle/jdbc/driver/OracleStatement.java:1119:in `doExecuteWithTimeout'
oracle/jdbc/driver/OraclePreparedStatement.java:3780:in `executeInternal'
oracle/jdbc/driver/T4CPreparedStatement.java:1343:in `executeInternal'
oracle/jdbc/driver/OraclePreparedStatement.java:3887:in `execute'
oracle/jdbc/driver/OraclePreparedStatementWrapper.java:1079:in `execute'
jdk/internal/reflect/GeneratedMethodAccessor18:-1:in `invoke'
jdk/internal/reflect/DelegatingMethodAccessorImpl.java:43:in `invoke'
java/lang/reflect/Method.java:564:in `invoke'
org/jruby/javasupport/JavaMethod.java:438:in `invokeDirectWithExceptionHandling'
org/jruby/javasupport/JavaMethod.java:302:in `invokeDirect'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:274:in `exec_no_retry'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:254:in `block in exec'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:241:in `with_retry'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:253:in `exec'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:13:in `block in execute'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:545:in `block in log'
/home/yahonda/.rbenv/versions/jruby-9.1.13.0/lib/ruby/stdlib/monitor.rb:214:in `mon_synchronize'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:544:in `block in log'
/home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:535:in `log'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/dbms_output.rb:36:in `log'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:13:in `execute'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:445:in `rename_column'
/home/yahonda/git/rails/activerecord/test/cases/migration/helper.rb:38:in `rename_column'
/home/yahonda/git/rails/activerecord/test/cases/migration/columns_test.rb:85:in `block in test_rename_nonexistent_column'
---------------

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
```


```ruby
$ ARCONN=oracle bin/test test/cases/adapter_test.rb:210
... snip ...
Using oracle
Run options: --seed 43762

# Running:

F

Finished in 0.323139s, 3.0946 runs/s, 3.0946 assertions/s.

  1) Failure:
ActiveRecord::AdapterTest#test_database_related_exceptions_are_translated_to_statement_invalid [/home/yahonda/git/rails/activerecord/test/cases/adapter_test.rb:210]:
[ActiveRecord::StatementInvalid] exception expected, not
Class: <NativeException>
Message: <"java.sql.SQLSyntaxErrorException: ORA-00900: invalid SQL statement\n">
---Backtrace---
oracle/jdbc/driver/T4CTTIoer11.java:494:in `processError'
oracle/jdbc/driver/T4CTTIoer11.java:446:in `processError'
oracle/jdbc/driver/T4C8Oall.java:1054:in `processError'
oracle/jdbc/driver/T4CTTIfun.java:623:in `receive'
oracle/jdbc/driver/T4CTTIfun.java:252:in `doRPC'
oracle/jdbc/driver/T4C8Oall.java:612:in `doOALL'
oracle/jdbc/driver/T4CPreparedStatement.java:226:in `doOall8'
oracle/jdbc/driver/T4CPreparedStatement.java:59:in `doOall8'
oracle/jdbc/driver/T4CPreparedStatement.java:910:in `executeForRows'
oracle/jdbc/driver/OracleStatement.java:1119:in `doExecuteWithTimeout'
oracle/jdbc/driver/OraclePreparedStatement.java:3780:in `executeInternal'
oracle/jdbc/driver/T4CPreparedStatement.java:1343:in `executeInternal'
oracle/jdbc/driver/OraclePreparedStatement.java:3887:in `execute'
oracle/jdbc/driver/OraclePreparedStatementWrapper.java:1079:in `execute'
jdk/internal/reflect/GeneratedMethodAccessor18:-1:in `invoke'
jdk/internal/reflect/DelegatingMethodAccessorImpl.java:43:in `invoke'
java/lang/reflect/Method.java:564:in `invoke'
org/jruby/javasupport/JavaMethod.java:438:in `invokeDirectWithExceptionHandling'
org/jruby/javasupport/JavaMethod.java:302:in `invokeDirect'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:274:in `exec_no_retry'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:254:in `block in exec'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:241:in `with_retry'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:253:in `exec'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:13:in `block in execute'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:545:in `block in log'
/home/yahonda/.rbenv/versions/jruby-9.1.13.0/lib/ruby/stdlib/monitor.rb:214:in `mon_synchronize'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:544:in `block in log'
/home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:535:in `log'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/dbms_output.rb:36:in `log'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:13:in `execute'
/home/yahonda/git/rails/activerecord/test/cases/adapter_test.rb:211:in `block in test_database_related_exceptions_are_translated_to_statement_invalid'
---------------

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```


```ruby

$ ARCONN=oracle bin/test test/cases/disconnected_test.rb:25
... snip ...
Using oracle
Run options: --seed 19882

# Running:

F

Finished in 0.138185s, 7.2367 runs/s, 7.2367 assertions/s.

  1) Failure:
TestDisconnectedAdapter#test_can't_execute_statements_while_disconnected [/home/yahonda/git/rails/activerecord/test/cases/disconnected_test.rb:25]:
[ActiveRecord::StatementInvalid] exception expected, not
Class: <NativeException>
Message: <"java.sql.SQLRecoverableException: Closed Connection">
---Backtrace---
oracle/jdbc/driver/PhysicalConnection.java:1631:in `prepareStatementInternal'
oracle/jdbc/driver/PhysicalConnection.java:1606:in `prepareStatement'
oracle/jdbc/driver/PhysicalConnection.java:1533:in `prepareStatement'
jdk/internal/reflect/GeneratedMethodAccessor11:-1:in `invoke'
jdk/internal/reflect/DelegatingMethodAccessorImpl.java:43:in `invoke'
java/lang/reflect/Method.java:564:in `invoke'
org/jruby/javasupport/JavaMethod.java:453:in `invokeDirectWithExceptionHandling'
org/jruby/javasupport/JavaMethod.java:314:in `invokeDirect'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:273:in `exec_no_retry'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:254:in `block in exec'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:241:in `with_retry'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:253:in `exec'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:13:in `block in execute'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:545:in `block in log'
/home/yahonda/.rbenv/versions/jruby-9.1.13.0/lib/ruby/stdlib/monitor.rb:214:in `mon_synchronize'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:544:in `block in log'
/home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:535:in `log'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/dbms_output.rb:36:in `log'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:13:in `execute'
/home/yahonda/git/rails/activerecord/test/cases/disconnected_test.rb:27:in `block in test_can't_execute_statements_while_disconnected'
/home/yahonda/git/rails/activesupport/lib/active_support/core_ext/kernel/reporting.rb:15:in `block in silence_warnings'
/home/yahonda/git/rails/activesupport/lib/active_support/core_ext/kernel/reporting.rb:28:in `with_warnings'
/home/yahonda/git/rails/activesupport/lib/active_support/core_ext/kernel/reporting.rb:15:in `silence_warnings'
/home/yahonda/git/rails/activerecord/test/cases/disconnected_test.rb:26:in `block in test_can't_execute_statements_while_disconnected'
---------------

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```
