### PR TITLE
`update_attributes` will be deprecated in Rails 6

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -585,7 +585,7 @@ describe "OracleEnhancedAdapter" do
           TestPost.transaction do
             t1.lock!
             barrier.wait
-            t2.update_attributes(title: "one")
+            t2.update(title: "one")
           end
         end
 
@@ -593,7 +593,7 @@ describe "OracleEnhancedAdapter" do
           TestPost.transaction do
             t2.lock!
             barrier.wait
-            t1.update_attributes(title: "two")
+            t1.update(title: "two")
           end
         ensure
           thread.join


### PR DESCRIPTION
Follows up #1665

This pull request should suppress these deprecation warnings shown at https://travis-ci.org/rsim/oracle-enhanced/jobs/348521316

```ruby
DEPRECATION WARNING: update_attributes is deprecated and will be removed from Rails 6.1 (called from block (6 levels) in <top (required)> at /home/travis/build/rsim/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:588)
DEPRECATION WARNING: update_attributes is deprecated and will be removed from Rails 6.1 (called from block (5 levels) in <top (required)> at /home/travis/build/rsim/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:596)
```