### PR TITLE
No more ci against ruby-head for release52 aka Rails 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ rvm:
   - 2.5.5
   - 2.6.2
   - jruby-9.2.6.0
-  - ruby-head
   - jruby-head
 
 matrix:


### PR DESCRIPTION
As of Jan 2020, ruby-head is Ruby 2.8.0 which does implement the new keyword arguments.
As far as I know, there is no plan to support Rails 5.2 then let's remove Ci against ruby-head.