### PR TITLE
Suppress RuboCop's offenses

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -42,7 +42,7 @@ module ActiveRecord
               cursor.exec
             end
 
-            if (name == "EXPLAIN") && sql =~ /^EXPLAIN/
+            if (name == "EXPLAIN") && sql.start_with?("EXPLAIN")
               res = true
             else
               columns = cursor.get_col_names.map do |col_name|

--- a/lib/active_record/connection_adapters/oracle_enhanced/lob.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/lob.rb
@@ -18,7 +18,7 @@ module ActiveRecord #:nodoc:
         module ClassMethods
           def lob_columns
             columns.select do |column|
-              column.sql_type_metadata.sql_type =~ /LOB$/
+              column.sql_type_metadata.sql_type.end_with?("LOB")
             end
           end
         end

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -324,7 +324,7 @@ module ActiveRecord
             host ||= "localhost"
             host = "[#{host}]" if /^[^\[].*:/.match?(host)  # IPv6
             port ||= 1521
-            database = "/#{database}" unless database.match?(/^\//)
+            database = "/#{database}" unless database.start_with?("/")
             "//#{host}:#{port}#{database}"
           # if no host is specified then assume that
           # database parameter is TNS alias or TNS connection string

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -180,7 +180,7 @@ describe "OracleEnhancedConnection" do
   describe "with slash-prefixed database name (service name)" do
     before(:all) do
       params = CONNECTION_PARAMS.dup
-      params[:database] = "/#{params[:database]}" unless params[:database].match?(/^\//)
+      params[:database] = "/#{params[:database]}" unless params[:database].start_with?("/")
       @conn = ActiveRecord::ConnectionAdapters::OracleEnhanced::Connection.create(params)
     end
 


### PR DESCRIPTION
RuboCop Performance 1.6.0 has been released.
https://github.com/rubocop-hq/rubocop-performance/releases/tag/v1.6.0

This PR suppresss new RuboCop's offenses.

```consle
% bundle exec rubocop
(snip)

Offenses:

lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:45:39:
C: Performance/StartWith: Use String#start_with? instead of a regex
match anchored to the beginning of the string.
            if (name == "EXPLAIN") && sql =~ /^EXPLAIN/
                                      ^^^^^^^^^^^^^^^^^
lib/active_record/connection_adapters/oracle_enhanced/lob.rb:21:15: C:
Performance/EndWith: Use String#end_with? instead of a regex match
anchored to the end of the string.
              column.sql_type_metadata.sql_type =~ /LOB$/
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:327:46:
C: Performance/StartWith: Use String#start_with? instead of a regex
match anchored to the beginning of the string.
            database = "/#{database}" unless database.match?(/^\//)
                                             ^^^^^^^^^^^^^^^^^^^^^^
spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb:183:58:
C: Performance/StartWith: Use String#start_with? instead of a regex
match anchored to the beginning of the string.
      params[:database] = "/#{params[:database]}" unless params[:database].match?(/^\//)
                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

70 files inspected, 4 offenses detected
```

https://github.com/rsim/oracle-enhanced/runs/703504178