### PR TITLE
Remove deprecated `#insert_fixtures` method for Rails 6.0

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -222,17 +222,6 @@ module ActiveRecord
           end
         end
 
-        # fallback to non bulk fixture insert
-        def insert_fixtures(fixtures, table_name)
-          ActiveSupport::Deprecation.warn(<<-MSG.squish)
-            `insert_fixtures` is deprecated and will be removed in the next version of Rails.
-            Consider using `insert_fixtures_set` for performance improvement.
-          MSG
-          fixtures.each do |fixture|
-            insert_fixture(fixture, table_name)
-          end
-        end
-
         def insert_fixtures_set(fixture_set, tables_to_delete = [])
           disable_referential_integrity do
             transaction(requires_new: true) do


### PR DESCRIPTION
Follow up of https://github.com/rails/rails/commit/400ba786e1d154448235f5f90183e48a1043eece.