### PR TITLE
Bump RuboCop to 0.76.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -145,7 +145,7 @@ Layout/TrailingWhitespace:
   Enabled: true
 
 # Use quotes for string literals when they are enough.
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Enabled: true
 
 Lint/AmbiguousOperator:


### PR DESCRIPTION
Follow up of https://github.com/rails/rails/pull/37582.