### PR TITLE
CI with Ruby 2.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ rvm:
   - 2.2.9
   - 2.3.6
   - 2.4.3
+  - 2.5.0
   - ruby-head
   - jruby-9.1.15.0
   - jruby-head


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2017/12/25/ruby-2-5-0-released/