### PR TITLE
Use Ubuntu 18.04 (Bionic Beaver) at Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 sudo: required
 cache: bundler
 


### PR DESCRIPTION
This pull request bumps the OS version at Travis CI from 16.04 to 18.04.

https://docs.travis-ci.com/user/reference/bionic/