### PR TITLE
Use RuboCop 0.77

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,7 +61,7 @@ Layout/EmptyLinesAroundModuleBody:
 Style/HashSyntax:
   Enabled: true
 
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
   Enabled: true
 
 # Method definitions after `private` or `protected` isolated calls need one
@@ -139,8 +139,8 @@ Style/StringLiterals:
 Layout/Tab:
   Enabled: true
 
-# Blank lines should not have any spaces.
-Layout/TrailingBlankLines:
+# Empty lines should not have any spaces.
+Layout/TrailingEmptyLines:
   Enabled: true
 
 # No trailing whitespace.
@@ -167,7 +167,7 @@ Lint/RequireParentheses:
 Lint/ShadowingOuterLocalVariable:
   Enabled: true
 
-Lint/StringConversionInInterpolation:
+Lint/RedundantStringCoercion:
   Enabled: true
 
 Lint/UriEscapeUnescape:


### PR DESCRIPTION
This pull request updates .rubocop.yml to use RuboCop 0.77
https://github.com/rubocop-hq/rubocop/releases/tag/v0.77.0

* Update cop names as follows:

```ruby
$ bundle exec rubocop
Error: The `Layout/IndentFirstArgument` cop has been renamed to `Layout/FirstArgumentIndentation`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Layout/TrailingBlankLines` cop has been renamed to `Layout/TrailingEmptyLines`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Lint/StringConversionInInterpolation` cop has been renamed to `Lint/RedundantStringCoercion`.
(obsolete configuration found in .rubocop.yml, please update it)
$
```