### PR TITLE
Usage of bind variables for volatile filter conditions (2)

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -9,6 +9,7 @@ exemptLabels:
   - pinned
   - security
   - rails6
+  - upstream
 # Label to use when marking as stale
 staleLabel: wontfix
 # Comment to post when marking as stale. Set to `false` to disable

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Ruby 2.7
+    - name: Set up Ruby 3.0
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: 3.0
     - name: Install required package
       run: |
         sudo apt-get install alien

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,6 @@ jobs:
           2.7,
           2.6,
           2.5,
-          ruby-head,
-          ruby-debug,
           jruby,
           jruby-head
         ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         ruby: [
+          3.0,
           2.7,
           2.6,
           2.5,

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -101,6 +101,10 @@ Layout/SpaceAroundKeyword:
 Layout/SpaceAroundOperators:
   Enabled: true
 
+# This cop has not been enabled at rails/rails
+Layout/SpaceBeforeBrackets:
+  Enabled: true
+
 Layout/SpaceBeforeComma:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -166,6 +166,9 @@ Lint/AmbiguousOperator:
 Lint/AmbiguousRegexpLiteral:
   Enabled: true
 
+Lint/DuplicateRequire:
+  Enabled: true
+
 Lint/ErbNewArguments:
   Enabled: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-dist: bionic
-sudo: required
+os: linux
+dist: focal
 cache: bundler
 
 env:
@@ -38,10 +38,11 @@ script:
 
 language: ruby
 rvm:
+  - 3.0.0
   - 2.7.2
   - 2.6.6
   - 2.5.8
-  - jruby-9.2.13.0
+  - jruby-9.2.14.0
   - ruby-head
   - jruby-head
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,49 @@
+dist: bionic
+sudo: required
+cache: bundler
+
+env:
+  global:
+    - ORACLE_FILE=oracle11g/xe/oracle-xe-11.2.0-1.0.x86_64.rpm.zip
+    - ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe
+    - TNS_ADMIN=$ORACLE_HOME/network/admin
+    - NLS_LANG=AMERICAN_AMERICA.AL32UTF8
+    - ORACLE_BASE=/u01/app/oracle
+    - LD_LIBRARY_PATH=$ORACLE_HOME/lib
+    - PATH=$PATH:$ORACLE_HOME/jdbc/lib
+    - DATABASE_VERSION=11.2.0.1
+    - ORACLE_SID=XE
+    - DATABASE_NAME=XE
+    - ORA_SDTZ='Europe/Riga' #Needed as a client parameter
+    - TZ='Europe/Riga'       #Needed as a DB Server parameter
+    - "JRUBY_OPTS='--debug --dev -J-Xmx1024M'"
+
+before_install:
+  - chmod +x .travis/oracle/download.sh
+  - chmod +x .travis/oracle/install.sh
+  - chmod +x .travis/setup_accounts.sh
+
+install:
+  - .travis/oracle/download.sh
+  - .travis/oracle/install.sh
+  - .travis/setup_accounts.sh
+  - ruby -v
+  - bundle install
+
+script:
+  - bundle exec rake spec
+  - rm Gemfile.lock
+  - ruby guides/bug_report_templates/active_record_gem.rb
+  - ruby guides/bug_report_templates/active_record_gem_spec.rb
+
+language: ruby
+rvm:
+  - 2.7.2
+  - 2.6.6
+  - 2.5.8
+  - jruby-9.2.13.0
+  - ruby-head
+  - jruby-head
+
+notifications:
+    email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,5 +46,10 @@ rvm:
   - ruby-head
   - jruby-head
 
+matrix:
+  allow_failures:
+  - rvm: jruby-9.2.14.0
+  - rvm: jruby-head
+
 notifications:
     email: false

--- a/.travis/oracle/download.sh
+++ b/.travis/oracle/download.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "$(readlink -f "$0")")"
+
+deb_file=oracle-xe_11.2.0-1.0_amd64.deb
+
+git clone https://github.com/wnameless/docker-oracle-xe-11g.git
+
+cd docker-oracle-xe-11g/assets &&
+      cat "${deb_file}aa" "${deb_file}ab" "${deb_file}ac" > "${deb_file}"
+
+pwd
+
+ls -lAh "${deb_file}"

