### PR TITLE
Added gsub to remove backticks in columns_for_distinct method

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -623,7 +623,7 @@ module ActiveRecord
         #
         # It does not construct DISTINCT clause. Just return column names for distinct.
         order_columns = orders.reject(&:blank?).map { |s|
-            s = s.to_sql unless s.is_a?(String)
+            s = s.to_sql.gsub(/\`/, '') unless s.is_a?(String)
             # remove any ASC/DESC modifiers
             s.gsub(/\s+(ASC|DESC)\s*?/i, "")
           }.reject(&:blank?).map.with_index { |column, i|

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -623,7 +623,7 @@ module ActiveRecord
         #
         # It does not construct DISTINCT clause. Just return column names for distinct.
         order_columns = orders.reject(&:blank?).map { |s|
-            s = s.to_sql.gsub(/\`/, '') unless s.is_a?(String)
+            s = s.to_sql.gsub(/\`/, "") unless s.is_a?(String)
             # remove any ASC/DESC modifiers
             s.gsub(/\s+(ASC|DESC)\s*?/i, "")
           }.reject(&:blank?).map.with_index { |column, i|


### PR DESCRIPTION
Fixes #450

I know this is an ancient issue, but I still run into it today, anytime I combine MySQL and Oracle.

I've been monkeypatching all these years. :)
