### PR TITLE
Do not set nil value to java.util.Properties

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -125,6 +125,8 @@ module ActiveRecord
             time_zone = config[:time_zone] || ENV["TZ"] || java.util.TimeZone.default.getID
 
             properties = java.util.Properties.new
+            raise "username not set" unless username
+            raise "password not set" unless password
             properties.put("user", username)
             properties.put("password", password)
             properties.put("defaultRowPrefetch", "#{prefetch_rows}") if prefetch_rows


### PR DESCRIPTION
This returns easier to understand error message

Before this error in default full rails engine

```An error occurred while loading ./spec/spec_name_spec.rb.
Failure/Error: ActiveRecord::Migration.maintain_test_schema!

LoadError:
  load error: rails_helper -- java.lang.NullPointerException: null
# .rvm/gems/jruby-9.1.13.0/gems/activesupport-5.2.1/lib/active_support/dependencies.rb:287:in `block in require'
```

After this

```An error occurred while loading ./spec/spec_name_spec.rb.
Failure/Error: ActiveRecord::Migration.maintain_test_schema!

RuntimeError:
  password not set
# gems/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:129:in `new_connection'```
