### PR TITLE
write_lobs fix: handle table with composite primary key

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -250,9 +250,13 @@ module ActiveRecord
 
         # Writes LOB values from attributes for specified columns
         def write_lobs(table_name, klass, attributes, columns) #:nodoc:
-          id_clause = klass.primary_key.map { |key|
-            "#{quote_table_name(table_name)}.#{quote_column_name(key)} = #{quote(attributes[key])}"
-          }.join(' AND ')
+          if klass.primary_key.kind_of?(Array)
+            id_conditions = klass.primary_key.map { |key|
+              "#{quote_table_name(table_name)}.#{quote_column_name(key)} = #{quote(attributes[key])}"
+            }.join(' AND ')
+          else
+            id_conditions = "#{quote_table_name(table_name)}.#{quote_column_name(klass.primary_key)} = #{quote(attributes[klass.primary_key])}"
+          end
 
           columns.each do |col|
             value = attributes[col.name]
@@ -266,7 +270,7 @@ module ActiveRecord
             uncached do
               unless lob_record = select_one(sql = <<~SQL.squish, "Writable Large Object")
                 SELECT #{quote_column_name(col.name)} FROM #{quote_table_name(table_name)}
-                WHERE #{id_clause} FOR UPDATE
+                WHERE #{id_conditions} FOR UPDATE
               SQL
                 raise ActiveRecord::RecordNotFound, "statement #{sql} returned no rows"
               end

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -250,7 +250,10 @@ module ActiveRecord
 
         # Writes LOB values from attributes for specified columns
         def write_lobs(table_name, klass, attributes, columns) #:nodoc:
-          id = quote(attributes[klass.primary_key])
+          id_clause = klass.primary_key.map { |key|
+            "#{quote_table_name(table_name)}.#{quote_column_name(key)} = #{quote(attributes[key])}"
+          }.join(' AND ')
+
           columns.each do |col|
             value = attributes[col.name]
             # changed sequence of next two lines - should check if value is nil before converting to yaml
@@ -263,7 +266,7 @@ module ActiveRecord
             uncached do
               unless lob_record = select_one(sql = <<~SQL.squish, "Writable Large Object")
                 SELECT #{quote_column_name(col.name)} FROM #{quote_table_name(table_name)}
-                WHERE #{quote_column_name(klass.primary_key)} = #{id} FOR UPDATE
+                WHERE #{id_clause} FOR UPDATE
               SQL
                 raise ActiveRecord::RecordNotFound, "statement #{sql} returned no rows"
               end


### PR DESCRIPTION
I ran into this issue trying to update a CLOB attribute in a table with a composite primary key. The SELECT FOR UPDATE statement was just dumping the comma delimited primary key into the where clause:

    WHERE 'column_a,column_b' = "I'm in the mood to help you dude..."

I added a check for an array of primary keys, and if found built the id conditions up.