### PR TITLE
Backport Fix write_lobs Invalid byte sequence in UTF-8 to release60

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -254,9 +254,11 @@ module ActiveRecord
           columns.each do |col|
             value = attributes[col.name]
             # changed sequence of next two lines - should check if value is nil before converting to yaml
-            next if value.blank?
+            next unless value
             if klass.attribute_types[col.name].is_a? Type::Serialized
               value = klass.attribute_types[col.name].serialize(value)
+               # value can be nil after serialization because ActiveRecord serializes [] and {} as nil
+              next unless value
             end
             uncached do
               unless lob_record = select_one(sql = <<~SQL.squish, "Writable Large Object")

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -431,6 +431,45 @@ describe "OracleEnhancedAdapter" do
     end
   end
 
+  describe "Binary lob column" do
+    before(:all) do
+      schema_define do
+        create_table :test_binary_columns do |t|
+          t.binary :attachment
+        end
+      end
+      class ::TestBinaryColumn < ActiveRecord::Base
+      end
+    end
+
+    after(:all) do
+      schema_define do
+        drop_table :test_binary_columns
+      end
+      Object.send(:remove_const, "TestBinaryColumn")
+      ActiveRecord::Base.table_name_prefix = nil
+      ActiveRecord::Base.clear_cache!
+    end
+
+    before(:each) do
+      set_logger
+    end
+
+    after(:each) do
+      clear_logger
+    end
+
+    it "should serialize with non UTF-8 data" do
+      binary_value = +"Hello \x93\xfa\x96\x7b"
+      binary_value.force_encoding "UTF-8"
+
+      binary_column_object = TestBinaryColumn.new
+      binary_column_object.attachment = binary_value
+
+      expect(binary_column_object.save!).to eq(true)
+    end
+  end
+  
   describe "quoting" do
     before(:all) do
       schema_define do


### PR DESCRIPTION
Backport fix from master.
write_lobs checks to see whether the value is blank before executing the SQL statement. If the LOB is binary blank? call causes "invalid byte sequence in UTF-8" exception. We can instead use unless value, which is applicable both to strings and binary data.