### PR TITLE
Suppress warning `BigDecimal.new` is deprecated

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -480,7 +480,7 @@ module ActiveRecord
             elsif d.isInt
               Integer(d.stringValue)
             else
-              BigDecimal.new(d.stringValue)
+              BigDecimal(d.stringValue)
             end
           when :BINARY_FLOAT
             rset.getFloat(i)

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -124,7 +124,7 @@ module ActiveRecord
             when Type::OracleEnhanced::Raw
               @raw_cursor.bind_param(position, OracleEnhanced::Quoting.encode_raw(value))
             when ActiveModel::Type::Decimal
-              @raw_cursor.bind_param(position, BigDecimal.new(value.to_s))
+              @raw_cursor.bind_param(position, BigDecimal(value.to_s))
             when NilClass
               @raw_cursor.bind_param(position, nil, String)
             else


### PR DESCRIPTION
Follow up of rails/rails#31435.

This PR suppresses the following warning.

```console
% bundle exec rspec

(snip)

/home/travis/build/rsim/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:484:
warning: BigDecimal.new is deprecated
```

https://travis-ci.org/rsim/oracle-enhanced/jobs/409700715#L775

This is a warning found in JRuby, but this commit has made same changes to MRI (OCI connection) .