### PR TITLE
Add `supports_common_table_expressions?` for CTE testing

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -285,6 +285,10 @@ module ActiveRecord
         true
       end
 
+      def supports_common_table_expressions?
+        true
+      end
+
       def supports_views?
         true
       end


### PR DESCRIPTION
Follow up of https://github.com/rails/rails/commit/d775176d3a20a5e02b4fbcd0ae8379b53238f787.

As far as I can see, Oracle supports Common Table Expression.
And this patch passed the following AR test.

```console
% ARCONN=oracle bundle exec ruby -w -Itest test/cases/adapter_test.rb -n
test_doesnt_error_when_a_read_query_with_a_cte_is_called_while_preventing_writes
Using oracle
Run options: -n
test_doesnt_error_when_a_read_query_with_a_cte_is_called_while_preventing_writes
--seed 45728

# Running:

.

Finished in 0.014451s, 69.2015 runs/s, 69.2015 assertions/s.
1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
```