### PR TITLE
Support `jruby-head` again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ install:
 
 script:
   - bundle exec rake spec
+  - rm Gemfile.lock
   - ruby guides/bug_report_templates/active_record_gem.rb
   - ruby guides/bug_report_templates/active_record_gem_spec.rb
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,5 @@ rvm:
   - ruby-head
   - jruby-head
 
-matrix:
-  allow_failures:
-  - rvm: jruby-head
-
 notifications:
     email: false


### PR DESCRIPTION
This pull request removes `allow_failures:` for `jruby-head` because the bundler inline issue can be addressed.

There are possible two workarounds for jruby-head.

- Bump Bundler version to 2.2.0.rc.1 RubyGems version to 3.1.4
- Remove Gemfile.lock before using bundle inline

In this pull request, I prefer the second one.
Refer https://github.com/rubygems/rubygems/issues/3796