### PR TITLE
Add missing method to Oracle columns

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column.rb
@@ -13,6 +13,10 @@ module ActiveRecord
         def virtual?
           virtual
         end
+        
+        def array?
+          false
+        end
       end
     end
   end


### PR DESCRIPTION
This is currently available for Postgres https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/postgresql/column.rb#L21.
can we have it as well? does oracle enhanced support array columns?