### PR TITLE
Bump Oracle Instant Client version to 19.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,8 @@ jobs:
           jruby-head
         ]
     env:
-      ORACLE_HOME: /usr/lib/oracle/18.5/client64
-      LD_LIBRARY_PATH: /usr/lib/oracle/18.5/client64/lib
+      ORACLE_HOME: /usr/lib/oracle/19.9/client64
+      LD_LIBRARY_PATH: /usr/lib/oracle/19.9/client64/lib
       NLS_LANG: AMERICAN_AMERICA.AL32UTF8
       TNS_ADMIN: ./ci/network/admin
       DATABASE_NAME: XEPDB1
@@ -46,14 +46,14 @@ jobs:
         sudo apt-get install alien
     - name: Download Oracle client
       run: |
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/185000/oracle-instantclient18.5-basic-18.5.0.0.0-3.x86_64.rpm
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/185000/oracle-instantclient18.5-sqlplus-18.5.0.0.0-3.x86_64.rpm
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/185000/oracle-instantclient18.5-devel-18.5.0.0.0-3.x86_64.rpm
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/199000/oracle-instantclient19.9-basic-19.9.0.0.0-1.x86_64.rpm
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/199000/oracle-instantclient19.9-sqlplus-19.9.0.0.0-1.x86_64.rpm
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/199000/oracle-instantclient19.9-devel-19.9.0.0.0-1.x86_64.rpm
     - name: Install Oracle client
       run: |
-        sudo alien -i oracle-instantclient18.5-basic-18.5.0.0.0-3.x86_64.rpm
-        sudo alien -i oracle-instantclient18.5-sqlplus-18.5.0.0.0-3.x86_64.rpm
-        sudo alien -i oracle-instantclient18.5-devel-18.5.0.0.0-3.x86_64.rpm
+        sudo alien -i oracle-instantclient19.9-basic-19.9.0.0.0-1.x86_64.rpm
+        sudo alien -i oracle-instantclient19.9-sqlplus-19.9.0.0.0-1.x86_64.rpm
+        sudo alien -i oracle-instantclient19.9-devel-19.9.0.0.0-1.x86_64.rpm
     - name: Install JDBC Driver
       run: |
         cp $ORACLE_HOME/lib/ojdbc8.jar lib/.


### PR DESCRIPTION
* Instant Client Downloads for Linux x86-64 (64-bit)
https://www.oracle.com/database/technologies/instant-client/linux-x86-64-downloads.html