### PR TITLE
Use i18n 1.2 for JRuby now

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,5 +18,6 @@ group :development do
 
   platforms :jruby do
     gem 'ruby-debug'
+    gem 'i18n', '~> 1.2.0'
   end
 end


### PR DESCRIPTION
This pull request kind of backports #1804 to release17 branch.

git cherry-pick causes conflict then made a similar change by myself.