### PR TITLE
Use i18n 1.2 for JRuby now

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :development do
   platforms :jruby do
     gem "pry"
     gem "pry-nav"
+    gem "i18n", "~> 1.2.0"
   end
 end
 


### PR DESCRIPTION
This pull request workarounds #1803 temporarily. 

I believe #1803 is duplicate with https://github.com/svenfuchs/i18n/issues/449

According to https://github.com/svenfuchs/i18n/issues/447#issuecomment-449160914 it would take some time this issue addressed. In the meantime, I'd like to implement a workaround to use i18n 1.2 for JRuby.

