### PR TITLE
Bump Ruby versions to the latest patch release and remove CI against ruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,11 @@ install:
 
 language: ruby
 rvm:
-  - 2.7.0
-  - 2.6.5
-  - 2.5.7
-  - jruby-9.2.9.0
-  - ruby-head
+  - 3.0.0
+  - 2.7.2
+  - 2.6.6
+  - 2.5.8
+  - jruby-9.2.14.0
   - jruby-head
 
 notifications:


### PR DESCRIPTION
This pull request bumps Ruby versions to the latest patch release and remove CI against ruby-head at release60 branch.