### PR TITLE
CI against Ruby 2.5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
 language: ruby
 rvm:
   - 2.6.2
-  - 2.5.4
+  - 2.5.5
   - jruby-9.2.6.0
   - ruby-head
   - jruby-head


### PR DESCRIPTION
* Ruby 2.5.5 Released
https://www.ruby-lang.org/en/news/2019/03/15/ruby-2-5-5-released/