### PR TITLE
Enable GitHub Actions and run RuboCop

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,38 @@
+name: Ruby
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Ruby 2.6
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+    - name: Install required package
+      run: |
+        sudo apt-get install alien
+    - name: Download Oracle instant client
+      run: |
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/193000/oracle-instantclient19.3-basic-19.3.0.0.0-1.x86_64.rpm
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/193000/oracle-instantclient19.3-sqlplus-19.3.0.0.0-1.x86_64.rpm
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/193000/oracle-instantclient19.3-devel-19.3.0.0.0-1.x86_64.rpm
+    - name: Install Oracle instant client
+      run: |
+        sudo alien -i oracle-instantclient19.3-basic-19.3.0.0.0-1.x86_64.rpm
+        sudo alien -i oracle-instantclient19.3-sqlplus-19.3.0.0.0-1.x86_64.rpm
+        sudo alien -i oracle-instantclient19.3-devel-19.3.0.0.0-1.x86_64.rpm
+
+    - name: Update environment variables
+      run: |
+        export PATH=/usr/lib/oracle/19.3/client64/bin:$PATH
+        export LD_LIBRARY_PATH=/usr/lib/oracle/19.3/client64/lib:$LD_LIBRARY_PATH
+
+    - name: Build and run RuboCop
+      run: |
+        bundle install --jobs 4 --retry 3
+        bundle exec rubocop --parallel


### PR DESCRIPTION
This pull request implements GitHub Actions to run RuboCop.

* Use Ruby 2.6
* Download and Install Oracle Instant Client
* Update environment variables for Oracle Instant Client
* Execute `bundle exec rubocop`
* Not execute `bundle exec rspec` in this commit
* Use `--parallel` option for RuboCop