### PR TITLE
CI against Ruby 2.6.4 and Ruby 2.5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ install:
 
 language: ruby
 rvm:
-  - 2.6.3
-  - 2.5.5
+  - 2.6.4
+  - 2.5.6
   - jruby-9.2.8.0
   - ruby-head
   - jruby-head


### PR DESCRIPTION
* Ruby 2.6.4 Released
https://www.ruby-lang.org/en/news/2019/08/28/ruby-2-6-4-released/

* Ruby 2.5.6 Released
https://www.ruby-lang.org/en/news/2019/08/28/ruby-2-5-6-released/