### PR TITLE
Don't allow unsupported NLS parameters

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -161,6 +161,10 @@ module ActiveRecord
             end
           end
 
+          OracleEnhancedAdapter::FIXED_NLS_PARAMETERS.each do |key, value|
+            exec "alter session set #{key} = '#{value}'"
+          end
+
           self.autocommit = true
 
           schema = config[:schema] && config[:schema].to_s

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -328,6 +328,10 @@ module ActiveRecord
               conn.exec "alter session set #{key} = '#{value}'"
             end
           end
+
+          OracleEnhancedAdapter::FIXED_NLS_PARAMETERS.each do |key, value|
+            conn.exec "alter session set #{key} = '#{value}'"
+          end
           conn
         end
       end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -120,8 +120,6 @@ module ActiveRecord
     # * <tt>:nls_calendar</tt>
     # * <tt>:nls_comp</tt>
     # * <tt>:nls_currency</tt>
-    # * <tt>:nls_date_format</tt> - format for :date columns, defaults to <tt>YYYY-MM-DD HH24:MI:SS</tt>
-    #   (changing `nls_date_format` parameter value is not supported. Use the default value.)
     # * <tt>:nls_date_language</tt>
     # * <tt>:nls_dual_currency</tt>
     # * <tt>:nls_iso_currency</tt>
@@ -132,11 +130,14 @@ module ActiveRecord
     # * <tt>:nls_numeric_characters</tt>
     # * <tt>:nls_sort</tt>
     # * <tt>:nls_territory</tt>
-    # * <tt>:nls_timestamp_format</tt> - format for :timestamp columns, defaults to <tt>YYYY-MM-DD HH24:MI:SS:FF6</tt>
-    #   (changing `nls_timestamp_format` parameter value is not supported. Use the default value.)
     # * <tt>:nls_timestamp_tz_format</tt>
     # * <tt>:nls_time_format</tt>
     # * <tt>:nls_time_tz_format</tt>
+    #
+    # Fixed NLS values (not overridable):
+    #
+    # * <tt>:nls_date_format</tt> - format for :date columns is <tt>YYYY-MM-DD HH24:MI:SS</tt>
+    # * <tt>:nls_timestamp_format</tt> - format for :timestamp columns is <tt>YYYY-MM-DD HH24:MI:SS:FF6</tt>
     #
     class OracleEnhancedAdapter < AbstractAdapter
       include OracleEnhanced::DatabaseStatements
@@ -306,7 +307,6 @@ module ActiveRecord
         nls_calendar: nil,
         nls_comp: nil,
         nls_currency: nil,
-        nls_date_format: "YYYY-MM-DD HH24:MI:SS",
         nls_date_language: nil,
         nls_dual_currency: nil,
         nls_iso_currency: nil,
@@ -316,10 +316,15 @@ module ActiveRecord
         nls_numeric_characters: nil,
         nls_sort: nil,
         nls_territory: nil,
-        nls_timestamp_format: "YYYY-MM-DD HH24:MI:SS:FF6",
         nls_timestamp_tz_format: nil,
         nls_time_format: nil,
         nls_time_tz_format: nil
+      }
+
+      #:stopdoc:
+      FIXED_NLS_PARAMETERS = {
+        nls_date_format: "YYYY-MM-DD HH24:MI:SS",
+        nls_timestamp_format: "YYYY-MM-DD HH24:MI:SS:FF6"
       }
 
       #:stopdoc:


### PR DESCRIPTION
I ran into this issue with NLS date/timestamp formats recently. I hadn't configured any of
the [optional NLS parameters](https://github.com/rsim/oracle-enhanced/blob/master/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb#L118) and knew that `nls_date_format` and `nls_timestamp_format` were unsupported, but was still running into this catastrophic error:

```
OCIError: ORA-01830: date format picture ends before converting entire input string
```

It turned out that the machine I was running on had the `NLS_TIMESTAMP_FORMAT` environment variable set and oracle_enhanced was consuming it and using the non-standard format.

This is probably not a commonly-encountered situation, but it was very confusing and time-consuming to track down for me. This PR I think makes this restriction clearer if you choose to accept it.

Since this is an ActiveRecord adapter, it seems OK to force these parameters (`NLS_TIMESTAMP_FORMAT` and `NLS_DATE_FORMAT`) to the format Rails expects; I can't think of a use case for changing these values if it fundamentally breaks ActiveRecord.

Thanks for considering!