### PR TITLE
CI against Ruby 2.6 and bump other Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,5 @@ rvm:
   - ruby-head
   - jruby-head
 
-matrix:
-   allow_failures:
-     - rvm: jruby-head
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,10 @@ language: ruby
 rvm:
   - 2.2.10
   - 2.3.7
-  - 2.4.4
-  - 2.5.1
-  - jruby-9.2.0.0
+  - 2.4.5
+  - 2.5.3
+  - 2.6.0
+  - jruby-9.2.5.0
   - ruby-head
   - jruby-head
 


### PR DESCRIPTION
Kind of backporting #1806 to release52 and revert #1740 since #1737 had been addressed.