### PR TITLE
[WIP] Migrate Arel code from Rails to Oracle enhanced adapter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :development do
   gem "rubocop-performance", require: false
   gem "rubocop-rails", require: false
 
-  gem "activerecord",   github: "rails/rails", branch: "master"
+  gem "activerecord",   github: "kamipo/rails", branch: "remove_unused_visitors"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do


### PR DESCRIPTION
This is a draft pull request to support https://github.com/rails/rails/pull/38946 

### Required
- [ ] Migrate Arel library code to make CI green
- [ ] Migrate git commit history

### Optional
- [ ] Migrate test code
because the unit test for Arel is written in Minitest, Oracle enhanced adapter uses RSpec. Arel has been a private API at Rails then it may be fine without tests for the time being.