### PR TITLE
CI against Ruby 2.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
 
 language: ruby
 rvm:
-  - 2.6.0
+  - 2.6.1
   - 2.5.3
   - jruby-9.2.5.0
   - ruby-head


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/01/30/ruby-2-6-1-released/

It should be merged when https://github.com/rvm/rvm/pull/4597 or equivalent commit is ready.