### PR TITLE
Use Ubuntu Xenial at Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: required
 cache: bundler
 


### PR DESCRIPTION
This pull request upgrades Ubuntu version to Xenial at Travis CI 

https://docs.travis-ci.com/user/reference/xenial/