### PR TITLE
Don't refer `allowed_index_name_length` directly

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_limits.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_limits.rb
@@ -25,15 +25,6 @@ module ActiveRecord
         end
         deprecate :column_name_length
 
-        # Returns the maximum allowed length for an index name. This
-        # limit is enforced by rails and Is less than or equal to
-        # <tt>index_name_length</tt>. The gap between
-        # <tt>index_name_length</tt> is to allow internal rails
-        # opreations to use prefixes in temporary opreations.
-        def allowed_index_name_length
-          index_name_length
-        end
-
         # the maximum length of an index name
         # supported by this database
         def index_name_length

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -311,13 +311,11 @@ module ActiveRecord
           index_type = options[:unique] ? "UNIQUE" : ""
           index_name = options[:name].to_s if options.key?(:name)
           tablespace = tablespace_for(:index, options[:tablespace])
-          max_index_length = options.fetch(:internal, false) ? index_name_length : allowed_index_name_length
-          # TODO: This option is used for NOLOGGING, needs better argumetn name
+          # TODO: This option is used for NOLOGGING, needs better argument name
           index_options = options[:options]
 
-          if index_name.to_s.length > max_index_length
-            raise ArgumentError, "Index name '#{index_name}' on table '#{table_name}' is too long; the limit is #{max_index_length} characters"
-          end
+          validate_index_length!(table_name, index_name, options.fetch(:internal, false))
+
           if table_exists?(table_name) && index_name_exists?(table_name, index_name)
             raise ArgumentError, "Index name '#{index_name}' on table '#{table_name}' already exists"
           end


### PR DESCRIPTION
`allowed_index_name_length` is deprecated and will be removed in the
future version of Rails.

See https://github.com/rails/rails/pull/39083.