### PR TITLE
Address `uninitialized constant ActiveRecord::ConnectionAdapters::AbstractAdapter::Quoting (NameError)

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -30,6 +30,7 @@
 # contribution.
 # portions Copyright 2005 Graham Jenkins
 
+require "active_record/connection_adapters"
 require "active_record/connection_adapters/abstract_adapter"
 require "active_record/connection_adapters/statement_pool"
 require "active_record/connection_adapters/oracle_enhanced/connection"


### PR DESCRIPTION
This pull request addresses `uninitialized constant ActiveRecord::ConnectionAdapters::AbstractAdapter::Quoting (NameError)`

Fix #1935

```ruby
$ ruby guides/bug_report_templates/active_record_gem.rb
Fetching https://github.com/rails/rails.git
Fetching gem metadata from https://rubygems.org/..........
Fetching gem metadata from https://rubygems.org/............
Fetching gem metadata from https://rubygems.org/............
Resolving dependencies...
Using rake 13.0.0
Using concurrent-ruby 1.1.5
Using i18n 1.7.0
Using minitest 5.13.0
Using thread_safe 0.3.6
Using tzinfo 1.2.5
Using zeitwerk 2.2.1
Using activesupport 6.1.0.alpha from https://github.com/rails/rails.git (at master@a98b950)
Using builder 3.2.3
Using erubi 1.9.0
Using mini_portile2 2.4.0
Using nokogiri 1.10.5
Using rails-dom-testing 2.0.3
Using crass 1.0.5
Using loofah 2.3.1
Using rails-html-sanitizer 1.3.0
Using actionview 6.1.0.alpha from https://github.com/rails/rails.git (at master@a98b950)
Using rack 2.0.7
Using rack-test 1.1.0
Using actionpack 6.1.0.alpha from https://github.com/rails/rails.git (at master@a98b950)
Using nio4r 2.5.2
Using websocket-extensions 0.1.4
Using websocket-driver 0.7.1
Using actioncable 6.1.0.alpha from https://github.com/rails/rails.git (at master@a98b950)
Using globalid 0.4.2
Using activejob 6.1.0.alpha from https://github.com/rails/rails.git (at master@a98b950)
Using activemodel 6.1.0.alpha from https://github.com/rails/rails.git (at master@a98b950)
Using activerecord 6.1.0.alpha from https://github.com/rails/rails.git (at master@a98b950)
Using mimemagic 0.3.3
Using marcel 0.3.3
Using activestorage 6.1.0.alpha from https://github.com/rails/rails.git (at master@a98b950)
Using mini_mime 1.0.2
Using mail 2.7.1
Using actionmailbox 6.1.0.alpha from https://github.com/rails/rails.git (at master@a98b950)
Using actionmailer 6.1.0.alpha from https://github.com/rails/rails.git (at master@a98b950)
Using actiontext 6.1.0.alpha from https://github.com/rails/rails.git (at master@a98b950)
Using ruby-plsql 0.7.1
Using activerecord-oracle_enhanced-adapter 6.1.0.alpha from https://github.com/rsim/oracle-enhanced.git (at /home/yahonda/git/oracle-enhanced@b1d46a7)
Using bundler 1.17.3
Using method_source 0.9.2
Using thor 0.20.3
Using railties 6.1.0.alpha from https://github.com/rails/rails.git (at master@a98b950)
Using sprockets 4.0.0
Using sprockets-rails 3.2.1
Using rails 6.1.0.alpha from https://github.com/rails/rails.git (at master@a98b950)
Using ruby-oci8 2.2.7
Traceback (most recent call last):
	5: from guides/bug_report_templates/active_record_gem.rb:22:in `<main>'
	4: from /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:33:in `<top (required)>'
	3: from /home/yahonda/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/bundler/gems/rails-a98b9505885d/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:15:in `<top (required)>'
	2: from /home/yahonda/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/bundler/gems/rails-a98b9505885d/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:16:in `<module:ActiveRecord>'
	1: from /home/yahonda/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/bundler/gems/rails-a98b9505885d/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:30:in `<module:ConnectionAdapters>'
/home/yahonda/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/bundler/gems/rails-a98b9505885d/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:35:in `<class:AbstractAdapter>': uninitialized constant ActiveRecord::ConnectionAdapters::AbstractAdapter::Quoting (NameError)
$
```