### PR TITLE
Arity change at sql_for_insert

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -76,8 +76,8 @@ module ActiveRecord
 
         # New method in ActiveRecord 3.1
         # Will add RETURNING clause in case of trigger generated primary keys
-        def sql_for_insert(sql, pk, id_value, sequence_name, binds)
-          unless id_value || pk == false || pk.nil? ||  pk.is_a?(Array)
+        def sql_for_insert(sql, pk, sequence_name, binds)
+          unless pk == false || pk.nil? || pk.is_a?(Array)
             sql = "#{sql} RETURNING #{quote_column_name(pk)} INTO :returning_id"
             (binds = binds.dup) << ActiveRecord::Relation::QueryAttribute.new("returning_id", nil, Type::OracleEnhanced::Integer.new)
           end
@@ -91,7 +91,7 @@ module ActiveRecord
 
         # New method in ActiveRecord 3.1
         def exec_insert(sql, name = nil, binds = [], pk = nil, sequence_name = nil)
-          sql, binds = sql_for_insert(sql, pk, nil, sequence_name, binds)
+          sql, binds = sql_for_insert(sql, pk, sequence_name, binds)
           type_casted_binds = type_casted_binds(binds)
 
           log(sql, name, binds, type_casted_binds) do


### PR DESCRIPTION
Refer https://github.com/rails/rails/commit/5f9e0f848e8

This pull request addresses specs like this:
```ruby
$ bundle exec rspec ./spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb:183
==> Loading config from ENV or use default
==> Running specs with MRI version 2.6.0
==> Effective ActiveRecord version 6.0.0.alpha
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb"=>[183]}}
F

Failures:

  1) OracleEnhancedConnection default_timezone should respect default_timezone = :utc than time_zone setting
     Failure/Error: super

     ArgumentError:
       wrong number of arguments (given 5, expected 4)
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:467:in `sql_for_insert'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:84:in `sql_for_insert'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:94:in `exec_insert'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:159:in `insert'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:21:in `insert'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:89:in `insert'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activerecord/lib/active_record/persistence.rb:186:in `_insert_record'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activerecord/lib/active_record/persistence.rb:740:in `_create_record'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activerecord/lib/active_record/counter_cache.rb:163:in `_create_record'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activerecord/lib/active_record/locking/optimistic.rb:70:in `_create_record'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activerecord/lib/active_record/attribute_methods/dirty.rb:178:in `_create_record'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activerecord/lib/active_record/callbacks.rb:332:in `block in _create_record'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activesupport/lib/active_support/callbacks.rb:101:in `run_callbacks'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activesupport/lib/active_support/callbacks.rb:827:in `_run_create_callbacks'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activerecord/lib/active_record/callbacks.rb:332:in `_create_record'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activerecord/lib/active_record/timestamp.rb:101:in `_create_record'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activerecord/lib/active_record/persistence.rb:713:in `create_or_update'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activerecord/lib/active_record/callbacks.rb:328:in `block in create_or_update'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activesupport/lib/active_support/callbacks.rb:101:in `run_callbacks'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activesupport/lib/active_support/callbacks.rb:827:in `_run_save_callbacks'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activerecord/lib/active_record/callbacks.rb:328:in `create_or_update'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activerecord/lib/active_record/persistence.rb:314:in `save!'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activerecord/lib/active_record/validations.rb:52:in `save!'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activerecord/lib/active_record/transactions.rb:313:in `block in save!'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activerecord/lib/active_record/transactions.rb:374:in `block in with_transaction_returning_status'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:264:in `block in transaction'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:287:in `block in within_new_transaction'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/2.6.0/monitor.rb:230:in `mon_synchronize'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:285:in `within_new_transaction'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:264:in `transaction'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activerecord/lib/active_record/transactions.rb:212:in `transaction'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activerecord/lib/active_record/transactions.rb:372:in `with_transaction_returning_status'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activerecord/lib/active_record/transactions.rb:313:in `save!'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activerecord/lib/active_record/suppressor.rb:48:in `save!'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/rails-3631d7eee4bd/activerecord/lib/active_record/persistence.rb:53:in `create!'
     # ./spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb:186:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/example.rb:254:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/example.rb:254:in `block in run'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/example.rb:500:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/example.rb:457:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/example.rb:457:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/example.rb:500:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/example_group.rb:629:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/example_group.rb:625:in `map'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/example_group.rb:625:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/example_group.rb:591:in `run'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/example_group.rb:592:in `block in run'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/example_group.rb:592:in `map'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/example_group.rb:592:in `run'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:116:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:116:in `map'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:116:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/configuration.rb:1989:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:111:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/reporter.rb:74:in `report'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:110:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.6.0/bin/rspec:23:in `load'
     # /home/yahonda/.rbenv/versions/2.6.0/bin/rspec:23:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/2.6.0/bundler/cli/exec.rb:74:in `load'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/2.6.0/bundler/cli/exec.rb:74:in `kernel_load'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/2.6.0/bundler/cli/exec.rb:28:in `run'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/2.6.0/bundler/cli.rb:463:in `exec'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/2.6.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/2.6.0/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/2.6.0/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/2.6.0/bundler/cli.rb:27:in `dispatch'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/2.6.0/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/2.6.0/bundler/cli.rb:18:in `start'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/bundler-1.17.2/exe/bundle:30:in `block in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/2.6.0/bundler/friendly_errors.rb:124:in `with_friendly_errors'
     # /home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/bundler-1.17.2/exe/bundle:22:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.6.0/bin/bundle:23:in `load'
     # /home/yahonda/.rbenv/versions/2.6.0/bin/bundle:23:in `<main>'

Finished in 2.83 seconds (files took 0.71585 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb:183 # OracleEnhancedConnection default_timezone should respect default_timezone = :utc than time_zone setting

Coverage report generated for RSpec to /home/yahonda/git/oracle-enhanced/coverage. 995 / 2081 LOC (47.81%) covered.
$
```