### PR TITLE
Add RuboCop to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :development do
   gem "rspec"
   gem "rdoc"
   gem "rake"
+  gem "rubocop", "~> 0.63.0", require: false
 
   gem "activerecord",   github: "rails/rails", branch: "master"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"


### PR DESCRIPTION
Oracle enhanced adapter CI runs RuboCop. It would be nice to install RuboCop to the development environment. 