### PR TITLE
CI against JRuby 9.2.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ language: ruby
 rvm:
   - 2.4.5
   - 2.5.3
-  - jruby-9.2.0.0
+  - jruby-9.2.1.0
   - ruby-head
   - jruby-head
 


### PR DESCRIPTION
JRuby 9.2.1.0 has been released.
https://www.jruby.org/2018/11/06/jruby-9-2-1-0.html