### PR TITLE
Raise `NoDatabaseError` when db does not exist

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -73,6 +73,12 @@ module ActiveRecord
         ConnectionAdapters::OracleEnhancedAdapter.new(
           ConnectionAdapters::OracleEnhanced::Connection.create(config), logger, config)
       end
+    rescue OCIError => error
+      if /ORA-12154/.match?(error.message)
+        raise ActiveRecord::NoDatabaseError
+      else
+        raise
+      end
     end
   end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -244,6 +244,14 @@ describe "OracleEnhancedAdapter" do
     end
   end
 
+  describe "oracle_enhanced_connection" do
+    it "should bad connection" do
+      expect {
+        ActiveRecord::Base.oracle_enhanced_connection(adapter: "oracle_enhanced", database: "should_not_exist-cinco-dog-db")
+      }.to raise_error(ActiveRecord::NoDatabaseError)
+    end
+  end
+
   describe "explain" do
     before(:all) do
       @conn = ActiveRecord::Base.connection


### PR DESCRIPTION
Follow up https://github.com/rails/rails/pull/13469 and https://github.com/rails/rails/pull/13427.

This PR raises `NoDatabaseError` when db does not exist.

`OCIError` was raised when database does not exist.
This change uses `NoDatabaseError` as other core adapters.