### PR TITLE
Use ruby 2.3.7 and 2.2.10 for CI at release52 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ install:
 
 language: ruby
 rvm:
-  - 2.2.9
-  - 2.3.6
+  - 2.2.10
+  - 2.3.7
   - 2.4.4
   - 2.5.1
   - ruby-head


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-3-7-released/
https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-2-10-released/