### PR TITLE
Drop db link support

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -24,11 +24,8 @@ module ActiveRecord
           def describe(name)
             name = name.to_s
             if name.include?("@")
-              name, db_link = name.split("@")
-              default_owner = _select_value("SELECT username FROM all_db_links WHERE db_link = '#{db_link.upcase}'")
-              db_link = "@#{db_link}"
+              raise ArgumentError "db link is not supported"
             else
-              db_link = nil
               default_owner = @owner
             end
             real_name = OracleEnhanced::Quoting.valid_table_name?(name) ? name.upcase : name
@@ -39,31 +36,31 @@ module ActiveRecord
             end
             sql = <<-SQL.strip.gsub(/\s+/, " ")
           SELECT owner, table_name, 'TABLE' name_type
-          FROM all_tables#{db_link}
+          FROM all_tables
           WHERE owner = '#{table_owner}'
             AND table_name = '#{table_name}'
           UNION ALL
           SELECT owner, view_name table_name, 'VIEW' name_type
-          FROM all_views#{db_link}
+          FROM all_views
           WHERE owner = '#{table_owner}'
             AND view_name = '#{table_name}'
           UNION ALL
-          SELECT table_owner, DECODE(db_link, NULL, table_name, table_name||'@'||db_link), 'SYNONYM' name_type
-          FROM all_synonyms#{db_link}
+          SELECT table_owner, table_name, 'SYNONYM' name_type
+          FROM all_synonyms
           WHERE owner = '#{table_owner}'
             AND synonym_name = '#{table_name}'
           UNION ALL
-          SELECT table_owner, DECODE(db_link, NULL, table_name, table_name||'@'||db_link), 'SYNONYM' name_type
-          FROM all_synonyms#{db_link}
+          SELECT table_owner, table_name, 'SYNONYM' name_type
+          FROM all_synonyms
           WHERE owner = 'PUBLIC'
             AND synonym_name = '#{real_name}'
         SQL
             if result = _select_one(sql)
               case result["name_type"]
               when "SYNONYM"
-                describe("#{result['owner'] && "#{result['owner']}."}#{result['table_name']}#{db_link}")
+                describe("#{result['owner'] && "#{result['owner']}."}#{result['table_name']}")
               else
-                db_link ? [result["owner"], result["table_name"], db_link] : [result["owner"], result["table_name"]]
+                [result["owner"], result["table_name"]]
               end
             else
               raise OracleEnhanced::ConnectionException, %Q{"DESC #{name}" failed; does it exist?}

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -35,7 +35,7 @@ module ActiveRecord
         end
       end
 
-      class SynonymDefinition < Struct.new(:name, :table_owner, :table_name, :db_link) #:nodoc:
+      class SynonymDefinition < Struct.new(:name, :table_owner, :table_name) #:nodoc:
       end
 
       class IndexDefinition < ActiveRecord::ConnectionAdapters::IndexDefinition

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -42,7 +42,6 @@ module ActiveRecord #:nodoc:
               next if ignored? syn.name
               table_name = syn.table_name
               table_name = "#{syn.table_owner}.#{table_name}" if syn.table_owner
-              table_name = "#{table_name}@#{syn.db_link}" if syn.db_link
               stream.print "  add_synonym #{syn.name.inspect}, #{table_name.inspect}, force: true"
               stream.puts
             end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -252,13 +252,6 @@ describe "OracleEnhancedAdapter schema dump" do
       expect(standard_dump).to match(/add_synonym "test_synonym", "schema_name.table_name", force: true/)
     end
 
-    it "should include synonym to other database table in schema dump" do
-      schema_define do
-        add_synonym :test_synonym, "table_name@link_name", force: true
-      end
-      expect(standard_dump).to match(/add_synonym "test_synonym", "table_name@link_name(\.[-A-Za-z0-9_]+)*", force: true/)
-    end
-
     it "should not include ignored table names in schema dump" do
       schema_define do
         add_synonym :test_synonym, "schema_name.table_name", force: true

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -1028,18 +1028,6 @@ end
         TestPost.create(title: "test")
       end.not_to raise_error
     end
-
-    it "should create synonym to table over database link" do
-      db_link = @db_link
-      schema_define do
-        add_synonym :synonym_to_posts, "test_posts@#{db_link}", force: true
-        add_synonym :synonym_to_posts_seq, "test_posts_seq@#{db_link}", force: true
-      end
-      expect do
-        TestPost.create(title: "test")
-      end.not_to raise_error
-    end
-
   end
 
   describe "alter columns with column cache" do

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -99,55 +99,6 @@ describe "OracleEnhancedAdapter" do
     end
   end
 
-  describe "access table over database link" do
-    before(:all) do
-      @conn = ActiveRecord::Base.connection
-      @db_link = "db_link"
-      @sys_conn = ActiveRecord::Base.oracle_enhanced_connection(SYSTEM_CONNECTION_PARAMS)
-      @sys_conn.drop_table :test_posts, if_exists: true
-      @sys_conn.create_table :test_posts do |t|
-        t.string      :title
-        # cannot update LOBs over database link
-        t.string      :body
-        t.timestamps null: true
-      end
-      @db_link_username = SYSTEM_CONNECTION_PARAMS[:username]
-      @db_link_password = SYSTEM_CONNECTION_PARAMS[:password]
-      @db_link_database = SYSTEM_CONNECTION_PARAMS[:database]
-      @conn.execute "DROP DATABASE LINK #{@db_link}" rescue nil
-      @conn.execute "CREATE DATABASE LINK #{@db_link} CONNECT TO #{@db_link_username} IDENTIFIED BY \"#{@db_link_password}\" USING '#{@db_link_database}'"
-      @conn.execute "CREATE OR REPLACE SYNONYM test_posts FOR test_posts@#{@db_link}"
-      @conn.execute "CREATE OR REPLACE SYNONYM test_posts_seq FOR test_posts_seq@#{@db_link}"
-      class ::TestPost < ActiveRecord::Base
-      end
-      TestPost.table_name = "test_posts"
-    end
-
-    after(:all) do
-      @conn.execute "DROP SYNONYM test_posts"
-      @conn.execute "DROP SYNONYM test_posts_seq"
-      @conn.execute "DROP DATABASE LINK #{@db_link}" rescue nil
-      @sys_conn.drop_table :test_posts, if_exists: true
-      Object.send(:remove_const, "TestPost") rescue nil
-      ActiveRecord::Base.clear_cache!
-    end
-
-    it "should verify database link" do
-      @conn.select_value("select * from dual@#{@db_link}") == "X"
-    end
-
-    it "should get column names" do
-      expect(TestPost.column_names).to eq(["id", "title", "body", "created_at", "updated_at"])
-    end
-
-    it "should create record" do
-      p = TestPost.create(title: "Title", body: "Body")
-      expect(p.id).not_to be_nil
-      expect(TestPost.find(p.id)).not_to be_nil
-    end
-
-  end
-
   describe "session information" do
     before(:all) do
       @conn = ActiveRecord::Base.connection


### PR DESCRIPTION
Oracle enhanced adapter 6 drops support for db link
If users need to use database link, please consider to
- Use multiple database connections
- Create a view over the database link