### PR TITLE
Bump RuboCop to 0.82.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -136,7 +136,7 @@ Style/StringLiterals:
   EnforcedStyle: double_quotes
 
 # Detect hard tabs, no hard tabs.
-Layout/Tab:
+Layout/IndentationStyle:
   Enabled: true
 
 # Empty lines should not have any spaces.


### PR DESCRIPTION
Follow up of https://github.com/rails/rails/pull/38980.