### PR TITLE
Exclude `ruby-head` and `ruby-debug` until minitest allows Ruby 3.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,6 @@ jobs:
           2.7,
           2.6,
           2.5,
-          ruby-head,
-          ruby-debug,
           jruby,
           jruby-head
         ]


### PR DESCRIPTION
Refer https://github.com/seattlerb/minitest/pull/861
https://github.com/seattlerb/minitest/pull/862