### PR TITLE
Add spec for custom sequence name

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -556,4 +556,26 @@ describe "OracleEnhancedAdapter" do
       Thread.report_on_exception = @original_report_on_exception
     end
   end
+
+  describe "Sequence" do
+    before(:all) do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+      @conn = ActiveRecord::Base.connection
+      schema_define do
+        create_table :table_with_name_thats_just_ok,
+          sequence_name: "suitably_short_seq", force: true do |t|
+          t.column :foo, :string, null: false
+        end
+      end
+    end
+    after(:all) do
+      schema_define do
+        drop_table :table_with_name_thats_just_ok,
+          sequence_name: "suitably_short_seq" rescue nil
+      end
+    end
+    it "should create table with custom sequence name" do
+      expect(@conn.select_value("select suitably_short_seq.nextval from dual")).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
[MigrationTest#test_create_table_with_custom_sequence_name ](https://github.com/rails/rails/blob/50e01ec01a7658ba4542bb5f9b68223e98ce6180/activerecord/test/cases/migration_test.rb#L570-L602) is only executed for `OracleAdapter`, it would be nice to run this test at Oracle enhanced adapter.

As Oracle enhanced adapter with Oracle Database 12c supports longer identifier,
this pull request does not test 29 byte length table name and 33-byte length sequence name.

Will open a pull request at Rails to remove `MigrationTest#test_create_table_with_custom_sequence_name`