### PR TITLE
Fix `after(:all)` in oracle_enhanced_adapter_spec.rb

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -598,13 +598,13 @@ describe "OracleEnhancedAdapter" do
         end
       }.to raise_error(ActiveRecord::Deadlocked)
     end
-  end
 
-  after(:all) do
-    schema_define do
-      drop_table :test_posts
+    after(:all) do
+      schema_define do
+        drop_table :test_posts
+      end
+      Object.send(:remove_const, "TestPost") rescue nil
+      ActiveRecord::Base.clear_cache!
     end
-    Object.send(:remove_const, "TestPost") rescue nil
-    ActiveRecord::Base.clear_cache!
   end
 end


### PR DESCRIPTION
Follow up of #1591.

This is my mistake 💦  This commit fixes the position of `after(:all)` used for spec of `ActiveRecord::Deadlocked`.