### PR TITLE
Use `SYS_CONTEXT('userenv', 'current_schema')` to find schema objects

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -167,7 +167,7 @@ module ActiveRecord #:nodoc:
             table_name = column.table_name
             @connection.select_value(<<-SQL.strip.gsub(/\s+/, " "), "Table comment", [bind_string("table_name", table_name.upcase), bind_string("column_name", column_name.upcase)]).inspect
               select data_default from all_tab_columns
-              where owner = SYS_CONTEXT('userenv', 'session_user')
+              where owner = SYS_CONTEXT('userenv', 'current_schema')
               and table_name = :table_name
               and column_name = :column_name
             SQL

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -70,7 +70,7 @@ module ActiveRecord
         def synonyms
           result = select_all(<<-SQL.strip.gsub(/\s+/, " "), "synonyms")
           SELECT synonym_name, table_owner, table_name
-          FROM all_synonyms where owner = SYS_CONTEXT('userenv', 'session_user')
+          FROM all_synonyms where owner = SYS_CONTEXT('userenv', 'current_schema')
         SQL
 
           result.collect do |row|
@@ -503,7 +503,7 @@ module ActiveRecord
             SELECT tablespace_name
             FROM all_tables
             WHERE table_name='#{table_name.to_s.upcase}'
-            AND owner = SYS_CONTEXT('userenv', 'session_user')
+            AND owner = SYS_CONTEXT('userenv', 'current_schema')
           SQL
         end
 
@@ -558,7 +558,7 @@ module ActiveRecord
             FROM all_constraints
             WHERE constraint_type = 'R'
             AND status = 'ENABLED'
-            AND owner = SYS_CONTEXT('userenv', 'session_user')
+            AND owner = SYS_CONTEXT('userenv', 'current_schema')
           SQL
           begin
             old_constraints.each do |constraint|

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -596,7 +596,7 @@ module ActiveRecord
 
       def temporary_table?(table_name) #:nodoc:
         select_value(<<-SQL.strip.gsub(/\s+/, " "), "temporary table", [bind_string("table_name", table_name.upcase)]) == "Y"
-          SELECT temporary FROM all_tables WHERE table_name = :table_name and owner = SYS_CONTEXT('userenv', 'session_user')
+          SELECT temporary FROM all_tables WHERE table_name = :table_name and owner = SYS_CONTEXT('userenv', 'current_schema')
         SQL
       end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -88,6 +88,7 @@ describe "OracleEnhancedConnection" do
     it "should swith to specified schema" do
       ActiveRecord::Base.establish_connection(CONNECTION_WITH_SCHEMA_PARAMS)
       expect(ActiveRecord::Base.connection.current_schema).to eq(CONNECTION_WITH_SCHEMA_PARAMS[:schema].upcase)
+      expect(ActiveRecord::Base.connection.current_user).to eq(CONNECTION_WITH_SCHEMA_PARAMS[:username].upcase)
     end
 
     it "should swith to specified schema after reset" do


### PR DESCRIPTION
Also updated a spec not to update `current_user` method

Since#742 most of method should use `current_schema` to find schema
objects.

This pull request should not be backported into release52 branch.
I believe it will not cause regressions but this may change some
untested/undefined behavior.