### PR TITLE
Revert "Use i18n 1.2 for JRuby now"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ group :development do
   platforms :jruby do
     gem "pry"
     gem "pry-nav"
-    gem "i18n", "~> 1.2.0"
   end
 end
 


### PR DESCRIPTION
This pull request reverts commit 1a9c2754542ad2817c923113aa7a166de5925a2e by #1804
