### PR TITLE
CI against Ruby 2.5.2 and 2.4.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ install:
 
 language: ruby
 rvm:
-  - 2.4.4
-  - 2.5.1
+  - 2.4.5
+  - 2.5.2
   - jruby-9.2.0.0
   - ruby-head
   - jruby-head


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2018/10/17/ruby-2-4-5-released/
https://www.ruby-lang.org/en/news/2018/10/17/ruby-2-5-2-released/