### PR TITLE
CI against Ruby 2.5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
 language: ruby
 rvm:
   - 2.4.5
-  - 2.5.2
+  - 2.5.3
   - jruby-9.2.0.0
   - ruby-head
   - jruby-head


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2018/10/18/ruby-2-5-3-released/