### PR TITLE
Deduplicate various Active Record schema cache structures

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/type_metadata.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/type_metadata.rb
@@ -4,6 +4,8 @@ module ActiveRecord
   module ConnectionAdapters #:nodoc:
     module OracleEnhanced
       class TypeMetadata < DelegateClass(ActiveRecord::ConnectionAdapters::SqlTypeMetadata) # :nodoc:
+        include Deduplicable
+
         attr_reader :virtual
 
         def initialize(type_metadata, virtual: nil)


### PR DESCRIPTION
This pull request needs merged once #1896 merged.

Refer rails/rails#35891

This pulll request addresses 28 failures. Here is the one of them:
You can see entire failures at https://travis-ci.org/rsim/oracle-enhanced/jobs/547963138

```ruby
$ bundle exec rspec ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:62
==> Loading config from ENV or use default
==> Running specs with MRI version 2.6.3
==> Effective ActiveRecord version 6.1.0.alpha
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb"=>[62]}}
F

Failures:

  1) OracleEnhancedAdapter cache table columns without column caching should identify virtual columns as such
     Failure/Error: delegate :virtual, to: :sql_type_metadata, allow_nil: true

     NoMethodError:
       undefined method `virtual' for #<ActiveRecord::ConnectionAdapters::SqlTypeMetadata:0x00005564d0332fb8>
     # ./lib/active_record/connection_adapters/oracle_enhanced/column.rb:7:in `virtual'
     # ./lib/active_record/connection_adapters/oracle_enhanced/column.rb:14:in `virtual?'
     # ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:64:in `each'
     # ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:64:in `detect'
     # ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:64:in `block (4 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/example.rb:254:in `instance_exec'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/example.rb:254:in `block in run'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/example.rb:500:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/example.rb:457:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/hooks.rb:464:in `block in run'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/hooks.rb:464:in `run'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/example.rb:457:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/example.rb:500:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/example.rb:251:in `run'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/example_group.rb:629:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/example_group.rb:625:in `map'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/example_group.rb:625:in `run_examples'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/example_group.rb:591:in `run'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/example_group.rb:592:in `block in run'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/example_group.rb:592:in `map'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/example_group.rb:592:in `run'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/example_group.rb:592:in `block in run'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/example_group.rb:592:in `map'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/example_group.rb:592:in `run'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/runner.rb:116:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/runner.rb:116:in `map'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/runner.rb:116:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/configuration.rb:2008:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/runner.rb:111:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/reporter.rb:74:in `report'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/runner.rb:110:in `run_specs'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/runner.rb:87:in `run'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.1/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.6.3/bin/rspec:23:in `load'
     # /home/yahonda/.rbenv/versions/2.6.3/bin/rspec:23:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-1.17.3/lib/bundler/cli/exec.rb:74:in `load'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-1.17.3/lib/bundler/cli/exec.rb:74:in `kernel_load'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-1.17.3/lib/bundler/cli/exec.rb:28:in `run'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-1.17.3/lib/bundler/cli.rb:463:in `exec'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-1.17.3/lib/bundler/cli.rb:27:in `dispatch'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-1.17.3/lib/bundler/cli.rb:18:in `start'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-1.17.3/exe/bundle:30:in `block in <top (required)>'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-1.17.3/lib/bundler/friendly_errors.rb:124:in `with_friendly_errors'
     # /home/yahonda/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/bundler-1.17.3/exe/bundle:22:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/2.6.3/bin/bundle:23:in `load'
     # /home/yahonda/.rbenv/versions/2.6.3/bin/bundle:23:in `<main>'

Finished in 2.7 seconds (files took 1.1 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:62 # OracleEnhancedAdapter cache table columns without column caching should identify virtual columns as such

Coverage report generated for RSpec to /home/yahonda/git/oracle-enhanced/coverage. 1019 / 2186 LOC (46.61%) covered.
$
```