### PR TITLE
Use i18n 1.2 for JRuby now

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :development do
   platforms :jruby do
     gem "pry"
     gem "pry-nav"
+    gem "i18n", "~> 1.2.0"
   end
 end
 


### PR DESCRIPTION
This pull request backports #1804 to release52 branch.