### PR TITLE
CI against JRuby 9.2.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ rvm:
   - 2.7.0
   - 2.6.5
   - 2.5.7
-  - jruby-9.2.9.0
+  - jruby-9.2.10.0
   - ruby-head
   - jruby-head
 


### PR DESCRIPTION
* JRuby 9.2.10.0 Released
https://www.jruby.org/2020/02/18/jruby-9-2-10-0.html