### PR TITLE
CI against Ruby 2.5.7 and Ruby 2.6.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ install:
 
 language: ruby
 rvm:
-  - 2.6.4
-  - 2.5.6
+  - 2.6.5
+  - 2.5.7
   - jruby-9.2.9.0
   - ruby-head
   - jruby-head


### PR DESCRIPTION
* Ruby 2.5.7 Released
https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-5-7-released/

* Ruby 2.6.5 Released
https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-6-5-released/