### PR TITLE
Remove unused `sequence_name` in `sql_for_insert`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -76,7 +76,7 @@ module ActiveRecord
 
         # New method in ActiveRecord 3.1
         # Will add RETURNING clause in case of trigger generated primary keys
-        def sql_for_insert(sql, pk, sequence_name, binds)
+        def sql_for_insert(sql, pk, binds)
           unless pk == false || pk.nil? || pk.is_a?(Array)
             sql = "#{sql} RETURNING #{quote_column_name(pk)} INTO :returning_id"
             (binds = binds.dup) << ActiveRecord::Relation::QueryAttribute.new("returning_id", nil, Type::OracleEnhanced::Integer.new)
@@ -91,7 +91,7 @@ module ActiveRecord
 
         # New method in ActiveRecord 3.1
         def exec_insert(sql, name = nil, binds = [], pk = nil, sequence_name = nil)
-          sql, binds = sql_for_insert(sql, pk, sequence_name, binds)
+          sql, binds = sql_for_insert(sql, pk, binds)
           type_casted_binds = type_casted_binds(binds)
 
           log(sql, name, binds, type_casted_binds) do


### PR DESCRIPTION
Follow up https://github.com/rails/rails/commit/f21bc468c35c295351309aada83ccbe44738e653.

This PR fixes the following error.

```console
% bundle exec rake

(snip)

  265) OracleEnhancedAdapter timestamp with timezone support / TIMESTAMP
  WITH TIME ZONE values from ActiveRecord model should return Time value
  from TIMESTAMP columns
       Failure/Error: super

       ArgumentError:
         wrong number of arguments (given 4, expected 3)
       #
         /home/vagrant/.rvm/gems/ruby-2.6.2/bundler/gems/rails-7cb3e8b8efb1/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:490:in
         `sql_for_insert'
       #
         ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:84:in
         `sql_for_insert'
       #
         ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:94:in
         `exec_insert'
```