### PR TITLE
Remove `rails/arel` from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ group :development do
   gem "rake"
 
   gem "activerecord",   github: "rails/rails", branch: "5-2-stable"
-  gem "arel",   github: "rails/arel", branch: "master"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do


### PR DESCRIPTION
Addresses this error at https://travis-ci.org/rsim/oracle-enhanced/jobs/370937600
```
Your bundle requires gems that depend on each other, creating an infinite loop.

```
Backport #1711 to release52