### PR TITLE
Enable `Lint/UselessAssignment` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -159,6 +159,9 @@ Lint/StringConversionInInterpolation:
 Lint/UriEscapeUnescape:
   Enabled: true
 
+Lint/UselessAssignment:
+  Enabled: true
+
 Style/ParenthesesAroundCondition:
   Enabled: true
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -52,7 +52,7 @@ module ActiveRecord
         end
 
         def data_source_exists?(table_name)
-          (_owner, table_name) = @connection.describe(table_name)
+          (_owner, _table_name) = @connection.describe(table_name)
           true
         rescue
           false

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -291,12 +291,11 @@ describe "OracleEnhancedAdapter" do
       @employee = Class.new(ActiveRecord::Base) do
         self.table_name = :test_employees
       end
-      i = 0
-      @employee.create!(sort_order: i += 1, first_name: "Peter",   last_name: "Parker")
-      @employee.create!(sort_order: i += 1, first_name: "Tony",    last_name: "Stark")
-      @employee.create!(sort_order: i += 1, first_name: "Steven",  last_name: "Rogers")
-      @employee.create!(sort_order: i += 1, first_name: "Bruce",   last_name: "Banner")
-      @employee.create!(sort_order: i += 1, first_name: "Natasha", last_name: "Romanova")
+      @employee.create!(sort_order: 1, first_name: "Peter",   last_name: "Parker")
+      @employee.create!(sort_order: 2, first_name: "Tony",    last_name: "Stark")
+      @employee.create!(sort_order: 3, first_name: "Steven",  last_name: "Rogers")
+      @employee.create!(sort_order: 4, first_name: "Bruce",   last_name: "Banner")
+      @employee.create!(sort_order: 5, first_name: "Natasha", last_name: "Romanova")
     end
 
     after(:all) do

--- a/spec/active_record/oracle_enhanced/type/character_string_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/character_string_spec.rb
@@ -30,7 +30,7 @@ describe "OracleEnhancedAdapter processing CHAR column" do
 
   it "should create and find record" do
     str = "ABC"
-    item = TestItem.create!
+    TestItem.create!
     item = TestItem.first
     item.padded = str
     item.save


### PR DESCRIPTION
This cop does not support auto correct, fixed these offenses manually.

```ruby
$ rubocop -v
0.62.0
$ rubocop -a
Inspecting 65 files
........W.........W....................................W.........

Offenses:

spec/active_record/oracle_enhanced/type/character_string_spec.rb:33:5: W: Lint/UselessAssignment: Useless assignment to variable - item.
    item = TestItem.create!
    ^^^^
spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:299:37: W: Lint/UselessAssignment: Useless assignment to variable - i.
      @employee.create!(sort_order: i += 1, first_name: "Natasha", last_name: "Romanova")
                                    ^
lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:55:20: W: Lint/UselessAssignment: Useless assignment to variable - table_name. Use _ or _table_name as a variable name to indicate that it won't be used.
          (_owner, table_name) = @connection.describe(table_name)
                   ^^^^^^^^^^

65 files inspected, 3 offenses detected
$
```

Related to https://github.com/rails/rails/pull/34904