### PR TITLE
`references` column type should be :integer, not :bigint

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -76,6 +76,11 @@ module ActiveRecord
           end
           super
         end
+
+        def references(*args, **options)
+          super(*args, type: :integer, **options)
+        end
+        alias :belongs_to :references
       end
 
       class AlterTable < ActiveRecord::ConnectionAdapters::AlterTable


### PR DESCRIPTION
Oracle enhanced adapter :integer is mapped to `NUMBER(38)` sql type,
:bigint is mapped to `NUMBER(19)` sql type.

Unlike other database adapters whose :integer is mapped to `INT(4)`,
Oracle enhanced adapter :integer is larger than :bigint.

Oracle enhanced adapter `primary_key` is mapped to `NUMBER(38)`, not `NUMBER(19)`
`references` should be mapped to `NUMBER(38)` by using `:integer`.

This pull request addresses the following failure.

```ruby
$ ARCONN=oracle bin/test test/cases/base_test.rb -n test_primary_key_and_references_columns_should_be_identical_type
Using oracle
Run options: -n test_primary_key_and_references_columns_should_be_identical_type --seed 56227

F

Failure:
BasicsTest#test_primary_key_and_references_columns_should_be_identical_type [/home/yahonda/git/rails/activerecord/test/cases/base_test.rb:106]:
Expected: "NUMBER(38)"
  Actual: "NUMBER(19)"

bin/test test/cases/base_test.rb:102

Finished in 20.597513s, 0.0485 runs/s, 0.0485 assertions/s.
1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```

Fix #1831
Related to rails/rails#27334