### PR TITLE
Include sync option when dumping a context index

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -50,6 +50,7 @@ module ActiveRecord #:nodoc:
                   else
                     statement_parts = [ ("add_context_index " + remove_prefix_and_suffix(table).inspect) ]
                     statement_parts << index.columns.inspect
+                    statement_parts << ("sync: " + $1.inspect) if index.parameters =~ /SYNC\((.*?)\)/
                     statement_parts << ("name: " + index.name.inspect)
                   end
                 else

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -71,7 +71,7 @@ module ActiveRecord #:nodoc:
               index_statements = indexes.map do |index|
                 "    t.index #{index_parts(index).join(', ')}" unless index.type == "CTXSYS.CONTEXT"
               end
-              stream.puts index_statements.sort.join("\n")
+              stream.puts index_statements.compact.sort.join("\n")
             end
           end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -313,7 +313,7 @@ describe "OracleEnhancedAdapter schema dump" do
           t.string :body
           t.index :title
         end
-        add_context_index :test_context_indexed_posts, :body
+        add_context_index :test_context_indexed_posts, :body, sync: "ON COMMIT"
       end
     end
 
@@ -325,6 +325,10 @@ describe "OracleEnhancedAdapter schema dump" do
 
     it "should dump the context index" do
       expect(standard_dump).to include(%(add_context_index "test_context_indexed_posts", ["body"]))
+    end
+
+    it "dumps the sync option" do
+      expect(standard_dump).to include(%(sync: "ON COMMIT"))
     end
   end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -305,6 +305,29 @@ describe "OracleEnhancedAdapter schema dump" do
     end
   end
 
+  describe "context indexes" do
+    before(:each) do
+      schema_define do
+        create_table :test_context_indexed_posts, force: true do |t|
+          t.string :title
+          t.string :body
+          t.index :title
+        end
+        add_context_index :test_context_indexed_posts, :body
+      end
+    end
+
+    after(:each) do
+      schema_define do
+        drop_table :test_context_indexed_posts
+      end
+    end
+
+    it "should dump the context index" do
+      expect(standard_dump).to include(%(add_context_index "test_context_indexed_posts", ["body"]))
+    end
+  end
+
   describe "virtual columns" do
     before(:all) do
       skip "Not supported in this database version" unless @oracle11g_or_higher


### PR DESCRIPTION
Includes `sync` option in `schema.rb` when dumping a context index.

Fixes #1987 

I didn't want to duplicate the test case I wrote in #1986, so this also includes that. I'm happy to split it out if you're rather see it separately.