### PR TITLE
Address `BasicsTest#test_clear_cache!` failure

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/type_metadata.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/type_metadata.rb
@@ -11,6 +11,22 @@ module ActiveRecord
           @type_metadata = type_metadata
           @virtual = virtual
         end
+
+        def ==(other)
+          other.is_a?(OracleEnhanced::TypeMetadata) &&
+            attributes_for_hash == other.attributes_for_hash
+        end
+        alias eql? ==
+
+        def hash
+          attributes_for_hash.hash
+        end
+
+        protected
+
+          def attributes_for_hash
+            [self.class, @type_metadata, virtual]
+          end
       end
     end
   end


### PR DESCRIPTION
by implementing `OracleEnhanced::TypeMetadata#==` and other methods.

Refer https://github.com/rails/rails/commit/158c7eb1d61a28452e0aafd1e05314352eea2749

This pull request addresses this failure:
```ruby
$ ARCONN=oracle bin/test test/cases/base_test.rb:1188
Using oracle
Run options: --seed 59553

F

Finished in 39.866759s, 0.0251 runs/s, 0.3010 assertions/s.

  1) Failure:
BasicsTest#test_clear_cache! [/home/yahonda/git/rails/activerecord/test/cases/base_test.rb:1188]:
No visible difference in the Array#inspect output.
You should look at the implementation of #== on Array or its members.
[#<ActiveRecord::ConnectionAdapters::OracleEnhanced::Column:0xXXXXXX @table_name="posts", @name="id", @collation=nil, @default_function=nil, @sql_type_metadata=#<ActiveRecord::ConnectionAdapters::SqlTypeMetadata:0xXXXXXX @limit=38, @scale=nil, @precision=38, @sql_type="NUMBER(38)", @type=:integer>, @null=false, @default=nil, @comment=nil>, #<ActiveRecord::ConnectionAdapters::OracleEnhanced::Column:0xXXXXXX @table_name="posts", @name="author_id", @collation=nil, @default_function=nil, @sql_type_metadata=#<ActiveRecord::ConnectionAdapters::SqlTypeMetadata:0xXXXXXX @limit=19, @scale=nil, @precision=19, @sql_type="NUMBER(19)", @type=:integer>, @null=true, @default=nil, @comment=nil>, #<ActiveRecord::ConnectionAdapters::OracleEnhanced::Column:0xXXXXXX @table_name="posts", @name="title", @collation=nil, @default_function=nil, @sql_type_metadata=#<ActiveRecord::ConnectionAdapters::SqlTypeMetadata:0xXXXXXX @limit=255, @scale=nil, @precision=nil, @sql_type="VARCHAR2(255)", @type=:string>, @null=false, @default=nil, @comment=nil>, #<ActiveRecord::ConnectionAdapters::OracleEnhanced::Column:0xXXXXXX @table_name="posts", @name="body", @collation=nil, @default_function=nil, @sql_type_metadata=#<ActiveRecord::ConnectionAdapters::SqlTypeMetadata:0xXXXXXX @limit=4000, @scale=nil, @precision=nil, @sql_type="VARCHAR2(4000)", @type=:string>, @null=false, @default=nil, @comment=nil>, #<ActiveRecord::ConnectionAdapters::OracleEnhanced::Column:0xXXXXXX @table_name="posts", @name="type", @collation=nil, @default_function=nil, @sql_type_metadata=#<ActiveRecord::ConnectionAdapters::SqlTypeMetadata:0xXXXXXX @limit=255, @scale=nil, @precision=nil, @sql_type="VARCHAR2(255)", @type=:string>, @null=true, @default=nil, @comment=nil>, #<ActiveRecord::ConnectionAdapters::OracleEnhanced::Column:0xXXXXXX @table_name="posts", @name="comments_count", @collation=nil, @default_function=nil, @sql_type_metadata=#<ActiveRecord::ConnectionAdapters::SqlTypeMetadata:0xXXXXXX @limit=38, @scale=nil, @precision=38, @sql_type="NUMBER(38)", @type=:integer>, @null=true, @default="0", @comment=nil>, #<ActiveRecord::ConnectionAdapters::OracleEnhanced::Column:0xXXXXXX @table_name="posts", @name="taggings_with_delete_all_count", @collation=nil, @default_function=nil, @sql_type_metadata=#<ActiveRecord::ConnectionAdapters::SqlTypeMetadata:0xXXXXXX @limit=38, @scale=nil, @precision=38, @sql_type="NUMBER(38)", @type=:integer>, @null=true, @default="0", @comment=nil>, #<ActiveRecord::ConnectionAdapters::OracleEnhanced::Column:0xXXXXXX @table_name="posts", @name="taggings_with_destroy_count", @collation=nil, @default_function=nil, @sql_type_metadata=#<ActiveRecord::ConnectionAdapters::SqlTypeMetadata:0xXXXXXX @limit=38, @scale=nil, @precision=38, @sql_type="NUMBER(38)", @type=:integer>, @null=true, @default="0", @comment=nil>, #<ActiveRecord::ConnectionAdapters::OracleEnhanced::Column:0xXXXXXX @table_name="posts", @name="tags_count", @collation=nil, @default_function=nil, @sql_type_metadata=#<ActiveRecord::ConnectionAdapters::SqlTypeMetadata:0xXXXXXX @limit=38, @scale=nil, @precision=38, @sql_type="NUMBER(38)", @type=:integer>, @null=true, @default="0", @comment=nil>, #<ActiveRecord::ConnectionAdapters::OracleEnhanced::Column:0xXXXXXX @table_name="posts", @name="tags_with_destroy_count", @collation=nil, @default_function=nil, @sql_type_metadata=#<ActiveRecord::ConnectionAdapters::SqlTypeMetadata:0xXXXXXX @limit=38, @scale=nil, @precision=38, @sql_type="NUMBER(38)", @type=:integer>, @null=true, @default="0", @comment=nil>, #<ActiveRecord::ConnectionAdapters::OracleEnhanced::Column:0xXXXXXX @table_name="posts", @name="tags_with_nullify_count", @collation=nil, @default_function=nil, @sql_type_metadata=#<ActiveRecord::ConnectionAdapters::SqlTypeMetadata:0xXXXXXX @limit=38, @scale=nil, @precision=38, @sql_type="NUMBER(38)", @type=:integer>, @null=true, @default="0", @comment=nil>]

1 runs, 12 assertions, 1 failures, 0 errors, 0 skips
```