### PR TITLE
Use `SYS_CONTEXT('userenv', 'current_schema')` for owner

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -224,9 +224,8 @@ describe "OracleEnhancedAdapter schema definition" do
       create_test_employees_table(table_comment)
       class ::TestEmployee < ActiveRecord::Base; end
       expect(@conn.table_comment(TestEmployee.table_name)).to eq(table_comment)
-      expect(@logger.logged(:debug).last).to match(/:owner/)
       expect(@logger.logged(:debug).last).to match(/:table_name/)
-      expect(@logger.logged(:debug).last).to match(/\[\["owner", "#{DATABASE_USER.upcase}"\], \["table_name", "TEST_EMPLOYEES"\]\]/)
+      expect(@logger.logged(:debug).last).to match(/\["table_name", "TEST_EMPLOYEES"\]\]/)
     end
 
     it "should query column_comment using bind variables" do
@@ -235,10 +234,9 @@ describe "OracleEnhancedAdapter schema definition" do
       create_test_employees_table(table_comment, column_comment)
       class ::TestEmployee < ActiveRecord::Base; end
       expect(@conn.column_comment(TestEmployee.table_name, :first_name)).to eq(column_comment[:first_name])
-      expect(@logger.logged(:debug).last).to match(/:owner/)
       expect(@logger.logged(:debug).last).to match(/:table_name/)
       expect(@logger.logged(:debug).last).to match(/:column_name/)
-      expect(@logger.logged(:debug).last).to match(/\[\["owner", "#{DATABASE_USER.upcase}"\], \["table_name", "TEST_EMPLOYEES"\], \["column_name", "FIRST_NAME"\]\]/)
+      expect(@logger.logged(:debug).last).to match(/\["table_name", "TEST_EMPLOYEES"\], \["column_name", "FIRST_NAME"\]\]/)
     end
 
   end
@@ -533,9 +531,8 @@ end
         add_foreign_key :test_comments, :test_posts
       end
       ActiveRecord::Base.connection.foreign_keys(:test_comments)
-      expect(@logger.logged(:debug).last).to match(/:owner/)
       expect(@logger.logged(:debug).last).to match(/:desc_table_name/)
-      expect(@logger.logged(:debug).last).to match(/\[\["owner", "#{DATABASE_USER.upcase}"\], \["desc_table_name", "TEST_COMMENTS"\]\]/)
+      expect(@logger.logged(:debug).last).to match(/\["desc_table_name", "TEST_COMMENTS"\]\]/)
     end
 
   end

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -472,35 +472,26 @@ describe "OracleEnhancedAdapter" do
       expect(@conn.table_exists?("NOT_EXISTING")).to eq false
     end
 
-    it "should return array from indexes with bind usage" do
-      expect(@conn.indexes("TEST_POSTS").class).to eq Array
-      expect(@logger.logged(:debug).last).to match(/:owner/)
-      expect(@logger.logged(:debug).last).to match(/\[\["owner", "#{DATABASE_USER.upcase}"\], \["owner", "#{DATABASE_USER.upcase}"\]\]/)
-    end
-
     it "should return content from columns with bind usage" do
       expect(@conn.columns("TEST_POSTS").length).to be > 0
-      expect(@logger.logged(:debug).last).to match(/:owner/)
       expect(@logger.logged(:debug).last).to match(/:table_name/)
-      expect(@logger.logged(:debug).last).to match(/\[\["owner", "#{DATABASE_USER.upcase}"\], \["table_name", "TEST_POSTS"\]\]/)
+      expect(@logger.logged(:debug).last).to match(/\["table_name", "TEST_POSTS"\]/)
     end
 
     it "should return pk and sequence from pk_and_sequence_for with bind usage" do
       expect(@conn.pk_and_sequence_for("TEST_POSTS").length).to eq 2
-      expect(@logger.logged(:debug).last).to match(/:owner/)
-      expect(@logger.logged(:debug).last).to match(/\[\["owner", "#{DATABASE_USER.upcase}"\], \["table_name", "TEST_POSTS"\]\]/)
+      expect(@logger.logged(:debug).last).to match(/\["table_name", "TEST_POSTS"\]/)
     end
 
     it "should return pk from primary_keys with bind usage" do
       expect(@conn.primary_keys("TEST_POSTS")).to eq ["id"]
-      expect(@logger.logged(:debug).last).to match(/:owner/)
-      expect(@logger.logged(:debug).last).to match(/\[\["owner", "#{DATABASE_USER.upcase}"\], \["table_name", "TEST_POSTS"\]\]/)
+      expect(@logger.logged(:debug).last).to match(/\["table_name", "TEST_POSTS"\]/)
     end
 
     it "should return false from temporary_table? with bind usage" do
       expect(@conn.temporary_table?("TEST_POSTS")).to eq false
       expect(@logger.logged(:debug).last).to match(/:table_name/)
-      expect(@logger.logged(:debug).last).to match(/\[\["table_name", "TEST_POSTS"\]\]/)
+      expect(@logger.logged(:debug).last).to match(/\["table_name", "TEST_POSTS"\]/)
     end
 
   end


### PR DESCRIPTION
Use `SYS_CONTEXT('userenv', 'current_schema')` for owner not using owner value from `OracleEnhanced::Connection#describe`

This is a first step to remove `OracleEnhanced::Connection#describe`. `OracleEnhanced::Connection#describe` method executes SQL query for the data dictionary, which can be reduced.

Also `describe` method is owned by `OracleEnhanced::Connection`, not `OracleEnhanedAdapter`, therefore this method is not reachable from other modules.