### PR TITLE
Restore Schema Dumper behavior changed by #2019

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -4,7 +4,16 @@ module ActiveRecord #:nodoc:
   module ConnectionAdapters #:nodoc:
     module OracleEnhanced #:nodoc:
       class SchemaDumper < ConnectionAdapters::SchemaDumper #:nodoc:
+        DEFAULT_PRIMARY_KEY_COLUMN_SPEC = { precision: "38", null: "false" }.freeze
+        private_constant :DEFAULT_PRIMARY_KEY_COLUMN_SPEC
+
         private
+          def column_spec_for_primary_key(column)
+            spec = super
+            spec.except!(:precision) if prepare_column_options(column) == DEFAULT_PRIMARY_KEY_COLUMN_SPEC
+            spec
+          end
+
           def tables(stream)
             # do not include materialized views in schema dump - they should be created separately after schema creation
             sorted_tables = (@connection.tables - @connection.materialized_views).sort

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -436,7 +436,7 @@ describe "OracleEnhancedAdapter schema dump" do
 
     it "should dump table comments" do
       output = dump_table_schema "test_table_comments"
-      expect(output).to match(/create_table "test_table_comments", id: { precision: 38 }, comment: "this is a \\"table comment\\"!", force: :cascade do \|t\|$/)
+      expect(output).to match(/create_table "test_table_comments", comment: "this is a \\"table comment\\"!", force: :cascade do \|t\|$/)
     end
   end
 


### PR DESCRIPTION
This pull request restores Schema Dumper behavior changed by #2019
because rails/rails#39365 does not intend to dump the default primary key configuration.

Related to rails/rails#39365
Follow up #2019