### PR TITLE
CI against JRuby 9.1.15.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ rvm:
   - 2.3.5
   - 2.4.2
   - ruby-head
-  - jruby-9.1.14.0
+  - jruby-9.1.15.0
   - jruby-head
 
 notifications:


### PR DESCRIPTION
JRuby 9.1.15.0 has been released.
http://jruby.org/2017/12/07/jruby-9-1-15-0.html