### PR TITLE
Run CI with GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,66 @@
+name: test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        ruby: [
+          2.7,
+          2.6,
+          2.5,
+          ruby-head,
+          ruby-debug
+        ]
+    env:
+      ORACLE_HOME: /opt/oracle/product/18c/dbhomeXE
+      LD_LIBRARY_PATH: /opt/oracle/product/18c/dbhomeXE/lib
+      NLS_LANG: AMERICAN_AMERICA.AL32UTF8
+      TNS_ADMIN: ./ci/network/admin
+      DATABASE_NAME: XEPDB1
+      TZ: Europe/Riga
+      DATABASE_SYS_PASSWORD: Oracle18
+
+    services:
+      oracle:
+        image: quillbuilduser/oracle-18-xe
+        ports:
+          - 1521:1521
+        env:
+          TZ: Europe/Riga
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+    - name: Install required package
+      run: |
+        sudo apt-get install alien
+    - name: Download Oracle client
+      run: |
+        wget -q https://download.oracle.com/otn-pub/otn_software/db-express/oracle-database-xe-18c-1.0-1.x86_64.rpm
+    - name: Install Oracle client
+      run: |
+        sudo alien -i oracle-database-xe-18c-1.0-1.x86_64.rpm
+    - name: Install JDBC Driver
+      run: |
+        cp $ORACLE_HOME/jdbc/lib/ojdbc8.jar lib/.
+    - name: Create database user
+      run: |
+        ./ci/setup_accounts.sh
+    - name: Bundle install
+      run: |
+        bundle install --jobs 4 --retry 3
+    - name: Run RSpec
+      run: |
+        bundle exec rspec
+    - name: Run bug report templates
+      run: |
+        ruby guides/bug_report_templates/active_record_gem.rb
+        ruby guides/bug_report_templates/active_record_gem_spec.rb

--- a/ci/network/admin/tnsnames.ora
+++ b/ci/network/admin/tnsnames.ora
@@ -1,0 +1,7 @@
+XEPDB1 =
+  (DESCRIPTION =
+    (ADDRESS = (PROTOCOL = TCP)(HOST = 127.0.0.1)(PORT = 1521))
+    (CONNECT_DATA =
+      (SERVICE_NAME = XEPDB1)
+    )
+  )

--- a/ci/setup_accounts.sh
+++ b/ci/setup_accounts.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -ev
+
+/opt/oracle/product/18c/dbhomeXE/bin/sqlplus system/Oracle18@XEPDB1 <<SQL
+@@spec/support/alter_system_user_password.sql
+@@spec/support/alter_system_set_open_cursors.sql
+@@spec/support/create_oracle_enhanced_users.sql
+exit
+SQL


### PR DESCRIPTION
Here are some notable changes:

- Use `ubuntu-20.04` to install `oracle-database-xe-18c-1.0-1.x86_64.rpm`

- CI against Ruby 2.7, 2,6, 2,5 ruby-head (Ruby 2.8.0dev)
  and `ruby-debug`, which is `ruby-head` but with assertions enabled (-DRUBY_DEBUG=1).

- Use Oracle Database 18c Express Edition (XE) as Oracle client
  to workaround ORA-1805 error.
  Refer https://github.com/rsim/oracle-enhanced/issues/2033

- Run Oracle Database 18c Express Edition (XE) as Docker container
  https://hub.docker.com/r/quillbuilduser/oracle-18-xe

This pull request does not include CI against Jruby because:
- No JRuby support because it requires to support "Thin-style Service Name Syntax"

  ```
  jdbc:oracle:thin:HR/hr@//localhost:5221/orcl
  ```

    Refer "8.2.4 Thin-style Service Name Syntax"
    https://docs.oracle.com/en/database/oracle/oracle-database/18/jjdbc/data-sources-and-URLs.html#GUID-EF07727C-50AB-4DCE-8EDC-57F0927FF61A

- Oracle Database 18c Express Edtition (XE) runs the pluggable database
  called 'XEPDB1' by default. This XEPDB1 is actually a service name,
  not Oracle SID.

Fixes #1910