### PR TITLE
    Add /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ hint to address slow SCHEMA queries

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -34,7 +34,7 @@ module ActiveRecord
               table_owner, table_name = default_owner, real_name
             end
             sql = <<~SQL.squish
-              SELECT owner, table_name, 'TABLE' name_type
+              SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ owner, table_name, 'TABLE' name_type
               FROM all_tables
               WHERE owner = '#{table_owner}'
                 AND table_name = '#{table_name}'

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -181,7 +181,7 @@ module ActiveRecord #:nodoc:
           def extract_expression_for_virtual_column(column)
             column_name = column.name
             @connection.select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name.upcase), bind_string("column_name", column_name.upcase)]).inspect
-              select data_default from all_tab_columns
+              select /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ data_default from all_tab_columns
               where owner = SYS_CONTEXT('userenv', 'current_schema')
               and table_name = :table_name
               and column_name = :column_name

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -12,7 +12,8 @@ module ActiveRecord
 
         def tables #:nodoc:
           select_values(<<~SQL.squish, "SCHEMA")
-            SELECT DECODE(table_name, UPPER(table_name), LOWER(table_name), table_name)
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */
+            DECODE(table_name, UPPER(table_name), LOWER(table_name), table_name)
             FROM all_tables
             WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
             AND secondary = 'N'
@@ -44,7 +45,7 @@ module ActiveRecord
           end
 
           select_values(<<~SQL.squish, "SCHEMA", [bind_string("owner", table_owner), bind_string("table_name", table_name)]).any?
-            SELECT owner, table_name
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ owner, table_name
             FROM all_tables
             WHERE owner = :owner
             AND table_name = :table_name
@@ -60,20 +61,22 @@ module ActiveRecord
 
         def views # :nodoc:
           select_values(<<~SQL.squish, "SCHEMA")
-            SELECT LOWER(view_name) FROM all_views WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */
+            LOWER(view_name) FROM all_views WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
           SQL
         end
 
         def materialized_views #:nodoc:
           select_values(<<~SQL.squish, "SCHEMA")
-            SELECT LOWER(mview_name) FROM all_mviews WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */
+            LOWER(mview_name) FROM all_mviews WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
           SQL
         end
 
         # get synonyms for schema dump
         def synonyms
           result = select_all(<<~SQL.squish, "SCHEMA")
-            SELECT synonym_name, table_owner, table_name
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ synonym_name, table_owner, table_name
             FROM all_synonyms where owner = SYS_CONTEXT('userenv', 'current_schema')
           SQL
 
@@ -88,7 +91,7 @@ module ActiveRecord
           default_tablespace_name = default_tablespace
 
           result = select_all(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name)])
-            SELECT LOWER(i.table_name) AS table_name, LOWER(i.index_name) AS index_name, i.uniqueness,
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ LOWER(i.table_name) AS table_name, LOWER(i.index_name) AS index_name, i.uniqueness,
               i.index_type, i.ityp_owner, i.ityp_name, i.parameters,
               LOWER(i.tablespace_name) AS tablespace_name,
               LOWER(c.column_name) AS column_name, e.column_expression,
@@ -118,7 +121,7 @@ module ActiveRecord
               if row["index_type"] == "DOMAIN" && row["ityp_owner"] == "CTXSYS" && row["ityp_name"] == "CONTEXT"
                 procedure_name = default_datastore_procedure(row["index_name"])
                 source = select_values(<<~SQL.squish, "SCHEMA", [bind_string("procedure_name", procedure_name.upcase)]).join
-                  SELECT text
+                  SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ text
                   FROM all_source
                   WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
                     AND name = :procedure_name
@@ -365,7 +368,7 @@ module ActiveRecord
         def index_name_exists?(table_name, index_name)
           (_owner, table_name) = @connection.describe(table_name)
           result = select_value(<<~SQL.squish, "SCHEMA")
-            SELECT 1 FROM all_indexes i
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ 1 FROM all_indexes i
             WHERE i.owner = SYS_CONTEXT('userenv', 'current_schema')
                AND i.table_owner = SYS_CONTEXT('userenv', 'current_schema')
                AND i.table_name = '#{table_name}'
@@ -500,7 +503,7 @@ module ActiveRecord
           # TODO
           (_owner, table_name) = @connection.describe(table_name)
           select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name)])
-            SELECT comments FROM all_tab_comments
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ comments FROM all_tab_comments
             WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
               AND table_name = :table_name
           SQL
@@ -516,7 +519,7 @@ module ActiveRecord
           # TODO: it  does not exist in Abstract adapter
           (_owner, table_name) = @connection.describe(table_name)
           select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name), bind_string("column_name", column_name.upcase)])