--- a/.travis/oracle/install.sh
+++ b/.travis/oracle/install.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+[ -n "$ORACLE_FILE" ] || { echo "Missing ORACLE_FILE environment variable!"; exit 1; }
+[ -n "$ORACLE_HOME" ] || { echo "Missing ORACLE_HOME environment variable!"; exit 1; }
+
+cd "$(dirname "$(readlink -f "$0")")"
+
+ORACLE_DEB=docker-oracle-xe-11g/assets/oracle-xe_11.2.0-1.0_amd64.deb
+
+sudo apt-get -qq update
+sudo apt-get --no-install-recommends -qq install bc libaio1
+
+df -B1 /dev/shm | awk 'END { if ($1 != "shmfs" && $1 != "tmpfs" || $2 < 2147483648) exit 1 }' ||
+    ( sudo rm -r /dev/shm && sudo mkdir /dev/shm && sudo mount -t tmpfs shmfs -o size=2G /dev/shm )
+
+test -f /sbin/chkconfig ||
+    ( echo '#!/bin/sh' | sudo tee /sbin/chkconfig > /dev/null && sudo chmod u+x /sbin/chkconfig )
+
+test -d /var/lock/subsys || sudo mkdir /var/lock/subsys
+
+sudo dpkg -i "${ORACLE_DEB}"
+
+echo 'OS_AUTHENT_PREFIX=""' | sudo tee -a "$ORACLE_HOME/config/scripts/init.ora" > /dev/null
+echo 'disk_asynch_io=false' | sudo tee -a "$ORACLE_HOME/config/scripts/init.ora" > /dev/null
+
+sudo usermod -aG dba $USER
+
+( echo ; echo ; echo travis ; echo travis ; echo n ) | sudo AWK='/usr/bin/awk' /etc/init.d/oracle-xe configure
+
+"$ORACLE_HOME/bin/sqlplus" -L -S / AS SYSDBA <<SQL
+CREATE USER $USER IDENTIFIED EXTERNALLY;
+GRANT CONNECT, RESOURCE TO $USER;
+SQL

--- a/.travis/setup_accounts.sh
+++ b/.travis/setup_accounts.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -ev
+
+"$ORACLE_HOME/bin/sqlplus" -L -S / AS SYSDBA <<SQL
+@@spec/support/alter_system_user_password.sql
+@@spec/support/alter_system_set_open_cursors.sql
+@@spec/support/create_oracle_enhanced_users.sql
+exit
+SQL

