### PR TITLE
Use longer identifier for `DatabaseLimits` when using Oracle 12.2 or higher

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -20,14 +20,14 @@ module ActiveRecord
 
         private
           # Used always by JDBC connection as well by OCI connection when describing tables over database link
-          def describe(name)
+          def describe(name, supports_longer_identifier)
             name = name.to_s
             if name.include?("@")
               raise ArgumentError "db link is not supported"
             else
               default_owner = @owner
             end
-            real_name = OracleEnhanced::Quoting.valid_table_name?(name) ? name.upcase : name
+            real_name = OracleEnhanced::Quoting.valid_table_name?(name, supports_longer_identifier) ? name.upcase : name
             if real_name.include?(".")
               table_owner, table_name = real_name.split(".")
             else
@@ -57,7 +57,7 @@ module ActiveRecord
             if result = _select_one(sql, "CONNECTION", [table_owner, table_name, table_owner, table_name, table_owner, table_name, real_name])
               case result["name_type"]
               when "SYNONYM"
-                describe("#{result['owner'] && "#{result['owner']}."}#{result['table_name']}")
+                describe("#{result['owner'] && "#{result['owner']}."}#{result['table_name']}", supports_longer_identifier)
               else
                 [result["owner"], result["table_name"]]
               end

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_limits.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_limits.rb
@@ -6,34 +6,31 @@ module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced
       module DatabaseLimits
-        # maximum length of Oracle identifiers
-        IDENTIFIER_MAX_LENGTH = 30
-
         def table_alias_length #:nodoc:
-          IDENTIFIER_MAX_LENGTH
+          max_identifier_length
         end
 
         # the maximum length of a table name
         def table_name_length
-          IDENTIFIER_MAX_LENGTH
+          max_identifier_length
         end
         deprecate :table_name_length
 
         # the maximum length of a column name
         def column_name_length
-          IDENTIFIER_MAX_LENGTH
+          max_identifier_length
         end
         deprecate :column_name_length
 
         # the maximum length of an index name
         # supported by this database
         def index_name_length
-          IDENTIFIER_MAX_LENGTH
+          max_identifier_length
         end
 
         # the maximum length of a sequence name
         def sequence_name_length
-          IDENTIFIER_MAX_LENGTH
+          max_identifier_length
         end
 
         # To avoid ORA-01795: maximum number of expressions in a list is 1000

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -457,7 +457,7 @@ module ActiveRecord
         end
 
         # To allow private method called from `JDBCConnection`
-        def describe(name)
+        def describe(name, supports_longer_identifier)
           super
         end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -225,7 +225,7 @@ module ActiveRecord
           lob.write value
         end
 
-        def describe(name)
+        def describe(name, supports_longer_identifier)
           super
         end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -491,7 +491,7 @@ module ActiveRecord
         table_name = table_name.to_s
         do_not_prefetch = @do_not_prefetch_primary_key[table_name]
         if do_not_prefetch.nil?
-          owner, desc_table_name = @connection.describe(table_name)
+          owner, desc_table_name = @connection.describe(table_name, supports_longer_identifier?)
           @do_not_prefetch_primary_key[table_name] = do_not_prefetch = !has_primary_key?(table_name, owner, desc_table_name)
         end
         !do_not_prefetch
@@ -560,7 +560,7 @@ module ActiveRecord
       end
 
       def column_definitions(table_name)
-        (owner, desc_table_name) = @connection.describe(table_name)
+        (owner, desc_table_name) = @connection.describe(table_name, supports_longer_identifier?)
 
         select_all(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("table_name", desc_table_name)])
           SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ cols.column_name AS name, cols.data_type AS sql_type,
@@ -592,7 +592,7 @@ module ActiveRecord
       # Find a table's primary key and sequence.
       # *Note*: Only primary key is implemented - sequence will be nil.
       def pk_and_sequence_for(table_name, owner = nil, desc_table_name = nil) #:nodoc:
-        (owner, desc_table_name) = @connection.describe(table_name)
+        (owner, desc_table_name) = @connection.describe(table_name, supports_longer_identifier?)
 
         seqs = select_values_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("sequence_name", default_sequence_name(desc_table_name))])
           select /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ us.sequence_name
@@ -634,7 +634,7 @@ module ActiveRecord
       end
 
       def primary_keys(table_name) # :nodoc:
-        (_owner, desc_table_name) = @connection.describe(table_name)
+        (_owner, desc_table_name) = @connection.describe(table_name, supports_longer_identifier?)
 
         pks = select_values_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("table_name", desc_table_name)])
           SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ cc.column_name

--- a/spec/active_record/connection_adapters/oracle_enhanced/quoting_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/quoting_spec.rb
@@ -64,55 +64,66 @@ describe "OracleEnhancedAdapter quoting" do
   describe "valid table names" do
     before(:all) do
       @adapter = ActiveRecord::ConnectionAdapters::OracleEnhanced::Quoting
+
+      @oracle12cr2_or_higher = !!ActiveRecord::Base.connection.select_value(
+        "select * from product_component_version where product like 'Oracle%' and to_number(substr(version,1,4)) >= 12.2")
     end
 
     it "should be valid with letters and digits" do
-      expect(@adapter.valid_table_name?("abc_123")).to be_truthy
+      expect(@adapter.valid_table_name?("abc_123", @oracle12cr2_or_higher)).to be_truthy
     end
 
     it "should be valid with schema name" do
