### PR TITLE
`NOT IN` clause needs separated by `AND`

### DIFF
--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -95,9 +95,9 @@ module Arel # :nodoc: all
           column_name = quote_table_name(o.table_name) + "." + quote_column_name(o.column_name)
           operator =
             if o.type == :in
-              "IN ("
+              " IN ("
             else
-              "NOT IN ("
+              " NOT IN ("
             end
 
           if !Array === values || values.length <= in_clause_length
@@ -114,9 +114,15 @@ module Arel # :nodoc: all
             collector << expr
             collector << ")"
           else
+            separator =
+              if o.type == :in
+                " OR "
+              else
+                " AND "
+              end
             collector << "("
             values.each_slice(in_clause_length).each_with_index do |valuez, i|
-              collector << " OR " unless i == 0
+              collector << separator unless i == 0
               collector << column_name
               collector << operator
               collector << valuez.join(",")

--- a/lib/arel/visitors/oracle12.rb
+++ b/lib/arel/visitors/oracle12.rb
@@ -48,9 +48,9 @@ module Arel # :nodoc: all
           column_name = quote_table_name(o.table_name) + "." + quote_column_name(o.column_name)
           operator =
             if o.type == :in
-              "IN ("
+              " IN ("
             else
-              "NOT IN ("
+              " NOT IN ("
             end
 
           if !Array === values || values.length <= in_clause_length
@@ -67,9 +67,15 @@ module Arel # :nodoc: all
             collector << expr
             collector << ")"
           else
+            separator =
+              if o.type == :in
+                " OR "
+              else
+                " AND "
+              end
             collector << "("
             values.each_slice(in_clause_length).each_with_index do |valuez, i|
-              collector << " OR " unless i == 0
+              collector << separator unless i == 0
               collector << column_name
               collector << operator
               collector << valuez.join(",")


### PR DESCRIPTION
* Steps to reproduce

```ruby
$ cd activerecord
$ ARCONN=oracle bin/test test/cases/bind_parameter_test.rb -n test_too_many_binds
Using oracle
Run options: -n test_too_many_binds --seed 56030

F

Failure:
ActiveRecord::BindParameterTest#test_too_many_binds [/home/yahonda/src/github.com/rails/rails/activerecord/test/cases/bind_parameter_test.rb:116]:
Expected: 0
  Actual: 5

bin/test test/cases/bind_parameter_test.rb:109

Finished in 6.902430s, 0.1449 runs/s, 0.2898 assertions/s.
1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
$
```

* Rails Active Record unit test is modified temporary not to use huge memory which
  causes `ORA-27102: out of memory`

```diff
$ git diff
diff --git a/activerecord/test/cases/bind_parameter_test.rb b/activerecord/test/cases/bind_parameter_test.rb
index 701b3b51bf..7fed0af8bd 100644
--- a/activerecord/test/cases/bind_parameter_test.rb
+++ b/activerecord/test/cases/bind_parameter_test.rb
@@ -107,7 +107,7 @@ def test_statement_cache_with_sql_string_literal
       end

       def test_too_many_binds
-        bind_params_length = @connection.send(:bind_params_length)
+        bind_params_length = 1000

         topics = Topic.where(id: (1 .. bind_params_length).to_a << 2**63)
         assert_equal Topic.count, topics.count
$
```

* error when bind_parames_length is 65535

```ruby
ActiveRecord::BindParameterTest#test_too_many_binds:
ActiveRecord::StatementInvalid: OCIError: ORA-27102: out of memory
Linux-x86_64 Error: 12: Cannot allocate memory
Additional information: 11242
Additional information: 131072
Additional information: 140139539222528
ORA-04036: PGA memory used by the instance exceeds PGA_AGGREGATE_LIMIT
```

Fix #2078