--- a/History.md
+++ b/History.md
@@ -1,3 +1,17 @@
+## 6.1.1 / 2021-01-14
+
+* Changes and bug fixes
+  * Remove /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ hint for all_synonyms [#2110, #2119]
+  * Fix write_lobs Invalid byte sequence in UTF-8 [#2097, #2111]
+  * Ensure FKs are properly included in structure dumps [#2109, #2113]
+
+* CI
+  * CI against JRuby 9.2.14.0 [#2085]
+  * CI against Ruby 3.0.0 [#2091, #2092]
+  * Address Travis CI warnings and bump Ubuntu version to 20.04 [#2086]
+  * Exclude `ruby-head` and `ruby-debug` until minitest allows Ruby 3.1 #2094, #2095
+  * CI against Ruby 3.0.0 at Travis CI [#2093]
+
 ## 6.1.0 / 2020-12-15
 
 * Changes and bug fixes

--- a/guides/bug_report_templates/active_record_gem_spec.rb
+++ b/guides/bug_report_templates/active_record_gem_spec.rb
@@ -17,7 +17,7 @@ gemfile(true) do
 end
 
 require "active_record"
-require "rspec"
+require "rspec/autorun"
 require "logger"
 require "active_record/connection_adapters/oracle_enhanced_adapter"
 

--- a/guides/bug_report_templates/active_record_gem_spec.rb
+++ b/guides/bug_report_templates/active_record_gem_spec.rb
@@ -17,7 +17,7 @@ gemfile(true) do
 end
 
 require "active_record"
-require "rspec/autorun"
+require "rspec"
 require "logger"
 require "active_record/connection_adapters/oracle_enhanced_adapter"
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -101,7 +101,7 @@ module ActiveRecord
               _oracle_downcase(col_name)
             end
             row = cursor.fetch
-            columns.each_with_index.map { |x,i| [x, row[i]] }.to_h if row
+            columns.each_with_index.map { |x, i| [x, row[i]] }.to_h if row
           ensure
             cursor.close
           end

--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -34,7 +34,7 @@ module ActiveRecord
               table_owner, table_name = default_owner, real_name
             end
             sql = <<~SQL.squish
-              SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ owner, table_name, 'TABLE' name_type
+              SELECT owner, table_name, 'TABLE' name_type
               FROM all_tables
               WHERE owner = '#{table_owner}'
                 AND table_name = '#{table_name}'

--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -36,25 +36,25 @@ module ActiveRecord
             sql = <<~SQL.squish
               SELECT owner, table_name, 'TABLE' name_type
               FROM all_tables
-              WHERE owner = '#{table_owner}'
-                AND table_name = '#{table_name}'
+              WHERE owner = :table_owner
+                AND table_name = :table_name
               UNION ALL
               SELECT owner, view_name table_name, 'VIEW' name_type
               FROM all_views
-              WHERE owner = '#{table_owner}'
-                AND view_name = '#{table_name}'
+              WHERE owner = :table_owner
+                AND view_name = :table_name
               UNION ALL
               SELECT table_owner, table_name, 'SYNONYM' name_type
               FROM all_synonyms
-              WHERE owner = '#{table_owner}'
-                AND synonym_name = '#{table_name}'
+              WHERE owner = :table_owner
+                AND synonym_name = :table_name
               UNION ALL
               SELECT table_owner, table_name, 'SYNONYM' name_type
               FROM all_synonyms
               WHERE owner = 'PUBLIC'
-                AND synonym_name = '#{real_name}'
+                AND synonym_name = :real_name
             SQL
-            if result = _select_one(sql)
+            if result = _select_one(sql, "CONNECTION", [table_owner, table_name, table_owner, table_name, table_owner, table_name, real_name])
               case result["name_type"]
               when "SYNONYM"
                 describe("#{result['owner'] && "#{result['owner']}."}#{result['table_name']}")
@@ -92,14 +92,23 @@ module ActiveRecord
 
           # Returns a record hash with the column names as keys and column values
           # as values.
+          # binds is a array of native values in contrast to ActiveRecord::Relation::QueryAttribute
           def _select_one(arel, name = nil, binds = [])
-            result = select(arel)
-            result.first if result
+            cursor = prepare(arel)
+            cursor.bind_params(binds)
+            cursor.exec
+            columns = cursor.get_col_names.map do |col_name|
+              _oracle_downcase(col_name)
+            end
+            row = cursor.fetch
+            columns.each_with_index.map { |x,i| [x, row[i]] }.to_h if row
+          ensure
+            cursor.close
           end
 
           # Returns a single value from a record
           def _select_value(arel, name = nil, binds = [])
-            if result = _select_one(arel)
+            if result = _select_one(arel, name, binds)
               result.values.first
             end
           end

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -254,9 +254,11 @@ module ActiveRecord
           columns.each do |col|
             value = attributes[col.name]
             # changed sequence of next two lines - should check if value is nil before converting to yaml
-            next if value.blank?
+            next unless value
             if klass.attribute_types[col.name].is_a? Type::Serialized
               value = klass.attribute_types[col.name].serialize(value)
+              # value can be nil after serialization because ActiveRecord serializes [] and {} as nil
+              next unless value
             end
             uncached do
               unless lob_record = select_one(sql = <<~SQL.squish, "Writable Large Object")

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -148,6 +148,12 @@ module ActiveRecord
               @raw_connection.setSessionTimeZone("UTC")
             end
 
+            if config[:jdbc_statement_cache_size]
+              raise "Integer value expected for :jdbc_statement_cache_size" unless config[:jdbc_statement_cache_size].instance_of? Integer
+              @raw_connection.setImplicitCachingEnabled(true)
+              @raw_connection.setStatementCacheSize(config[:jdbc_statement_cache_size])
+            end
+
             # Set default number of rows to prefetch
             # @raw_connection.setDefaultRowPrefetch(prefetch_rows) if prefetch_rows
           end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -367,12 +367,12 @@ module ActiveRecord
         # Will always query database and not index cache.
         def index_name_exists?(table_name, index_name)
           (_owner, table_name) = @connection.describe(table_name)
-          result = select_value(<<~SQL.squish, "SCHEMA")
+          result = select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name), bind_string("index_name", index_name.to_s.upcase)])
             SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ 1 FROM all_indexes i
             WHERE i.owner = SYS_CONTEXT('userenv', 'current_schema')
                AND i.table_owner = SYS_CONTEXT('userenv', 'current_schema')
-               AND i.table_name = '#{table_name}'
-               AND i.index_name = '#{index_name.to_s.upcase}'
+               AND i.table_name = :table_name
+               AND i.index_name = :index_name
           SQL
           result == 1
         end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -76,7 +76,7 @@ module ActiveRecord
         # get synonyms for schema dump
         def synonyms
           result = select_all(<<~SQL.squish, "SCHEMA")
-            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ synonym_name, table_owner, table_name
+            SELECT synonym_name, table_owner, table_name
             FROM all_synonyms where owner = SYS_CONTEXT('userenv', 'current_schema')
           SQL
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -55,8 +55,9 @@ module ActiveRecord #:nodoc:
             structure << structure_dump_column_comments(table_name)
           end
 
-          join_with_statement_token(structure) << structure_dump_fk_constraints
-          join_with_statement_token(structure) << structure_dump_views
+          join_with_statement_token(structure) <<
+            structure_dump_fk_constraints <<
+            structure_dump_views
         end
 
         def structure_dump_column(column) #:nodoc:

--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -30,11 +30,11 @@ module ActiveRecord #:nodoc:
           tables.each do |table_name|
             virtual_columns = virtual_columns_for(table_name) if supports_virtual_columns?
             ddl = +"CREATE#{ ' GLOBAL TEMPORARY' if temporary_table?(table_name)} TABLE \"#{table_name}\" (\n"
-            columns = select_all(<<~SQL.squish, "SCHEMA")
+            columns = select_all(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name)])
               SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ column_name, data_type, data_length, char_used, char_length,
               data_precision, data_scale, data_default, nullable
               FROM all_tab_columns
-              WHERE table_name = '#{table_name}'
+              WHERE table_name = :table_name
               AND owner = SYS_CONTEXT('userenv', 'current_schema')
               ORDER BY column_id
             SQL
@@ -174,10 +174,10 @@ module ActiveRecord #:nodoc:
 
         def structure_dump_column_comments(table_name)
           comments = []
-          columns = select_values(<<~SQL.squish, "SCHEMA")
+          columns = select_values(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name)])
             SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ column_name FROM all_tab_columns
             WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
-            AND table_name = '#{table_name}' ORDER BY column_id
+            AND table_name = :table_name ORDER BY column_id
           SQL
 
           columns.each do |column|
@@ -218,11 +218,11 @@ module ActiveRecord #:nodoc:
           SQL
           all_source.each do |source|
             ddl = +"CREATE OR REPLACE   \n"
-            texts = select_all(<<~SQL.squish, "all source at structure dump")
+            texts = select_all(<<~SQL.squish, "all source at structure dump", [bind_string("source_name", source['name']), bind_string("source_type", source['type']),])
               SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ text
               FROM all_source
-              WHERE name = '#{source['name']}'
-              AND type = '#{source['type']}'
+              WHERE name = :source_name
+              AND type = :source_type
               AND owner = SYS_CONTEXT('userenv', 'current_schema')
               ORDER BY line
             SQL
@@ -323,12 +323,12 @@ module ActiveRecord #:nodoc:
         # Called only if `supports_virtual_columns?` returns true
         # return [{'column_name' => 'FOOS', 'data_default' => '...'}, ...]
         def virtual_columns_for(table)
-          select_all(<<~SQL.squish, "SCHEMA")
+          select_all(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table.upcase)])
             SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ column_name, data_default
             FROM all_tab_cols
             WHERE virtual_column = 'YES'
             AND owner = SYS_CONTEXT('userenv', 'current_schema')
