### PR TITLE
fix mapping of decimal type to map to `NUMBER` instead of `DECIMAL`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -357,7 +357,7 @@ module ActiveRecord
         ntext: { name: "NCLOB" },
         integer: { name: "NUMBER", limit: 38 },
         float: { name: "BINARY_FLOAT" },
-        decimal: { name: "DECIMAL" },
+        decimal: { name: "NUMBER" },
         datetime: { name: "TIMESTAMP" },
         timestamp: { name: "TIMESTAMP" },
         timestamptz: { name: "TIMESTAMP WITH TIME ZONE" },

--- a/spec/active_record/oracle_enhanced/type/decimal_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/decimal_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+describe "OracleEnhancedAdapter handling of DECIMAL columns" do
+  include SchemaSpecHelper
+
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @conn = ActiveRecord::Base.connection
+    schema_define do
+      create_table :test2_employees, force: true do |t|
+        t.string  :first_name, limit: 20
+        t.string  :last_name, limit: 25
+        t.string  :email, limit: 25
+        t.string  :phone_number, limit: 25
+        t.date    :hire_date
+        t.integer :job_id
+        t.integer :salary
+        t.decimal :commission_pct, scale: 2, precision: 2
+        t.decimal :hourly_rate
+        t.integer :manager_id,  limit: 6
+        t.integer :is_manager,  limit: 1
+        t.decimal :department_id, scale: 0, precision: 4
+        t.timestamps
+      end
+    end
+    class ::Test2Employee < ActiveRecord::Base
+    end
+  end
+
+  after(:all) do
+    Object.send(:remove_const, "Test2Employee")
+    @conn.drop_table :test2_employees, if_exists:  true
+  end
+
+  it "should set DECIMAL column type as decimal" do
+    columns = @conn.columns("test2_employees")
+    column = columns.detect { |c| c.name == "hourly_rate" }
+    expect(column.type).to eq(:decimal)
+  end
+
+  it "should DECIMAL column type returns an exact value" do
+    employee = Test2Employee.create(hourly_rate: 4.40125)
+
+    employee.reload
+
+    expect(employee.hourly_rate).to eq(4.40125)
+  end
+
+  it "should DECIMAL column type rounds if scale is specified and value exceeds scale" do
+    employee = Test2Employee.create(commission_pct: 0.1575)
+
+    employee.reload
+
+    expect(employee.commission_pct).to eq(0.16)
+  end
+end


### PR DESCRIPTION
This patch to the `OracleEnhancedAdapte`r is necessary because of the way that the gem generates the SQL to create tables with decimal columns. Without the patch, if you were to create a migration that defined a table with a `decimal` column without specifiying a precision and scale such as:

    class AddExampleTable < ActiveRecord::Migration[5.2]
      def change
        create_table :example do |t|
          t.string :name
          t.decimal :value
        end
      end
    end

The `OracleEnhancedAdapter` would generate the following SQL:

    CREATE TABLE example (
        id NUMBER(5) PRIMARY KEY,
        name VARCHAR2(15) NOT NULL,
        value DECIMAL)

This is problematic because Oracle then translates the `DECIMAL` datatype to `NUMBER(18,0)` effectively making this an `INTEGER`.

Older versions of this gem used to correctly map `t.decimal` to the Oracle type `NUMBER()`. Not sure when it changed, but we just upgraded our app this past week and noticed this strange behavior.

Basically if we defined a column as being `t.decimal` with no `precision` or `scale`, by the time the migration was run and the `schema.rb` was re-generated, it would then show up as a `t.integer` in the `schema.rb`.