### PR TITLE
Revert "Add allow_railures for jruby-head until #1737 resolved"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,6 @@ rvm:
   - ruby-head
   - jruby-head
 
-matrix:
-   allow_failures:
-     - rvm: jruby-head
 notifications:
     email: false
 


### PR DESCRIPTION
This reverts commit 5fe95d42f48d134406ac9f607aecef6e0a5b5fb3.

Since #1737 has been resolved.