### PR TITLE
Enable `Layout/EmptyLinesAroundAccessModifier` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,10 @@ Layout/ElseAlignment:
 Layout/EmptyLineAfterMagicComment:
   Enabled: true
 
+Layout/EmptyLinesAroundAccessModifier:
+  Enabled: true
+  EnforcedStyle: only_before
+
 Layout/EmptyLinesAroundBlockBody:
   Enabled: true
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -19,7 +19,6 @@ module ActiveRecord
         attr_reader :raw_connection
 
         private
-
           # Used always by JDBC connection as well by OCI connection when describing tables over database link
           def describe(name)
             name = name.to_s

--- a/lib/active_record/connection_adapters/oracle_enhanced/context_index.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/context_index.rb
@@ -142,7 +142,6 @@ module ActiveRecord
         end
 
         private
-
           def create_datastore_procedure(table_name, procedure_name, column_names, options)
             quoted_table_name = quote_table_name(table_name)
             select_queries, column_names = column_names.partition { |c| c.to_s =~ /^\s*SELECT\s+/i }

--- a/lib/active_record/connection_adapters/oracle_enhanced/dbms_output.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/dbms_output.rb
@@ -31,7 +31,6 @@ module ActiveRecord
         end
 
       private
-
         def log(sql, name = "SQL", binds = [], type_casted_binds = [], statement_name = nil)
           super
         ensure

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -512,7 +512,6 @@ module ActiveRecord
         end
 
       private
-
         def lob_to_ruby_value(val)
           case val
           when ::Java::OracleSql::CLOB

--- a/lib/active_record/connection_adapters/oracle_enhanced/lob.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/lob.rb
@@ -24,7 +24,6 @@ module ActiveRecord #:nodoc:
         end
 
         private
-
           def enhanced_write_lobs
             if self.class.connection.is_a?(ConnectionAdapters::OracleEnhancedAdapter) &&
                 !(self.class.custom_create_method || self.class.custom_update_method)

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -265,7 +265,6 @@ module ActiveRecord
         end
 
       private
-
         def date_without_time?(value)
           case value
           when OraDate

--- a/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
@@ -97,7 +97,6 @@ module ActiveRecord #:nodoc:
     end
 
     private
-
       # Creates a record with custom create method
       # and returns its id.
       def _create_record

--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -133,7 +133,6 @@ module ActiveRecord
         end
 
         private
-
           def oracle_downcase(column_name)
             return nil if column_name.nil?
             /[a-z]/.match?(column_name) ? column_name : column_name.downcase

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module OracleEnhanced
       class SchemaCreation < AbstractAdapter::SchemaCreation
         private
-
           def visit_ColumnDefinition(o)
             if [:blob, :clob, :nclob].include?(sql_type = type_to_sql(o.type,  o.options).downcase.to_sym)
               if (tablespace = default_tablespace_for(sql_type))

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -5,7 +5,6 @@ module ActiveRecord #:nodoc:
     module OracleEnhanced #:nodoc:
       class SchemaDumper < ConnectionAdapters::SchemaDumper #:nodoc:
         private
-
           def tables(stream)
             # do not include materialized views in schema dump - they should be created separately after schema creation
             sorted_tables = (@connection.tables - @connection.materialized_views).sort

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -619,7 +619,6 @@ module ActiveRecord
         end
 
         private
-
           def schema_creation
             OracleEnhanced::SchemaCreation.new self
           end

--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -316,7 +316,6 @@ module ActiveRecord #:nodoc:
         end
 
       private
-
         # Called only if `supports_virtual_columns?` returns true
         # return [{'column_name' => 'FOOS', 'data_default' => '...'}, ...]
         def virtual_columns_for(table)

--- a/lib/active_record/connection_adapters/oracle_enhanced/type_metadata.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/type_metadata.rb
@@ -23,7 +23,6 @@ module ActiveRecord
         end
 
         protected
-
           def attributes_for_hash
             [self.class, @type_metadata, virtual]
           end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -231,7 +231,6 @@ module ActiveRecord
 
       class StatementPool < ConnectionAdapters::StatementPool
         private
-
           def dealloc(stmt)
             stmt.close
           end

--- a/lib/active_record/type/oracle_enhanced/boolean.rb
+++ b/lib/active_record/type/oracle_enhanced/boolean.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module OracleEnhanced
       class Boolean < ActiveModel::Type::Boolean # :nodoc:
         private
-
           def cast_value(value)
             # Kind of adding 'n' and 'N' to  `FALSE_VALUES`
             if ["n", "N"].include?(value)

--- a/lib/active_record/type/oracle_enhanced/integer.rb
+++ b/lib/active_record/type/oracle_enhanced/integer.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module OracleEnhanced
       class Integer < ActiveModel::Type::Integer # :nodoc:
         private
-
           def max_value
             ("9" * 38).to_i
           end

--- a/spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb
@@ -133,7 +133,6 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
       end
 
       private
-
         def raise_make_transaction_rollback
           raise "Make the transaction rollback"
         end


### PR DESCRIPTION
Follow up https://github.com/rails/rails/pull/36472.

This PR enables `Layout/EmptyLinesAroundAccessModifier` cop with `EnforcedStyle: only_before`.