### PR TITLE
Remove /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ hint for all_synonyms

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -34,7 +34,7 @@ module ActiveRecord
               table_owner, table_name = default_owner, real_name
             end
             sql = <<~SQL.squish
-              SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ owner, table_name, 'TABLE' name_type
+              SELECT owner, table_name, 'TABLE' name_type
               FROM all_tables
               WHERE owner = '#{table_owner}'
                 AND table_name = '#{table_name}'

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -76,7 +76,7 @@ module ActiveRecord
         # get synonyms for schema dump
         def synonyms
           result = select_all(<<~SQL.squish, "SCHEMA")
-            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ synonym_name, table_owner, table_name
+            SELECT synonym_name, table_owner, table_name
             FROM all_synonyms where owner = SYS_CONTEXT('userenv', 'current_schema')
           SQL
 


### PR DESCRIPTION
Since #2055 added /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ hint to most of the SCHEMA queries and there is a performance regression reported for `OracleEnhanced::Connection#describe` method which performs query to all_synonyms.

Fix #2090