### PR TITLE
`build_subselect` does not have ordering

### DIFF
--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -248,6 +248,17 @@ module Arel # :nodoc: all
           collector = visit [o.left, o.right, 0, 1], collector
           collector << ")"
         end
+
+        # Oracle will occur an error `ORA-00907: missing right parenthesis`
+        # when using `ORDER BY` in `UPDATE` or `DELETE`'s subquery.
+        #
+        # This method has been overridden based on the following code.
+        # https://github.com/rails/rails/blob/v6.1.0.rc1/activerecord/lib/arel/visitors/to_sql.rb#L815-L825
+        def build_subselect(key, o)
+          stmt             = super
+          stmt.orders      = [] # `orders` will never be set to prevent `ORA-00907`.
+          stmt
+        end
     end
   end
 end

--- a/lib/arel/visitors/oracle12.rb
+++ b/lib/arel/visitors/oracle12.rb
@@ -155,6 +155,17 @@ module Arel # :nodoc: all
           collector = visit [o.left, o.right, 0, 1], collector
           collector << ")"
         end
+
+        # Oracle will occur an error `ORA-00907: missing right parenthesis`
+        # when using `ORDER BY` in `UPDATE` or `DELETE`'s subquery.
+        #
+        # This method has been overridden based on the following code.
+        # https://github.com/rails/rails/blob/v6.1.0.rc1/activerecord/lib/arel/visitors/to_sql.rb#L815-L825
+        def build_subselect(key, o)
+          stmt             = super
+          stmt.orders      = [] # `orders` will never be set to prevent `ORA-00907`.
+          stmt
+        end
     end
   end
 end


### PR DESCRIPTION
Fixes #2023.

This PR fixes `ActiveRecord::StatementInvalid: OCIError: ORA-00907: missing right parenthesis` error when using assoc has `dependent: :delete_all` and `order`.

```ruby
has_many :assoc, -> { order(:foo) }, dependent: :delete_all
```

Oracle does not accept `ORDER BY` in `DELETE` and `UPDATE`'s subquery. This PR adds the following reproduction test and passes it.

```console
vagrant@rails-dev-box:~/src/oracle-enhanced$ bundle exec rspec
spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:187
==> Loading config from ENV or use default
==> Running specs with ruby version 2.7.2
==> Effective ActiveRecord version 6.1.0.rc1
Run options: include
{:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb"=>[187]}}
F

Failures:

  1) OracleEnhancedAdapter `has_many` assoc has `dependent: :delete_all`
  with `order` should load included association with more than 1000
  records
     Failure/Error: @raw_cursor.exec

     ActiveRecord::StatementInvalid: OCIError: ORA-00907: missing right parenthesis
     # stmt.c:267:in oci8lib_270.so
     # /home/vagrant/.rvm/gems/ruby-2.7.2/bundler/gems/ruby-oci8-446ad166808c/lib/oci8/cursor.rb:137:in `exec'
     # ./lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:150:in `exec_update'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:158:in `block (2 levels) in exec_update'
```