-            AND table_name = '#{table.upcase}'
+            AND table_name = :table_name
           SQL
         end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -218,7 +218,7 @@ module ActiveRecord #:nodoc:
           SQL
           all_source.each do |source|
             ddl = +"CREATE OR REPLACE   \n"
-            texts = select_all(<<~SQL.squish, "all source at structure dump", [bind_string("source_name", source['name']), bind_string("source_type", source['type']),])
+            texts = select_all(<<~SQL.squish, "all source at structure dump", [bind_string("source_name", source["name"]), bind_string("source_type", source["type"]),])
               SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ text
               FROM all_source
               WHERE name = :source_name

--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -175,8 +175,9 @@ module ActiveRecord #:nodoc:
         def structure_dump_column_comments(table_name)
           comments = []
           columns = select_values(<<~SQL.squish, "SCHEMA")
-            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ column_name FROM user_tab_columns
-            WHERE table_name = '#{table_name}' ORDER BY column_id
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ column_name FROM all_tab_columns
+            WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
+            AND table_name = '#{table_name}' ORDER BY column_id
           SQL
 
           columns.each do |column|

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -562,7 +562,7 @@ module ActiveRecord
       def column_definitions(table_name)
         (owner, desc_table_name) = @connection.describe(table_name)
 
-        select_all(<<~SQL.squish, "SCHEMA")
+        select_all(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("table_name", desc_table_name)])
           SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ cols.column_name AS name, cols.data_type AS sql_type,
                  cols.data_default, cols.nullable, cols.virtual_column, cols.hidden_column,
                  cols.data_type_owner AS sql_type_owner,
