### PR TITLE
Share the column and table name quote cache between connections

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -10,7 +10,7 @@ module ActiveRecord
 
         def quote_column_name(name) #:nodoc:
           name = name.to_s
-          @quoted_column_names[name] ||= begin
+          self.class.quoted_column_names[name] ||= begin
             # if only valid lowercase column characters in name
             if /\A[a-z][a-z_0-9\$#]*\Z/.match?(name)
               "\"#{name.upcase}\""
@@ -70,7 +70,7 @@ module ActiveRecord
 
         def quote_table_name(name) #:nodoc:
           name, _link = name.to_s.split("@")
-          @quoted_table_names[name] ||= [name.split(".").map { |n| quote_column_name(n) }].join(".")
+          self.class.quoted_table_names[name] ||= [name.split(".").map { |n| quote_column_name(n) }].join(".")
         end
 
         def quote_string(s) #:nodoc:


### PR DESCRIPTION
Refer rails/rails#36637

This pull request addresses this kind of failures:

```ruby
$ bundle exec rspec ./spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb:65
... snip ...
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:73: warning: instance variable @quoted_table_names not initialized
FFFFFFFFFF/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:73: warning: instance variable @quoted_table_names not initialized

An error occurred in an `after(:context)` hook.
Failure/Error: @quoted_table_names[name] ||= [name.split(".").map { |n| quote_column_name(n) }].join(".")

NoMethodError:
  undefined method `[]' for nil:NilClass
```