### PR TITLE
Backport #1962 to release60 branch

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -252,7 +252,7 @@ module ActiveRecord
               value = klass.attribute_types[col.name].serialize(value)
             end
             uncached do
-              unless lob_record = select_one(<<~SQL.squish, "Writable Large Object")
+              unless lob_record = select_one(sql = <<~SQL.squish, "Writable Large Object")
                 SELECT #{quote_column_name(col.name)} FROM #{quote_table_name(table_name)}
                 WHERE #{quote_column_name(klass.primary_key)} = #{id} FOR UPDATE
               SQL


### PR DESCRIPTION
This pull request backports #1962 to release60 branch as follows.

I used to cherry-pick the original commit, this time cherry-pick the merge commit with `-m 1` option now.

```
$ git cherry-pick -m 1 becf833
```