### PR TITLE
CI against JRuby 9.2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ language: ruby
 rvm:
   - 2.6.1
   - 2.5.3
-  - jruby-9.2.5.0
+  - jruby-9.2.6.0
   - ruby-head
   - jruby-head
 


### PR DESCRIPTION
JRuby 9.2.6.0 has been released.
https://www.jruby.org/2019/02/11/jruby-9-2-6-0