### PR TITLE
Opt out of `SuggestExtensions` message

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ require:
 AllCops:
   TargetRubyVersion: 2.5
   DisabledByDefault: true
+  SuggestExtensions: false
 
 Rails/IndexBy:
   Enabled: true


### PR DESCRIPTION
Follow https://github.com/rails/rails/commit/458f19a0f7c296a8d01c97a6b86821bceb130327

This PR suppresses the following `SuggestExtensions` message.

```console
% bundle exec rubocop
(snip)

70 files inspected, no offenses detected

Tip: Based on detected gems, the following RuboCop extension libraries
might be helpful:
* rubocop-rake (http://github.com/rubocop-hq/rubocop-rake)
* rubocop-rspec (http://github.com/rubocop-hq/rubocop-rspec)

You can opt out of this message by adding the following to your config (see
https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
AllCops:
  SuggestExtensions: false
```

I think Oracle enhanced adapter will not add its own 3rd party gems because the adapter coding style is based on Rails.