### PR TITLE
CI against JRuby 9.1.14.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ rvm:
   - 2.3.5
   - 2.4.2
   - ruby-head
-  - jruby-9.1.13.0
+  - jruby-9.1.14.0
   - jruby-head
 
 notifications:


### PR DESCRIPTION
JRuby 9.1.14.0 has been released and this version is available on Travis CI.
http://jruby.org/2017/11/08/jruby-9-1-14-0