### PR TITLE
Suppress Ruby 2.7's real kwargs warning for release60 branch

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -7,7 +7,7 @@ module ActiveRecord
         private
 
           def visit_ColumnDefinition(o)
-            if [:blob, :clob, :nclob].include?(sql_type = type_to_sql(o.type,  o.options).downcase.to_sym)
+            if [:blob, :clob, :nclob].include?(sql_type = type_to_sql(o.type, **o.options).downcase.to_sym)
               if (tablespace = default_tablespace_for(sql_type))
                 @lob_tablespaces ||= {}
                 @lob_tablespaces[o.name] = tablespace

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -17,7 +17,7 @@ module ActiveRecord
         ].each do |column_type|
           module_eval <<-CODE, __FILE__, __LINE__ + 1
             def #{column_type}(*args, **options)
-              args.each { |name| column(name, :#{column_type}, options) }
+              args.each { |name| column(name, :#{column_type}, **options) }
             end
           CODE
         end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -198,7 +198,7 @@ module ActiveRecord
 
         def create_table(table_name, **options)
           create_sequence = options[:id] != false
-          td = create_table_definition table_name, options
+          td = create_table_definition table_name, **options
 
           if options[:id] != false && !options[:as]
             pk = options.fetch(:primary_key) do
@@ -208,7 +208,7 @@ module ActiveRecord
             if pk.is_a?(Array)
               td.primary_keys pk
             else
-              td.primary_key pk, options.fetch(:id, :primary_key), options
+              td.primary_key pk, options.fetch(:id, :primary_key), **options
             end
           end
 
@@ -288,7 +288,7 @@ module ActiveRecord
         end
 
         def add_index(table_name, column_name, options = {}) #:nodoc:
-          index_name, index_type, quoted_column_names, tablespace, index_options = add_index_options(table_name, column_name, options)
+          index_name, index_type, quoted_column_names, tablespace, index_options = add_index_options(table_name, column_name, **options)
           execute "CREATE #{index_type} INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} (#{quoted_column_names})#{tablespace} #{index_options}"
           if index_type == "UNIQUE"
             unless /\(.*\)/.match?(quoted_column_names)
@@ -402,8 +402,8 @@ module ActiveRecord
           execute "DROP SYNONYM #{quote_table_name(name)}"
         end
 
-        def add_reference(table_name, *args)
-          OracleEnhanced::ReferenceDefinition.new(*args).add_to(update_table_definition(table_name, self))
+        def add_reference(table_name, ref_name, **options)
+          OracleEnhanced::ReferenceDefinition.new(ref_name, **options).add_to(update_table_definition(table_name, self))
         end
 
         def add_column(table_name, column_name, type, **options) #:nodoc:
@@ -453,7 +453,7 @@ module ActiveRecord
           end
 
           td = create_table_definition(table_name)
-          cd = td.new_column_definition(column.name, type, options)
+          cd = td.new_column_definition(column.name, type, **options)
           change_column_stmt = schema_creation.accept cd
           change_column_stmt << tablespace_for((type_to_sql(type).downcase.to_sym), nil, options[:table_name], options[:column_name]) if type
           change_column_sql = "ALTER TABLE #{quote_table_name(table_name)} MODIFY #{change_column_stmt}"

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -406,10 +406,10 @@ module ActiveRecord
           OracleEnhanced::ReferenceDefinition.new(*args).add_to(update_table_definition(table_name, self))
         end
 
-        def add_column(table_name, column_name, type, options = {}) #:nodoc:
+        def add_column(table_name, column_name, type, **options) #:nodoc:
           type = aliased_types(type.to_s, type)
           at = create_alter_table table_name
-          at.add_column(column_name, type, options)
+          at.add_column(column_name, type, **options)
           add_column_sql = schema_creation.accept at
           add_column_sql << tablespace_for((type_to_sql(type).downcase.to_sym), nil, table_name, column_name)
           execute add_column_sql
@@ -619,8 +619,8 @@ module ActiveRecord
             OracleEnhanced::SchemaCreation.new self
           end
 
-          def create_table_definition(*args)
-            OracleEnhanced::TableDefinition.new(self, *args)
+          def create_table_definition(*args, **options)
+            OracleEnhanced::TableDefinition.new(self, *args, **options)
           end
 
           def new_column_from_field(table_name, field)

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -21,7 +21,7 @@ describe "OracleEnhancedAdapter schema dump" do
   def create_test_posts_table(options = {})
     options[:force] = true
     schema_define do
-      create_table :test_posts, options do |t|
+      create_table :test_posts, **options do |t|
         t.string :title
         t.timestamps null: true
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -80,7 +80,8 @@ describe "OracleEnhancedAdapter schema definition" do
   describe "sequence creation parameters" do
     def create_test_employees_table(sequence_start_value = nil)
       schema_define do
-        create_table :test_employees, sequence_start_value ? { sequence_start_value: sequence_start_value } : {} do |t|
+        options = sequence_start_value ? { sequence_start_value: sequence_start_value } : {}
+        create_table :test_employees, **options do |t|
           t.string      :first_name
           t.string      :last_name
         end


### PR DESCRIPTION
This PR backports these following commits to release60 branch.

- https://github.com/rsim/oracle-enhanced/commit/13abef9e7ebd81882fb1d5702d51a54f5152abf1
- https://github.com/rsim/oracle-enhanced/commit/a93bf5597367bb388f935519ef8f3d0c4f58a680
- https://github.com/rsim/oracle-enhanced/commit/fcd7278b0412d336d12ec620969973cc40718ebb

It suppresses Ruby 2.7's real kwargs warning for Rails 6.0.

@yahonda I would like to use this patch with Rails 6.0. Can you cut activerecord-oracle_enhanced-adapter 6.0.4?
