### PR TITLE
Refactor index options dumping

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -128,7 +128,7 @@ module ActiveRecord
                 row["index_name"],
                 row["uniqueness"] == "UNIQUE",
                 [],
-                nil,
+                {},
                 row["index_type"] == "DOMAIN" ? "#{row['ityp_owner']}.#{row['ityp_name']}" : nil,
                 row["parameters"],
                 statement_parameters,


### PR DESCRIPTION
Follow up of https://github.com/rails/rails/commit/01fb0907b2dafcecf63eedb80408d4cbff5f4d23

And fix the following build error.
https://travis-ci.org/rsim/oracle-enhanced/builds/310949529

```console
% bundle exec rspec ./spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:167

Failures:

  1) OracleEnhancedAdapter structure dump structure dump should dump unique keys
     Failure/Error: super(table, name, unique, columns, orders: orders, type: type)

     NoMethodError:
       undefined method `size' for nil:NilClass

(snip)

1 example, 1 failure
```