### PR TITLE
Bump RuboCop version to 0.67

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -23,7 +23,7 @@ checks:
 engines:
   rubocop:
     enabled: true
-    channel: rubocop-0-66
+    channel: rubocop-0-67
 
 ratings:
   paths:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-performance
+
 AllCops:
   TargetRubyVersion: 2.5
   DisabledByDefault: true

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :development do
   gem "rdoc"
   gem "rake"
   gem "rubocop", "~> 0.67.0", require: false
+  gem "rubocop-performance", require: false
 
   gem "activerecord",   github: "rails/rails", branch: "master"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development do
   gem "rspec"
   gem "rdoc"
   gem "rake"
-  gem "rubocop", "~> 0.66.0", require: false
+  gem "rubocop", "~> 0.67.0", require: false
 
   gem "activerecord",   github: "rails/rails", branch: "master"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"


### PR DESCRIPTION
* Bump RuboCop version to 0.67.x
https://rubygems.org/gems/rubocop/versions/0.67.0

* Use rubocop-0-67 channel
https://github.com/codeclimate/codeclimate/releases/tag/v0.85.2

* Bundle `rubocop-performance` gem
https://github.com/rubocop-hq/rubocop/blob/master/manual/migrate_performance_cops.md