### PR TITLE
[WIP] Support `ActiveRecord::ReadOnlyError`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -17,6 +17,10 @@ module ActiveRecord
 
         # Executes a SQL statement
         def execute(sql, name = nil)
+          p '=========================================='
+          p "preventing_writes?: #{preventing_writes?}"
+          p "write_query?: #{write_query?(sql)}"
+          p "sql: #{sql}"
           if preventing_writes? && write_query?(sql)
             raise ActiveRecord::ReadOnlyError, "Write query attempted while in readonly mode: #{sql}"
           end
@@ -200,6 +204,8 @@ module ActiveRecord
         end
 
         def create_savepoint(name = current_savepoint_name) #:nodoc:
+          pp '------------------------------------------------------------'
+          pp caller
           execute("SAVEPOINT #{name}", "TRANSACTION")
         end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -261,6 +261,10 @@ module ActiveRecord
         StatementPool.new(self.class.type_cast_config_to_integer(@config[:statement_limit]))
       end
 
+      def supports_lazy_transactions?
+        true
+      end
+
       def supports_savepoints? #:nodoc:
         true
       end


### PR DESCRIPTION
Refer rails/rails#34505 rails/rails#34632


```ruby
$ cd activerecord
$ ARCONN=oracle bin/test test/cases/adapter_test.rb test/cases/base_test.rb -n /preventing_writes/
Using oracle
Run options: -n /preventing_writes/ --seed 62121

# Running:

.F

Failure:
ActiveRecord::AdapterTest#test_errors_when_a_delete_query_is_called_while_preventing_writes [/home/yahonda/git/rails/activerecord/test/cases/adapter_test.rb:206]:
ActiveRecord::ReadOnlyError expected but nothing was raised.


bin/test test/cases/adapter_test.rb:203

F

Failure:
ActiveRecord::AdapterTest#test_errors_when_an_update_query_is_called_while_preventing_writes [/home/yahonda/git/rails/activerecord/test/cases/adapter_test.rb:192]:
ActiveRecord::ReadOnlyError expected but nothing was raised.


bin/test test/cases/adapter_test.rb:189

F

Failure:
ActiveRecord::AdapterTest#test_errors_when_an_insert_query_is_called_while_preventing_writes [/home/yahonda/git/rails/activerecord/test/cases/adapter_test.rb:178]:
ActiveRecord::ReadOnlyError expected but nothing was raised.


bin/test test/cases/adapter_test.rb:177

.F

Failure:
BasicsTest#test_preventing_writes_with_multiple_handlers [/home/yahonda/git/rails/activerecord/test/cases/base_test.rb:1594]:
ActiveRecord::ReadOnlyError expected but nothing was raised.


bin/test test/cases/base_test.rb:1591

F

Failure:
BasicsTest#test_updating_a_record_raises_if_preventing_writes [/home/yahonda/git/rails/activerecord/test/cases/base_test.rb:1521]:
ActiveRecord::ReadOnlyError expected but nothing was raised.


bin/test test/cases/base_test.rb:1518

F

Failure:
BasicsTest#test_creating_a_record_raises_if_preventing_writes [/home/yahonda/git/rails/activerecord/test/cases/base_test.rb:1509]:
ActiveRecord::ReadOnlyError expected but nothing was raised.


bin/test test/cases/base_test.rb:1508

F

Failure:
BasicsTest#test_an_empty_transaction_does_not_raise_if_preventing_writes [/home/yahonda/git/rails/activerecord/test/cases/base_test.rb:1560]:
1 instead of 2 queries were executed.
Queries:
SAVEPOINT active_record_1.
Expected: 2
  Actual: 1


bin/test test/cases/base_test.rb:1558

F

Failure:
BasicsTest#test_preventing_writes_applies_to_all_connections_on_a_handler [/home/yahonda/git/rails/activerecord/test/cases/base_test.rb:1569]:
ActiveRecord::ReadOnlyError expected but nothing was raised.


bin/test test/cases/base_test.rb:1568

.F

Failure:
BasicsTest#test_deleting_a_record_raises_if_preventing_writes [/home/yahonda/git/rails/activerecord/test/cases/base_test.rb:1533]:
ActiveRecord::ReadOnlyError expected but nothing was raised.


bin/test test/cases/base_test.rb:1530

F

Failure:
BasicsTest#test_an_explain_query_does_not_raise_if_preventing_writes [/home/yahonda/git/rails/activerecord/test/cases/base_test.rb:1554]:
3 instead of 2 queries were executed.
Queries:
SELECT "BIRDS".* FROM "BIRDS" WHERE "BIRDS"."NAME" = :a1
EXPLAIN PLAN FOR SELECT "BIRDS".* FROM "BIRDS" WHERE "BIRDS"."NAME" = :a1
SELECT * FROM TABLE(DBMS_XPLAN.DISPLAY).
Expected: 2
  Actual: 3


bin/test test/cases/base_test.rb:1550



Finished in 41.900314s, 0.3103 runs/s, 0.4296 assertions/s.
13 runs, 18 assertions, 10 failures, 0 errors, 0 skips
$
```