### PR TITLE
Cache database version in schema cache

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -269,7 +269,7 @@ module ActiveRecord
       end
 
       def supports_fetch_first_n_rows_and_offset?
-        if !use_old_oracle_visitor && @connection.database_version.first >= 12
+        if !use_old_oracle_visitor && database_version.first >= 12
           true
         else
           false
@@ -285,11 +285,11 @@ module ActiveRecord
       end
 
       def supports_multi_insert?
-        @connection.database_version.to_s >= [11, 2].to_s
+        database_version.to_s >= [11, 2].to_s
       end
 
       def supports_virtual_columns?
-        @connection.database_version.first >= 11
+        database_version.first >= 11
       end
 
       def supports_json?
@@ -324,7 +324,7 @@ module ActiveRecord
       end
 
       def supports_longer_identifier?
-        if !use_shorter_identifier && @connection.database_version.to_s >= [12, 2].to_s
+        if !use_shorter_identifier && database_version.to_s >= [12, 2].to_s
           true
         else
           false
@@ -647,15 +647,19 @@ module ActiveRecord
       alias table_alias_length max_identifier_length
       alias index_name_length max_identifier_length
 
-      private
-        def check_version
-          database_version = @connection.database_version.join(".").to_f
+      def get_database_version
+        @connection.database_version
+      end
 
-          if database_version < 10
-            raise "Your version of Oracle (#{database_version}) is too old. Active Record Oracle enhanced adapter supports Oracle >= 10g."
-          end
+      def check_version
+        version = get_database_version.join(".").to_f
+
+        if version < 10
+          raise "Your version of Oracle (#{version}) is too old. Active Record Oracle enhanced adapter supports Oracle >= 10g."
         end
+      end
 
+      private
         def initialize_type_map(m = type_map)
           super
           # oracle


### PR DESCRIPTION
Follow up of https://github.com/rails/rails/pull/35795.

This PR fixes the following error.

```console
% cd path/to/oracle-enhanced
% bundle exec rake
==> Loading config from ENV or use default
==> Running specs with MRI version 2.6.1
==> Effective ActiveRecord version 6.0.0.beta3
rake aborted!
NoMethodError: private method `check_version' called for
#<ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter:0x0000000003bce0c8>
/home/vagrant/.rvm/gems/ruby-2.6.1/bundler/gems/rails-c9981ae6e022/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:813:in
`block in new_connection'
```

And this PR confirmed the following AR test.

```console
% cd path/to/rails/activerecord
% ARCONN=oracle be ruby -w -Itest test/cases/connection_adapters/schema_cache_test.rb
Using oracle

(snip)

Finished in 1.752895s, 9.1278 runs/s, 21.6784 assertions/s.
16 runs, 38 assertions, 0 failures, 0 errors, 0 skips
```