### PR TITLE
CI against Ruby 2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ script:
 
 language: ruby
 rvm:
+  - 2.7.0
   - 2.6.5
   - 2.5.7
   - jruby-9.2.9.0


### PR DESCRIPTION
* Ruby 2.7.0 Released
https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/

* RVM support may be necessary
https://github.com/rvm/rvm/pull/4837