### PR TITLE
Add `ORA-02449` to be recognized as `ActiveRecord::StatementInvalid`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -674,7 +674,7 @@ module ActiveRecord
             RecordNotUnique.new(message)
           when 60
             Deadlocked.new(message)
-          when 900, 904, 942, 955, 1418, 2289, 17008
+          when 900, 904, 942, 955, 1418, 2289, 2449, 17008
             ActiveRecord::StatementInvalid.new(message)
           when 1400
             ActiveRecord::NotNullViolation.new(message)


### PR DESCRIPTION
ORA-02449: unique/primary keys in table referenced by foreign keys

This pull request addresses this failure when tested with JRuby.

```ruby
$ ARCONN=oracle bin/test test/cases/migration/change_schema_test.rb:457
Using oracle
Run options: --seed 28400

# Running:

F

Finished in 1.530418s, 0.6534 runs/s, 0.6534 assertions/s.

  1) Failure:
ActiveRecord::Migration::ChangeSchemaWithDependentObjectsTest#test_create_table_with_force_cascade_drops_dependent_objects [/home/yahonda/git/rails/activerecord/test/cases/migration/change_schema_test.rb:457]:
[ActiveRecord::StatementInvalid] exception expected, not
Class: <NativeException>
Message: <"java.sql.SQLException: ORA-02449: unique/primary keys in table referenced by foreign keys\n">
---Backtrace---
oracle/jdbc/driver/T4CTTIoer11.java:494:in `processError'
oracle/jdbc/driver/T4CTTIoer11.java:446:in `processError'
oracle/jdbc/driver/T4C8Oall.java:1054:in `processError'
oracle/jdbc/driver/T4CTTIfun.java:623:in `receive'
oracle/jdbc/driver/T4CTTIfun.java:252:in `doRPC'
oracle/jdbc/driver/T4C8Oall.java:612:in `doOALL'
oracle/jdbc/driver/T4CStatement.java:213:in `doOall8'
oracle/jdbc/driver/T4CStatement.java:37:in `doOall8'
oracle/jdbc/driver/T4CStatement.java:896:in `executeForRows'
oracle/jdbc/driver/OracleStatement.java:1119:in `doExecuteWithTimeout'
oracle/jdbc/driver/OracleStatement.java:1737:in `executeInternal'
oracle/jdbc/driver/OracleStatement.java:1692:in `execute'
oracle/jdbc/driver/OracleStatementWrapper.java:300:in `execute'
java/lang/reflect/Method.java:498:in `invoke'
org/jruby/javasupport/JavaMethod.java:453:in `invokeDirectWithExceptionHandling'
org/jruby/javasupport/JavaMethod.java:314:in `invokeDirect'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:270:in `exec_no_retry'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:254:in `block in exec'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:241:in `with_retry'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:253:in `exec'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:13:in `block in execute'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:544:in `block in log'
/home/yahonda/.rbenv/versions/jruby-9.1.14.0/lib/ruby/stdlib/monitor.rb:214:in `mon_synchronize'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:543:in `block in log'
/home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:534:in `log'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/dbms_output.rb:36:in `log'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:13:in `execute'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:246:in `drop_table'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:217:in `create_table'
/home/yahonda/git/rails/activerecord/test/cases/migration/change_schema_test.rb:458:in `block in test_create_table_with_force_cascade_drops_dependent_objects'
---------------

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```
