### PR TITLE
Turn on performance based cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -155,3 +155,12 @@ Style/Semicolon:
 # Prefer Foo.method over Foo::method
 Style/ColonMethodCall:
   Enabled: true
+
+Style/TrivialAccessors:
+  Enabled: true
+
+Performance/FlatMap:
+  Enabled: true
+
+Performance/RedundantMerge:
+  Enabled: true

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -19,7 +19,7 @@ describe "OracleEnhancedAdapter schema dump" do
   end
 
   def create_test_posts_table(options = {})
-    options.merge! force: true
+    options[:force] = true
     schema_define do
       create_table :test_posts, options do |t|
         t.string :title


### PR DESCRIPTION
Follow up of rails/rails#32381.

In addition, this PR applies the following auto-correct.

```console
% rubocop -a
Inspecting 64 files
..........C.....................................................

Offenses:

spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb:22:5:
C: [Corrected] Performance/RedundantMerge: Use options[:force] = true
instead of options.merge! force: true.
    options.merge! force: true
    ^^^^^^^^^^^^^^^^^^^^^^^^^^

64 files inspected, 1 offense detected, 1 offense corrected
```