### PR TITLE
Use the new API for build_results

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -53,7 +53,7 @@ module ActiveRecord
               while row = cursor.fetch(fetch_options)
                 rows << row
               end
-              res = build_result(columns, rows)
+              res = build_result(columns: columns, rows: rows)
             end
 
             cursor.close unless cached
@@ -130,7 +130,7 @@ module ActiveRecord
               rows << [returning_id]
             end
             cursor.close unless cached
-            build_result(returning_id_col || [], rows)
+            build_result(columns: returning_id_col || [], rows: rows)
           end
         end
 


### PR DESCRIPTION
I changed the API to accepts keyword arguments in rails/rails@f735a2167c