### PR TITLE
Handle ORA-02292 as `InvalidForeignKey`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -702,7 +702,7 @@ module ActiveRecord
             ActiveRecord::StatementInvalid.new(message)
           when 1400
             ActiveRecord::NotNullViolation.new(message)
-          when 2291
+          when 2291, 2292
             InvalidForeignKey.new(message)
           when 12899
             ValueTooLong.new(message)


### PR DESCRIPTION
Refer https://github.com/rails/rails/commit/59c3ed1b3f9

This pull request addresses the following failure.

```ruby
$ ARCONN=oracle bundle exec ruby -w -Itest test/cases/adapter_test.rb -n test_foreign_key_violations_on_delete_are_translated_to_specific_exception
... snip ...

F

Failure:
ActiveRecord::AdapterForeignKeyTest#test_foreign_key_violations_on_delete_are_translated_to_specific_exception [test/cases/adapter_test.rb:368]:
[ActiveRecord::InvalidForeignKey] exception expected, not
Class: <ActiveRecord::StatementInvalid>
Message: <"OCIError: ORA-02292: integrity constraint (ARUNIT.FK_NAME) violated - child record found: DELETE FROM fk_test_has_pk WHERE pk_id = 1">
---Backtrace---
stmt.c:243:in oci8lib_260.so
/home/yahonda/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/ruby-oci8-2.2.6.1/lib/oci8/cursor.rb:131:in `exec'
/home/yahonda/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/ruby-oci8-2.2.6.1/lib/oci8/oci8.rb:272:in `exec_internal'
/home/yahonda/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/ruby-oci8-2.2.6.1/lib/oci8/oci8.rb:263:in `exec'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:406:in `exec'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:97:in `exec'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:13:in `block in execute'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:601:in `block (2 levels) in log'
/home/yahonda/.rbenv/versions/2.6.0-dev/lib/ruby/2.6.0/monitor.rb:226:in `mon_synchronize'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:600:in `block in log'
/home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:591:in `log'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/dbms_output.rb:36:in `log'
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:13:in `execute'
test/cases/adapter_test.rb:369:in `block in test_foreign_key_violations_on_delete_are_translated_to_specific_exception'
---------------

rails test test/cases/adapter_test.rb:365

Finished in 2.367780s, 0.4223 runs/s, 0.4223 assertions/s.
1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```