### PR TITLE
Address `ORA-32794: cannot drop a system-generated sequence: DROP SEQ…

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -11,7 +11,8 @@ module ActiveRecord #:nodoc:
           sequences = select(<<-SQL.strip.gsub(/\s+/, " "), "sequences to dump at structure dump")
             SELECT sequence_name, min_value, max_value, increment_by, order_flag, cycle_flag
             FROM all_sequences
-            where sequence_owner = SYS_CONTEXT('userenv', 'session_user') ORDER BY 1
+            where sequence_owner = SYS_CONTEXT('userenv', 'session_user')
+            and sequence_name not like 'ISEQ$$%' ORDER BY 1
           SQL
 
           structure = sequences.map do |result|
@@ -264,7 +265,8 @@ module ActiveRecord #:nodoc:
 
         def structure_drop #:nodoc:
           sequences = select_values(<<-SQL.strip.gsub(/\s+/, " "), "sequences to drop at structure dump")
-            SELECT sequence_name FROM all_sequences where sequence_owner = SYS_CONTEXT('userenv', 'session_user') ORDER BY 1
+            SELECT sequence_name FROM all_sequences where sequence_owner = SYS_CONTEXT('userenv', 'session_user')
+            and sequence_name not like 'ISEQ$$%' ORDER BY 1
           SQL
           statements = sequences.map do |seq|
             "DROP SEQUENCE \"#{seq}\""


### PR DESCRIPTION
…UENCE "ISEQ$$_nnnnnn"`

Each Identity datatype creates a sequence named "ISEC$$_nnnnn", which
depends on the table. This sequence cannot be dropped separately and it
will be dropped once the base table dropped.

Example with SQL statements:

```sql
SQL> CREATE TABLE "TEST_POSTS" ("ID" NUMBER(38) GENERATED BY DEFAULT AS IDENTITY PRIMARY KEY, "SUBJECT" VARCHAR2(255));

Table created.

SQL> select object_name,object_type from user_objects;

OBJECT_NAME                    OBJECT_TYPE
------------------------------ -----------------------
SYS_C00208553                  INDEX
ISEQ$$_447502                  SEQUENCE
TEST_POSTS                     TABLE

SQL> drop sequence ISEQ$$_447502;
drop sequence ISEQ$$_447502
              *
ERROR at line 1:
ORA-32794: cannot drop a system-generated sequence

SQL> drop table "TEST_POSTS";

Table dropped.

SQL>  select object_name,object_type from user_objects;

no rows selected

SQL>
```

Kind of backporting/cherry-picking #1316 to poc_identity