### PR TITLE
Revert "Add allow_railures for jruby-head until #1833 resolved"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,5 @@ rvm:
   - ruby-head
   - jruby-head
 
-matrix:
-   allow_failures:
-     - rvm: jruby-head
 notifications:
     email: false


### PR DESCRIPTION
This reverts commit d06a35ab4d9ab85d18b4a7a0e94be0fd2fde92cc.

Related to #1833 #1834