### PR TITLE
Merge pull request #2094 from yahonda/exclude_ruby31_now

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,6 @@ jobs:
           2.7,
           2.6,
           2.5,
-          ruby-head,
-          ruby-debug,
           jruby,
           jruby-head
         ]


### PR DESCRIPTION
This pull request backports #2094 to release61 branch.