### PR TITLE
Ensure FKs are properly included in structure dumps

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -55,8 +55,9 @@ module ActiveRecord #:nodoc:
             structure << structure_dump_column_comments(table_name)
           end
 
-          join_with_statement_token(structure) << structure_dump_fk_constraints
-          join_with_statement_token(structure) << structure_dump_views
+          join_with_statement_token(structure) <<
+            structure_dump_fk_constraints <<
+            structure_dump_views
         end
 
         def structure_dump_column(column) #:nodoc:

--- a/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
@@ -66,7 +66,7 @@ describe "OracleEnhancedAdapter structure dump" do
         ALTER TABLE TEST_POSTS
         ADD CONSTRAINT fk_test_post_foo FOREIGN KEY (foo_id) REFERENCES foos(id)
       SQL
-      dump = ActiveRecord::Base.connection.structure_dump_fk_constraints
+      dump = ActiveRecord::Base.connection.structure_dump
       expect(dump.split('\n').length).to eq(1)
       expect(dump).to match(/ALTER TABLE "?TEST_POSTS"? ADD CONSTRAINT "?FK_TEST_POST_FOO"? FOREIGN KEY \("?FOO_ID"?\) REFERENCES "?FOOS"?\("?ID"?\)/i)
     end
@@ -86,7 +86,7 @@ describe "OracleEnhancedAdapter structure dump" do
         ADD CONSTRAINT fk_test_post_baz FOREIGN KEY (baz_id) REFERENCES foos(baz_id)
       SQL
 
-      dump = ActiveRecord::Base.connection.structure_dump_fk_constraints
+      dump = ActiveRecord::Base.connection.structure_dump
       expect(dump.split('\n').length).to eq(1)
       expect(dump).to match(/ALTER TABLE "?TEST_POSTS"? ADD CONSTRAINT "?FK_TEST_POST_BAZ"? FOREIGN KEY \("?BAZ_ID"?\) REFERENCES "?FOOS"?\("?BAZ_ID"?\)/i)
     end


### PR DESCRIPTION
# Issue Summary

FK constraints are mistakenly not being included in SQL structure dumps (`rails db:structure:dump`).

## Issue Details

Due to a bug that I believe was introduced quite a while ago (in #1641, fixing #1625), the DDL describing foreign keys is being discarded in favour of the DDL describing views.

I believe this was missed because the test coverage of the FK dumping tests only the standalone method that does this (`#structure_dump_fk_constraints`), rather than the main `#structure_dump` method.

# PR Details

This PR ensures that both the view DDL and the foreign key DDL gets included when a structure dump is performed, and adjusts the specs accordingly.

## Note on testing

I could only get a limited Oracle enviroment working, but was able to run the appropriate specs:

```
$ bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
==> Loading config from /Users/josh/work/forks/oracle-enhanced/spec/spec_config.yaml
==> Running specs with ruby version 2.6.3

==> Effective ActiveRecord version 6.2.0.alpha
..............................*..

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) OracleEnhancedAdapter structure dump schema migrations multi insert is NOT supported should dump schema migrations one version per insert
     # Not supported in this database version
     # ./spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:376


Finished in 34.71 seconds (files took 1.16 seconds to load)
33 examples, 0 failures, 1 pending
```

Many thanks for all the hard work on this gem! 😃 