### PR TITLE
CI against latest rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,10 @@ install:
 
 language: ruby
 rvm:
-  - 2.6.4
-  - 2.5.6
-  - jruby-9.2.8.0
+  - 2.7.0
+  - 2.6.5
+  - 2.5.7
+  - jruby-9.2.9.0
   - ruby-head
   - jruby-head
 


### PR DESCRIPTION
* Ruby 2.6.5 Released
https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-6-5-released/

* Ruby 2.5.7 Released
https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-5-7-released/

* JRuby 9.2.9.0 Released
https://www.jruby.org/2019/10/30/jruby-9-2-9-0.html