### PR TITLE
Do not run CI against Ruby 2.2, which will not be supported with Rails 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ install:
 
 language: ruby
 rvm:
-  - 2.2.9
   - 2.3.6
   - 2.4.3
   - 2.5.0


### PR DESCRIPTION
This is part of #1651. Wanted to make #1652 CI green first. 