### PR TITLE
Allow TruffleRuby RUBY_ENGINE

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -115,8 +115,8 @@ module ActiveRecord
   end
 end
 
-# if MRI or YARV
-if !defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby"
+# if MRI or YARV or TruffleRuby
+if !defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby" || RUBY_ENGINE == "truffleruby"
   ORACLE_ENHANCED_CONNECTION = :oci
   require "active_record/connection_adapters/oracle_enhanced/oci_connection"
 # if JRuby

--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -178,8 +178,8 @@ module ActiveRecord
   end
 end
 
-# if MRI or YARV
-if !defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby"
+# if MRI or YARV or TruffleRuby
+if !defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby"|| RUBY_ENGINE == "truffleruby"
   require "active_record/connection_adapters/oracle_enhanced/oci_quoting"
 # if JRuby
 elsif RUBY_ENGINE == "jruby"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,8 +17,8 @@ end
 
 require "rspec"
 
-if !defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby"
-  puts "==> Running specs with MRI version #{RUBY_VERSION}"
+if !defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby" || RUBY_ENGINE == "truffleruby"
+  puts "==> Running specs with ruby version #{RUBY_VERSION}"
   require "oci8"
 elsif RUBY_ENGINE == "jruby"
   puts "==> Running specs with JRuby version #{JRUBY_VERSION}"


### PR DESCRIPTION
Hello, please allow the `truffleruby` `RUBY_ENGINE`. I am also currently testing `ruby-plsql` and `ruby-oci8` gems and most tests pass with `truffleruby-head` version and the few failures I have seen will be worked on. Thank you.