### PR TITLE
table with quoted name (case sensitive) and synonym

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -24,11 +24,8 @@ module ActiveRecord
           def describe(name)
             name = name.to_s
             if name.include?("@")
-              name, db_link = name.split("@")
-              default_owner = _select_value("SELECT username FROM all_db_links WHERE db_link = '#{db_link.upcase}'")
-              db_link = "@#{db_link}"
+              raise ArgumentError "db link is not supported"
             else
-              db_link = nil
               default_owner = @owner
             end
             real_name = OracleEnhanced::Quoting.valid_table_name?(name) ? name.upcase : name
@@ -40,22 +37,22 @@ module ActiveRecord
             table_name.sub! '"', ''
             sql = <<-SQL.strip.gsub(/\s+/, " ")
           SELECT owner, table_name, 'TABLE' name_type
-          FROM all_tables#{db_link}
+          FROM all_tables
           WHERE owner = '#{table_owner}'
             AND table_name = '#{table_name}'
           UNION ALL
           SELECT owner, view_name table_name, 'VIEW' name_type
-          FROM all_views#{db_link}
+          FROM all_views
           WHERE owner = '#{table_owner}'
             AND view_name = '#{table_name}'
           UNION ALL
-          SELECT table_owner, DECODE(db_link, NULL, table_name, table_name||'@'||db_link), 'SYNONYM' name_type
-          FROM all_synonyms#{db_link}
+          SELECT table_owner, table_name, 'SYNONYM' name_type
+          FROM all_synonyms
           WHERE owner = '#{table_owner}'
             AND synonym_name = '#{table_name}'
           UNION ALL
-          SELECT table_owner, DECODE(db_link, NULL, table_name, table_name||'@'||db_link), 'SYNONYM' name_type
-          FROM all_synonyms#{db_link}
+          SELECT table_owner, table_name, 'SYNONYM' name_type
+          FROM all_synonyms
           WHERE owner = 'PUBLIC'
             AND synonym_name = '#{real_name}'
         SQL
@@ -63,12 +60,12 @@ module ActiveRecord
               case result["name_type"]
               when "SYNONYM"
                 if result['table_name'] == result['table_name'].upcase
