### PR TITLE
Remove `--force` option for installing bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
 
 install:
   - "travis_retry gem update --system"
-  - "travis_retry gem install bundler --force"
+  - "travis_retry gem install bundler"
   - .travis/oracle/download.sh
   - .travis/oracle/install.sh
   - .travis/setup_accounts.sh


### PR DESCRIPTION
because Ruby 2.5.0 does not have bundler by default.