### PR TITLE
Support JDBC service name syntax

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,9 @@ jobs:
           2.6,
           2.5,
           ruby-head,
-          ruby-debug
+          ruby-debug,
+          jruby,
+          jruby-head
         ]
     env:
       ORACLE_HOME: /usr/lib/oracle/18.5/client64
@@ -64,6 +66,9 @@ jobs:
     - name: Run RSpec
       run: |
         bundle exec rspec
+    - name: Workaround jruby-head failure by removing Gemfile.lock
+      run: |
+        rm Gemfile.lock
     - name: Run bug report templates
       run: |
         ruby guides/bug_report_templates/active_record_gem.rb

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -115,9 +115,9 @@ module ActiveRecord
             else
               unless database.match?(/^(\:|\/)/)
                 # assume database is a SID if no colon or slash are supplied (backward-compatibility)
-                database = ":#{database}"
+                database = "/#{database}"
               end
-              url = config[:url] || "jdbc:oracle:thin:@#{host || 'localhost'}:#{port || 1521}#{database}"
+              url = config[:url] || "jdbc:oracle:thin:@//#{host || 'localhost'}:#{port || 1521}#{database}"
             end
 
             prefetch_rows = config[:prefetch_rows] || 100

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -40,6 +40,12 @@ describe "OracleEnhancedAdapter establish connection" do
     ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS.merge(cursor_sharing: :exact))
     expect(ActiveRecord::Base.connection.select_value("select value from v$parameter where name = 'cursor_sharing'")).to eq("EXACT")
   end
+
+  it "should connect to database using service_name" do
+    ActiveRecord::Base.establish_connection(SERVICE_NAME_CONNECTION_PARAMS)
+    expect(ActiveRecord::Base.connection).not_to be_nil
+    expect(ActiveRecord::Base.connection.class).to eq(ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter)
+  end
 end
 
 describe "OracleEnhancedConnection" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -185,6 +185,15 @@ SYSTEM_CONNECTION_PARAMS = {
   password: DATABASE_SYS_PASSWORD
 }
 
+SERVICE_NAME_CONNECTION_PARAMS = {
+  adapter: "oracle_enhanced",
+  database: "/#{DATABASE_NAME}",
+  host: DATABASE_HOST,
+  port: DATABASE_PORT,
+  username: DATABASE_USER,
+  password: DATABASE_PASSWORD
+}
+
 DATABASE_NON_DEFAULT_TABLESPACE = config["database"]["non_default_tablespace"] || ENV["DATABASE_NON_DEFAULT_TABLESPACE"] || "SYSTEM"
 
 # set default time zone in TZ environment variable


### PR DESCRIPTION
This pull request implements JDBC Thin-style service name syntax.

Oracle enhanced has supported Oracle SID syntax, Since Oracle service name is mandatory for Oracle pluggable database,
it's time to support service name connection syntax.

- SID syntax
```java
jdbc:oracle:thin:@myhost:1521:orcl
```

Refer
https://docs.oracle.com/cd/E11882_01/appdev.112/e13995/oracle/jdbc/OracleDriver.html

- Service name syntax
```java
jdbc:oracle:thin:@//127.0.0.1:1521/ORCLPDB1
```

Refer "8.2.4 Thin-style Service Name Syntax"
https://docs.oracle.com/en/database/oracle/oracle-database/18/jjdbc/data-sources-and-URLs.html#GUID-EF07727C-50AB-4DCE-8EDC-57F0927FF61A

Also, this pull request enables CI against JRuby versions.