-            SELECT comments FROM all_col_comments
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ comments FROM all_col_comments
             WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
               AND table_name = :table_name
               AND column_name = :column_name
@@ -533,7 +536,7 @@ module ActiveRecord
 
         def tablespace(table_name)
           select_value(<<~SQL.squish, "SCHEMA")
-            SELECT tablespace_name
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ tablespace_name
             FROM all_tables
             WHERE table_name='#{table_name.to_s.upcase}'
             AND owner = SYS_CONTEXT('userenv', 'current_schema')
@@ -545,7 +548,7 @@ module ActiveRecord
           (_owner, desc_table_name) = @connection.describe(table_name)
 
           fk_info = select_all(<<~SQL.squish, "SCHEMA", [bind_string("desc_table_name", desc_table_name)])
-            SELECT r.table_name to_table
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ r.table_name to_table
                   ,rc.column_name references_column
                   ,cc.column_name
                   ,c.constraint_name name
@@ -587,7 +590,7 @@ module ActiveRecord
 
         def disable_referential_integrity(&block) #:nodoc:
           old_constraints = select_all(<<~SQL.squish, "SCHEMA")
-            SELECT constraint_name, owner, table_name
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ constraint_name, owner, table_name
               FROM all_constraints
               WHERE constraint_type = 'R'
               AND status = 'ENABLED'
@@ -702,7 +705,7 @@ module ActiveRecord
             return unless tablespace
 
             index_name = select_value(<<~SQL.squish, "Index name for primary key",  [bind_string("table_name", table_name.upcase)])
-              SELECT index_name FROM all_constraints
+              SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ index_name FROM all_constraints
                   WHERE table_name = :table_name
                   AND constraint_type = 'P'
                   AND owner = SYS_CONTEXT('userenv', 'current_schema')

--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -9,7 +9,8 @@ module ActiveRecord #:nodoc:
 
         def structure_dump #:nodoc:
           sequences = select(<<~SQL.squish, "SCHEMA")
-            SELECT sequence_name, min_value, max_value, increment_by, order_flag, cycle_flag
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */
+            sequence_name, min_value, max_value, increment_by, order_flag, cycle_flag
             FROM all_sequences
             where sequence_owner = SYS_CONTEXT('userenv', 'current_schema') ORDER BY 1
           SQL
@@ -18,7 +19,7 @@ module ActiveRecord #:nodoc:
             "CREATE SEQUENCE #{quote_table_name(result["sequence_name"])} MINVALUE #{result["min_value"]} MAXVALUE #{result["max_value"]} INCREMENT BY #{result["increment_by"]} #{result["order_flag"] == 'Y' ? "ORDER" : "NOORDER"} #{result["cycle_flag"] == 'Y' ? "CYCLE" : "NOCYCLE"}"
           end
           tables = select_values(<<~SQL.squish, "SCHEMA")
-            SELECT table_name FROM all_tables t
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ table_name FROM all_tables t
             WHERE owner = SYS_CONTEXT('userenv', 'current_schema') AND secondary = 'N'
             AND NOT EXISTS (SELECT mv.mview_name FROM all_mviews mv
                             WHERE mv.owner = t.owner AND mv.mview_name = t.table_name)
@@ -30,7 +31,7 @@ module ActiveRecord #:nodoc:
             virtual_columns = virtual_columns_for(table_name) if supports_virtual_columns?
             ddl = +"CREATE#{ ' GLOBAL TEMPORARY' if temporary_table?(table_name)} TABLE \"#{table_name}\" (\n"
             columns = select_all(<<~SQL.squish, "SCHEMA")
-              SELECT column_name, data_type, data_length, char_used, char_length,
+              SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ column_name, data_type, data_length, char_used, char_length,
               data_precision, data_scale, data_default, nullable
               FROM all_tab_columns
               WHERE table_name = '#{table_name}'
@@ -90,7 +91,7 @@ module ActiveRecord #:nodoc:
         def structure_dump_primary_key(table) #:nodoc:
           opts = { name: "", cols: [] }
           pks = select_all(<<~SQL.squish, "SCHEMA")
-            SELECT a.constraint_name, a.column_name, a.position
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ a.constraint_name, a.column_name, a.position
               FROM all_cons_columns a
               JOIN all_constraints c
                 ON a.constraint_name = c.constraint_name
@@ -109,7 +110,7 @@ module ActiveRecord #:nodoc:
         def structure_dump_unique_keys(table) #:nodoc:
           keys = {}
           uks = select_all(<<~SQL.squish, "SCHEMA")
-            SELECT a.constraint_name, a.column_name, a.position
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ a.constraint_name, a.column_name, a.position
               FROM all_cons_columns a
               JOIN all_constraints c
                 ON a.constraint_name = c.constraint_name
