### PR TITLE
Remove `rails/arel` from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ group :development do
   gem "rake"
 
   gem "activerecord",   github: "rails/rails", branch: "master"
-  gem "arel",   github: "rails/arel", branch: "master"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do


### PR DESCRIPTION
Arel is part of Rails now https://github.com/rails/rails/pull/32097