### PR TITLE
Fix `NameError` for `SchemaCreation`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced
-      class SchemaCreation < AbstractAdapter::SchemaCreation
+      class SchemaCreation < SchemaCreation
         private
           def visit_ColumnDefinition(o)
             if [:blob, :clob, :nclob].include?(sql_type = type_to_sql(o.type,  o.options).downcase.to_sym)


### PR DESCRIPTION
Follow up of https://github.com/rails/rails/pull/37187.

This PR fixes the following `NameError`.

```console
% bundle exec rake
(snip)
rake aborted!
NameError: uninitialized constant
ActiveRecord::ConnectionAdapters::AbstractAdapter::SchemaCreation
Did you mean?  ActiveRecord::ConnectionAdapters::SchemaCreation
               ActiveRecord::SchemaMigration
/home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb:6:in
`<module:OracleEnhanced>'
```