### PR TITLE
Revert "Require `rspec/autorun` to run one line spec file"

### DIFF
--- a/guides/bug_report_templates/active_record_gem_spec.rb
+++ b/guides/bug_report_templates/active_record_gem_spec.rb
@@ -17,7 +17,7 @@ gemfile(true) do
 end
 
 require "active_record"
-require "rspec/autorun"
+require "rspec"
 require "logger"
 require "active_record/connection_adapters/oracle_enhanced_adapter"
 


### PR DESCRIPTION
Reverts rsim/oracle-enhanced#2098