### PR TITLE
Add support to change the permissions granted when creating DB

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_tasks.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_tasks.rb
@@ -27,11 +27,10 @@ module ActiveRecord
               raise e
             end
           end
-          connection.execute "GRANT unlimited tablespace TO #{@config['username']}"
-          connection.execute "GRANT create session TO #{@config['username']}"
-          connection.execute "GRANT create table TO #{@config['username']}"
-          connection.execute "GRANT create view TO #{@config['username']}"
-          connection.execute "GRANT create sequence TO #{@config['username']}"
+
+          OracleEnhancedAdapter.permissions.each do |permission|
+            connection.execute "GRANT #{permission} TO #{@config['username']}"
+          end
         end
 
         def drop

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -215,6 +215,18 @@ module ActiveRecord
 
       ##
       # :singleton-method:
+      # By default, OracleEnhanced adapter will grant unlimited tablespace, create session, create table, create view,
+      # and create sequence when running the rake task db:create.
+      #
+      # If you wish to change these permissions you can add the following line to your initializer file:
+      #
+      #   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.permissions =
+      #   ["create session", "create table", "create view", "create sequence", "create trigger", "ctxapp"]
+      cattr_accessor :permissions
+      self.permissions = ["create session", "create table", "create view", "create sequence"]
+
+      ##
+      # :singleton-method:
       # Specify default sequence start with value (by default 1 if not explicitly set), e.g.:
 
       class StatementPool < ConnectionAdapters::StatementPool

--- a/spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb
@@ -20,6 +20,11 @@ describe "Oracle Enhanced adapter database tasks" do
       query = "SELECT COUNT(*) FROM dba_users WHERE UPPER(username) = '#{new_user_config[:username].upcase}'"
       expect(ActiveRecord::Base.connection.select_value(query)).to eq(1)
     end
+    it "grants permissions defined by OracleEnhancedAdapter.persmissions" do
+      query = "SELECT COUNT(*) FROM DBA_SYS_PRIVS WHERE GRANTEE = '#{new_user_config[:username].upcase}'"
+      permissions_count = ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.permissions.size
+      expect(ActiveRecord::Base.connection.select_value(query)).to eq(permissions_count)
+    end
     after do
       ActiveRecord::Base.connection.execute("DROP USER #{new_user_config[:username]}")
     end


### PR DESCRIPTION
I've got this idea from @ebeigarts in [this comment](https://github.com/rsim/oracle-enhanced/issues/103#issuecomment-2126138)

To change the permissions add the following line to the initializer of
the application:
```ruby
 ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.permissions =
   ["create session", "create table", "create view",  "create sequence", "create trigger", "ctxapp"]
```

This is useful for when running `rails db:create` from a CI to build a
DB for testing. As it has the credentials and the connection ready, it
would be easier if the required permissions are granted in on go.

For example, when using `add_context_index`, permissions to
`create trigger`, `create procedure`, and `ctxapp` are required. But
these permissions are not included in this db create task.