### PR TITLE
Enable  `Style/RedundantRegexpEscape` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -204,6 +204,9 @@ Style/RedundantReturn:
   Enabled: true
   AllowMultipleReturnValues: true
 
+Style/RedundantRegexpEscape:
+  Enabled: true
+
 Style/Semicolon:
   Enabled: true
   AllowAsExpressionSeparator: true

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -113,7 +113,7 @@ module ActiveRecord
             if database && (using_tns_alias || host == "connection-string")
               url = "jdbc:oracle:thin:@#{database}"
             else
-              unless database.match?(/^(\:|\/)/)
+              unless database.match?(/^(:|\/)/)
                 # assume database is a SID if no colon or slash are supplied (backward-compatibility)
                 database = "/#{database}"
               end

--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -12,7 +12,7 @@ module ActiveRecord
           name = name.to_s
           self.class.quoted_column_names[name] ||= begin
             # if only valid lowercase column characters in name
-            if /\A[a-z][a-z_0-9\$#]*\Z/.match?(name)
+            if /\A[a-z][a-z_0-9$#]*\Z/.match?(name)
               "\"#{name.upcase}\""
             else
               # remove double quotes which cannot be used inside quoted identifier
@@ -27,9 +27,9 @@ module ActiveRecord
           name = name.to_s
           case name
           # if only valid lowercase column characters in name
-          when /^[a-z][a-z_0-9\$#]*$/
+          when /^[a-z][a-z_0-9$#]*$/
             "\"#{name.upcase}\""
-          when /^[a-z][a-z_0-9\$#\-]*$/i
+          when /^[a-z][a-z_0-9$#\-]*$/i
             "\"#{name}\""
           # if other characters present then assume that it is expression
           # which should not be quoted

--- a/spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb
@@ -326,7 +326,7 @@ describe "OracleEnhancedAdapter context index" do
       it "should dump definition of single column index" do
         @conn.add_context_index :posts, :title
         output = dump_table_schema "posts"
-        expect(output).to match(/add_context_index "posts", \["title"\], name: \"index_posts_on_title\"$/)
+        expect(output).to match(/add_context_index "posts", \["title"\], name: "index_posts_on_title"$/)
         @conn.remove_context_index :posts, :title
       end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -71,7 +71,7 @@ describe "OracleEnhancedAdapter schema dump" do
 
     it "should be able to dump default values using special characters" do
       output = dump_table_schema "test_defaults"
-      expect(output).to match(/t.string \"special_c\", default: "\\n"/)
+      expect(output).to match(/t.string "special_c", default: "\\n"/)
     end
   end
 
@@ -104,7 +104,7 @@ describe "OracleEnhancedAdapter schema dump" do
 
     it "should be able to dump ntext columns" do
       output = dump_table_schema "test_ntexts"
-      expect(output).to match(/t.ntext \"ntext_column\"/)
+      expect(output).to match(/t.ntext "ntext_column"/)
     end
   end
 
@@ -370,7 +370,7 @@ describe "OracleEnhancedAdapter schema dump" do
       expect(output).to match(/t\.virtual "full_name",(\s*)type: :string,(\s*)limit: 512,(\s*)as: "\\"FIRST_NAME\\"\|\|', '\|\|\\"LAST_NAME\\""/)
       expect(output).to match(/t\.virtual "short_name",(\s*)type: :string,(\s*)limit: 300,(\s*)as:(.*)/)
       expect(output).to match(/t\.virtual "full_name_length",(\s*)type: :integer,(\s*)precision: 38,(\s*)as:(.*)/)
-      expect(output).to match(/t\.virtual "name_ratio",(\s*)as:(.*)\"$/) # no :type
+      expect(output).to match(/t\.virtual "name_ratio",(\s*)as:(.*)"$/) # no :type
       expect(output).to match(/t\.virtual "abbrev_name",(\s*)type: :string,(\s*)limit: 100,(\s*)as:(.*)/)
       expect(output).to match(/t\.virtual "field_with_leading_space",(\s*)type: :string,(\s*)limit: 300,(\s*)as: "' '\|\|\\"FIRST_NAME\\"\|\|' '"/)
     end

--- a/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
@@ -68,7 +68,7 @@ describe "OracleEnhancedAdapter structure dump" do
       SQL
       dump = ActiveRecord::Base.connection.structure_dump_fk_constraints
       expect(dump.split('\n').length).to eq(1)
-      expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_FOO\"? FOREIGN KEY \(\"?FOO_ID\"?\) REFERENCES \"?FOOS\"?\(\"?ID\"?\)/i)
+      expect(dump).to match(/ALTER TABLE "?TEST_POSTS"? ADD CONSTRAINT "?FK_TEST_POST_FOO"? FOREIGN KEY \("?FOO_ID"?\) REFERENCES "?FOOS"?\("?ID"?\)/i)
     end
 
     it "should dump foreign keys when reference column name is not 'id'" do
@@ -88,7 +88,7 @@ describe "OracleEnhancedAdapter structure dump" do
 
       dump = ActiveRecord::Base.connection.structure_dump_fk_constraints
       expect(dump.split('\n').length).to eq(1)
-      expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_BAZ\"? FOREIGN KEY \(\"?BAZ_ID\"?\) REFERENCES \"?FOOS\"?\(\"?BAZ_ID\"?\)/i)
+      expect(dump).to match(/ALTER TABLE "?TEST_POSTS"? ADD CONSTRAINT "?FK_TEST_POST_BAZ"? FOREIGN KEY \("?BAZ_ID"?\) REFERENCES "?FOOS"?\("?BAZ_ID"?\)/i)
     end
 
     it "should not error when no foreign keys are present" do
@@ -136,7 +136,7 @@ describe "OracleEnhancedAdapter structure dump" do
         )
       SQL
       dump = ActiveRecord::Base.connection.structure_dump
-      expect(dump).to match(/\"?ID_PLUS\"? NUMBER GENERATED ALWAYS AS \(ID\+2\) VIRTUAL/)
+      expect(dump).to match(/"?ID_PLUS"? NUMBER GENERATED ALWAYS AS \(ID\+2\) VIRTUAL/)
     end
 
     it "should dump RAW virtual columns" do
@@ -149,7 +149,7 @@ describe "OracleEnhancedAdapter structure dump" do
         )
       SQL
       dump = ActiveRecord::Base.connection.structure_dump
-      expect(dump).to match(/CREATE TABLE \"BARS\" \(\n \"ID\" NUMBER\(38,0\) NOT NULL,\n \"SUPER\" RAW\(255\) GENERATED ALWAYS AS \(HEXTORAW\(TO_CHAR\(ID\)\)\) VIRTUAL/)
+      expect(dump).to match(/CREATE TABLE "BARS" \(\n "ID" NUMBER\(38,0\) NOT NULL,\n "SUPER" RAW\(255\) GENERATED ALWAYS AS \(HEXTORAW\(TO_CHAR\(ID\)\)\) VIRTUAL/)
     end
 
     it "should dump NCLOB columns" do
@@ -161,7 +161,7 @@ describe "OracleEnhancedAdapter structure dump" do
         )
       SQL
       dump = ActiveRecord::Base.connection.structure_dump
-      expect(dump).to match(/CREATE TABLE \"BARS\" \(\n \"ID\" NUMBER\(38,0\) NOT NULL,\n \"NCLOB_TEXT\" NCLOB/)
+      expect(dump).to match(/CREATE TABLE "BARS" \(\n "ID" NUMBER\(38,0\) NOT NULL,\n "NCLOB_TEXT" NCLOB/)
     end
 
     it "should dump unique keys" do
@@ -187,7 +187,7 @@ describe "OracleEnhancedAdapter structure dump" do
 
       dump = ActiveRecord::Base.connection.structure_dump
       expect(dump).to match(/CREATE UNIQUE INDEX "?IX_TEST_POSTS_FOO_ID"? ON "?TEST_POSTS"? \("?FOO_ID"?\)/i)
-      expect(dump).to match(/CREATE  INDEX "?IX_TEST_POSTS_FOO\"? ON "?TEST_POSTS"? \("?FOO"?\)/i)
+      expect(dump).to match(/CREATE  INDEX "?IX_TEST_POSTS_FOO"? ON "?TEST_POSTS"? \("?FOO"?\)/i)
       expect(dump).not_to match(/CREATE UNIQUE INDEX "?UK_TEST_POSTS_/i)
     end
 
@@ -199,8 +199,8 @@ describe "OracleEnhancedAdapter structure dump" do
       SQL
 
       dump = ActiveRecord::Base.connection.structure_dump
-      expect(dump).to match(/CREATE  INDEX "?IX_TEST_POSTS_FOO_FOO_ID\"? ON "?TEST_POSTS"? \("?FOO"?, "?FOO_ID"?\)/i)
-      expect(dump).to match(/CREATE  INDEX "?IX_TEST_POSTS_FUNCTION\"? ON "?TEST_POSTS"? \(TO_CHAR\(LENGTH\("?FOO"?\)\)\|\|"?FOO"?\)/i)
+      expect(dump).to match(/CREATE  INDEX "?IX_TEST_POSTS_FOO_FOO_ID"? ON "?TEST_POSTS"? \("?FOO"?, "?FOO_ID"?\)/i)
+      expect(dump).to match(/CREATE  INDEX "?IX_TEST_POSTS_FUNCTION"? ON "?TEST_POSTS"? \(TO_CHAR\(LENGTH\("?FOO"?\)\)\|\|"?FOO"?\)/i)
     end
 
     it "should dump RAW columns" do
@@ -212,7 +212,7 @@ describe "OracleEnhancedAdapter structure dump" do
         )
       SQL
       dump = ActiveRecord::Base.connection.structure_dump
-      expect(dump).to match(/CREATE TABLE \"BARS\" \(\n \"ID\" NUMBER\(38,0\) NOT NULL,\n \"SUPER\" RAW\(255\)/)
+      expect(dump).to match(/CREATE TABLE "BARS" \(\n "ID" NUMBER\(38,0\) NOT NULL,\n "SUPER" RAW\(255\)/)
     end
 
     it "should dump table comments" do
@@ -269,7 +269,7 @@ describe "OracleEnhancedAdapter structure dump" do
     end
     context "default sequence" do
       let(:sql) { "CREATE SEQUENCE \"#{sequence_name}\"" }
-      it { is_expected.to_not match(%r{CREATE SEQUENCE \"#{sequence_name}" MAXVALUE \d+ MINVALUE \d+ NOORDER NOCYCLE}) }
+      it { is_expected.to_not match(%r{CREATE SEQUENCE "#{sequence_name}" MAXVALUE \d+ MINVALUE \d+ NOORDER NOCYCLE}) }
     end
     context "noorder" do
       let(:sql) { "CREATE SEQUENCE \"#{sequence_name}\" NOORDER" }

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -99,10 +99,10 @@ describe "OracleEnhancedAdapter" do
 
       it "should get sequence value at next time" do
         TestEmployee.create!
-        expect(@logger.logged(:debug).first).not_to match(/SELECT \"TEST_EMPLOYEES_SEQ\".NEXTVAL FROM dual/im)
+        expect(@logger.logged(:debug).first).not_to match(/SELECT "TEST_EMPLOYEES_SEQ".NEXTVAL FROM dual/im)
         @logger.clear(:debug)
         TestEmployee.create!
-        expect(@logger.logged(:debug).first).to match(/SELECT \"TEST_EMPLOYEES_SEQ\".NEXTVAL FROM dual/im)
+        expect(@logger.logged(:debug).first).to match(/SELECT "TEST_EMPLOYEES_SEQ".NEXTVAL FROM dual/im)
       end
     end
   end


### PR DESCRIPTION
Follow up https://github.com/rails/rails/commit/a908d06c8539ac967aae7897e1b72279016f7dcc

```ruby
$ bundle exec rubocop -a
Inspecting 70 files
.............C.....C........................C....C.CC.................

Offenses:

lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb:116:41: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
              unless database.match?(/^(\:|\/)/)
                                        ^^
lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:15:32: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
            if /\A[a-z][a-z_0-9\$#]*\Z/.match?(name)
                               ^^
lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:30:31: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
          when /^[a-z][a-z_0-9\$#]*$/
                              ^^
lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:32:31: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
          when /^[a-z][a-z_0-9\$#\-]*$/i
                              ^^
spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb:329:80: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
        expect(output).to match(/add_context_index "posts", \["title"\], name: \"index_posts_on_title\"$/)
                                                                               ^^
spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb:329:102: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
        expect(output).to match(/add_context_index "posts", \["title"\], name: \"index_posts_on_title\"$/)
                                                                                                     ^^
spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb:74:41: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(output).to match(/t.string \"special_c\", default: "\\n"/)
                                        ^^
spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb:74:52: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(output).to match(/t.string \"special_c\", default: "\\n"/)
                                                   ^^
spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb:107:40: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(output).to match(/t.ntext \"ntext_column\"/)
                                       ^^
spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb:107:54: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(output).to match(/t.ntext \"ntext_column\"/)
                                                     ^^
spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb:373:68: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(output).to match(/t\.virtual "name_ratio",(\s*)as:(.*)\"$/) # no :type
                                                                   ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:71:42: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_FOO\"? FOREIGN KEY \(\"?FOO_ID\"?\) REFERENCES \"?FOOS\"?\(\"?ID\"?\)/i)
                                         ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:71:55: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_FOO\"? FOREIGN KEY \(\"?FOO_ID\"?\) REFERENCES \"?FOOS\"?\(\"?ID\"?\)/i)
                                                      ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:71:74: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_FOO\"? FOREIGN KEY \(\"?FOO_ID\"?\) REFERENCES \"?FOOS\"?\(\"?ID\"?\)/i)
                                                                         ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:71:93: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_FOO\"? FOREIGN KEY \(\"?FOO_ID\"?\) REFERENCES \"?FOOS\"?\(\"?ID\"?\)/i)
                                                                                            ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:71:111: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_FOO\"? FOREIGN KEY \(\"?FOO_ID\"?\) REFERENCES \"?FOOS\"?\(\"?ID\"?\)/i)
                                                                                                              ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:71:120: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_FOO\"? FOREIGN KEY \(\"?FOO_ID\"?\) REFERENCES \"?FOOS\"?\(\"?ID\"?\)/i)
                                                                                                                       ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:71:137: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_FOO\"? FOREIGN KEY \(\"?FOO_ID\"?\) REFERENCES \"?FOOS\"?\(\"?ID\"?\)/i)
                                                                                                                                        ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:71:144: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_FOO\"? FOREIGN KEY \(\"?FOO_ID\"?\) REFERENCES \"?FOOS\"?\(\"?ID\"?\)/i)
                                                                                                                                               ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:71:149: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_FOO\"? FOREIGN KEY \(\"?FOO_ID\"?\) REFERENCES \"?FOOS\"?\(\"?ID\"?\)/i)
                                                                                                                                                    ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:71:154: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_FOO\"? FOREIGN KEY \(\"?FOO_ID\"?\) REFERENCES \"?FOOS\"?\(\"?ID\"?\)/i)
                                                                                                                                                         ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:91:42: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_BAZ\"? FOREIGN KEY \(\"?BAZ_ID\"?\) REFERENCES \"?FOOS\"?\(\"?BAZ_ID\"?\)/i)
                                         ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:91:55: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_BAZ\"? FOREIGN KEY \(\"?BAZ_ID\"?\) REFERENCES \"?FOOS\"?\(\"?BAZ_ID\"?\)/i)
                                                      ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:91:74: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_BAZ\"? FOREIGN KEY \(\"?BAZ_ID\"?\) REFERENCES \"?FOOS\"?\(\"?BAZ_ID\"?\)/i)
                                                                         ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:91:93: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_BAZ\"? FOREIGN KEY \(\"?BAZ_ID\"?\) REFERENCES \"?FOOS\"?\(\"?BAZ_ID\"?\)/i)
                                                                                            ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:91:111: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_BAZ\"? FOREIGN KEY \(\"?BAZ_ID\"?\) REFERENCES \"?FOOS\"?\(\"?BAZ_ID\"?\)/i)
                                                                                                              ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:91:120: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_BAZ\"? FOREIGN KEY \(\"?BAZ_ID\"?\) REFERENCES \"?FOOS\"?\(\"?BAZ_ID\"?\)/i)
                                                                                                                       ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:91:137: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_BAZ\"? FOREIGN KEY \(\"?BAZ_ID\"?\) REFERENCES \"?FOOS\"?\(\"?BAZ_ID\"?\)/i)
                                                                                                                                        ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:91:144: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_BAZ\"? FOREIGN KEY \(\"?BAZ_ID\"?\) REFERENCES \"?FOOS\"?\(\"?BAZ_ID\"?\)/i)
                                                                                                                                               ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:91:149: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_BAZ\"? FOREIGN KEY \(\"?BAZ_ID\"?\) REFERENCES \"?FOOS\"?\(\"?BAZ_ID\"?\)/i)
                                                                                                                                                    ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:91:158: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/ALTER TABLE \"?TEST_POSTS\"? ADD CONSTRAINT \"?FK_TEST_POST_BAZ\"? FOREIGN KEY \(\"?BAZ_ID\"?\) REFERENCES \"?FOOS\"?\(\"?BAZ_ID\"?\)/i)
                                                                                                                                                             ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:139:30: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/\"?ID_PLUS\"? NUMBER GENERATED ALWAYS AS \(ID\+2\) VIRTUAL/)
                             ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:139:40: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/\"?ID_PLUS\"? NUMBER GENERATED ALWAYS AS \(ID\+2\) VIRTUAL/)
                                       ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:152:43: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/CREATE TABLE \"BARS\" \(\n \"ID\" NUMBER\(38,0\) NOT NULL,\n \"SUPER\" RAW\(255\) GENERATED ALWAYS AS \(HEXTORAW\(TO_CHAR\(ID\)\)\) VIRTUAL/)
                                          ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:152:49: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/CREATE TABLE \"BARS\" \(\n \"ID\" NUMBER\(38,0\) NOT NULL,\n \"SUPER\" RAW\(255\) GENERATED ALWAYS AS \(HEXTORAW\(TO_CHAR\(ID\)\)\) VIRTUAL/)
                                                ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:152:57: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/CREATE TABLE \"BARS\" \(\n \"ID\" NUMBER\(38,0\) NOT NULL,\n \"SUPER\" RAW\(255\) GENERATED ALWAYS AS \(HEXTORAW\(TO_CHAR\(ID\)\)\) VIRTUAL/)
                                                        ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:152:61: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/CREATE TABLE \"BARS\" \(\n \"ID\" NUMBER\(38,0\) NOT NULL,\n \"SUPER\" RAW\(255\) GENERATED ALWAYS AS \(HEXTORAW\(TO_CHAR\(ID\)\)\) VIRTUAL/)
                                                            ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:152:91: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/CREATE TABLE \"BARS\" \(\n \"ID\" NUMBER\(38,0\) NOT NULL,\n \"SUPER\" RAW\(255\) GENERATED ALWAYS AS \(HEXTORAW\(TO_CHAR\(ID\)\)\) VIRTUAL/)
                                                                                          ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:152:98: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/CREATE TABLE \"BARS\" \(\n \"ID\" NUMBER\(38,0\) NOT NULL,\n \"SUPER\" RAW\(255\) GENERATED ALWAYS AS \(HEXTORAW\(TO_CHAR\(ID\)\)\) VIRTUAL/)
                                                                                                 ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:164:43: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/CREATE TABLE \"BARS\" \(\n \"ID\" NUMBER\(38,0\) NOT NULL,\n \"NCLOB_TEXT\" NCLOB/)
                                          ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:164:49: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/CREATE TABLE \"BARS\" \(\n \"ID\" NUMBER\(38,0\) NOT NULL,\n \"NCLOB_TEXT\" NCLOB/)
                                                ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:164:57: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/CREATE TABLE \"BARS\" \(\n \"ID\" NUMBER\(38,0\) NOT NULL,\n \"NCLOB_TEXT\" NCLOB/)
                                                        ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:164:61: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/CREATE TABLE \"BARS\" \(\n \"ID\" NUMBER\(38,0\) NOT NULL,\n \"NCLOB_TEXT\" NCLOB/)
                                                            ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:164:91: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/CREATE TABLE \"BARS\" \(\n \"ID\" NUMBER\(38,0\) NOT NULL,\n \"NCLOB_TEXT\" NCLOB/)
                                                                                          ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:164:103: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/CREATE TABLE \"BARS\" \(\n \"ID\" NUMBER\(38,0\) NOT NULL,\n \"NCLOB_TEXT\" NCLOB/)
                                                                                                      ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:190:63: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/CREATE  INDEX "?IX_TEST_POSTS_FOO\"? ON "?TEST_POSTS"? \("?FOO"?\)/i)
                                                              ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:202:70: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/CREATE  INDEX "?IX_TEST_POSTS_FOO_FOO_ID\"? ON "?TEST_POSTS"? \("?FOO"?, "?FOO_ID"?\)/i)
                                                                     ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:203:68: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/CREATE  INDEX "?IX_TEST_POSTS_FUNCTION\"? ON "?TEST_POSTS"? \(TO_CHAR\(LENGTH\("?FOO"?\)\)\|\|"?FOO"?\)/i)
                                                                   ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:215:43: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/CREATE TABLE \"BARS\" \(\n \"ID\" NUMBER\(38,0\) NOT NULL,\n \"SUPER\" RAW\(255\)/)
                                          ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:215:49: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/CREATE TABLE \"BARS\" \(\n \"ID\" NUMBER\(38,0\) NOT NULL,\n \"SUPER\" RAW\(255\)/)
                                                ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:215:57: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/CREATE TABLE \"BARS\" \(\n \"ID\" NUMBER\(38,0\) NOT NULL,\n \"SUPER\" RAW\(255\)/)
                                                        ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:215:61: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/CREATE TABLE \"BARS\" \(\n \"ID\" NUMBER\(38,0\) NOT NULL,\n \"SUPER\" RAW\(255\)/)
                                                            ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:215:91: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/CREATE TABLE \"BARS\" \(\n \"ID\" NUMBER\(38,0\) NOT NULL,\n \"SUPER\" RAW\(255\)/)
                                                                                          ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:215:98: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      expect(dump).to match(/CREATE TABLE \"BARS\" \(\n \"ID\" NUMBER\(38,0\) NOT NULL,\n \"SUPER\" RAW\(255\)/)
                                                                                                 ^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:272:56: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
      it { is_expected.to_not match(%r{CREATE SEQUENCE \"#{sequence_name}" MAXVALUE \d+ MINVALUE \d+ NOORDER NOCYCLE}) }
                                                       ^^
spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:102:67: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
        expect(@logger.logged(:debug).first).not_to match(/SELECT \"TEST_EMPLOYEES_SEQ\".NEXTVAL FROM dual/im)
                                                                  ^^
spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:102:87: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
        expect(@logger.logged(:debug).first).not_to match(/SELECT \"TEST_EMPLOYEES_SEQ\".NEXTVAL FROM dual/im)
                                                                                      ^^
spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:105:63: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
        expect(@logger.logged(:debug).first).to match(/SELECT \"TEST_EMPLOYEES_SEQ\".NEXTVAL FROM dual/im)
                                                              ^^
spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:105:83: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
        expect(@logger.logged(:debug).first).to match(/SELECT \"TEST_EMPLOYEES_SEQ\".NEXTVAL FROM dual/im)
                                                                                  ^^

70 files inspected, 59 offenses detected, 59 offenses corrected

Tip: Based on detected gems, the following RuboCop extension libraries might be helpful:
  * rubocop-rake (http://github.com/rubocop-hq/rubocop-rake)
  * rubocop-rspec (http://github.com/rubocop-hq/rubocop-rspec)

You can opt out of this message by adding the following to your config (see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
  AllCops:
    SuggestExtensions: false
$
```