### PR TITLE
Enabled Dependabot by creating .dependabot/config.yml

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,7 @@
+version: 1
+update_configs:
+  # Update your Gemfile (& lockfiles) as soon as
+  # new versions are published to the RubyGems registry
+  - package_manager: "ruby:bundler"
+    directory: "/"
+    update_schedule: "live"


### PR DESCRIPTION
This pull request enables Dependabot to see if it works and helps Oracle enhanced adapter development.

Refer https://dependabot.com/docs/config-file/ to create with only required options.