### PR TITLE
Support schema names with only numbers

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -168,7 +168,7 @@ module ActiveRecord
             # default schema owner
             @owner = username.upcase unless username.nil?
           else
-            exec "alter session set current_schema = #{schema}"
+            exec "alter session set current_schema = \"#{schema}\""
             @owner = schema
           end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -329,7 +329,7 @@ module ActiveRecord
           elsif ActiveRecord::Base.default_timezone == :utc
             conn.exec "alter session set time_zone = '+00:00'"
           end
-          conn.exec "alter session set current_schema = #{schema}" unless schema.blank?
+          conn.exec "alter session set current_schema = \"#{schema}\"" unless schema.blank?
 
           # Initialize NLS parameters
           OracleEnhancedAdapter::DEFAULT_NLS_PARAMETERS.each do |key, default_value|


### PR DESCRIPTION
When a schema name is only numbers, eg. "0000" or "1", all request failed with this error : 
```
OCIError: ORA-02421: missing or invalid schema authorization identifier
```
In this PR, I force the SQL `alter session` to understand the name as a string.
Thanks for reviewing !