### PR TITLE
`OracleEnhanced::SchemaStatements#tables` excludes materialized views

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -16,6 +16,10 @@ module ActiveRecord
           FROM all_tables
           WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
           AND secondary = 'N'
+          minus
+          SELECT DECODE(mview_name, UPPER(mview_name), LOWER(mview_name), mview_name)
+          FROM all_mviews
+          WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
         SQL
         end
 


### PR DESCRIPTION
If users want to see materialized views, call `OracleEnhanced::SchemaStatements#materialized_views`

Addresses #1505