### PR TITLE
Convert version numbers from Integer to String

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :development do
   gem "rubocop-performance", require: false
   gem "rubocop-rails", require: false
 
-  gem "activerecord",   github: "rails/rails", branch: "master"
+  gem "activerecord",   github: "rails/rails", branch: "master", ref: "aeba121a83965d242ed6d7fd46e9c166079a3230"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -277,17 +277,17 @@ module ActiveRecord
 
           if supports_multi_insert?
             versions.inject(+"INSERT ALL\n") { |sql, version|
-              sql << "INTO #{sm_table} (version) VALUES (#{quote(version)})\n"
+              sql << "INTO #{sm_table} (version) VALUES (#{quote(version.to_s)})\n"
             } << "SELECT * FROM DUAL\n"
           else
             if versions.is_a?(Array)
               # called from ActiveRecord::Base.connection#dump_schema_information
               versions.map { |version|
-                "INSERT INTO #{sm_table} (version) VALUES (#{quote(version)})"
+                "INSERT INTO #{sm_table} (version) VALUES (#{quote(version.to_s)})"
               }.join("\n\n/\n\n")
             else
               # called from ActiveRecord::Base.connection#assume_migrated_upto_version
-              "INSERT INTO #{sm_table} (version) VALUES (#{quote(versions)})"
+              "INSERT INTO #{sm_table} (version) VALUES (#{quote(versions.to_s)})"
             end
           end
         end


### PR DESCRIPTION
This pull request fix #1893

rails/rails#36439 introduces the change below.

https://github.com/rails/rails/blob/aae270de9e0862f31b14642908472d235a17936f/activerecord/lib/active_record/schema_migration.rb#L47-L49

```ruby
def all_versions
  order(:version).pluck(:version).map(&:to_i)
end
```

Here `all_versions` returns version numbers as an array of Integer, while Oracle enhanced adapter expects them as an array of String.

This pull request has a workaround commit to specify the commit has of Rails because Oracle enhanced adapter does not support rails/rails#35891 yet. This commit will be reverted later.
