### PR TITLE
Limit number of expressions in a list during a "homogenous in" operation

### DIFF
--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -93,21 +93,23 @@ module Arel # :nodoc: all
           in_clause_length = @connection.in_clause_length
           values = o.casted_values.map { |v| @connection.quote(v) }
           column_name = quote_table_name(o.table_name) << "." << quote_column_name(o.column_name)
-          operator = if o.type == :in
-                       "IN ("
-                     else
-                       "NOT IN ("
-                     end
+          operator =
+            if o.type == :in
+              "IN ("
+            else
+              "NOT IN ("
+            end
 
           if !Array === values || values.length <= in_clause_length
             collector << column_name
             collector << operator
 
-            expr = if values.empty?
-                     @connection.quote(nil)
-                   else
-                     values.join(",")
-                   end
+            expr =
+              if values.empty?
+                @connection.quote(nil)
+              else
+                values.join(",")
+              end
 
             collector << expr
             collector << ")"

--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -86,6 +86,46 @@ module Arel # :nodoc: all
           collector << " )"
         end
 
+        ##
+        # To avoid ORA-01795: maximum number of expressions in a list is 1000
+        # tell ActiveRecord to limit us to 1000 ids at a time
+        def visit_Arel_Nodes_HomogeneousIn(o, collector)
+          in_clause_length = @connection.in_clause_length
+          values = o.casted_values.map { |v| @connection.quote(v) }
+          column_name = quote_table_name(o.table_name) << "." << quote_column_name(o.column_name)
+          operator = if o.type == :in
+                       "IN ("
+                     else
+                       "NOT IN ("
+                     end
+
+          if !Array === values || values.length <= in_clause_length
+            collector << column_name
+            collector << operator
+
+            expr = if values.empty?
+                     @connection.quote(nil)
+                   else
+                     values.join(",")
+                   end
+
+            collector << expr
+            collector << ")"
+          else
+            collector << "("
+            values.each_slice(in_clause_length).each_with_index do |valuez, i|
+              collector << " OR " unless i == 0
+              collector << column_name
+              collector << operator
+              collector << valuez.join(",")
+              collector << ")"
+            end
+            collector << ")"
+          end
+
+          collector
+        end
+
         def visit_Arel_Nodes_In(o, collector)
           attr, values = o.left, o.right
 

--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -92,7 +92,7 @@ module Arel # :nodoc: all
         def visit_Arel_Nodes_HomogeneousIn(o, collector)
           in_clause_length = @connection.in_clause_length
           values = o.casted_values.map { |v| @connection.quote(v) }
-          column_name = quote_table_name(o.table_name) + '.' + quote_column_name(o.column_name)
+          column_name = quote_table_name(o.table_name) + "." + quote_column_name(o.column_name)
           operator =
             if o.type == :in
               "IN ("

--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -92,7 +92,7 @@ module Arel # :nodoc: all
         def visit_Arel_Nodes_HomogeneousIn(o, collector)
           in_clause_length = @connection.in_clause_length
           values = o.casted_values.map { |v| @connection.quote(v) }
-          column_name = quote_table_name(o.table_name) << "." << quote_column_name(o.column_name)
+          column_name = quote_table_name(o.table_name) + '.' + quote_column_name(o.column_name)
           operator =
             if o.type == :in
               "IN ("

--- a/lib/arel/visitors/oracle12.rb
+++ b/lib/arel/visitors/oracle12.rb
@@ -46,21 +46,23 @@ module Arel # :nodoc: all
           in_clause_length = @connection.in_clause_length
           values = o.casted_values.map { |v| @connection.quote(v) }
           column_name = quote_table_name(o.table_name) << "." << quote_column_name(o.column_name)
-          operator = if o.type == :in
-                       "IN ("
-                     else
-                       "NOT IN ("
-                     end
+          operator =
+            if o.type == :in
+              "IN ("
+            else
+              "NOT IN ("
+            end
 
           if !Array === values || values.length <= in_clause_length
             collector << column_name
             collector << operator
 
-            expr = if values.empty?
-                     @connection.quote(nil)
-                   else
-                     values.join(",")
-                   end
+            expr =
+              if values.empty?
+                @connection.quote(nil)
+              else
+                values.join(",")
+              end
 
             collector << expr
             collector << ")"

