### PR TITLE
CI againt Ruby 2.7.1, 2.6.6 and 2.5.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,9 @@ script:
 
 language: ruby
 rvm:
-  - 2.7.0
-  - 2.6.5
-  - 2.5.7
+  - 2.7.1
+  - 2.6.6
+  - 2.5.8
   - jruby-9.2.11.1
   - ruby-head
   - jruby-head


### PR DESCRIPTION
* Ruby 2.7.1 Released
https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-7-1-released/

* Ruby 2.6.6 Released
https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-6-6-released/

* Ruby 2.5.8 Released
https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-5-8-released/