### PR TITLE
Enable `Lint/DeprecatedClassMethods` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -162,6 +162,9 @@ Lint/UriEscapeUnescape:
 Lint/UselessAssignment:
   Enabled: true
 
+Lint/DeprecatedClassMethods:
+  Enabled: true
+
 Style/ParenthesesAroundCondition:
   Enabled: true
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -26,7 +26,7 @@ begin
     ["./lib"].concat($LOAD_PATH).concat(env_path).detect do |dir|
       # check any compatible JDBC driver in the priority order
       ojdbc_jars.any? do |ojdbc_jar|
-        if File.exists?(file_path = File.join(dir, ojdbc_jar))
+        if File.exist?(file_path = File.join(dir, ojdbc_jar))
           require file_path
           true
         end


### PR DESCRIPTION
Follow up of https://github.com/rails/rails/pull/34903.

This PR auto-corrects the following offense.

```console
% rubocop -a
Inspecting 66 files
...........................................................W......

Offenses:

lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:29:17:
W: [Corrected] Lint/DeprecatedClassMethods: File.exists? is deprecated
in favor of File.exist?.
        if File.exists?(file_path = File.join(dir, ojdbc_jar))
                ^^^^^^^

66 files inspected, 1 offense detected, 1 offense corrected
```