### PR TITLE
Revert "Use Bundler 1.15 to workaround bundler/bundler#6072"

### DIFF
--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-gem "bundler", "< 1.16"
-
 begin
   require "bundler/inline"
 rescue LoadError => e

--- a/guides/bug_report_templates/active_record_gem_spec.rb
+++ b/guides/bug_report_templates/active_record_gem_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-gem "bundler", "< 1.16"
-
 begin
   require "bundler/inline"
 rescue LoadError => e


### PR DESCRIPTION
This reverts commit 33caae0b9cafad35b57c76157a131fc43f02cf7a.

Reverted #1590 since bundler/bundler#6072 has been fixed by bundler 1.16.1