### PR TITLE
Do not install bundler explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ before_install:
   - chmod +x .travis/setup_accounts.sh
 
 install:
-  - "travis_retry gem update --system"
-  - "travis_retry gem install bundler"
   - .travis/oracle/download.sh
   - .travis/oracle/install.sh
   - .travis/setup_accounts.sh


### PR DESCRIPTION
Refer

https://changelog.travis-ci.com/rubygems-updates-60220

> This update fixes failures with bundle exec commands, where the previous workaround was to add gem install bundler to your .travis.yml configuration file.

https://github.com/travis-ci/travis-ci/issues/8969#issuecomment-390330259
https://github.com/travis-ci/travis-ci/issues/9333#issuecomment-390330511

> I think I tracked down the issue to an older version of RubyGems in use by the current Ruby 2.5.1, 2.5.0, 2.4.4 archives (there may be others). I've repackaged the affected Linux archives so that they use RubyGems 2.7.7 (there should be a line in your build log gem --version inside the ruby --version fold; cf. https://travis-ci.com/BanzaiMan/vandamme/builds/73872255#L475). If applicable, please try restarting the affected job, or drop the gem install bundler workaround and test the latest archive, and please report the results here.`

Will see how it works.