### PR TITLE
Enable `Layout/SpaceBeforeBrackets` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -101,6 +101,10 @@ Layout/SpaceAroundKeyword:
 Layout/SpaceAroundOperators:
   Enabled: true
 
+# This cop has not been enabled at rails/rails
+Layout/SpaceBeforeBrackets:
+  Enabled: true
+
 Layout/SpaceBeforeComma:
   Enabled: true
 

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -492,7 +492,7 @@ module ActiveRecord
         do_not_prefetch = @do_not_prefetch_primary_key[table_name]
         if do_not_prefetch.nil?
           owner, desc_table_name = @connection.describe(table_name)
-          @do_not_prefetch_primary_key [table_name] = do_not_prefetch = !has_primary_key?(table_name, owner, desc_table_name)
+          @do_not_prefetch_primary_key[table_name] = do_not_prefetch = !has_primary_key?(table_name, owner, desc_table_name)
         end
         !do_not_prefetch
       end


### PR DESCRIPTION
This pull request enables `Layout/SpaceBeforeBrackets` cop, which has not been enabled at rails/rails repository. Actually, Rails code does not have any offenses detected by this cop then I have no plan to open a pull request to Rails repository to enable it.

This cop should work with RuboCop 1.8 which includes https://github.com/rubocop-hq/rubocop/pull/9291

```ruby
$ bundle exec rubocop -a
Inspecting 71 files
...........................C...........................................

Offenses:

lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:495:39: C: [Corrected] Layout/SpaceBeforeBrackets: Remove the space before the opening brackets.
          @do_not_prefetch_primary_key [table_name] = do_not_prefetch = !has_primary_key?(table_name, owner, desc_table_name)
                                      ^

71 files inspected, 1 offense detected, 1 offense corrected

Tip: Based on detected gems, the following RuboCop extension libraries might be helpful:
  * rubocop-rake (http://github.com/rubocop-hq/rubocop-rake)
  * rubocop-rspec (http://github.com/rubocop-hq/rubocop-rspec)

You can opt out of this message by adding the following to your config (see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
  AllCops:
    SuggestExtensions: false
$
```
Refer https://github.com/rubocop-hq/rubocop/issues/9305