### PR TITLE
Merge pull request #2070 from koic/build_subselect_doesnt_have_ordering

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -746,3 +746,26 @@ require "active_record/connection_adapters/oracle_enhanced/version"
 module ActiveRecord
   autoload :OracleEnhancedProcedures, "active_record/connection_adapters/oracle_enhanced/procedures"
 end
+
+# Backport #2070 into relese60 branch by adding some dirty monkey patch
+# Because #2002 has been merged to release61 branch or newer, not available for release60 branch.
+module Arel # :nodoc: all
+  module Visitors
+    class Oracle < Arel::Visitors::ToSql
+      private
+        def build_subselect(key, o)
+          stmt             = super
+          stmt.orders      = [] # `orders` will never be set to prevent `ORA-00907`.
+          stmt
+        end
+    end
+    class Oracle12 < Arel::Visitors::ToSql
+      private
+        def build_subselect(key, o)
+          stmt             = super
+          stmt.orders      = [] # `orders` will never be set to prevent `ORA-00907`.
+          stmt
+        end
+    end
+  end
+end


### PR DESCRIPTION
This pull request backports #2070 into the release60 branch. 
Since #2002 has been merged to release61 branch or newer, #2070 is not feasible to merge to release60 branch. Then applied some dirty monkey patch to `lib/active_record/connection_adapters/oracle_enhanced_adapter.rb` file.