### PR TITLE
Fix an error when writing lobs

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -252,7 +252,7 @@ module ActiveRecord
               value = klass.attribute_types[col.name].serialize(value)
             end
             uncached do
-              unless lob_record = select_one(<<~SQL.squish, "Writable Large Object")
+              unless lob_record = select_one(sql = <<~SQL.squish, "Writable Large Object")
                 SELECT #{quote_column_name(col.name)} FROM #{quote_table_name(table_name)}
                 WHERE #{quote_column_name(klass.primary_key)} = #{id} FOR UPDATE
               SQL


### PR DESCRIPTION
### Summary

Fixes #1932.

This PR fixes an error when writing lobs.
This error seems to be caused by #1546. Rails 5.2 and 6.0 has been targeted.

### Other Information

#1932 discusses backporting to Rails 5.2 and Rails 6.0.