### PR TITLE
CI against Ruby 2.6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
 
 language: ruby
 rvm:
-  - 2.6.2
+  - 2.6.3
   - 2.5.5
   - jruby-9.2.7.0
   - ruby-head


### PR DESCRIPTION
* Ruby 2.6.3 Released
https://www.ruby-lang.org/en/news/2019/04/17/ruby-2-6-3-released/