### PR TITLE
Address `guides/bug_report_templates/active_record_gem_spec.rb` error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,8 @@ jobs:
       DATABASE_NAME: XEPDB1
       TZ: Europe/Riga
       DATABASE_SYS_PASSWORD: Oracle18
+      DATABASE_HOST: localhost
+      DATABASE_PORT: 1521
 
     services:
       oracle:
@@ -74,5 +76,6 @@ jobs:
         rm Gemfile.lock
     - name: Run bug report templates
       run: |
-        ruby guides/bug_report_templates/active_record_gem.rb
-        ruby guides/bug_report_templates/active_record_gem_spec.rb
+        cd guides/bug_report_templates
+        ruby active_record_gem.rb
+        ruby active_record_gem_spec.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,9 @@ install:
 script:
   - bundle exec rake spec
   - rm Gemfile.lock
-  - ruby guides/bug_report_templates/active_record_gem.rb
-  - ruby guides/bug_report_templates/active_record_gem_spec.rb
+  - cd guides/bug_report_templates
+  - ruby active_record_gem.rb
+  - ruby active_record_gem_spec.rb
 
 language: ruby
 rvm:

--- a/guides/bug_report_templates/active_record_gem_spec.rb
+++ b/guides/bug_report_templates/active_record_gem_spec.rb
@@ -9,7 +9,7 @@ gemfile(true) do
 
   gem "rails", github: "rails/rails", branch: "main"
   gem "activerecord-oracle_enhanced-adapter",  github: "rsim/oracle-enhanced", branch: "master"
-  gem "rspec"
+  gem "rspec", require: "rspec/autorun"
 
   platforms :ruby do
     gem "ruby-oci8"
@@ -17,7 +17,6 @@ gemfile(true) do
 end
 
 require "active_record"
-require "rspec"
 require "logger"
 require "active_record/connection_adapters/oracle_enhanced_adapter"
 


### PR DESCRIPTION
Fixes #2100

* With this fix

```ruby
$ cd guides/bug_report_templates/
$ ruby active_record_gem_spec.rb
... snip ...
-- create_table(:posts, {:force=>true})
D, [2021-01-05T22:54:08.522170 #238157] DEBUG -- :    (21.9ms)  DROP TABLE "POSTS"
D, [2021-01-05T22:54:08.527701 #238157] DEBUG -- :    (5.1ms)  DROP SEQUENCE "POSTS_SEQ"
D, [2021-01-05T22:54:08.535820 #238157] DEBUG -- :    (7.8ms)  CREATE TABLE "POSTS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY)
D, [2021-01-05T22:54:08.538683 #238157] DEBUG -- :    (2.6ms)  CREATE SEQUENCE "POSTS_SEQ" START WITH 1
   -> 0.2223s
-- create_table(:comments, {:force=>true})
D, [2021-01-05T22:54:08.705173 #238157] DEBUG -- :    (18.4ms)  DROP TABLE "COMMENTS"
D, [2021-01-05T22:54:08.709548 #238157] DEBUG -- :    (4.1ms)  DROP SEQUENCE "COMMENTS_SEQ"
D, [2021-01-05T22:54:08.717271 #238157] DEBUG -- :    (7.4ms)  CREATE TABLE "COMMENTS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY, "POST_ID" NUMBER(38))
D, [2021-01-05T22:54:08.720099 #238157] DEBUG -- :    (2.6ms)  CREATE SEQUENCE "COMMENTS_SEQ" START WITH 1
   -> 0.1813s
D, [2021-01-05T22:54:08.908798 #238157] DEBUG -- :   ActiveRecord::InternalMetadata Load (1.4ms)  SELECT "AR_INTERNAL_METADATA".* FROM "AR_INTERNAL_METADATA" WHERE "AR_INTERNAL_METADATA"."KEY" = :a1 FETCH FIRST :a2 ROWS ONLY  [["key", "environment"], ["LIMIT", 1]]
D, [2021-01-05T22:54:09.756091 #238157] DEBUG -- :   Post Create (7.9ms)  INSERT INTO "POSTS" ("ID") VALUES (:a1)  [["id", 1]]
D, [2021-01-05T22:54:10.514187 #238157] DEBUG -- :   Comment Create (7.4ms)  INSERT INTO "COMMENTS" ("ID") VALUES (:a1)  [["id", 1]]
D, [2021-01-05T22:54:10.525006 #238157] DEBUG -- :   Comment Update (3.4ms)  UPDATE "COMMENTS" SET "POST_ID" = :a1 WHERE "COMMENTS"."ID" = :a2  [["post_id", 1], ["id", 1]]
D, [2021-01-05T22:54:10.532210 #238157] DEBUG -- :   Comment Count (5.2ms)  SELECT COUNT(*) FROM "COMMENTS" WHERE "COMMENTS"."POST_ID" = :a1  [["post_id", 1]]
D, [2021-01-05T22:54:10.537725 #238157] DEBUG -- :   Comment Count (4.2ms)  SELECT COUNT(*) FROM "COMMENTS"
D, [2021-01-05T22:54:10.541628 #238157] DEBUG -- :   Comment Load (2.6ms)  SELECT "COMMENTS".* FROM "COMMENTS" ORDER BY "COMMENTS"."ID" ASC FETCH FIRST :a1 ROWS ONLY  [["LIMIT", 1]]
D, [2021-01-05T22:54:10.545887 #238157] DEBUG -- :   Post Load (2.6ms)  SELECT "POSTS".* FROM "POSTS" WHERE "POSTS"."ID" = :a1 FETCH FIRST :a2 ROWS ONLY  [["id", 1], ["LIMIT", 1]]
.

Finished in 2.23 seconds (files took 0.25352 seconds to load)
1 example, 0 failures

$
```