@@ -575,8 +575,8 @@ module ActiveRecord
                  DECODE(data_type, 'NUMBER', data_scale, NULL) AS scale,
                  comments.comments as column_comment
             FROM all_tab_cols cols, all_col_comments comments
-           WHERE cols.owner      = '#{owner}'
-             AND cols.table_name = #{quote(desc_table_name)}
+           WHERE cols.owner      = :owner
+             AND cols.table_name = :table_name
              AND cols.hidden_column = 'NO'
              AND cols.owner = comments.owner
              AND cols.table_name = comments.table_name
@@ -594,19 +594,19 @@ module ActiveRecord
       def pk_and_sequence_for(table_name, owner = nil, desc_table_name = nil) #:nodoc:
         (owner, desc_table_name) = @connection.describe(table_name)
 
-        seqs = select_values(<<~SQL.squish, "SCHEMA")
+        seqs = select_values(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("sequence_name", default_sequence_name(desc_table_name))])
           select /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ us.sequence_name
           from all_sequences us
-          where us.sequence_owner = '#{owner}'
-          and us.sequence_name = upper(#{quote(default_sequence_name(desc_table_name))})
+          where us.sequence_owner = :owner
+          and us.sequence_name = upper(:sequence_name)
         SQL
 
         # changed back from user_constraints to all_constraints for consistency
-        pks = select_values(<<~SQL.squish, "SCHEMA")
+        pks = select_values(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("table_name", desc_table_name)])
           SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ cc.column_name
             FROM all_constraints c, all_cons_columns cc
