### PR TITLE
Add database_exists? method to connection adapters

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -249,6 +249,14 @@ module ActiveRecord
         ADAPTER_NAME
       end
 
+      # Oracle enhanced adapter has no implementation because
+      # Oracle Database cannot detect `NoDatabaseError`.
+      # Please refer to the following discussion for details.
+      # https://github.com/rsim/oracle-enhanced/pull/1900
+      def self.database_exists?(config)
+        raise NotImplementedError
+      end
+
       def arel_visitor # :nodoc:
         if supports_fetch_first_n_rows_and_offset?
           Arel::Visitors::Oracle12.new(self)

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -244,6 +244,14 @@ describe "OracleEnhancedAdapter" do
     end
   end
 
+  describe "database_exists?" do
+    it "should raise `NotImplementedError`" do
+      expect {
+        ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.database_exists?(CONNECTION_PARAMS)
+      }.to raise_error(NotImplementedError)
+    end
+  end
+
   describe "explain" do
     before(:all) do
       @conn = ActiveRecord::Base.connection


### PR DESCRIPTION
### Summary

Follow up https://github.com/rails/rails/pull/36471.

Oracle enhanced adapter has no implementation because Oracle Database cannot detect `NoDatabaseError`.

Please refer to the following discussion for details.
https://github.com/rsim/oracle-enhanced/pull/1900

### Other Information

The following is an implementation example I gave up.

```diff
diff --git
a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
index af99718..77a5b90 100644
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -249,6 +249,12 @@ module ActiveRecord
         ADAPTER_NAME
       end

+      def self.database_exists?(config)
+        !!ActiveRecord::Base.oracle_enhanced_connection(config)
+      rescue ActiveRecord::NoDatabaseError
+        false
+      end
+
```

This is an implementation example when `NoDatabaseError` can be supported in the future.