### PR TITLE
Add table_name search condition to `indexes(table_name)` method

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -87,7 +87,7 @@ module ActiveRecord
           (_owner, table_name) = @connection.describe(table_name)
           default_tablespace_name = default_tablespace
 
-          result = select_all(<<-SQL.strip.gsub(/\s+/, " "), "indexes")
+          result = select_all(<<-SQL.strip.gsub(/\s+/, " "), "indexes", [bind_string("table_name", table_name)])
             SELECT LOWER(i.table_name) AS table_name, LOWER(i.index_name) AS index_name, i.uniqueness,
               i.index_type, i.ityp_owner, i.ityp_name, i.parameters,
               LOWER(i.tablespace_name) AS tablespace_name,
@@ -101,6 +101,7 @@ module ActiveRecord
                 c.column_name = atc.column_name AND i.owner = atc.owner AND atc.hidden_column = 'NO'
             WHERE i.owner = SYS_CONTEXT('userenv', 'current_schema')
                AND i.table_owner = SYS_CONTEXT('userenv', 'current_schema')
+               AND i.table_name = :table_name
                AND NOT EXISTS (SELECT uc.index_name FROM all_constraints uc
                 WHERE uc.index_name = i.index_name AND uc.owner = i.owner AND uc.constraint_type = 'P')
             ORDER BY i.index_name, c.column_position

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -478,6 +478,12 @@ describe "OracleEnhancedAdapter" do
       expect(@conn.table_exists?("NOT_EXISTING")).to eq false
     end
 
+    it "should return array from indexes with bind usage" do
+       expect(@conn.indexes("TEST_POSTS").class).to eq Array
+       expect(@logger.logged(:debug).last).to match(/:table_name/)
+       expect(@logger.logged(:debug).last).to match(/\["table_name", "TEST_POSTS"\]/)
+     end
+
     it "should return content from columns without bind usage" do
       expect(@conn.columns("TEST_POSTS").length).to be > 0
       expect(@logger.logged(:debug).last).not_to match(/:table_name/)


### PR DESCRIPTION
Add table_name search condition to `indexes(table_name)` method and restored one spec which has been removed at https://github.com/rsim/oracle-enhanced/pull/1672

Related to #1720