### PR TITLE
Do not register `VARCHAR2(1)` sql type as `Type:Boolean`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -646,11 +646,7 @@ module ActiveRecord
           end
 
           if OracleEnhancedAdapter.emulate_booleans
-            if OracleEnhancedAdapter.emulate_booleans_from_strings
-              m.register_type %r(^VARCHAR2\(1\))i, Type::OracleEnhanced::Boolean.new
-            else
-              m.register_type %r(^NUMBER\(1\))i, Type::Boolean.new
-            end
+            m.register_type %r(^NUMBER\(1\))i, Type::Boolean.new
           end
         end
 

--- a/spec/active_record/oracle_enhanced/type/boolean_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/boolean_spec.rb
@@ -190,6 +190,7 @@ describe "OracleEnhancedAdapter boolean support when emulate_booleans_from_strin
 
   before(:each) do
     class ::Post < ActiveRecord::Base
+      attribute :is_default, :boolean
     end
   end
 


### PR DESCRIPTION
Do not register `VARCHAR2(1)` sql type as `Type:Boolean` if `emulate_booleans_from_strings = true`

Users will need to set `attribute` explicitly as follows if `emulate_booleans_from_strings = true`

```ruby
class Post < ActiveRecord::Base
    attribute :is_default, :boolean
end
```

Address #1621