### PR TITLE
Revert "allow_railures for jruby-head until #1614 resolved"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,5 @@ rvm:
   - jruby-9.1.15.0
   - jruby-head
 
-matrix:
-   allow_failures:
-     - rvm: jruby-head
 notifications:
     email: false


### PR DESCRIPTION
This reverts commit 81927d600d52aa7237642f23280a393685c539b0.

Since https://github.com/bundler/bundler/issues/6228 has been closed.