-                  describe("#{result['owner'] && "#{result['owner']}."}#{result['table_name']}#{db_link}")
+                  describe("#{result['owner'] && "#{result['owner']}."}#{result['table_name']}")
                 else
-                  describe("#{result['owner'] && "#{result['owner']}."}\"#{result['table_name']}\"#{db_link}")
+                  describe("#{result['owner'] && "#{result['owner']}."}\"#{result['table_name']}\"")
                 end
               else
-                db_link ? [result["owner"], result["table_name"], db_link] : [result["owner"], result["table_name"]]
+                [result["owner"], result["table_name"]]
               end
             else
               raise OracleEnhanced::ConnectionException, %Q{"DESC #{name}" failed; does it exist?}

--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -34,7 +34,7 @@ module ActiveRecord
             else
               table_owner, table_name = default_owner, real_name
             end
-            table_name.delete! "\""
+            table_name = table_name.delete "\""
             sql = <<-SQL.strip.gsub(/\s+/, " ")
           SELECT owner, table_name, 'TABLE' name_type
           FROM all_tables

--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -34,7 +34,7 @@ module ActiveRecord
             else
               table_owner, table_name = default_owner, real_name
             end
-            table_name.sub! "\"", ""
+            table_name.delete! "\""
             sql = <<-SQL.strip.gsub(/\s+/, " ")
           SELECT owner, table_name, 'TABLE' name_type
           FROM all_tables

--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -34,7 +34,7 @@ module ActiveRecord
             else
               table_owner, table_name = default_owner, real_name
             end
-            table_name.sub! '"', ''
+            table_name.sub! "\"", ""
             sql = <<-SQL.strip.gsub(/\s+/, " ")
           SELECT owner, table_name, 'TABLE' name_type
           FROM all_tables
@@ -59,7 +59,7 @@ module ActiveRecord
             if result = _select_one(sql)
               case result["name_type"]
               when "SYNONYM"
-                if result['table_name'] == result['table_name'].upcase
+                if result["table_name"] == result["table_name"].upcase
                   describe("#{result['owner'] && "#{result['owner']}."}#{result['table_name']}")
                 else
                   describe("#{result['owner'] && "#{result['owner']}."}\"#{result['table_name']}\"")

--- a/spec/active_record/connection_adapters/oracle_enhanced/quoting_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/quoting_spec.rb
@@ -139,6 +139,14 @@ describe "OracleEnhancedAdapter quoting" do
       end
     end
 
+    def create_camel_case_synonym
+      ActiveRecord::Schema.define do
+        suppress_messages do
+          add_synonym :camelcase, "CamelCase", force: true
+        end
+      end
+    end
+
     before(:all) do
       @conn = ActiveRecord::Base.connection
     end
@@ -176,6 +184,19 @@ describe "OracleEnhancedAdapter quoting" do
       expect(cc.id).not_to be_nil
 
       expect(@conn.tables).to include("CamelCase")
+    end
+
+    it "should allow creation and data selection of a table with CamelCase name and synonym with case insensitive name" do
+      create_camel_case_synonym
+      class ::CamelCase < ActiveRecord::Base
+        self.table_name = "CamelCase"
+      end
+
+      cc = CamelCase.create!(name: "Foo", foo: 2)
+      new_id = cc.id
+      expect(CamelCase.exists?(new_id)).to be_truthy
+
+      expect(@conn.synonyms).to include(:camelcase)
     end
   end
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced/quoting_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/quoting_spec.rb
@@ -160,7 +160,6 @@ describe "OracleEnhancedAdapter quoting" do
         suppress_messages do
           drop_table "warehouse-things", if_exists: true
           drop_table "CamelCase", if_exists: true
-          remove_synonym "CAMELCASESYNONYM"
           drop_table "CamelCaseSynonym", if_exists: true
         end
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced/quoting_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/quoting_spec.rb
@@ -146,7 +146,7 @@ describe "OracleEnhancedAdapter quoting" do
             t.string      :name
             t.integer     :foo
           end
-          add_synonym :camelcasesynonym, "CamelCaseSynonym", force: true
+          add_synonym "CAMELCASESYNONYM", "CamelCaseSynonym", force: true
         end
       end
     end
@@ -160,7 +160,7 @@ describe "OracleEnhancedAdapter quoting" do
         suppress_messages do
           drop_table "warehouse-things", if_exists: true
           drop_table "CamelCase", if_exists: true
-          remove_synonym :camelcasesynonym
+          remove_synonym "CAMELCASESYNONYM"
           drop_table "CamelCaseSynonym", if_exists: true
         end
       end
@@ -202,8 +202,6 @@ describe "OracleEnhancedAdapter quoting" do
       cc = CamelCaseSynonym.create!(name: "Foo", foo: 2)
       new_record_id = cc.id
       expect(CamelCaseSynonym.exists?(new_record_id)).to be_truthy
-
-      expect(@conn.synonyms).to include(:camelcasesynonym)
     end
   end
 end


### PR DESCRIPTION
I've a database that have many tables with quoted name (case sensitive). It's a problem because when I use a model class to make reference to the table and I use `self.table_name = 'MYSCHEMA."mytable"'` I get this error: `ActiveRecord::ConnectionAdapters::OracleEnhanced::ConnectionException ("DESC SPDNET."config_tmp"" failed; does it exist?)`. This table have a **synonym**, but, if I use this synonym in `table_name` of the model class, then the gem stay in loop in the method `OracleEnhanced::Connection.describe` and generate this error: `SystemStackError (stack level too deep)`.
Because this, I changed `OracleEnhanced::Connection.describe` to verify if table_name of synonym is case sensitive or not and replace **"** when search a database object (table, view or synonym) in Oracle's system tables.