### PR TITLE
Use Bundler 1.15 to workaround bundler/bundler#6072

### DIFF
--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+gem "bundler", "< 1.16"
+
 begin
   require "bundler/inline"
 rescue LoadError => e

--- a/guides/bug_report_templates/active_record_gem_spec.rb
+++ b/guides/bug_report_templates/active_record_gem_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+gem "bundler", "< 1.16"
+
 begin
   require "bundler/inline"
 rescue LoadError => e


### PR DESCRIPTION
Use Bundler 1.15 to workaround bundler/bundler#6072
Related to rails/rails#31039

```ruby
$ ruby -v
ruby 2.4.2p198 (2017-09-14 revision 59899) [x86_64-linux]
$ bundler -v
Bundler version 1.16.0
$
```

```ruby
$ cd guides/bug_report_templates/
$ ruby active_record_gem.rb
... snip ...
/home/yahonda/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/bundler-1.16.0/lib/bundler/runtime.rb:28:in `block in setup': rake-12.2.1 is missing. Run `bundle install` to get it. (Bundler::GemNotFound)
        from /home/yahonda/.rbenv/versions/2.4.2/lib/ruby/2.4.0/forwardable.rb:229:in `each'
        from /home/yahonda/.rbenv/versions/2.4.2/lib/ruby/2.4.0/forwardable.rb:229:in `each'
        from /home/yahonda/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/bundler-1.16.0/lib/bundler/runtime.rb:26:in `map'
        from /home/yahonda/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/bundler-1.16.0/lib/bundler/runtime.rb:26:in `setup'
        from /home/yahonda/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/bundler-1.16.0/lib/bundler/inline.rb:70:in `gemfile'
        from active_record_gem.rb:10:in `<main>'
$
```

```ruby
$ ruby active_record_gem_spec.rb
... snip ...
/home/yahonda/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/bundler-1.16.0/lib/bundler/runtime.rb:28:in `block in setup': rake-12.2.1 is missing. Run `bundle install` to get it. (Bundler::GemNotFound)
        from /home/yahonda/.rbenv/versions/2.4.2/lib/ruby/2.4.0/forwardable.rb:229:in `each'
        from /home/yahonda/.rbenv/versions/2.4.2/lib/ruby/2.4.0/forwardable.rb:229:in `each'
        from /home/yahonda/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/bundler-1.16.0/lib/bundler/runtime.rb:26:in `map'
        from /home/yahonda/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/bundler-1.16.0/lib/bundler/runtime.rb:26:in `setup'
        from /home/yahonda/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/bundler-1.16.0/lib/bundler/inline.rb:70:in `gemfile'
        from active_record_gem_spec.rb:10:in `<main>'
$
```