### PR TITLE
Deprecated `table_name_length` and `column_name_length`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_limits.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_limits.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/deprecation"
+
 module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced
@@ -15,11 +17,13 @@ module ActiveRecord
         def table_name_length
           IDENTIFIER_MAX_LENGTH
         end
+        deprecate :table_name_length
 
         # the maximum length of a column name
         def column_name_length
           IDENTIFIER_MAX_LENGTH
         end
+        deprecate :column_name_length
 
         # Returns the maximum allowed length for an index name. This
         # limit is enforced by rails and Is less than or equal to


### PR DESCRIPTION
This pull request addresses these two failures to support https://github.com/rails/rails/pull/33799
```ruby
$ ARCONN=oracle bundle exec ruby -w -Itest test/cases/adapter_test.rb -n /length_is_deprecated/
... snip ...
Using oracle
Run options: -n /length_is_deprecated/ --seed 13009

.F

Failure:
ActiveRecord::AdapterTest#test_column_name_length_is_deprecated [test/cases/adapter_test.rb:306]:
Expected a deprecation warning within the block but received none

rails test test/cases/adapter_test.rb:305

F

Failure:
ActiveRecord::AdapterTest#test_table_name_length_is_deprecated [test/cases/adapter_test.rb:310]:
Expected a deprecation warning within the block but received none

rails test test/cases/adapter_test.rb:309

Finished in 0.020496s, 146.3696 runs/s, 146.3696 assertions/s.
3 runs, 3 assertions, 2 failures, 0 errors, 0 skips
$
```