-      expect(@adapter.valid_table_name?("abc_123.def_456")).to be_truthy
+      expect(@adapter.valid_table_name?("abc_123.def_456", @oracle12cr2_or_higher)).to be_truthy
     end
 
     it "should be valid with schema name and object name in different case" do
-      expect(@adapter.valid_table_name?("TEST_DBA.def_456")).to be_truthy
+      expect(@adapter.valid_table_name?("TEST_DBA.def_456", @oracle12cr2_or_higher)).to be_truthy
     end
 
     it "should be valid with $ in name" do
-      expect(@adapter.valid_table_name?("sys.v$session")).to be_truthy
+      expect(@adapter.valid_table_name?("sys.v$session", @oracle12cr2_or_higher)).to be_truthy
     end
 
     it "should be valid with upcase schema name" do
-      expect(@adapter.valid_table_name?("ABC_123.DEF_456")).to be_truthy
+      expect(@adapter.valid_table_name?("ABC_123.DEF_456", @oracle12cr2_or_higher)).to be_truthy
     end
 
     it "should not be valid with two dots in name" do
-      expect(@adapter.valid_table_name?("abc_123.def_456.ghi_789")).to be_falsey
+      expect(@adapter.valid_table_name?("abc_123.def_456.ghi_789", @oracle12cr2_or_higher)).to be_falsey
     end
 
     it "should not be valid with invalid characters" do
-      expect(@adapter.valid_table_name?("warehouse-things")).to be_falsey
+      expect(@adapter.valid_table_name?("warehouse-things", @oracle12cr2_or_higher)).to be_falsey
     end
 
     it "should not be valid with for camel-case" do
-      expect(@adapter.valid_table_name?("Abc")).to be_falsey
-      expect(@adapter.valid_table_name?("aBc")).to be_falsey
-      expect(@adapter.valid_table_name?("abC")).to be_falsey
+      expect(@adapter.valid_table_name?("Abc", @oracle12cr2_or_higher)).to be_falsey
+      expect(@adapter.valid_table_name?("aBc", @oracle12cr2_or_higher)).to be_falsey
+      expect(@adapter.valid_table_name?("abC", @oracle12cr2_or_higher)).to be_falsey
     end
 
-    it "should not be valid for names > 30 characters" do
-      expect(@adapter.valid_table_name?("a" * 31)).to be_falsey
+    it "should not be valid for names over maximum characters" do
+      if @oracle12cr2_or_higher
+        expect(@adapter.valid_table_name?("a" * 129, @oracle12cr2_or_higher)).to be_falsey
+      else
+        expect(@adapter.valid_table_name?("a" * 31, @oracle12cr2_or_higher)).to be_falsey
+      end
     end
 
-    it "should not be valid for schema names > 30 characters" do
-      expect(@adapter.valid_table_name?(("a" * 31) + ".validname")).to be_falsey
+    it "should not be valid for schema names over maximum characters" do
+      if @oracle12cr2_or_higher
+        expect(@adapter.valid_table_name?(("a" * 129) + ".validname", @oracle12cr2_or_higher)).to be_falsey
+      else
+        expect(@adapter.valid_table_name?(("a" * 31) + ".validname", @oracle12cr2_or_higher)).to be_falsey
+      end
     end
 
     it "should not be valid for names that do not begin with alphabetic characters" do
-      expect(@adapter.valid_table_name?("1abc")).to be_falsey
-      expect(@adapter.valid_table_name?("_abc")).to be_falsey
-      expect(@adapter.valid_table_name?("abc.1xyz")).to be_falsey
-      expect(@adapter.valid_table_name?("abc._xyz")).to be_falsey
+      expect(@adapter.valid_table_name?("1abc", @oracle12cr2_or_higher)).to be_falsey
+      expect(@adapter.valid_table_name?("_abc", @oracle12cr2_or_higher)).to be_falsey
+      expect(@adapter.valid_table_name?("abc.1xyz", @oracle12cr2_or_higher)).to be_falsey
+      expect(@adapter.valid_table_name?("abc._xyz", @oracle12cr2_or_higher)).to be_falsey
     end
   end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -284,9 +284,15 @@ describe "OracleEnhancedAdapter schema definition" do
     end
 
     it "should raise error when new table name length is too long" do
-      expect do
-        @conn.rename_table("test_employees", "a" * 31)
-      end.to raise_error(ArgumentError)
+      if @oracle12cr2_or_higher
+        expect do
+          @conn.rename_table("test_employees", "a" * 129)
+        end.to raise_error(ArgumentError)
+      else
+        expect do
+          @conn.rename_table("test_employees", "a" * 31)
+        end.to raise_error(ArgumentError)
+      end
     end
 
     it "should not raise error when new sequence name length is too long" do


### PR DESCRIPTION
Follow #1703.

Oracle enhanced adapter supports longer identifier by #1703.
I encountered the following error when using `rename_table` in Oracle 12c.

```console
New table name 'identifier_of_thirty_bytes_or_more' is too long; the limit is 30 characters
```

Because `IDENTIFIER_MAX_LENGTH` constant was fixed to 30 bytes.

This PR will use `max_identifier_length` method instead of the constant and accept longer identifier (max 128 bytes) when using Oracle 12.2 or higher.

I encountered the error in Rails 6.0. So I'd like to backport to 6.1 and 6.0 stable branches.