### PR TITLE
Use `supports_foreign_keys?` instead of removed `supports_foreign_keys_in_create?`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -21,7 +21,7 @@ module ActiveRecord
             statements = o.columns.map { |c| accept c }
             statements << accept(o.primary_keys) if o.primary_keys
 
-            if supports_foreign_keys_in_create?
+            if supports_foreign_keys?
               statements.concat(o.foreign_keys.map { |to_table, options| foreign_key_in_create(o.name, to_table, options) })
             end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -257,10 +257,6 @@ module ActiveRecord
         true
       end
 
-      def supports_foreign_keys_in_create?
-        supports_foreign_keys?
-      end
-
       def supports_views?
         true
       end


### PR DESCRIPTION
Follow up of https://github.com/rails/rails/pull/35212.

This PR fixes the following error.

```console
$ bundle exec rspec ./spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb:179

(snip)

Failures:

  1) OracleEnhancedConnection default_timezone should respect
  default_timezone = :utc than time_zone setting
     Failure/Error: if supports_foreign_keys_in_create?

     NoMethodError:
       undefined method `supports_foreign_keys_in_create?' for
       #<ActiveRecord::ConnectionAdapters::OracleEnhanced::SchemaCreation:0x0000000003ef9108>
       Did you mean?  supports_foreign_keys?
     # ./lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb:24:in `visit_TableDefinition'
     # /home/vagrant/.rvm/gems/ruby-2.6.0/bundler/gems/rails-8d9d46fdae45/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:14:in `accept'
     # ./lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:233:in `create_table'
```

https://travis-ci.org/rsim/oracle-enhanced/jobs/492524301#L932