### PR TITLE
WIP - What happens if channel name removed

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,7 +1,6 @@
 engines:
   rubocop:
     enabled: true
-    channel: rubocop-0-51
 
 ratings:
   paths:


### PR DESCRIPTION
This pull request attempts to see which versions of RuboCop used at codeclimate if the channel removed. 

Please do not merge yet.