### PR TITLE
Make index options to kwargs

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -244,7 +244,7 @@ module ActiveRecord
               change_column_comment(table_name, column.name, column.comment) if column.comment.present?
             end
           end
-          td.indexes.each { |c, o| add_index table_name, c, o }
+          td.indexes.each { |c, o| add_index table_name, c, **o }
 
           rebuild_primary_key_index_to_default_tablespace(table_name, options)
         end
@@ -292,7 +292,7 @@ module ActiveRecord
           end
         end
 
-        def add_index(table_name, column_name, options = {}) #:nodoc:
+        def add_index(table_name, column_name, **options) #:nodoc:
           index_name, index_type, quoted_column_names, tablespace, index_options = add_index_options(table_name, column_name, **options)
           execute "CREATE #{index_type} INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} (#{quoted_column_names})#{tablespace} #{index_options}"
           if index_type == "UNIQUE"
@@ -326,7 +326,7 @@ module ActiveRecord
 
         # Remove the given index from the table.
         # Gives warning if index does not exist
-        def remove_index(table_name, column_name = nil, options = {}) #:nodoc:
+        def remove_index(table_name, column_name = nil, **options) #:nodoc:
           index_name = index_name_for_remove(table_name, column_name, options)
           # TODO: It should execute only when index_type == "UNIQUE"
           execute "ALTER TABLE #{quote_table_name(table_name)} DROP CONSTRAINT #{quote_column_name(index_name)}" rescue nil


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/commit/b9e5859.

This PR resolves the following error.

```console
bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb:389
(snip)

An error occurred in an `after(:context)` hook.
Failure/Error: index_name = index_name_for_remove(table_name,
column_name, options)

ArgumentError:
  No indexes found on test_names with the options provided.
# /home/vagrant/.rvm/gems/ruby-2.7.1/bundler/gems/rails-844106efa9bc/activerecord/lib/active_record/
connection_adapters/abstract/schema_statements.rb:1356:in `index_name_for_remove'
# ./lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:330:in `remove_index'
# /home/vagrant/.rvm/gems/ruby-2.7.1/bundler/gems/rails-844106efa9bc/activerecord/lib/active_record/
migration.rb:911:in `block in method_missing'
# /home/vagrant/.rvm/gems/ruby-2.7.1/bundler/gems/rails-844106efa9bc/activerecord/lib/active_record/
migration.rb:879:in `block in say_with_time'
# /home/vagrant/.rvm/rubies/ruby-2.7.1/lib/ruby/2.7.0/benchmark.rb:293:in `measure'
# /home/vagrant/.rvm/gems/ruby-2.7.1/bundler/gems/rails-844106efa9bc/activerecord/lib/active_record/
migration.rb:879:in `say_with_time'
# /home/vagrant/.rvm/gems/ruby-2.7.1/bundler/gems/rails-844106efa9bc/activerecord/lib/active_record/
migration.rb:900:in `method_missing'
# ./spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb:389:in `block (5 levels)
in <top (required)>'
```

https://travis-ci.org/github/rsim/oracle-enhanced/jobs/691993596#L451