### PR TITLE
CI against JRuby 9.2.14.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ rvm:
   - 2.7.2
   - 2.6.6
   - 2.5.8
-  - jruby-9.2.13.0
+  - jruby-9.2.14.0
   - ruby-head
   - jruby-head
 


### PR DESCRIPTION
* JRuby 9.2.14.0 Released
https://www.jruby.org/2020/12/08/jruby-9-2-14-0

This commit will be merged to release61 directly because
Oracle enhanced master branch CI has been migrated to GitHub Actions.