### PR TITLE
CI against JRuby 9.2.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ rvm:
   - 2.7.1
   - 2.6.6
   - 2.5.8
-  - jruby-9.2.11.1
+  - jruby-9.2.12.0
   - ruby-head
   - jruby-head
 


### PR DESCRIPTION
JRuby 9.2.12.0 has been released.
https://www.jruby.org/files/downloads/9.2.12.0/index.html