### PR TITLE
Except `table_name` from column objects

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column.rb
@@ -6,8 +6,8 @@ module ActiveRecord
       class Column < ActiveRecord::ConnectionAdapters::Column
         delegate :virtual, to: :sql_type_metadata, allow_nil: true
 
-        def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, comment = nil) #:nodoc:
-          super(name, default, sql_type_metadata, null, table_name, comment: comment)
+        def initialize(name, default, sql_type_metadata = nil, null = true, comment: nil) #:nodoc:
+          super(name, default, sql_type_metadata, null, comment: comment)
         end
 
         def virtual?

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -85,6 +85,8 @@ module ActiveRecord #:nodoc:
           def table(table, stream)
             columns = @connection.columns(table)
             begin
+              self.table_name = table
+
               tbl = StringIO.new
 
               # first dump primary key column
@@ -144,6 +146,8 @@ module ActiveRecord #:nodoc:
               stream.puts "# Could not dump table #{table.inspect} because of following #{e.class}"
               stream.puts "#   #{e.message}"
               stream.puts
+            ensure
+              self.table_name = nil
             end
           end
 
@@ -164,7 +168,6 @@ module ActiveRecord #:nodoc:
 
           def extract_expression_for_virtual_column(column)
             column_name = column.name
-            table_name = column.table_name
             @connection.select_value(<<-SQL.strip.gsub(/\s+/, " "), "Table comment", [bind_string("table_name", table_name.upcase), bind_string("column_name", column_name.upcase)]).inspect
               select data_default from all_tab_columns
               where owner = SYS_CONTEXT('userenv', 'current_schema')

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -652,8 +652,7 @@ module ActiveRecord
                              default_value,
                              type_metadata,
                              field["nullable"] == "Y",
-                             table_name,
-                             field["column_comment"]
+                             comment: field["column_comment"]
                       )
           end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -344,7 +344,7 @@ describe "OracleEnhancedConnection" do
     it "should execute prepared statement with decimal bind parameter " do
       cursor = @conn.prepare("INSERT INTO test_employees VALUES(:1)")
       type_metadata = ActiveRecord::ConnectionAdapters::SqlTypeMetadata.new(sql_type: "NUMBER", type: :decimal, limit: 10, precision: nil, scale: 2)
-      column = ActiveRecord::ConnectionAdapters::OracleEnhanced::Column.new("age", nil, type_metadata, false, "test_employees", nil)
+      column = ActiveRecord::ConnectionAdapters::OracleEnhanced::Column.new("age", nil, type_metadata, false, comment: nil)
       expect(column.type).to eq(:decimal)
       # Here 1.5 expects that this value has been type casted already
       # it should use bind_params in the long term.


### PR DESCRIPTION
Follow up https://github.com/rails/rails/pull/35890.

This PR fixes the following error.

```consle
% cd path/to/oracle-enhanced
% bundle exec rake

(snip)

Failures:

  1) OracleEnhancedAdapter schema dump virtual columns should dump
  correctly
     Failure/Error: expect(output).to match(/t\.virtual
  "full_name",(\s*)type: :string,(\s*)limit: 512,(\s*)as:
  "\\"FIRST_NAME\\"\|\|', '\|\|\\"LAST_NAME\\""/)

       expected "# This file is auto-generated from the current state of
       the database. Instead\n# of editing this fil...e_name' for
       #<ActiveRecord::ConnectionAdapters::OracleEnhanced::Column:0x0000000003a21bd0>\n\nend\n"
       to match /t\.virtual "full_name",(\s*)type: :string,(\s*)limit:
       512,(\s*)as: "\\"FIRST_NAME\\"\|\|', '\|\|\\"LAST_NAME\\""/
       Diff:
       @@ -1,2 +1,19 @@
       -/t\.virtual "full_name",(\s*)type: :string,(\s*)limit:
       512,(\s*)as: "\\"FIRST_NAME\\"\|\|', '\|\|\\"LAST_NAME\\""/
       +# This file is auto-generated from the current state of the
       database. Instead
       +# of editing this file, please use the migrations feature of
       Active Record to
       +# incrementally modify your database, and then regenerate this
       schema definition.
       +#
       +# This file is the source Rails uses to define your schema when
       running `rails
       +# db:schema:load`. When creating a new database, `rails
       db:schema:load` tends to
       +# be faster and is potentially less error prone than running all
       of your
       +# migrations from scratch. Old migrations may fail to apply
       correctly if those
       +# migrations use external dependencies or application code.
       +#
       +# It's strongly recommended that you check this file into your
       version control system.
       +
       +ActiveRecord::Schema.define(version: 0) do
       +
       +# Could not dump table "test_names" because of following
       NoMethodError
       +#   undefined method `table_name' for
       #<ActiveRecord::ConnectionAdapters::OracleEnhanced::Column:0x0000000003a21bd0>
       +
       +end
```