### PR TITLE
`references` column type should be :integer, not :bigint

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -66,6 +66,11 @@ module ActiveRecord
           end
           super
         end
+
+        def references(*args, **options)
+          super(*args, type: :integer, **options)
+        end
+        alias :belongs_to :references
       end
 
       class AlterTable < ActiveRecord::ConnectionAdapters::AlterTable


### PR DESCRIPTION
This pull request backports #1832 to relese52 branch.