### PR TITLE
Migrate to `ruby/setup-ruby` to use Ruby 2.7

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+    - name: Set up Ruby 2.7
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.7
     - name: Install required package
       run: |
         sudo apt-get install alien

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,14 +22,14 @@ jobs:
         sudo apt-get install alien
     - name: Download Oracle instant client
       run: |
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/193000/oracle-instantclient19.3-basic-19.3.0.0.0-1.x86_64.rpm
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/193000/oracle-instantclient19.3-sqlplus-19.3.0.0.0-1.x86_64.rpm
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/193000/oracle-instantclient19.3-devel-19.3.0.0.0-1.x86_64.rpm
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/19600/oracle-instantclient19.6-basic-19.6.0.0.0-1.x86_64.rpm
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/19600/oracle-instantclient19.6-sqlplus-19.6.0.0.0-1.x86_64.rpm
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/19600/oracle-instantclient19.6-devel-19.6.0.0.0-1.x86_64.rpm
     - name: Install Oracle instant client
       run: |
-        sudo alien -i oracle-instantclient19.3-basic-19.3.0.0.0-1.x86_64.rpm
-        sudo alien -i oracle-instantclient19.3-sqlplus-19.3.0.0.0-1.x86_64.rpm
-        sudo alien -i oracle-instantclient19.3-devel-19.3.0.0.0-1.x86_64.rpm
+        sudo alien -i oracle-instantclient19.6-basic-19.6.0.0.0-1.x86_64.rpm
+        sudo alien -i oracle-instantclient19.6-sqlplus-19.6.0.0.0-1.x86_64.rpm
+        sudo alien -i oracle-instantclient19.6-devel-19.6.0.0.0-1.x86_64.rpm
 
     - name: Build and run RuboCop
       run: |


### PR DESCRIPTION
This pull request migrates from `actions/setup-ruby` to `ruby/setup-ruby` and bumps Oracle instant client version from 19.3 to 19.6.