### PR TITLE
Remove `rails/arel` from bug report templates [skip ci]

### DIFF
--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -13,7 +13,6 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   gem "rails", github: "rails/rails", branch: "master"
-  gem "arel", github: "rails/arel", branch: "master"
   gem "activerecord-oracle_enhanced-adapter",  github: "rsim/oracle-enhanced", branch: "master"
   gem "minitest"
 

--- a/guides/bug_report_templates/active_record_gem_spec.rb
+++ b/guides/bug_report_templates/active_record_gem_spec.rb
@@ -13,7 +13,6 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   gem "rails", github: "rails/rails", branch: "master"
-  gem "arel", github: "rails/arel", branch: "master"
   gem "activerecord-oracle_enhanced-adapter",  github: "rsim/oracle-enhanced", branch: "master"
   gem "rspec"
 


### PR DESCRIPTION
Arel is now bundled in the Active Record gem, and maintained in the rails/rails repository.

Related PR is #1711.