### PR TITLE
CI against JRuby 9.2.11.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ rvm:
   - 2.7.0
   - 2.6.5
   - 2.5.7
-  - jruby-9.2.11.0
+  - jruby-9.2.11.1
   - ruby-head
   - jruby-head
 


### PR DESCRIPTION
* JRuby 9.2.11.1 Released
https://www.jruby.org/2020/03/25/jruby-9-2-11-1.html