--- a/lib/arel/visitors/oracle12.rb
+++ b/lib/arel/visitors/oracle12.rb
@@ -39,6 +39,46 @@ module Arel # :nodoc: all
           collector << " )"
         end
 
+        ##
+        # To avoid ORA-01795: maximum number of expressions in a list is 1000
+        # tell ActiveRecord to limit us to 1000 ids at a time
+        def visit_Arel_Nodes_HomogeneousIn(o, collector)
+          in_clause_length = @connection.in_clause_length
+          values = o.casted_values.map { |v| @connection.quote(v) }
+          column_name = quote_table_name(o.table_name) << "." << quote_column_name(o.column_name)
+          operator = if o.type == :in
+                       "IN ("
+                     else
+                       "NOT IN ("
+                     end
+
+          if !Array === values || values.length <= in_clause_length
+            collector << column_name
+            collector << operator
+
+            expr = if values.empty?
+                     @connection.quote(nil)
+                   else
+                     values.join(",")
+                   end
+
+            collector << expr
+            collector << ")"
+          else
+            collector << "("
+            values.each_slice(in_clause_length).each_with_index do |valuez, i|
+              collector << " OR " unless i == 0
+              collector << column_name
+              collector << operator
+              collector << valuez.join(",")
+              collector << ")"
+            end
+            collector << ")"
+          end
+
+          collector
+        end
+
         def visit_Arel_Nodes_In(o, collector)
           attr, values = o.left, o.right
 

--- a/lib/arel/visitors/oracle12.rb
+++ b/lib/arel/visitors/oracle12.rb
@@ -45,7 +45,7 @@ module Arel # :nodoc: all
         def visit_Arel_Nodes_HomogeneousIn(o, collector)
           in_clause_length = @connection.in_clause_length
           values = o.casted_values.map { |v| @connection.quote(v) }
-          column_name = quote_table_name(o.table_name) + '.' + quote_column_name(o.column_name)
+          column_name = quote_table_name(o.table_name) + "." + quote_column_name(o.column_name)
           operator =
             if o.type == :in
               "IN ("

--- a/lib/arel/visitors/oracle12.rb
+++ b/lib/arel/visitors/oracle12.rb
@@ -45,7 +45,7 @@ module Arel # :nodoc: all
         def visit_Arel_Nodes_HomogeneousIn(o, collector)
           in_clause_length = @connection.in_clause_length
           values = o.casted_values.map { |v| @connection.quote(v) }
-          column_name = quote_table_name(o.table_name) << "." << quote_column_name(o.column_name)
+          column_name = quote_table_name(o.table_name) + '.' + quote_column_name(o.column_name)
           operator =
             if o.type == :in
               "IN ("

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -81,13 +81,13 @@ describe "OracleEnhancedConnection" do
       expect(ActiveRecord::Base.connection).to be_active
     end
 
-    it "should swith to specified schema" do
+    it "should switch to specified schema" do
       ActiveRecord::Base.establish_connection(CONNECTION_WITH_SCHEMA_PARAMS)
       expect(ActiveRecord::Base.connection.current_schema).to eq(CONNECTION_WITH_SCHEMA_PARAMS[:schema].upcase)
       expect(ActiveRecord::Base.connection.current_user).to eq(CONNECTION_WITH_SCHEMA_PARAMS[:username].upcase)
     end
 
-    it "should swith to specified schema after reset" do
+    it "should switch to specified schema after reset" do
       ActiveRecord::Base.connection.reset!
       expect(ActiveRecord::Base.connection.current_schema).to eq(CONNECTION_WITH_SCHEMA_PARAMS[:schema].upcase)
     end

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -197,7 +197,7 @@ describe "OracleEnhancedAdapter" do
     before(:all) do
       schema_define do
         create_table :test_posts do |t|
-          t.string      :title
+          t.string :title
         end
       end
       class ::TestPost < ActiveRecord::Base


### PR DESCRIPTION
* Oracle limits lists to a maximum of 1,000 items. 
* rails/rails@72fd0bae5948c1169411941aeea6fef4c58f34a9 implements a new type of `in` operation which can be performed under certain circumstances.
* This caused the test "OracleEnhancedAdapter eager loading should load included association with more than 1000 records" to fail with ORA-01795.
* The solution was to implement `visit_Arel_Nodes_HomogeneousIn`.
* Fixed a typo while I was at it.