### PR TITLE
Apply RuboCop 0.61.1

### DIFF
--- a/spec/active_record/oracle_enhanced/type/character_string_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/character_string_spec.rb
@@ -35,8 +35,8 @@ describe "OracleEnhancedAdapter processing CHAR column" do
     item.padded = str
     item.save
 
-    expect(TestItem.where(:padded => item.padded).count).to eq(1)
-    
+    expect(TestItem.where(padded: item.padded).count).to eq(1)
+
     item_reloaded = TestItem.first
     expect(item_reloaded.padded).to eq(str)
   end

--- a/spec/active_record/oracle_enhanced/type/dirty_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/dirty_spec.rb
@@ -123,7 +123,7 @@ describe "OracleEnhancedAdapter dirty object tracking" do
 
     oci_conn = @conn.instance_variable_get("@connection")
     class << oci_conn
-       def write_lob(lob, value, is_binary = false); raise "don't do this'"; end
+      def write_lob(lob, value, is_binary = false); raise "don't do this'"; end
     end
     expect { @employee.save! }.not_to raise_error
     class << oci_conn


### PR DESCRIPTION
This pull request applies changes made by RuboCop 0.61.1

```ruby
$ rubocop -v
0.61.1
$ rubocop -a
Inspecting 65 files
........C...C....................................................

Offenses:

spec/active_record/oracle_enhanced/type/character_string_spec.rb:38:27: C: [Corrected] Style/HashSyntax: Use the new Ruby 1.9 hash syntax.
    expect(TestItem.where(:padded => item.padded).count).to eq(1)
                          ^^^^^^^^^^
spec/active_record/oracle_enhanced/type/character_string_spec.rb:39:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/active_record/oracle_enhanced/type/dirty_spec.rb:126:5: C: [Corrected] Layout/IndentationWidth: Use 2 (not 3) spaces for indentation.
       def write_lob(lob, value, is_binary = false); raise "don't do this'"; end
    ^^^

65 files inspected, 3 offenses detected, 3 offenses corrected
$
```