### PR TITLE
Use cursor_sharing = force by default again

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -150,7 +150,7 @@ module ActiveRecord
             # @raw_connection.setDefaultRowPrefetch(prefetch_rows) if prefetch_rows
           end
 
-          cursor_sharing = config[:cursor_sharing]
+          cursor_sharing = config[:cursor_sharing] || "force"
           exec "alter session set cursor_sharing = #{cursor_sharing}" if cursor_sharing
 
           # Initialize NLS parameters

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -285,7 +285,7 @@ module ActiveRecord
           privilege = config[:privilege] && config[:privilege].to_sym
           async = config[:allow_concurrency]
           prefetch_rows = config[:prefetch_rows] || 100
-          cursor_sharing = config[:cursor_sharing]
+          cursor_sharing = config[:cursor_sharing] || "force"
           # get session time_zone from configuration or from TZ environment variable
           time_zone = config[:time_zone] || ENV["TZ"]
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -30,15 +30,15 @@ describe "OracleEnhancedAdapter establish connection" do
     expect(ActiveRecord::Base.connection).to be_active
   end
 
-  it "should use database default cursor_sharing parameter value exact by default" do
+  it "should use database default cursor_sharing parameter value force by default" do
     # Use `SYSTEM_CONNECTION_PARAMS` to query v$parameter
     ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS)
-    expect(ActiveRecord::Base.connection.select_value("select value from v$parameter where name = 'cursor_sharing'")).to eq("EXACT")
+    expect(ActiveRecord::Base.connection.select_value("select value from v$parameter where name = 'cursor_sharing'")).to eq("FORCE")
   end
 
-  it "should use modified cursor_sharing value force" do
-    ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS.merge(cursor_sharing: :force))
-    expect(ActiveRecord::Base.connection.select_value("select value from v$parameter where name = 'cursor_sharing'")).to eq("FORCE")
+  it "should use modified cursor_sharing value exact" do
+    ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS.merge(cursor_sharing: :exact))
+    expect(ActiveRecord::Base.connection.select_value("select value from v$parameter where name = 'cursor_sharing'")).to eq("EXACT")
   end
 end
 


### PR DESCRIPTION
It actually reverts #1503

#1498 implemented prepared statements for dictionary queries. However #1713 restored non-prepared statements for `column_definitions` and `pk_and_sequence_for`, which likely have caused
longer elapsed time for these queries reported at #1720

Those who need 'cursor_sharing = exact' can specify its own value to .database.yml