### PR TITLE
Use Oracle Instant Client 18.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,8 @@ jobs:
           ruby-debug
         ]
     env:
-      ORACLE_HOME: /opt/oracle/product/18c/dbhomeXE
-      LD_LIBRARY_PATH: /opt/oracle/product/18c/dbhomeXE/lib
+      ORACLE_HOME: /usr/lib/oracle/18.5/client64
+      LD_LIBRARY_PATH: /usr/lib/oracle/18.5/client64/lib
       NLS_LANG: AMERICAN_AMERICA.AL32UTF8
       TNS_ADMIN: ./ci/network/admin
       DATABASE_NAME: XEPDB1
@@ -44,13 +44,17 @@ jobs:
         sudo apt-get install alien
     - name: Download Oracle client
       run: |
-        wget -q https://download.oracle.com/otn-pub/otn_software/db-express/oracle-database-xe-18c-1.0-1.x86_64.rpm
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/185000/oracle-instantclient18.5-basic-18.5.0.0.0-3.x86_64.rpm
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/185000/oracle-instantclient18.5-sqlplus-18.5.0.0.0-3.x86_64.rpm
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/185000/oracle-instantclient18.5-devel-18.5.0.0.0-3.x86_64.rpm
     - name: Install Oracle client
       run: |
-        sudo alien -i oracle-database-xe-18c-1.0-1.x86_64.rpm
+        sudo alien -i oracle-instantclient18.5-basic-18.5.0.0.0-3.x86_64.rpm
+        sudo alien -i oracle-instantclient18.5-sqlplus-18.5.0.0.0-3.x86_64.rpm
+        sudo alien -i oracle-instantclient18.5-devel-18.5.0.0.0-3.x86_64.rpm
     - name: Install JDBC Driver
       run: |
-        cp $ORACLE_HOME/jdbc/lib/ojdbc8.jar lib/.
+        cp $ORACLE_HOME/lib/ojdbc8.jar lib/.
     - name: Create database user
       run: |
         ./ci/setup_accounts.sh

--- a/ci/setup_accounts.sh
+++ b/ci/setup_accounts.sh
@@ -2,7 +2,7 @@
 
 set -ev
 
-/opt/oracle/product/18c/dbhomeXE/bin/sqlplus system/Oracle18@XEPDB1 <<SQL
+/usr/lib/oracle/18.5/client64/bin/sqlplus system/Oracle18@XEPDB1 <<SQL
 @@spec/support/alter_system_user_password.sql
 @@spec/support/alter_system_set_open_cursors.sql
 @@spec/support/create_oracle_enhanced_users.sql


### PR DESCRIPTION
To meet the same timezone file version between Oracle client and server.
Fixes #2033