* Without this fix

```ruby
$ ruby -v
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-linux]
$ ruby guides/bug_report_templates/active_record_gem_spec.rb
... snip ...
/home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/bundler/gems/rails-c28c800803c2/activesupport/lib/active_support/dependencies.rb:332:in `require': cannot load such file -- rspec/core/formatters/progress_formatter (LoadError)
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/bundler/gems/rails-c28c800803c2/activesupport/lib/active_support/dependencies.rb:332:in `block in require'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/bundler/gems/rails-c28c800803c2/activesupport/lib/active_support/dependencies.rb:299:in `load_dependency'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/bundler/gems/rails-c28c800803c2/activesupport/lib/active_support/dependencies.rb:332:in `require'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/formatters.rb:212:in `built_in_formatter'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/formatters.rb:182:in `find_formatter'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/formatters.rb:152:in `add'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/formatters.rb:127:in `setup_default'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/reporter.rb:47:in `block in prepare_default'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/reporter.rb:236:in `ensure_listeners_ready'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/reporter.rb:207:in `notify'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/reporter.rb:100:in `message'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/reporter.rb:169:in `notify_non_example_exception'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration.rb:2120:in `rescue in load_file_handling_errors'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration.rb:2111:in `load_file_handling_errors'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration.rb:1574:in `block in requires='
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration.rb:1574:in `each'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration.rb:1574:in `requires='
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration_options.rb:113:in `block in process_options_into'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration_options.rb:112:in `each'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration_options.rb:112:in `process_options_into'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration_options.rb:22:in `configure'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:132:in `configure'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:99:in `setup'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:86:in `run'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:71:in `run'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:45:in `invoke'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:38:in `perform_at_exit'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:24:in `block in autorun'
/home/yahonda/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/spec_set.rb:87:in `block in materialize': Could not find ast-2.4.1 in any of the sources (Bundler::GemNotFound)
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/spec_set.rb:81:in `map!'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/spec_set.rb:81:in `materialize'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/definition.rb:175:in `specs'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/definition.rb:245:in `specs_for'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/runtime.rb:20:in `setup'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler.rb:151:in `setup'
	from /home/yahonda/src/github.com/rsim/oracle-enhanced/spec/spec_helper.rb:6:in `<top (required)>'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/bundler/gems/rails-c28c800803c2/activesupport/lib/active_support/dependencies.rb:332:in `require'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/bundler/gems/rails-c28c800803c2/activesupport/lib/active_support/dependencies.rb:332:in `block in require'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/bundler/gems/rails-c28c800803c2/activesupport/lib/active_support/dependencies.rb:299:in `load_dependency'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/bundler/gems/rails-c28c800803c2/activesupport/lib/active_support/dependencies.rb:332:in `require'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration.rb:2112:in `load_file_handling_errors'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration.rb:1574:in `block in requires='
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration.rb:1574:in `each'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration.rb:1574:in `requires='
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration_options.rb:113:in `block in process_options_into'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration_options.rb:112:in `each'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration_options.rb:112:in `process_options_into'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration_options.rb:22:in `configure'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:132:in `configure'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:99:in `setup'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:86:in `run'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:71:in `run'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:45:in `invoke'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:38:in `perform_at_exit'
	from /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:24:in `block in autorun'
$
```