### PR TITLE
Adds xml type support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development do
   gem "rspec"
   gem "rdoc"
   gem "rake"
-  gem 'xmlhasher'
+  gem "xmlhasher"
 
   gem "activerecord",   github: "rails/rails", branch: "master"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :development do
   gem "rspec"
   gem "rdoc"
   gem "rake"
+  gem 'xmlhasher'
 
   gem "activerecord",   github: "rails/rails", branch: "master"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -13,7 +13,8 @@ module ActiveRecord
           :raw,
           :timestamptz,
           :timestampltz,
-          :ntext
+          :ntext,
+          :xmltype
         ].each do |column_type|
           module_eval <<-CODE, __FILE__, __LINE__ + 1
             def #{column_type}(*args, **options)

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -373,7 +373,7 @@ module ActiveRecord
         boolean: { name: "NUMBER", limit: 1 },
         raw: { name: "RAW", limit: 2000 },
         bigint: { name: "NUMBER", limit: 19 },
-        xmltype: {name: "XMLTYPE"}
+        xmltype: { name: "XMLTYPE" }
       }
       # if emulate_booleans_from_strings then store booleans in VARCHAR2
       NATIVE_DATABASE_TYPES_BOOLEAN_STRINGS = NATIVE_DATABASE_TYPES.dup.merge(

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -58,6 +58,7 @@ require "active_record/type/oracle_enhanced/json"
 require "active_record/type/oracle_enhanced/timestamptz"
 require "active_record/type/oracle_enhanced/timestampltz"
 require "active_record/type/oracle_enhanced/character_string"
+require "active_record/type/oracle_enhanced/xml"
 
 module ActiveRecord
   module ConnectionHandling #:nodoc:
@@ -371,7 +372,8 @@ module ActiveRecord
         binary: { name: "BLOB" },
         boolean: { name: "NUMBER", limit: 1 },
         raw: { name: "RAW", limit: 2000 },
-        bigint: { name: "NUMBER", limit: 19 }
+        bigint: { name: "NUMBER", limit: 19 },
+        xmltype: {name: "XMLTYPE"}
       }
       # if emulate_booleans_from_strings then store booleans in VARCHAR2
       NATIVE_DATABASE_TYPES_BOOLEAN_STRINGS = NATIVE_DATABASE_TYPES.dup.merge(
@@ -664,6 +666,7 @@ module ActiveRecord
           register_class_with_limit m, %r(varchar)i,        Type::OracleEnhanced::String
           register_class_with_limit m, %r(clob)i,           Type::OracleEnhanced::Text
           register_class_with_limit m, %r(nclob)i,           Type::OracleEnhanced::NationalCharacterText
+          register_class_with_limit m, %r(xmltype)i,        Type::OracleEnhanced::XML
 
           m.register_type "NCHAR", Type::OracleEnhanced::NationalCharacterString.new
           m.alias_type %r(NVARCHAR2)i,    "NCHAR"

--- a/lib/active_record/type/oracle_enhanced/xml.rb
+++ b/lib/active_record/type/oracle_enhanced/xml.rb
@@ -1,0 +1,44 @@
+require "active_model/type/string"
+require 'xmlhasher'
+
+module ActiveRecord
+  module Type
+    module OracleEnhanced
+      class XML < ActiveRecord::Type::String # :nodoc:
+        def type
+          :xmltype
+        end
+
+        def serialize(value)
+          raise 'XMLTYPE column must be of type Hash' unless value.is_a?(Hash)
+          to_xml(value).first
+        end
+
+        def cast_value(value)
+          value
+        end
+
+        def deserialize(value)
+          XmlHasher.parse(value) if value.present?
+        end
+
+      private
+        def to_xml(hash_obj)
+          hash_obj.map do |key, value|
+            noderize(key, value)
+          end
+        end
+
+        def noderize(key, value)
+          if value.class == Hash
+            node_value = to_xml(value).join
+          else
+            node_value = value.nil? ? "" : value
+          end
+
+          "<#{key}>#{node_value}</#{key}>"
+        end
+      end
+    end
+  end
+end

--- a/lib/active_record/type/oracle_enhanced/xml.rb
+++ b/lib/active_record/type/oracle_enhanced/xml.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 require "active_model/type/string"
-require 'xmlhasher'
+require "xmlhasher"
 
 module ActiveRecord
   module Type
@@ -10,7 +12,7 @@ module ActiveRecord
         end
 
         def serialize(value)
-          raise 'XMLTYPE column must be of type Hash' unless value.is_a?(Hash)
+          raise "XMLTYPE column must be of type Hash" unless value.is_a?(Hash)
           to_xml(value).first
         end
 

--- a/spec/active_record/oracle_enhanced/type/xml_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/xml_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+describe "OracleEnhancedAdapter handling of XML columns" do
+  include SchemaSpecHelper
+
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    schema_define do
+      create_table :test_employees, force: true do |t|
+        t.string    :first_name,    limit: 20
+        t.string    :last_name,     limit: 25
+        t.xmltype       :metadata
+      end
+    end
+    @hash_data = {a: 'a'}
+    @another_hash_data = {a: {b:'b', c:'c'}}
+  end
+
+  after(:all) do
+    schema_define do
+      drop_table :test_employees
+    end
+  end
+
+  before(:each) do
+    class ::TestEmployee < ActiveRecord::Base
+    end
+  end
+
+  after(:each) do
+    Object.send(:remove_const, "TestEmployee")
+    ActiveRecord::Base.clear_cache!
+  end
+
+  it "should create record with XML data" do
+    @employee = TestEmployee.create!(
+      first_name: "First",
+      last_name: "Last",
+      metadata: @hash_data
+    )
+    @employee.reload
+    expect(@employee.metadata).to eq(@hash_data)
+  end
+
+  it "should throw exception when record has data other than xml in xml column" do
+    expect { TestEmployee.create!(first_name: "First", last_name: "Last", metadata: "")}.to raise_error(/XMLTYPE column must be of type Hash/)
+  end
+
+  it "should update record that has existing XML data with different XML data" do
+    @employee = TestEmployee.create!(
+      first_name: "First",
+      last_name: "Last",
+      metadata: @hash_data
+    )
+    @employee.reload
+    @employee.metadata = @another_hash_data
+    @employee.save!
+    @employee.reload
+    expect(@employee.metadata).to eq(@another_hash_data)
+  end
+
+end


### PR DESCRIPTION
This adds support for xml column to store a ruby hash. For example it will store `{key: 'value'}` to oracle xml type column as `<key>value</key>` and vice-versa.
