### PR TITLE
Suppress deprecated warning for `table_name_length`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -246,8 +246,8 @@ module ActiveRecord
         end
 
         def rename_table(table_name, new_name) #:nodoc:
-          if new_name.to_s.length > table_name_length
-            raise ArgumentError, "New table name '#{new_name}' is too long; the limit is #{table_name_length} characters"
+          if new_name.to_s.length > DatabaseLimits::IDENTIFIER_MAX_LENGTH
+            raise ArgumentError, "New table name '#{new_name}' is too long; the limit is #{DatabaseLimits::IDENTIFIER_MAX_LENGTH} characters"
           end
           execute "RENAME #{quote_table_name(table_name)} TO #{quote_table_name(new_name)}"
           execute "RENAME #{quote_table_name("#{table_name}_seq")} TO #{default_sequence_name(new_name)}" rescue nil


### PR DESCRIPTION
Follow up of #1770.

This PR suppresses the following warning.

```console
% bundle exec rspec ./spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
==> Loading config from ENV or use default
==> Running specs with MRI version 2.5.1
==> Effective ActiveRecord version 6.0.0.alpha
..............DEPRECATION WARNING: table_name_length is deprecated and
will be removed from Rails 6.1 (called from rename_table at
/home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:249)

(snip)

Finished in 14.69 seconds (files took 0.59003 seconds to load)
77 examples, 0 failures, 2 pending
```

This PR replaces `table_name_length` with `DatabaseLimits::IDENTIFIER_MAX_LENGTH`. `DatabaseLimits::IDENTIFIER_MAX_LENGTH` is the value internally used by `table_name_length`.
https://github.com/rsim/oracle-enhanced/blob/v5.2.3/lib/active_record/connection_adapters/oracle_enhanced/database_limits.rb#L16