@@ -145,7 +146,7 @@ module ActiveRecord #:nodoc:
 
         def structure_dump_fk_constraints #:nodoc:
           foreign_keys = select_all(<<~SQL.squish, "SCHEMA")
-            SELECT table_name FROM all_tables
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ table_name FROM all_tables
             WHERE owner = SYS_CONTEXT('userenv', 'current_schema') ORDER BY 1
           SQL
           fks = foreign_keys.map do |table|
@@ -173,7 +174,7 @@ module ActiveRecord #:nodoc:
         def structure_dump_column_comments(table_name)
           comments = []
           columns = select_values(<<~SQL.squish, "SCHEMA")
-            SELECT column_name FROM user_tab_columns
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ column_name FROM user_tab_columns
             WHERE table_name = '#{table_name}' ORDER BY column_id
           SQL
 
@@ -207,7 +208,7 @@ module ActiveRecord #:nodoc:
         def structure_dump_db_stored_code #:nodoc:
           structure = []
           all_source = select_all(<<~SQL.squish, "SCHEMA")
-            SELECT DISTINCT name, type
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ DISTINCT name, type
             FROM all_source
             WHERE type IN ('PROCEDURE', 'PACKAGE', 'PACKAGE BODY', 'FUNCTION', 'TRIGGER', 'TYPE')
             AND name NOT LIKE 'BIN$%'
@@ -216,7 +217,7 @@ module ActiveRecord #:nodoc:
           all_source.each do |source|
             ddl = +"CREATE OR REPLACE   \n"
             texts = select_all(<<~SQL.squish, "all source at structure dump")
-              SELECT text
+              SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ text
               FROM all_source
               WHERE name = '#{source['name']}'
               AND type = '#{source['type']}'
@@ -239,7 +240,7 @@ module ActiveRecord #:nodoc:
         def structure_dump_views #:nodoc:
           structure = []
           views = select_all(<<~SQL.squish, "SCHEMA")
-            SELECT view_name, text FROM all_views
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ view_name, text FROM all_views
             WHERE owner = SYS_CONTEXT('userenv', 'current_schema') ORDER BY view_name ASC
           SQL
           views.each do |view|
@@ -251,7 +252,7 @@ module ActiveRecord #:nodoc:
         def structure_dump_synonyms #:nodoc:
           structure = []
           synonyms = select_all(<<~SQL.squish, "SCHEMA")
-            SELECT owner, synonym_name, table_name, table_owner
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ owner, synonym_name, table_name, table_owner
             FROM all_synonyms
             WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
           SQL
@@ -264,13 +265,14 @@ module ActiveRecord #:nodoc:
 
         def structure_drop #:nodoc:
           sequences = select_values(<<~SQL.squish, "SCHEMA")
-            SELECT sequence_name FROM all_sequences where sequence_owner = SYS_CONTEXT('userenv', 'current_schema') ORDER BY 1
+            SELECT/*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */
+            sequence_name FROM all_sequences where sequence_owner = SYS_CONTEXT('userenv', 'current_schema') ORDER BY 1
           SQL
           statements = sequences.map do |seq|
             "DROP SEQUENCE \"#{seq}\""
           end
           tables = select_values(<<~SQL.squish, "SCHEMA")
-            SELECT table_name from all_tables t
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ table_name from all_tables t
             WHERE owner = SYS_CONTEXT('userenv', 'current_schema') AND secondary = 'N'
             AND NOT EXISTS (SELECT mv.mview_name FROM all_mviews mv
                             WHERE mv.owner = t.owner AND mv.mview_name = t.table_name)
@@ -286,7 +288,7 @@ module ActiveRecord #:nodoc:
 
         def temp_table_drop #:nodoc:
           temporary_tables = select_values(<<~SQL.squish, "SCHEMA")
-            SELECT table_name FROM all_tables
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ table_name FROM all_tables
             WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
             AND secondary = 'N' AND temporary = 'Y' ORDER BY 1
           SQL
@@ -320,7 +322,7 @@ module ActiveRecord #:nodoc:
         # return [{'column_name' => 'FOOS', 'data_default' => '...'}, ...]
         def virtual_columns_for(table)
           select_all(<<~SQL.squish, "SCHEMA")
-            SELECT column_name, data_default
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ column_name, data_default
             FROM all_tab_cols
             WHERE virtual_column = 'YES'
             AND owner = SYS_CONTEXT('userenv', 'current_schema')
@@ -331,7 +333,7 @@ module ActiveRecord #:nodoc:
         def drop_sql_for_feature(type)
           short_type = type == "materialized view" ? "mview" : type
           features = select_values(<<~SQL.squish, "SCHEMA")
