### PR TITLE
CI against Ruby 2.4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ language: ruby
 rvm:
   - 2.2.9
   - 2.3.6
-  - 2.4.3
+  - 2.4.4
   - 2.5.1
   - ruby-head
   - jruby-9.1.16.0


### PR DESCRIPTION
This PR backports #1686 into release52 branch.

https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-4-4-released/