### PR TITLE
Bump RuboCop to 0.74.0

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -25,7 +25,7 @@ checks:
 plugins:
   rubocop:
     enabled: true
-    channel: rubocop-0-71
+    channel: rubocop-0-74
 
 ratings:
   paths:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -71,7 +71,7 @@ Layout/IndentFirstArgument:
 # extra level of indentation.
 Layout/IndentationConsistency:
   Enabled: true
-  EnforcedStyle: rails
+  EnforcedStyle: indented_internal_methods
 
 # Two spaces, no tabs (for indentation).
 Layout/IndentationWidth:
@@ -93,9 +93,6 @@ Layout/SpaceAroundEqualsInParameterDefault:
   Enabled: true
 
 Layout/SpaceAroundKeyword:
-  Enabled: true
-
-Layout/SpaceAroundOperators:
   Enabled: true
 
 Layout/SpaceBeforeComma:

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development do
   gem "rspec"
   gem "rdoc"
   gem "rake"
-  gem "rubocop", "~> 0.71.0", require: false
+  gem "rubocop", "~> 0.74.0", require: false
   gem "rubocop-performance", require: false
   gem "rubocop-rails", require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :development do
   gem "rake"
   gem "rubocop", "~> 0.74.0", require: false
   gem "rubocop-performance", "~> 1.3.0", require: false
-  gem "rubocop-rails", require: false
+  gem "rubocop-rails", "~> 2.0.0", require: false
 
   gem "activerecord",   github: "rails/rails", branch: "master"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :development do
   gem "rdoc"
   gem "rake"
   gem "rubocop", "~> 0.74.0", require: false
-  gem "rubocop-performance", require: false
+  gem "rubocop-performance", "~> 1.3.0", require: false
   gem "rubocop-rails", require: false
 
   gem "activerecord",   github: "rails/rails", branch: "master"


### PR DESCRIPTION
This pull request bumps RuboCop to 0.74.0 and uses the same `rubocop-performance` gem CodeClimate provided

* Rename `EnforcedStyle` of `Layout/IndentationConsistency` cop
from `rails` to `indented_internal_methods`

* Disable `Layout/SpaceAroundOperators` cop
Refer rails/rails#36943

*   Use rubocop-performance gem 1.3.x
Refer: https://github.com/codeclimate/codeclimate-rubocop/blob/channel/rubocop-0-74/Gemfile.lock#L51-L55


