### PR TITLE
Suppress expected exceptions by `report_on_exception` = `false`

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -570,6 +570,7 @@ describe "OracleEnhancedAdapter" do
       end
       class ::TestPost < ActiveRecord::Base
       end
+      Thread.report_on_exception, @original_report_on_exception = false, Thread.report_on_exception if Thread.respond_to?(:report_on_exception)
     end
 
     it "Raises Deadlocked when a deadlock is encountered" do
@@ -606,6 +607,7 @@ describe "OracleEnhancedAdapter" do
       end
       Object.send(:remove_const, "TestPost") rescue nil
       ActiveRecord::Base.clear_cache!
+      Thread.report_on_exception = @original_report_on_exception if Thread.respond_to?(:report_on_exception)
     end
   end
 end


### PR DESCRIPTION
It should suppress this exception reported at  https://travis-ci.org/rsim/oracle-enhanced/jobs/342649225

```ruby
<Thread:0x00000000043db450@/home/travis/build/rsim/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:583 run> terminated with exception (report_on_exception is true):
```