### PR TITLE
Unlock RuboCop gem versions

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -22,11 +22,6 @@ checks:
   identical-code:
     enabled: false
 
-plugins:
-  rubocop:
-    enabled: true
-    channel: rubocop-0-74
-
 ratings:
   paths:
   - "**.rb"

--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,9 @@ group :development do
   gem "rspec"
   gem "rdoc"
   gem "rake", "~> 13.0.0.pre.1"
-  gem "rubocop", "~> 0.74.0", require: false
-  gem "rubocop-performance", "~> 1.3.0", require: false
-  gem "rubocop-rails", "~> 2.0.0", require: false
+  gem "rubocop", require: false
+  gem "rubocop-performance", require: false
+  gem "rubocop-rails", require: false
 
   gem "activerecord",   github: "rails/rails", branch: "master"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -65,7 +65,7 @@ module ActiveRecord
 
         def explain(arel, binds = [])
           sql = "EXPLAIN PLAN FOR #{to_sql(arel, binds)}"
-          return if sql =~ /FROM all_/
+          return if /FROM all_/.match?(sql)
           if ORACLE_ENHANCED_CONNECTION == :jdbc
             exec_query(sql, "EXPLAIN", binds)
           else

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -238,7 +238,7 @@ module ActiveRecord
           begin
             yield if block_given?
           rescue Java::JavaSql::SQLException => e
-            raise unless e.message =~ /^(Closed Connection|Io exception:|No more data to read from socket|IO Error:)/
+            raise unless /^(Closed Connection|Io exception:|No more data to read from socket|IO Error:)/.match?(e.message)
             @active = false
             raise unless should_retry
             should_retry = false

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -318,9 +318,9 @@ module ActiveRecord
           # connection using host, port and database name
           elsif host || port
             host ||= "localhost"
-            host = "[#{host}]" if host =~ /^[^\[].*:/  # IPv6
+            host = "[#{host}]" if /^[^\[].*:/.match?(host)  # IPv6
             port ||= 1521
-            database = "/#{database}" unless database.match(/^\//)
+            database = "/#{database}" unless database.match?(/^\//)
             "//#{host}:#{port}#{database}"
           # if no host is specified then assume that
           # database parameter is TNS alias or TNS connection string

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -647,7 +647,7 @@ module ActiveRecord
               # If a default contains a newline these cleanup regexes need to
               # match newlines.
               field["data_default"].sub!(/^'(.*)'$/m, '\1')
-              field["data_default"] = nil if field["data_default"] =~ /^(null|empty_[bc]lob\(\))$/i
+              field["data_default"] = nil if /^(null|empty_[bc]lob\(\))$/i.match?(field["data_default"])
               # TODO: Needs better fix to fallback "N" to false
               field["data_default"] = false if field["data_default"] == "N" && OracleEnhancedAdapter.emulate_booleans_from_strings
             end

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -180,7 +180,7 @@ describe "OracleEnhancedConnection" do
   describe "with slash-prefixed database name (service name)" do
     before(:all) do
       params = CONNECTION_PARAMS.dup
-      params[:database] = "/#{params[:database]}" unless params[:database].match(/^\//)
+      params[:database] = "/#{params[:database]}" unless params[:database].match?(/^\//)
       @conn = ActiveRecord::ConnectionAdapters::OracleEnhanced::Connection.create(params)
     end
 


### PR DESCRIPTION
This pull request unlocks RuboCop gem versions including these commits:

* Disable `rubocop` plugin from .codeclimate.yml
* Use the latest`rubocop`, `rubocop-performance` and `rubocop-rails` gem because we can run the latest versions of them with GitHub Actions
* Perform RuboCop autocorrect using `rubocop-performance` 1.4.1

This pull request is making use of GitHub Actions enabled at #1925