### PR TITLE
CI against Ruby 2.7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
 
 language: ruby
 rvm:
-  - 2.7.1
+  - 2.7.2
   - 2.6.6
   - 2.5.8
   - jruby-9.2.13.0


### PR DESCRIPTION
Ruby 2.7.2 has been released.
https://www.ruby-lang.org/en/news/2020/10/02/ruby-2-7-2-released/