### PR TITLE
CI against Ruby 2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ install:
 
 language: ruby
 rvm:
+  - 2.6.0
   - 2.5.3
   - jruby-9.2.5.0
   - ruby-head


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/