-           WHERE c.owner = '#{owner}'
-             AND c.table_name = #{quote(desc_table_name)}
+           WHERE c.owner = :owner
+             AND c.table_name = :table_name
              AND c.constraint_type = 'P'
              AND cc.owner = c.owner
              AND cc.constraint_name = c.constraint_name

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -594,7 +594,7 @@ module ActiveRecord
       def pk_and_sequence_for(table_name, owner = nil, desc_table_name = nil) #:nodoc:
         (owner, desc_table_name) = @connection.describe(table_name)
 
-        seqs = select_values(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("sequence_name", default_sequence_name(desc_table_name))])
+        seqs = select_values_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("sequence_name", default_sequence_name(desc_table_name))])
           select /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ us.sequence_name
           from all_sequences us
           where us.sequence_owner = :owner
@@ -602,7 +602,7 @@ module ActiveRecord
         SQL
 
         # changed back from user_constraints to all_constraints for consistency
-        pks = select_values(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("table_name", desc_table_name)])
+        pks = select_values_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("table_name", desc_table_name)])
           SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ cc.column_name
             FROM all_constraints c, all_cons_columns cc
            WHERE c.owner = :owner
@@ -636,7 +636,7 @@ module ActiveRecord
       def primary_keys(table_name) # :nodoc:
         (_owner, desc_table_name) = @connection.describe(table_name)
 
-        pks = select_values(<<~SQL.squish, "SCHEMA", [bind_string("table_name", desc_table_name)])
+        pks = select_values_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("table_name", desc_table_name)])
           SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ cc.column_name
             FROM all_constraints c, all_cons_columns cc
            WHERE c.owner = SYS_CONTEXT('userenv', 'current_schema')
@@ -666,7 +666,7 @@ module ActiveRecord
       end
 
       def temporary_table?(table_name) #:nodoc:
-        select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name.upcase)]) == "Y"
+        select_value_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name.upcase)]) == "Y"
           SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */
           temporary FROM all_tables WHERE table_name = :table_name and owner = SYS_CONTEXT('userenv', 'current_schema')
         SQL
@@ -762,6 +762,23 @@ module ActiveRecord
         # create bind object for type String
         def bind_string(name, value)
           ActiveRecord::Relation::QueryAttribute.new(name, value, Type::OracleEnhanced::String.new)
+        end
+
+        # call select_values using binds even if surrounding SQL preparation/execution is done
+        # with conn.unprepared_statement (like AR.to_sql)
+        def select_values_forcing_binds(arel, name, binds)
+          # remove possible force of unprepared SQL during dictionary access
+          unprepared_statement_forced = prepared_statements_disabled_cache.include?(object_id)
+          prepared_statements_disabled_cache.delete(object_id) if unprepared_statement_forced
+
+          select_values(arel, name, binds)
+        ensure
+          # Restore unprepared_statement setting for surrounding SQL
+          prepared_statements_disabled_cache.add(object_id) if unprepared_statement_forced
+        end
+
+        def select_value_forcing_binds(arel, name, binds)
+          single_value_from_rows(select_values_forcing_binds(arel, name, binds))
         end
 
         ActiveRecord::Type.register(:boolean, Type::OracleEnhanced::Boolean, adapter: :oracleenhanced)

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -492,7 +492,7 @@ module ActiveRecord
         do_not_prefetch = @do_not_prefetch_primary_key[table_name]
         if do_not_prefetch.nil?
           owner, desc_table_name = @connection.describe(table_name)
