### PR TITLE
Suppress `warning: already initialized constant`

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -105,14 +105,7 @@ module LoggerSpecHelper
   end
 end
 
-# TODO: Address these warnings:
-# /path/to/spec/spec_helper.rb:112: warning: already initialized constant ActiveRecord::LogSubscriber::IGNORE_PAYLOAD_NAMES
-# /path/to/rails/activerecord/lib/active_record/log_subscriber.rb:5: warning: previous definition of IGNORE_PAYLOAD_NAMES was here
-module ActiveRecord
-  class LogSubscriber
-    IGNORE_PAYLOAD_NAMES = ["EXPLAIN"]
-  end
-end
+ActiveRecord::LogSubscriber::IGNORE_PAYLOAD_NAMES.replace(["EXPLAIN"])
 
 module SchemaSpecHelper
   def schema_define(&block)


### PR DESCRIPTION
This PR suppresses the following `warning: already initialized constant`.

```console
% path/to/oracle-enhanced
% bundle exec rake
(snip)
==> Loading config from ENV or use default
==> Running specs with MRI version 2.7.1
==> Effective ActiveRecord version 6.1.0.alpha
/home/vagrant/src/oracle-enhanced/spec/spec_helper.rb:113: warning:
already initialized constant
ActiveRecord::LogSubscriber::IGNORE_PAYLOAD_NAMES
/home/vagrant/.rvm/gems/ruby-2.7.1/bundler/gems/rails-348e142b26b4/activerecord/lib/active_record/log_subscriber.rb:5:
warning: previous definition of IGNORE_PAYLOAD_NAMES was here
```