### PR TITLE
CI against JRuby 9.2.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ rvm:
   - 2.7.1
   - 2.6.6
   - 2.5.8
-  - jruby-9.2.12.0
+  - jruby-9.2.13.0
   - ruby-head
   - jruby-head
 


### PR DESCRIPTION
* JRuby 9.2.13.0 Released
https://www.jruby.org/2020/08/03/jruby-9-2-13-0.html