### PR TITLE
Introduce column cache per connection

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -157,6 +157,14 @@ module ActiveRecord
           all_schema_indexes.select { |i| i.table == table_name }
         end
 
+        def columns(table_name)
+          table_name = table_name.to_s
+          if @columns_cache[table_name]
+            @columns_cache[table_name]
+          else
+            @columns_cache[table_name] = super(table_name)
+          end
+        end
         # Additional options for +create_table+ method in migration files.
         #
         # You can specify individual starting value in table creation migration file, e.g.:
@@ -253,6 +261,8 @@ module ActiveRecord
           execute "DROP SEQUENCE #{quote_table_name(seq_name)}" rescue nil
         rescue ActiveRecord::StatementInvalid => e
           raise e unless options[:if_exists]
+        ensure
+          clear_table_columns_cache(table_name)
         end
 
         def insert_versions_sql(versions) # :nodoc:
@@ -403,6 +413,8 @@ module ActiveRecord
           execute add_column_sql
           create_sequence_and_trigger(table_name, options) if type && type.to_sym == :primary_key
           change_column_comment(table_name, column_name, options[:comment]) if options.key?(:comment)
+        ensure
+          clear_table_columns_cache(table_name)
         end
 
         def aliased_types(name, fallback)
@@ -412,6 +424,8 @@ module ActiveRecord
         def change_column_default(table_name, column_name, default_or_changes) #:nodoc:
           default = extract_new_default_value(default_or_changes)
           execute "ALTER TABLE #{quote_table_name(table_name)} MODIFY #{quote_column_name(column_name)} DEFAULT #{quote(default)}"
+        ensure
+          clear_table_columns_cache(table_name)
         end
 
         def change_column_null(table_name, column_name, null, default = nil) #:nodoc:
@@ -444,15 +458,21 @@ module ActiveRecord
           execute(change_column_sql)
 
           change_column_comment(table_name, column_name, options[:comment]) if options.key?(:comment)
+        ensure
+          clear_table_columns_cache(table_name)
         end
 
         def rename_column(table_name, column_name, new_column_name) #:nodoc:
           execute "ALTER TABLE #{quote_table_name(table_name)} RENAME COLUMN #{quote_column_name(column_name)} to #{quote_column_name(new_column_name)}"
           rename_column_indexes(table_name, column_name, new_column_name)
+        ensure
+          clear_table_columns_cache(table_name)
         end
 
         def remove_column(table_name, column_name, type = nil, options = {}) #:nodoc:
           execute "ALTER TABLE #{quote_table_name(table_name)} DROP COLUMN #{quote_column_name(column_name)} CASCADE CONSTRAINTS"
+        ensure
+          clear_table_columns_cache(table_name)
         end
 
         def change_table_comment(table_name, comment)

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -227,6 +227,7 @@ module ActiveRecord
         @statements = StatementPool.new(self.class.type_cast_config_to_integer(config[:statement_limit]))
         @enable_dbms_output = false
         @do_not_prefetch_primary_key = {}
+        @columns_cache = {}
       end
 
       ADAPTER_NAME = "OracleEnhanced".freeze
@@ -548,6 +549,10 @@ module ActiveRecord
              AND cols.column_name = comments.column_name
            ORDER BY cols.column_id
         SQL
+      end
+
+      def clear_table_columns_cache(table_name)
+        @columns_cache[table_name.to_s] = nil
       end
 
       # Find a table's primary key and sequence.

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -66,15 +66,16 @@ describe "OracleEnhancedAdapter" do
       end
 
       it "should get columns from database at first time" do
+        @conn.clear_table_columns_cache(:test_employees)
         expect(TestEmployee.connection.columns("test_employees").map(&:name)).to eq(@column_names)
         expect(@logger.logged(:debug).last).to match(/select .* from all_tab_cols/im)
       end
 
-      it "should get columns from database at second time" do
+      it "should not get columns from database at second time" do
         TestEmployee.connection.columns("test_employees")
         @logger.clear(:debug)
         expect(TestEmployee.connection.columns("test_employees").map(&:name)).to eq(@column_names)
-        expect(@logger.logged(:debug).last).to match(/select .* from all_tab_cols/im)
+        expect(@logger.logged(:debug).last).not_to match(/select .* from all_tab_cols/im)
       end
 
       it "should get primary key from database at first time" do


### PR DESCRIPTION
rsim/oracle-enhanced#1490 removed Oracle enhanced adapter own column cache feature
to use Rails `db:schema:cache:dump`.  However, it caused slower performance
about metadata search, such as column information.

This commit restores Oracle enhanced adapter own column cache feature.
It used to be class level caching, it is connection level caching now
since it is much easier and cleaner than class level ones.

Related to rsim/oracle-enhanced#1720