### PR TITLE
Memoize if the table needs to prefetch primary key

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -211,6 +211,7 @@ module ActiveRecord
         super(connection, logger, config)
         @statements = StatementPool.new(self.class.type_cast_config_to_integer(config[:statement_limit]))
         @enable_dbms_output = false
+        @do_not_prefetch_primary_key = {}
       end
 
       ADAPTER_NAME = "OracleEnhanced".freeze
@@ -430,8 +431,11 @@ module ActiveRecord
       def prefetch_primary_key?(table_name = nil)
         return true if table_name.nil?
         table_name = table_name.to_s
-        owner, desc_table_name = @connection.describe(table_name)
-        do_not_prefetch = !has_primary_key?(table_name, owner, desc_table_name)
+        do_not_prefetch = @do_not_prefetch_primary_key[table_name]
+        if do_not_prefetch.nil?
+          owner, desc_table_name = @connection.describe(table_name)
+          @do_not_prefetch_primary_key [table_name] = do_not_prefetch = !has_primary_key?(table_name, owner, desc_table_name)
+        end
         !do_not_prefetch
       end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -96,6 +96,14 @@ describe "OracleEnhancedAdapter" do
           expect(TestEmployee2.columns.map(&:sql_type)).to eq(@column_sql_types)
         end
       end
+
+      it "should get sequence value at next time" do
+        TestEmployee.create!
+        expect(@logger.logged(:debug).first).not_to match(/SELECT \"TEST_EMPLOYEES_SEQ\".NEXTVAL FROM dual/im)
+        @logger.clear(:debug)
+        TestEmployee.create!
+        expect(@logger.logged(:debug).first).to match(/SELECT \"TEST_EMPLOYEES_SEQ\".NEXTVAL FROM dual/im)
+      end
     end
   end
 


### PR DESCRIPTION
Address #1673

Kind of restoring #1496 using instance variable `@do_not_prefetch_primary_key`

Oracle enhanced adapter 1.8 or older used to have `@@do_not_prefetch_primary_key`
and other class variables to cache schema information.

Starting from Oracle enhanced adapter 5.2,
it starts using Rails standard `rails db:schema:cache` .
But it does not look like cacheing sequence names for primary keys
since no bundled database adapters - sqlite3, mysql2 and postgresql use prefetch primary key,
then sequence name for the table may not be included in the schema cache, I guess.