### PR TITLE
Use Rails 6-1-branch for Oracle enhanced adapter release61

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :development do
   gem "rubocop-performance", require: false
   gem "rubocop-rails", require: false
 
-  gem "activerecord",   github: "rails/rails", branch: "master"
+  gem "activerecord",   github: "rails/rails", branch: "6-1-stable"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do


### PR DESCRIPTION
This pull request uses Rails 6-1-branch for Oracle enhanced adapter release61.
Refer #1895 for Rails 6.0.