### PR TITLE
Lock simplecov version for Ruby 2.2 and 2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,5 +25,9 @@ group :development do
 end
 
 group :test do
-  gem "simplecov",  github: "colszowka/simplecov", branch: "master", require: false
+  if RUBY_VERSION < "2.4.0"
+    gem "simplecov",  "< 0.17", require: false
+  else
+    gem "simplecov",  github: "colszowka/simplecov", branch: "master", require: false
+  end
 end


### PR DESCRIPTION
This pull request addresses the following error. The latest version of simplecov drops support Ruby 2.3 or lower https://github.com/colszowka/simplecov/pull/729/files .

```
simplecov-0.17.0 requires ruby version >= 2.4.0
```

https://travis-ci.org/rsim/oracle-enhanced/jobs/558216175