### PR TITLE
Translate `ORA-00060` into `ActiveRecord::Deadlocked` error

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -460,6 +460,8 @@ module ActiveRecord
           case exception
           when NativeException
             exception.cause.getErrorCode
+          when Java::JavaSql::SQLException
+            exception.getErrorCode
           else
             nil
           end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -672,6 +672,8 @@ module ActiveRecord
           case @connection.error_code(exception)
           when 1
             RecordNotUnique.new(message)
+          when 60
+            Deadlocked.new(message)
           when 900, 904, 942, 955, 1418, 2289, 17008
             ActiveRecord::StatementInvalid.new(message)
           when 1400


### PR DESCRIPTION
This PR translates `ORA-00060` into `ActiveRecord::Deadlocked` error.

Added an `ORA-00060` reproduction test case equivalent to activerecord/test/cases/adapters/mysql2/transaction_test.rb.
https://github.com/rails/rails/blob/8f2490b57f488ed60fc6e0a201ccd5e66811ab51/activerecord/test/cases/adapters/mysql2/transaction_test.rb#L36-L61

The following is a reproduce testing log.

```console
% bundle exec rspec ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:575
(snip)

  1) OracleEnhancedAdapter Transaction Raises Deadlocked when a deadlock
  is encountered
     Failure/Error:
              expect {
                barrier = Concurrent::CyclicBarrier.new(2)

                t1 = TestPost.create(title: "one")
                t2 = TestPost.create(title: "two")

                thread = Thread.new do
                  TestPost.transaction do
                    t1.lock!
                    barrier.wait

       expected ActiveRecord::Deadlocked, got
       #<ActiveRecord::StatementInvalid: OCIError: ORA-00060: deadlock
       detected while waiting for resource: UPDATE "TEST_POSTS" SET
       "TITLE" = :a1 WHERE "TEST_POSTS"."ID" = :a2> with backtrace:
```