-          @do_not_prefetch_primary_key [table_name] = do_not_prefetch = !has_primary_key?(table_name, owner, desc_table_name)
+          @do_not_prefetch_primary_key[table_name] = do_not_prefetch = !has_primary_key?(table_name, owner, desc_table_name)
         end
         !do_not_prefetch
       end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -120,6 +120,7 @@ module ActiveRecord
     # * <tt>:schema</tt> - database schema which holds schema objects.
     # * <tt>:tcp_keepalive</tt> - TCP keepalive is enabled for OCI client, defaults to true
     # * <tt>:tcp_keepalive_time</tt> - TCP keepalive time for OCI client, defaults to 600
+    # * <tt>:jdbc_statement_cache_size</tt> - number of cached SQL cursors to keep open, disabled per default (for unpooled JDBC only)
     #
     # Optionals NLS parameters:
     #

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -41,6 +41,23 @@ describe "OracleEnhancedAdapter establish connection" do
     expect(ActiveRecord::Base.connection.select_value("select value from v$parameter where name = 'cursor_sharing'")).to eq("EXACT")
   end
 
+  it "should not use JDBC statement caching" do
+    if ORACLE_ENHANCED_CONNECTION == :jdbc
+      ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS)
+      expect(ActiveRecord::Base.connection.raw_connection.getImplicitCachingEnabled).to eq(false)
+      expect(ActiveRecord::Base.connection.raw_connection.getStatementCacheSize).to eq(-1)
+    end
+  end
+
+  it "should use JDBC statement caching" do
+    if ORACLE_ENHANCED_CONNECTION == :jdbc
+      ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS.merge(jdbc_statement_cache_size: 100))
+      expect(ActiveRecord::Base.connection.raw_connection.getImplicitCachingEnabled).to eq(true)
+      expect(ActiveRecord::Base.connection.raw_connection.getStatementCacheSize).to eq(100)
+      # else: don't raise error if OCI connection has parameter "jdbc_statement_cache_size", still ignore it
+    end
+  end
+
   it "should connect to database using service_name" do
     ActiveRecord::Base.establish_connection(SERVICE_NAME_CONNECTION_PARAMS)
     expect(ActiveRecord::Base.connection).not_to be_nil

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -7,9 +7,9 @@ describe "OracleEnhancedAdapter schema definition" do
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
     @oracle11g_or_higher = !! !! ActiveRecord::Base.connection.select_value(
-      "select * from product_component_version where product like 'Oracle%' and to_number(substr(version,1,2)) >= 11")
+      "select * from product_component_version where product like 'Oracle%' and to_number(substr(version,1,2), '99.9') >= 11")
     @oracle12cr2_or_higher = !! !! ActiveRecord::Base.connection.select_value(
-      "select * from product_component_version where product like 'Oracle%' and to_number(substr(version,1,4)) >= 12.2")
+      "select * from product_component_version where product like 'Oracle%' and to_number(substr(version,1,4), '99.9') >= 12.2")
   end
 
   describe "option to create sequence when adding a column" do

--- a/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
@@ -66,7 +66,7 @@ describe "OracleEnhancedAdapter structure dump" do
         ALTER TABLE TEST_POSTS
         ADD CONSTRAINT fk_test_post_foo FOREIGN KEY (foo_id) REFERENCES foos(id)
       SQL
-      dump = ActiveRecord::Base.connection.structure_dump_fk_constraints
+      dump = ActiveRecord::Base.connection.structure_dump
       expect(dump.split('\n').length).to eq(1)
       expect(dump).to match(/ALTER TABLE "?TEST_POSTS"? ADD CONSTRAINT "?FK_TEST_POST_FOO"? FOREIGN KEY \("?FOO_ID"?\) REFERENCES "?FOOS"?\("?ID"?\)/i)
     end
