### PR TITLE
structure dump: read column comments from all_tab_cols

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -175,8 +175,9 @@ module ActiveRecord #:nodoc:
         def structure_dump_column_comments(table_name)
           comments = []
           columns = select_values(<<~SQL.squish, "SCHEMA")
-            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ column_name FROM user_tab_columns
-            WHERE table_name = '#{table_name}' ORDER BY column_id
+            SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ column_name FROM all_tab_columns
+            WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
+            AND table_name = '#{table_name}' ORDER BY column_id
           SQL
 
           columns.each do |column|


### PR DESCRIPTION
## Issue Summary

Currently, when dumping column comments, `user_tab_columns` is used. This misses comments which are in the current schema, when the current user is not the owner.

## PR Summary

This PR dumps column comments from `all_tab_cols` instead, filtering `owner` to the `current_schema`. This is in line with the approach taken for the rest of the objects extracting during the structure dump.