### PR TITLE
CI against JRuby 9.2.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ language: ruby
 rvm:
   - 2.4.5
   - 2.5.3
-  - jruby-9.2.4.1
+  - jruby-9.2.5.0
   - ruby-head
   - jruby-head
 


### PR DESCRIPTION
JRuby 9.2.5.0 has been released.
https://www.jruby.org/2018/12/06/jruby-9-2-5-0