### PR TITLE
Use SQL literals for `column_definitions` and `pk_and_sequence_for`

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -542,17 +542,17 @@ describe "OracleEnhancedAdapter" do
       expect(@logger.logged(:debug).last).to match(/\[\["owner", "#{DATABASE_USER.upcase}"\], \["trigger_name", "TEST_POSTS_PKT"\], \["owner", "#{DATABASE_USER.upcase}"\], \["table_name", "TEST_POSTS"\]\]/)
     end
 
-    it "should return content from columns with bind usage" do
+    it "should return content from columns without bind usage" do
       expect(@conn.columns("TEST_POSTS").length).to be > 0
-      expect(@logger.logged(:debug).last).to match(/:owner/)
-      expect(@logger.logged(:debug).last).to match(/:table_name/)
-      expect(@logger.logged(:debug).last).to match(/\[\["owner", "#{DATABASE_USER.upcase}"\], \["table_name", "TEST_POSTS"\]\]/)
+      expect(@logger.logged(:debug).last).not_to match(/:owner/)
+      expect(@logger.logged(:debug).last).not_to match(/:table_name/)
+      expect(@logger.logged(:debug).last).not_to match(/\[\["owner", "#{DATABASE_USER.upcase}"\], \["table_name", "TEST_POSTS"\]\]/)
     end
 
-    it "should return pk and sequence from pk_and_sequence_for with bind usage" do
+    it "should return pk and sequence from pk_and_sequence_for without bind usage" do
       expect(@conn.pk_and_sequence_for("TEST_POSTS").length).to eq 2
-      expect(@logger.logged(:debug).last).to match(/:owner/)
-      expect(@logger.logged(:debug).last).to match(/\[\["owner", "#{DATABASE_USER.upcase}"\], \["table_name", "TEST_POSTS"\]\]/)
+      expect(@logger.logged(:debug).last).not_to match(/:owner/)
+      expect(@logger.logged(:debug).last).not_to match(/\[\["owner", "#{DATABASE_USER.upcase}"\], \["table_name", "TEST_POSTS"\]\]/)
     end
 
     it "should return pk from primary_keys with bind usage" do


### PR DESCRIPTION
since these methods called via `to_sql` method under `unprepared_statement`

Fix #1678 Backports #1713 to release52 branch

Starting from Oracle enhanced adapter 5.2.0.beta1 most of the queries for the dictionary, such as all_sequences use bind variables by #1498 .
It should help shared memory usage however, which eventually means Oracle enhanced adapter 5.2+ only supports `prepared_statements: true`
as Rails default configuration but it does not support `prepared_statements: false`.

Even if `prepared_statements: true`, `to_sql` uses `unprepared_statement` to generate SQL statement. If the connection already knows which table is associated with which model object in advance, `to_sql` works fine but when `to_sql` executed first the connection needs to know these relation then call
column_definitions` and `pk_and_sequence_for` methods at least.