### PR TITLE
CI against JRuby 9.2.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ language: ruby
 rvm:
   - 2.6.3
   - 2.5.5
-  - jruby-9.2.7.0
+  - jruby-9.2.8.0
   - ruby-head
   - jruby-head
 


### PR DESCRIPTION
https://www.jruby.org/2019/08/12/jruby-9-2-8-0.html