### PR TITLE
[5.2.3] table with quoted name (case sensitive) and synonym

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -37,6 +37,7 @@ module ActiveRecord
             else
               table_owner, table_name = default_owner, real_name
             end
+            table_name = table_name.delete "\""
             sql = <<-SQL.strip.gsub(/\s+/, " ")
           SELECT owner, table_name, 'TABLE' name_type
           FROM all_tables#{db_link}
@@ -61,7 +62,11 @@ module ActiveRecord
             if result = _select_one(sql)
               case result["name_type"]
               when "SYNONYM"
-                describe("#{result['owner'] && "#{result['owner']}."}#{result['table_name']}#{db_link}")
+                if result["table_name"] == result["table_name"].upcase
+                  describe("#{result['owner'] && "#{result['owner']}."}#{result['table_name']}#{db_link}")
+                else
+                  describe("#{result['owner'] && "#{result['owner']}."}\"#{result['table_name']}\"#{db_link}")
+                end
               else
                 db_link ? [result["owner"], result["table_name"], db_link] : [result["owner"], result["table_name"]]
               end

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -202,13 +202,17 @@ module ActiveRecord
         def describe(name)
           # fall back to SELECT based describe if using database link
           return super if name.to_s.include?("@")
-          quoted_name = OracleEnhanced::Quoting.valid_table_name?(name) ? name : "\"#{name}\""
+          if OracleEnhanced::Quoting.valid_table_name?(name)
+            quoted_name = name
+          else
+            quoted_name = name.to_s.include?('"') ? name : "\"#{name}\""
+          end
           @raw_connection.describe(quoted_name)
         rescue OCIException => e
           if e.code == 4043
             raise OracleEnhanced::ConnectionException, %Q{"DESC #{name}" failed; does it exist?}
           else
-            # fall back to SELECT which can handle synonyms to database links
+            #fall back to SELECT which can handle synonyms to database links
             super
           end
         end

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -205,7 +205,7 @@ module ActiveRecord
           if OracleEnhanced::Quoting.valid_table_name?(name)
             quoted_name = name
           else
-            quoted_name = name.to_s.include?('"') ? name : "\"#{name}\""
+            quoted_name = name.to_s.include?("\"") ? name : "\"#{name}\""
           end
           @raw_connection.describe(quoted_name)
         rescue OCIException => e


### PR DESCRIPTION
I've a database that have many tables with quoted name (case sensitive). It's a problem because when I use a model class to make reference to the table and I use self.table_name = 'MYSCHEMA."mytable"' I get this error: ActiveRecord::ConnectionAdapters::OracleEnhanced::ConnectionException ("DESC SPDNET."config_tmp"" failed; does it exist?). This table have a synonym, but, if I use this synonym in table_name of the model class, then the gem stay in loop in the method OracleEnhanced::Connection.describe and generate this error: SystemStackError (stack level too deep).
Because this, I changed OracleEnhanced::Connection.describe to verify if table_name of synonym is case sensitive or not and replace " when search a database object (table, view or synonym) in Oracle's system tables.