### PR TITLE
Uninstall SimpleCov

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,3 @@ group :development do
     gem "pry-nav"
   end
 end
-
-group :test do
-  gem "simplecov",  github: "colszowka/simplecov", branch: "master", require: false
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "simplecov"
-SimpleCov.start
 require "rubygems"
 require "bundler"
 require "yaml"


### PR DESCRIPTION
This pull request uninstalls SimpleCov.

This is triggered by the following error. Although I usually investigate these kind of errors,
We are not making use of SimpleCov to get test coverage then decided to uninstall SimpleCov

```
$ bundle
Fetching https://github.com/rails/rails.git
Fetching https://github.com/rsim/ruby-plsql.git
Fetching https://github.com/kubo/ruby-oci8.git
Fetching https://github.com/colszowka/simplecov.git
The dependency pry (>= 0) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for java. To add those platforms to the bundle, run `bundle lock --add-platform java`.
The dependency pry-nav (>= 0) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for java. To add those platforms to the bundle, run `bundle lock --add-platform java`.
Fetching gem metadata from https://rubygems.org/.........
Fetching gem metadata from https://rubygems.org/............
Fetching gem metadata from https://rubygems.org/............
Resolving dependencies...
Bundler could not find compatible versions for gem "simplecov-html":
  In Gemfile:
    simplecov was resolved to 0.18.0.pre.dev, which depends on
      simplecov-html (~> 0.11.0.pre.dev)

Could not find gem 'simplecov-html (~> 0.11.0.pre.dev)', which is required by gem 'simplecov', in any of the sources.
%
```

Refer #1108 #1118