### PR TITLE
Make `change_column_comment` and `change_table_comment` invertible

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -477,8 +477,9 @@ module ActiveRecord
           clear_table_columns_cache(table_name)
         end
 
-        def change_table_comment(table_name, comment)
+        def change_table_comment(table_name, comment_or_changes)
           clear_cache!
+          comment = extract_new_comment_value(comment_or_changes)
           if comment.nil?
             execute "COMMENT ON TABLE #{quote_table_name(table_name)} IS ''"
           else
@@ -486,8 +487,9 @@ module ActiveRecord
           end
         end
 
-        def change_column_comment(table_name, column_name, comment) #:nodoc:
+        def change_column_comment(table_name, column_name, comment_or_changes)
           clear_cache!
+          comment = extract_new_comment_value(comment_or_changes)
           execute "COMMENT ON COLUMN #{quote_table_name(table_name)}.#{quote_column_name(column_name)} IS '#{comment}'"
         end
 


### PR DESCRIPTION
Follow up https://github.com/rails/rails/pull/35970.

This PR fixes the following `TypeError: can't quote Hash`.

```consle
% cd path/to/rails/activerecord
% ARCONN=oracle be ruby -w -Itest test/cases/invertible_migration_test.rb -n test_migrate_revert_change_table_comment
Using oracle
Run options: -n test_migrate_revert_change_table_comment --seed 42508

# Running:

E

Error:
ActiveRecord::InvertibleMigrationTest#test_migrate_revert_change_table_comment:
TypeError: can't quote Hash
    /home/vagrant/src/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:178:in
    `_quote'
    /home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:93:in
    `_quote'
    /home/vagrant/src/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:18:in
    `quote'
    /home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:485:in
    `change_table_comment'
    /home/vagrant/src/rails/activerecord/lib/active_record/migration.rb:875:in
    `block in method_missing'
    /home/vagrant/src/rails/activerecord/lib/active_record/migration.rb:843:in
    `block in say_with_time'
    /home/vagrant/.rvm/rubies/ruby-2.6.2/lib/ruby/2.6.0/benchmark.rb:293:in
    `measure'
    /home/vagrant/src/rails/activerecord/lib/active_record/migration.rb:843:in
    `say_with_time'
    /home/vagrant/src/rails/activerecord/lib/active_record/migration.rb:864:in
    `method_missing'
    test/cases/invertible_migration_test.rb:128:in `change'
    /home/vagrant/src/rails/activerecord/lib/active_record/migration.rb:813:in
    `exec_migration'
    /home/vagrant/src/rails/activerecord/lib/active_record/migration.rb:797:in
    `block (2 levels) in migrate'
    /home/vagrant/.rvm/rubies/ruby-2.6.2/lib/ruby/2.6.0/benchmark.rb:293:in
    `measure'
    /home/vagrant/src/rails/activerecord/lib/active_record/migration.rb:796:in
    `block in migrate'
    /home/vagrant/src/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:416:in
    `with_connection'
    /home/vagrant/src/rails/activerecord/lib/active_record/migration.rb:795:in
    `migrate'
    test/cases/invertible_migration_test.rb:356:in
    `test_migrate_revert_change_table_comment'

rails test test/cases/invertible_migration_test.rb:349

Finished in 0.106411s, 9.3975 runs/s, 9.3975 assertions/s.
1 runs, 1 assertions, 0 failures, 1 errors, 0 skips
```