### PR TITLE
Follow rails/rails#39365

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -35,7 +35,7 @@ module ActiveRecord
                 create_sql << " TABLESPACE #{tablespace}"
               end
             end
-            add_table_options!(create_sql, table_options(o))
+            add_table_options!(create_sql, o)
             create_sql << " AS #{to_sql(o.as)}" if o.as
             create_sql
           end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -61,7 +61,8 @@ module ActiveRecord
           as: nil,
           tablespace: nil,
           organization: nil,
-          comment: nil
+          comment: nil,
+          **
         )
           @tablespace = tablespace
           @organization = organization

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -107,7 +107,10 @@ module ActiveRecord #:nodoc:
                 tbl.print ", primary_key: #{pk.inspect}" unless pk == "id"
                 pkcol = columns.detect { |c| c.name == pk }
                 pkcolspec = column_spec_for_primary_key(pkcol)
-                if pkcolspec.present?
+                unless pkcolspec.empty?
+                  if pkcolspec != pkcolspec.slice(:id, :default)
+                    pkcolspec = { id: { type: pkcolspec.delete(:id), **pkcolspec }.compact }
+                  end
                   tbl.print ", #{format_colspec(pkcolspec)}"
                 end
               when Array

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -622,8 +622,8 @@ module ActiveRecord
             OracleEnhanced::SchemaCreation.new self
           end
 
-          def create_table_definition(*args, **options)
-            OracleEnhanced::TableDefinition.new(self, *args, **options)
+          def create_table_definition(name, **options)
+            OracleEnhanced::TableDefinition.new(self, name, **options)
           end
 
           def new_column_from_field(table_name, field)

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -436,7 +436,7 @@ describe "OracleEnhancedAdapter schema dump" do
 
     it "should dump table comments" do
       output = dump_table_schema "test_table_comments"
-      expect(output).to match(/create_table "test_table_comments", comment: "this is a \\"table comment\\"!", force: :cascade do \|t\|$/)
+      expect(output).to match(/create_table "test_table_comments", id: { precision: 38 }, comment: "this is a \\"table comment\\"!", force: :cascade do \|t\|$/)
     end
   end
 


### PR DESCRIPTION
Follow up to rails/rails#39365.

This PR consists of the following two commits.

1. Default engine `ENGINE=InnoDB` is no longer dumped to make schema more agnostic (rails/rails@3c6be5e)
2. Separate primary key column options from table options (rails/rails@859681e)

The latter changes `create_table` format in the dumped schema file.