### PR TITLE
Use released version of rake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 group :development do
   gem "rspec"
   gem "rdoc"
-  gem "rake", "~> 13.0.0.pre.1"
+  gem "rake"
   gem "rubocop", require: false
   gem "rubocop-performance", require: false
   gem "rubocop-rails", require: false


### PR DESCRIPTION
Rake 13.0.0 has been released and no need to use pre version.
Kind of reverting #1924.