### PR TITLE
Add `ORA-02289` to be recognized as `ActiveRecord::StatementInvalid`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -672,7 +672,7 @@ module ActiveRecord
           case @connection.error_code(exception)
           when 1
             RecordNotUnique.new(message)
-          when 900, 904, 942, 955, 1418, 17008
+          when 900, 904, 942, 955, 1418, 2289, 17008
             ActiveRecord::StatementInvalid.new(message)
           when 1400
             ActiveRecord::NotNullViolation.new(message)


### PR DESCRIPTION
```sql
ORA-02289: "sequence does not exist"
```

This pull request addresses the following failure with JRuby.
```ruby
$ ARCONN=oracle bin/test test/cases/migration_test.rb:577
Using oracle
Run options: --seed 35273

# Running:

F

Finished in 3.232012s, 0.3094 runs/s, 0.3094 assertions/s.

  1) Failure:
MigrationTest#test_create_table_with_custom_sequence_name [/home/yahonda/git/rails/activerecord/test/cases/migration_test.rb:577]:
[ActiveRecord::StatementInvalid] exception expected, not
Class: <NativeException>
Message: <"java.sql.SQLSyntaxErrorException: ORA-02289: sequence does not exist\n">
---Backtrace---
oracle/jdbc/driver/T4CTTIoer11.java:494:in `processError'
oracle/jdbc/driver/T4CTTIoer11.java:446:in `processError'
oracle/jdbc/driver/T4C8Oall.java:1054:in `processError'
oracle/jdbc/driver/T4CTTIfun.java:623:in `receive'
oracle/jdbc/driver/T4CTTIfun.java:252:in `doRPC'
oracle/jdbc/driver/T4C8Oall.java:612:in `doOALL'
oracle/jdbc/driver/T4CPreparedStatement.java:226:in `doOall8'
oracle/jdbc/driver/T4CPreparedStatement.java:59:in `doOall8'
oracle/jdbc/driver/T4CPreparedStatement.java:747:in `executeForDescribe'
oracle/jdbc/driver/OracleStatement.java:904:in `executeMaybeDescribe'
oracle/jdbc/driver/OracleStatement.java:1082:in `doExecuteWithTimeout'
oracle/jdbc/driver/OraclePreparedStatement.java:3780:in `executeInternal'
oracle/jdbc/driver/T4CPreparedStatement.java:1343:in `executeInternal'
oracle/jdbc/driver/OraclePreparedStatement.java:3887:in `execute'
oracle/jdbc/driver/OraclePreparedStatementWrapper.java:1079:in `execute'
java/lang/reflect/Method.java:498:in `invoke'
org/jruby/javasupport/JavaMethod.java:438:in `invokeDirectWithExceptionHandling'
org/jruby/javasupport/JavaMethod.java:302:in `invokeDirect'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:274:in `exec_no_retry'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:254:in `block in exec'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:241:in `with_retry'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:253:in `exec'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:13:in `block in execute'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:545:in `block in log'
/home/yahonda/.rbenv/versions/jruby-9.1.13.0/lib/ruby/stdlib/monitor.rb:214:in `mon_synchronize'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:544:in `block in log'
/home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:535:in `log'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/dbms_output.rb:36:in `log'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:13:in `execute'
/home/yahonda/git/rails/activerecord/test/cases/migration_test.rb:578:in `block in test_create_table_with_custom_sequence_name'
---------------

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```