### PR TITLE
CI with JRuby 9.1.16.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ rvm:
   - 2.4.3
   - 2.5.0
   - ruby-head
-  - jruby-9.1.15.0
+  - jruby-9.1.16.0
   - jruby-head
 
 notifications:


### PR DESCRIPTION
http://jruby.org/2018/02/21/jruby-9-1-16-0.html

This pull request only goes to release52 branch. Rails master branch requires Ruby 2.4.1+ which will be compatible with current JRuby master branch.