### PR TITLE
Allow column name with function (e.g. `length(title)`) as safe SQL string

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -132,6 +132,42 @@ module ActiveRecord
           end
         end
 
+        def column_name_matcher
+          COLUMN_NAME
+        end
+
+        def column_name_with_order_matcher
+          COLUMN_NAME_WITH_ORDER
+        end
+
+        COLUMN_NAME = /
+          \A
+          (
+            (?:
+              # "table_name"."column_name" | function(one or no argument)
+              ((?:\w+\.|"\w+"\.)?(?:\w+|"\w+")) | \w+\((?:|\g<2>)\)
+            )
+            (?:(?:\s+AS)?\s+(?:\w+|"\w+"))?
+          )
+          (?:\s*,\s*\g<1>)*
+          \z
+        /ix
+
+        COLUMN_NAME_WITH_ORDER = /
+          \A
+          (
+            (?:
+              # "table_name"."column_name" | function(one or no argument)
+              ((?:\w+\.|"\w+"\.)?(?:\w+|"\w+")) | \w+\((?:|\g<2>)\)
+            )
+            (?:\s+ASC|\s+DESC)?
+            (?:\s+NULLS\s+(?:FIRST|LAST))?
+          )
+          (?:\s*,\s*\g<1>)*
+          \z
+        /ix
+        private_constant :COLUMN_NAME, :COLUMN_NAME_WITH_ORDER
+
         private
           def oracle_downcase(column_name)
             return nil if column_name.nil?


### PR DESCRIPTION
Follow rails/rails#36448, and follow rails/rails#36420, rails/rails@1340498, and rails/rails@6607ecb required for that change.

This PR fixes the following rails/activerecord's errors.

```console
% cd rails/activerecord
% ARCONN=oracle bundle exec ruby -w -Itest test/cases/unsafe_raw_sql_test.rb
Using oracle
Run options: -n /test_order/ --seed 62550

# Running:

..................DEPRECATION WARNING: Dangerous query method (method
whose arguments are used as raw SQL) called with non-attribute
argument(s): "\"POSTS\".\"TITLE\"". Non-attribute arguments will be
disallowed in Rails 6.1. This method should not be called with
user-provided values, such as request parameters or model
attributes. Known-safe values can be passed by wrapping them in
Arel.sql(). (called from block (3 levels) in run at
/home/vagrant/.rvm/gems/ruby-2.7.1/gems/minitest-5.14.0/lib/minitest/test.rb:98)
/home/vagrant/src/rails/activerecord/lib/active_record/relation/query_methods.rb:1338:in
`preprocess_order_args'
/home/vagrant/src/rails/activerecord/lib/active_record/relation/query_methods.rb:396:in
`order!'
/home/vagrant/src/rails/activerecord/lib/active_record/relation/query_methods.rb:391:in
`order'
/home/vagrant/src/rails/activerecord/lib/active_record/querying.rb:21:in
`order' test/cases/unsafe_raw_sql_test.rb:94:in `block (2 levels) in
<class:UnsafeRawSqlTest>' test/cases/unsafe_raw_sql_test.rb:348:in `with_config'
test/cases/unsafe_raw_sql_test.rb:342:in
`with_unsafe_raw_sql_deprecated' test/cases/unsafe_raw_sql_test.rb:94:in `block in
<class:UnsafeRawSqlTest>'

(snip)

Error:
UnsafeRawSqlTest#test_order:_allows_quoted_table_and_column_names:
ActiveRecord::UnknownAttributeReference: Query method called with
non-attribute argument(s): "\"POSTS\".\"TITLE\""
/home/vagrant/src/rails/activerecord/lib/active_record/sanitization.rb:157:in
`disallow_raw_sql!'
/home/vagrant/src/rails/activerecord/lib/active_record/relation/query_methods.rb:1338:in
`preprocess_order_args'
/home/vagrant/src/rails/activerecord/lib/active_record/relation/query_methods.rb:396:in `order!'
/home/vagrant/src/rails/activerecord/lib/active_record/relation/query_methods.rb:391:in `order'
/home/vagrant/src/rails/activerecord/lib/active_record/querying.rb:21:in `order'
test/cases/unsafe_raw_sql_test.rb:95:in `block (2 levels) in <class:UnsafeRawSqlTest>'
test/cases/unsafe_raw_sql_test.rb:348:in `with_config'
test/cases/unsafe_raw_sql_test.rb:338:in `with_unsafe_raw_sql_disabled'
test/cases/unsafe_raw_sql_test.rb:95:in `block in
<class:UnsafeRawSqlTest>'

rails test test/cases/unsafe_raw_sql_test.rb:90

(snip)

Error:
UnsafeRawSqlTest#test_pluck:_allows_quoted_table_and_column_names:
ActiveRecord::UnknownAttributeReference: Query method called with
non-attribute argument(s): "\"POSTS\".\"TITLE\""

/home/vagrant/src/rails/activerecord/lib/active_record/sanitization.rb:157:in
`disallow_raw_sql!'

/home/vagrant/src/rails/activerecord/lib/active_record/relation/calculations.rb:192:in
`pluck'

/home/vagrant/src/rails/activerecord/lib/active_record/querying.rb:21:in
`pluck'
test/cases/unsafe_raw_sql_test.rb:291:in `block (2 levels) in <class:UnsafeRawSqlTest>'
test/cases/unsafe_raw_sql_test.rb:348:in `with_config'
test/cases/unsafe_raw_sql_test.rb:338:in `with_unsafe_raw_sql_disabled'
test/cases/unsafe_raw_sql_test.rb:291:in `block in <class:UnsafeRawSqlTest>'

rails test test/cases/unsafe_raw_sql_test.rb:286

............

Finished in 0.898833s, 36.7143 runs/s, 57.8528 assertions/s.
33 runs, 52 assertions, 0 failures, 2 errors, 0 skips
```