### PR TITLE
Bump Ruby versions to 2.6.2 and 2.5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ install:
 
 language: ruby
 rvm:
-  - 2.6.1
-  - 2.5.3
+  - 2.6.2
+  - 2.5.4
   - jruby-9.2.6.0
   - ruby-head
   - jruby-head


### PR DESCRIPTION
* Ruby 2.6.2 Released
https://www.ruby-lang.org/en/news/2019/03/13/ruby-2-6-2-released/

* Ruby 2.5.4 Released
https://www.ruby-lang.org/en/news/2019/03/13/ruby-2-5-4-released/