### PR TITLE
create_table_definition and add_column take keyword arguments

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -411,10 +411,10 @@ module ActiveRecord
           OracleEnhanced::ReferenceDefinition.new(*args).add_to(update_table_definition(table_name, self))
         end
 
-        def add_column(table_name, column_name, type, options = {}) #:nodoc:
+        def add_column(table_name, column_name, type, **options) #:nodoc:
           type = aliased_types(type.to_s, type)
           at = create_alter_table table_name
-          at.add_column(column_name, type, options)
+          at.add_column(column_name, type, **options)
           add_column_sql = schema_creation.accept at
           add_column_sql << tablespace_for((type_to_sql(type).downcase.to_sym), nil, table_name, column_name)
           execute add_column_sql
@@ -624,8 +624,8 @@ module ActiveRecord
             OracleEnhanced::SchemaCreation.new self
           end
 
-          def create_table_definition(*args)
-            OracleEnhanced::TableDefinition.new(self, *args)
+          def create_table_definition(*args, **options)
+            OracleEnhanced::TableDefinition.new(self, *args, **options)
           end
 
           def new_column_from_field(table_name, field)


### PR DESCRIPTION
Follow up of https://github.com/rails/rails/commit/d700456cb72bd38dcf6f540a3b7f6593879b456f, https://github.com/rails/rails/commit/e02b3d1b0ede87396122f90d773b9030ce9d469e, and https://github.com/rails/rails/commit/70afbf245f1038b91a664dcee98cb8dea61d9b91