### PR TITLE
Tweak representation of build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
     strategy:
       matrix:
         ruby: [
-          3.0,
-          2.7,
-          2.6,
-          2.5,
+          '3.0',
+          '2.7',
+          '2.6',
+          '2.5',
           jruby,
           jruby-head
         ]


### PR DESCRIPTION
Ruby 3.0 version specification in YAML should be string `'3.0'` instead of float `3.0`. It will be `3` instead of the expected `3.0`.

<img width="949" alt="build-matrix" src="https://user-images.githubusercontent.com/13203/104992903-4de54580-5a65-11eb-9757-c5f446af2afc.png">

Before: `test / build (3)` -> After: `test / build (3.0)`
