### PR TITLE
Remove unnecessary `respond_to?(:report_on_exception)`

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -570,7 +570,7 @@ describe "OracleEnhancedAdapter" do
       end
       class ::TestPost < ActiveRecord::Base
       end
-      Thread.report_on_exception, @original_report_on_exception = false, Thread.report_on_exception if Thread.respond_to?(:report_on_exception)
+      Thread.report_on_exception, @original_report_on_exception = false, Thread.report_on_exception
     end
 
     it "Raises Deadlocked when a deadlock is encountered" do
@@ -607,7 +607,7 @@ describe "OracleEnhancedAdapter" do
       end
       Object.send(:remove_const, "TestPost") rescue nil
       ActiveRecord::Base.clear_cache!
-      Thread.report_on_exception = @original_report_on_exception if Thread.respond_to?(:report_on_exception)
+      Thread.report_on_exception = @original_report_on_exception
     end
   end
 end


### PR DESCRIPTION
`report_on_exception` is available since Ruby 2.4

Refer https://github.com/rails/rails/commit/b1a9cee83082d6c7a58d87d06055c86fcdbc7644