### PR TITLE
Address Travis CI warnings and bump Ubuntu version to 20.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-dist: bionic
-sudo: required
+os: linux
+dist: focal
 cache: bundler
 
 env:


### PR DESCRIPTION
* Warinings to be addressed
https://travis-ci.org/github/rsim/oracle-enhanced/builds/749919415/config

```
root: deprecated key sudo (The key `sudo` has no effect anymore.)
root: missing os, using the default linux
```

* The Ubuntu 20.04 (Focal Fossa) Build Environment
https://docs.travis-ci.com/user/reference/focal/