### PR TITLE
CI against Ruby 3.0.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Ruby 2.7
+    - name: Set up Ruby 3.0
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: 3.0
     - name: Install required package
       run: |
         sudo apt-get install alien

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         ruby: [
+          3.0,
           2.7,
           2.6,
           2.5,


### PR DESCRIPTION
* Ruby 3.0.0 Released
https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/