### PR TITLE
Add a check to supported Oracle database version

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -644,6 +644,13 @@ module ActiveRecord
       alias index_name_length max_identifier_length
 
       private
+        def check_version
+          database_version = @connection.database_version.join(".").to_f
+
+          if database_version < 10
+            raise "Your version of Oracle (#{database_version}) is too old. Active Record Oracle enhanced adapter supports Oracle >= 10g."
+          end
+        end
 
         def initialize_type_map(m = type_map)
           super


### PR DESCRIPTION
Follow up of rails/rails#34232.

This PR adds a check to supported Oracle database version.