-            SELECT #{short_type}_name FROM all_#{short_type.tableize}
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ #{short_type}_name FROM all_#{short_type.tableize}
             where owner = SYS_CONTEXT('userenv', 'current_schema')
           SQL
           statements = features.map do |name|
@@ -342,7 +344,7 @@ module ActiveRecord #:nodoc:
 
         def drop_sql_for_object(type)
           objects = select_values(<<~SQL.squish, "SCHEMA")
-            SELECT object_name FROM all_objects
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ object_name FROM all_objects
             WHERE object_type = '#{type.upcase}' and owner = SYS_CONTEXT('userenv', 'current_schema')
           SQL
           statements = objects.map do |name|

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -553,7 +553,7 @@ module ActiveRecord
       # Default tablespace name of current user
       def default_tablespace
         select_value(<<~SQL.squish, "SCHEMA")
-          SELECT LOWER(default_tablespace) FROM user_users
+          SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ LOWER(default_tablespace) FROM user_users
           WHERE username = SYS_CONTEXT('userenv', 'current_schema')
         SQL
       end
@@ -562,7 +562,7 @@ module ActiveRecord
         (owner, desc_table_name) = @connection.describe(table_name)
 
         select_all(<<~SQL.squish, "SCHEMA")
-          SELECT cols.column_name AS name, cols.data_type AS sql_type,
+          SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ cols.column_name AS name, cols.data_type AS sql_type,
                  cols.data_default, cols.nullable, cols.virtual_column, cols.hidden_column,
                  cols.data_type_owner AS sql_type_owner,
                  DECODE(cols.data_type, 'NUMBER', data_precision,
@@ -594,7 +594,7 @@ module ActiveRecord
         (owner, desc_table_name) = @connection.describe(table_name)
 
         seqs = select_values(<<~SQL.squish, "SCHEMA")
-          select us.sequence_name
+          select /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ us.sequence_name
           from all_sequences us
           where us.sequence_owner = '#{owner}'
           and us.sequence_name = upper(#{quote(default_sequence_name(desc_table_name))})
@@ -602,7 +602,7 @@ module ActiveRecord
 
         # changed back from user_constraints to all_constraints for consistency
         pks = select_values(<<~SQL.squish, "SCHEMA")
-          SELECT cc.column_name
+          SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ cc.column_name
             FROM all_constraints c, all_cons_columns cc
            WHERE c.owner = '#{owner}'
              AND c.table_name = #{quote(desc_table_name)}
@@ -636,7 +636,7 @@ module ActiveRecord
         (_owner, desc_table_name) = @connection.describe(table_name)
 
         pks = select_values(<<~SQL.squish, "SCHEMA", [bind_string("table_name", desc_table_name)])
-          SELECT cc.column_name
+          SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ cc.column_name
             FROM all_constraints c, all_cons_columns cc
            WHERE c.owner = SYS_CONTEXT('userenv', 'current_schema')
              AND c.table_name = :table_name
@@ -666,7 +666,8 @@ module ActiveRecord
 
       def temporary_table?(table_name) #:nodoc:
         select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name.upcase)]) == "Y"
-          SELECT temporary FROM all_tables WHERE table_name = :table_name and owner = SYS_CONTEXT('userenv', 'current_schema')
+          SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */
+          temporary FROM all_tables WHERE table_name = :table_name and owner = SYS_CONTEXT('userenv', 'current_schema')
         SQL
       end
 


### PR DESCRIPTION
Add /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ hint to address slow SCHEMA queries

Migrating Oracle Database version to higher like 12c, I have experienced
some slowness mainly due to SCHEMA queries. This commit should address
this slowness.

I have tested multiple values of optimizer_features_enable from 19.1.0 to 11.2.0.2,
then there is a significant elapsed time of `bundle exec rspec` between
11.2.0.3 to 11.2.0.2.

- optimizer_features_enable = 11.2.0.3
Finished in 848 minutes 28 seconds (files took 0.61873 seconds to load)

- optimizer_features_enable = 11.2.0.2
Finished in 2 minutes 30 seconds (files took 0.61398 seconds to load)

### Environment
Oracle Database 19c (19.3) on Docker
Intel NUC Kit NUC6i5SYH with 4 CPU and 32 GB memory

This initialization parameter value can be changed to instance level
by running `alter system set optimizer_features_enable = '11.2.0.2'`,
which could affect other queries' execution plans.

Refer "1.232 OPTIMIZER_FEATURES_ENABLE"
https://docs.oracle.com/en/database/oracle/oracle-database/19/refrn/OPTIMIZER_FEATURES_ENABLE.html#GUID-E193EC9E-B642-4C01-99EC-24E04AEA1A2C