### PR TITLE
Support longer identifier for Oracle database 12.2 or higher

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -303,6 +303,10 @@ module ActiveRecord
         false
       end
 
+      def supports_longer_identifier?
+        @connection.database_version.to_s >= [12, 2].to_s
+      end
+
       #:stopdoc:
       DEFAULT_NLS_PARAMETERS = {
         nls_calendar: nil,
@@ -608,6 +612,12 @@ module ActiveRecord
           SELECT temporary FROM all_tables WHERE table_name = :table_name and owner = SYS_CONTEXT('userenv', 'current_schema')
         SQL
       end
+
+      def max_identifier_length
+        supports_longer_identifier? ? 128 : 30
+      end
+      alias table_alias_length max_identifier_length
+      alias index_name_length max_identifier_length
 
       private
 


### PR DESCRIPTION
Longer identifier has been supported by aliasing `table_alias_length` and `index_name_length` method defined in `ActiveRecord::ConnectionAdapters::OracleEnhanced::DatabaseLimits` to use `max_identifier_length` method newly creted in `ActiveRecord::ConnectionAdapters::OracleEnhanced::OracleEnhancedAdapter`. Because ActiveRecord::ConnectionAdapters::OracleEnhanced::DatabaseLimits does not know the database version.

Refer
https://docs.oracle.com/en/database/oracle/oracle-database/12.2/sqlrf/Database-Object-Names-and-Qualifiers.html#GUID-75337742-67FD-4EC0-985F-741C93D918DA

Not implemented in this commit:
* Support longer identifiers for column name, sequence name
* Use 30 byte identifier for Oracle database 12.2 for those who prefer old behavior.

Addresses #1594