### PR TITLE
Usage of bind variables for volatile filter conditions (3)

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -36,25 +36,25 @@ module ActiveRecord
             sql = <<~SQL.squish
               SELECT owner, table_name, 'TABLE' name_type
               FROM all_tables
-              WHERE owner = '#{table_owner}'
-                AND table_name = '#{table_name}'
+              WHERE owner = :table_owner
+                AND table_name = :table_name
               UNION ALL
               SELECT owner, view_name table_name, 'VIEW' name_type
               FROM all_views
-              WHERE owner = '#{table_owner}'
-                AND view_name = '#{table_name}'
+              WHERE owner = :table_owner
+                AND view_name = :table_name
               UNION ALL
               SELECT table_owner, table_name, 'SYNONYM' name_type
               FROM all_synonyms
-              WHERE owner = '#{table_owner}'
-                AND synonym_name = '#{table_name}'
+              WHERE owner = :table_owner
+                AND synonym_name = :table_name
               UNION ALL
               SELECT table_owner, table_name, 'SYNONYM' name_type
               FROM all_synonyms
               WHERE owner = 'PUBLIC'
-                AND synonym_name = '#{real_name}'
+                AND synonym_name = :real_name
             SQL
-            if result = _select_one(sql)
+            if result = _select_one(sql, "CONNECTION", [table_owner, table_name, table_owner, table_name, table_owner, table_name, real_name])
               case result["name_type"]
               when "SYNONYM"
                 describe("#{result['owner'] && "#{result['owner']}."}#{result['table_name']}")
@@ -92,14 +92,23 @@ module ActiveRecord
 
           # Returns a record hash with the column names as keys and column values
           # as values.
+          # binds is a array of native values in contrast to ActiveRecord::Relation::QueryAttribute
           def _select_one(arel, name = nil, binds = [])
-            result = select(arel)
-            result.first if result
+            cursor = prepare(arel)
+            cursor.bind_params(binds)
+            cursor.exec
+            columns = cursor.get_col_names.map do |col_name|
+              _oracle_downcase(col_name)
+            end
+            row = cursor.fetch
+            columns.each_with_index.map { |x, i| [x, row[i]] }.to_h if row
+          ensure
+            cursor.close
           end
 
           # Returns a single value from a record
           def _select_value(arel, name = nil, binds = [])
-            if result = _select_one(arel)
+            if result = _select_one(arel, name, binds)
               result.values.first
             end
           end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -367,12 +367,12 @@ module ActiveRecord
         # Will always query database and not index cache.
         def index_name_exists?(table_name, index_name)
           (_owner, table_name) = @connection.describe(table_name)
-          result = select_value(<<~SQL.squish, "SCHEMA")
+          result = select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name), bind_string("index_name", index_name.to_s.upcase)])
             SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ 1 FROM all_indexes i
             WHERE i.owner = SYS_CONTEXT('userenv', 'current_schema')
                AND i.table_owner = SYS_CONTEXT('userenv', 'current_schema')
-               AND i.table_name = '#{table_name}'
-               AND i.index_name = '#{index_name.to_s.upcase}'
+               AND i.table_name = :table_name
+               AND i.index_name = :index_name
           SQL
           result == 1
         end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -666,7 +666,7 @@ module ActiveRecord
       end
 
       def temporary_table?(table_name) #:nodoc:
-      select_value_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name.upcase)]) == "Y"
+        select_value_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name.upcase)]) == "Y"
           SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */
           temporary FROM all_tables WHERE table_name = :table_name and owner = SYS_CONTEXT('userenv', 'current_schema')
         SQL


### PR DESCRIPTION
Bind variables are used for more volatile columns owner and table name.
For our larger OLTP systems it is essential to run them with cursor_sharing=exact.
In this case dictionary access without bind variables leads to significant longer CI pipeline runtime as well as production load.