### PR TITLE
Configure `continue-on-error: true` to run all CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ jobs:
   build:
 
     runs-on: ubuntu-20.04
+    continue-on-error: true
     strategy:
       matrix:
         ruby: [


### PR DESCRIPTION
This pull request changes to run all jobs even if any one gets failed.
Due to #2118 CI against JRuby has been failing. If any jog gets failed,
other remaining jobs will not run by default.