### PR TITLE
`update_attributes!` will be deprecated in Rails 6

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb
@@ -131,10 +131,10 @@ describe "OracleEnhancedAdapter context index" do
       @post = Post.create(title: "abc", body: "def")
       expect(Post.contains(:all_text, "abc").to_a).to eq([@post])
       expect(Post.contains(:all_text, "def").to_a).to eq([@post])
-      @post.update_attributes!(title: "ghi")
+      @post.update!(title: "ghi")
       # index will not be updated as all_text column is not changed
       expect(Post.contains(:all_text, "ghi").to_a).to be_empty
-      @post.update_attributes!(all_text: "1")
+      @post.update!(all_text: "1")
       # index will be updated when all_text column is changed
       expect(Post.contains(:all_text, "ghi").to_a).to eq([@post])
       @conn.remove_context_index :posts, index_column: :all_text
@@ -147,7 +147,7 @@ describe "OracleEnhancedAdapter context index" do
       @post = Post.create(title: "abc", body: "def")
       expect(Post.contains(:all_text, "abc").to_a).to eq([@post])
       expect(Post.contains(:all_text, "def").to_a).to eq([@post])
-      @post.update_attributes!(title: "ghi")
+      @post.update!(title: "ghi")
       # index should be updated as created_at column is changed
       expect(Post.contains(:all_text, "ghi").to_a).to eq([@post])
       @conn.remove_context_index :posts, index_column: :all_text
@@ -168,7 +168,7 @@ describe "OracleEnhancedAdapter context index" do
       Post.transaction do
         @post = Post.create(title: "abc")
         expect(Post.contains(:title, "abc").to_a).to eq([@post])
-        @post.update_attributes!(title: "ghi")
+        @post.update!(title: "ghi")
         expect(Post.contains(:title, "ghi").to_a).to eq([@post])
       end
       @conn.remove_context_index :posts, :title


### PR DESCRIPTION
Refer https://github.com/rails/rails/commit/5645149d3a27054450bd1130ff5715504638a5f5

This pull request suppresses these warnings:
```ruby
$ bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb
==> Loading config from ENV or use default
==> Running specs with MRI version 2.6.0
==> Effective ActiveRecord version 6.0.0.alpha
.....DEPRECATION WARNING: update_attributes! is deprecated and will be removed from Rails 6.1 (called from block (3 levels) in <top (required)> at /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb:134)
DEPRECATION WARNING: update_attributes! is deprecated and will be removed from Rails 6.1 (called from block (3 levels) in <top (required)> at /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb:137)
.DEPRECATION WARNING: update_attributes! is deprecated and will be removed from Rails 6.1 (called from block (3 levels) in <top (required)> at /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb:150)
..DEPRECATION WARNING: update_attributes! is deprecated and will be removed from Rails 6.1 (called from block (4 levels) in <top (required)> at /home/yahonda/git/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb:171)
...............

Finished in 2 minutes 21.7 seconds (files took 0.6458 seconds to load)
23 examples, 0 failures

Coverage report generated for RSpec to /home/yahonda/git/oracle-enhanced/coverage. 1432 / 2017 LOC (71.0%) covered.
$
```