### PR TITLE
Install bundler and fallback to 1.7.3 if Bundler 2 is not available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ install:
   - .travis/oracle/download.sh
   - .travis/oracle/install.sh
   - .travis/setup_accounts.sh
+  -  'gem install bundler || gem install bundler -v 1.17.3'
   - bundle install
 
 language: ruby


### PR DESCRIPTION
https://travis-ci.org/rsim/oracle-enhanced/jobs/475937653

```
$ bundle install
The program 'bundle' is currently not installed. To run 'bundle' please ask your administrator to install the package 'bundler'
The command "bundle install" failed and exited with 127 during .
```