@@ -86,7 +86,7 @@ describe "OracleEnhancedAdapter structure dump" do
         ADD CONSTRAINT fk_test_post_baz FOREIGN KEY (baz_id) REFERENCES foos(baz_id)
       SQL
 
-      dump = ActiveRecord::Base.connection.structure_dump_fk_constraints
+      dump = ActiveRecord::Base.connection.structure_dump
       expect(dump.split('\n').length).to eq(1)
       expect(dump).to match(/ALTER TABLE "?TEST_POSTS"? ADD CONSTRAINT "?FK_TEST_POST_BAZ"? FOREIGN KEY \("?BAZ_ID"?\) REFERENCES "?FOOS"?\("?BAZ_ID"?\)/i)
     end

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -610,15 +610,15 @@ describe "OracleEnhancedAdapter" do
        expect(@logger.logged(:debug).last).to match(/\["table_name", "TEST_POSTS"\]/)
      end
 
-    it "should return content from columns without bind usage" do
+    it "should return content from columns with bind usage" do
       expect(@conn.columns("TEST_POSTS").length).to be > 0
-      expect(@logger.logged(:debug).last).not_to match(/:table_name/)
-      expect(@logger.logged(:debug).last).not_to match(/\["table_name", "TEST_POSTS"\]/)
+      expect(@logger.logged(:debug).last).to match(/:table_name/)
+      expect(@logger.logged(:debug).last).to match(/\["table_name", "TEST_POSTS"\]/)
     end
 
-    it "should return pk and sequence from pk_and_sequence_for without bind usage" do
+    it "should return pk and sequence from pk_and_sequence_for with bind usage" do
       expect(@conn.pk_and_sequence_for("TEST_POSTS").length).to eq 2
-      expect(@logger.logged(:debug).last).not_to match(/\["table_name", "TEST_POSTS"\]/)
+      expect(@logger.logged(:debug).last).to match(/\["table_name", "TEST_POSTS"\]/)
     end
 
     it "should return pk from primary_keys with bind usage" do

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -479,6 +479,45 @@ describe "OracleEnhancedAdapter" do
     end
   end
 
+  describe "Binary lob column" do
+    before(:all) do
+      schema_define do
+        create_table :test_binary_columns do |t|
+          t.binary :attachment
+        end
+      end
+      class ::TestBinaryColumn < ActiveRecord::Base
+      end
+    end
+
+    after(:all) do
+      schema_define do
+        drop_table :test_binary_columns
+      end
+      Object.send(:remove_const, "TestBinaryColumn")
+      ActiveRecord::Base.table_name_prefix = nil
+      ActiveRecord::Base.clear_cache!
+    end
+
+    before(:each) do
+      set_logger
+    end
+
+    after(:each) do
+      clear_logger
+    end
+
+    it "should serialize with non UTF-8 data" do
+      binary_value = +"Hello \x93\xfa\x96\x7b"
+      binary_value.force_encoding "UTF-8"
+
+      binary_column_object = TestBinaryColumn.new
+      binary_column_object.attachment = binary_value
+
+      expect(binary_column_object.save!).to eq(true)
+    end
+  end
+
   describe "quoting" do
     before(:all) do
       schema_define do

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -588,7 +588,6 @@ describe "OracleEnhancedAdapter" do
         create_table :groups, force: true do |t|
           t.string :name
         end
-
       end
 
       class ::TestPost < ActiveRecord::Base
@@ -601,7 +600,6 @@ describe "OracleEnhancedAdapter" do
       class Group < ActiveRecord::Base
         has_one :user
       end
-
     end
 
     before(:each) do


### PR DESCRIPTION
Bind variables are used for more volatile columns owner and table name.
For our larger OLTP systems it is essential to run them with cursor_sharing=exact.
In this case dictionary access without bind variables leads to significant longer CI pipeline runtime as well as production load.
