### PR TITLE
Bump RuboCop version to 0.71

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -25,7 +25,7 @@ checks:
 plugins:
   rubocop:
     enabled: true
-    channel: rubocop-0-67
+    channel: rubocop-0-71
 
 ratings:
   paths:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
-require: rubocop-performance
+require:
+  - rubocop-performance
+  - rubocop-rails
 
 AllCops:
   TargetRubyVersion: 2.5
@@ -54,11 +56,11 @@ Layout/EmptyLinesAroundMethodBody:
 Layout/EmptyLinesAroundModuleBody:
   Enabled: true
 
-Layout/FirstParameterIndentation:
-  Enabled: true
-
 # Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }.
 Style/HashSyntax:
+  Enabled: true
+
+Layout/IndentFirstArgument:
   Enabled: true
 
 # Method definitions after `private` or `protected` isolated calls need one

--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,9 @@ group :development do
   gem "rspec"
   gem "rdoc"
   gem "rake"
-  gem "rubocop", "~> 0.67.0", require: false
+  gem "rubocop", "~> 0.71.0", require: false
   gem "rubocop-performance", require: false
+  gem "rubocop-rails", require: false
 
   gem "activerecord",   github: "rails/rails", branch: "master"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"


### PR DESCRIPTION
This pull request bump sRuboCop version to 0.71

https://github.com/rubocop-hq/rubocop/releases/tag/v0.71.0
    
### Additional changes made:

* Install `rubocop-rails` gem because Rails cops will be removed from RuboCop 0.72

* Rename `Layout/FirstParameterIndentation` to `Layout/IndentFirstArgument` to support RuboCop 0.68.0

```ruby
$ bundle exec rubocop
Error: The `Layout/FirstParameterIndentation` cop has been renamed to `Layout/IndentFirstArgument`.
(obsolete configuration found in .rubocop.yml, please update it)
$
```
* Use `rubocop-0-71` channel at Code Climate
Refer https://github.com/codeclimate/codeclimate/releases/tag/v0.85.3