### PR TITLE
CI against Ruby 2.4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
 
 language: ruby
 rvm:
-  - 2.4.3
+  - 2.4.4
   - 2.5.1
   - ruby-head
   - jruby-head


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-4-4-released/