### PR TITLE
[WIP] Bump RuboCop version to 0.67

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -23,7 +23,7 @@ checks:
 engines:
   rubocop:
     enabled: true
-    channel: rubocop-0-67
+    channel: rubocop-0-68
 
 ratings:
   paths:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -23,7 +23,7 @@ checks:
 engines:
   rubocop:
     enabled: true
-    channel: rubocop-0-66
+    channel: rubocop-0-67
 
 ratings:
   paths:

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development do
   gem "rspec"
   gem "rdoc"
   gem "rake"
-  gem "rubocop", "~> 0.66.0", require: false
+  gem "rubocop", "~> 0.67.0", require: false
 
   gem "activerecord",   github: "rails/rails", branch: "master"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"


### PR DESCRIPTION
I'd like to confirm when the new rubocop-0-67 channel is available.

https://github.com/codeclimate/codeclimate-rubocop/releases/tag/b449
