### PR TITLE
Make `t.timestamps` with precision by default

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -54,6 +54,7 @@ module ActiveRecord
 
         attr_accessor :tablespace, :organization
         def initialize(
+          conn,
           name,
           temporary: false,
           options: nil,
@@ -65,7 +66,7 @@ module ActiveRecord
         )
           @tablespace = tablespace
           @organization = organization
-          super(name, temporary: temporary, options: options, as: as, comment: comment)
+          super(conn, name, temporary: temporary, options: options, as: as, comment: comment)
         end
 
         def new_column_definition(name, type, **options) # :nodoc:

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -618,7 +618,7 @@ module ActiveRecord
           end
 
           def create_table_definition(*args)
-            OracleEnhanced::TableDefinition.new(*args)
+            OracleEnhanced::TableDefinition.new(self, *args)
           end
 
           def new_column_from_field(table_name, field)


### PR DESCRIPTION
Fixes #1817.
Follow up of https://github.com/rails/rails/commit/57015cdfa2083351f64a82f7566965172a41efcb.