### PR TITLE
Fallback to bundler 1.7.3 if bundler 2 is not available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - chmod +x .travis/setup_accounts.sh
 
 install:
-  - "gem install bundler"
+  - "travis_retry gem install bundler || travis_retry gem install bundler -v 1.17.3"
   - .travis/oracle/download.sh
   - .travis/oracle/install.sh
   - .travis/setup_accounts.sh


### PR DESCRIPTION
This pull request addresses the following error.

https://travis-ci.org/rsim/oracle-enhanced/jobs/484610915

```ruby
$ gem install bundler
ERROR:  Error installing bundler:
	bundler requires Ruby version >= 2.3.0.
The command "gem install bundler" failed and exited with 1 during .
```