### PR TITLE
CI against Ruby 3.0.0 at Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,6 @@ rvm:
   - 2.6.6
   - 2.5.8
   - jruby-9.2.14.0
-  - ruby-head
   - jruby-head
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ script:
 
 language: ruby
 rvm:
+  - 3.0.0
   - 2.7.2
   - 2.6.6
   - 2.5.8


### PR DESCRIPTION
* Ruby 3.0.0 Released
https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/