### PR TITLE
`attribute` should not require a connection is established

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -780,8 +780,8 @@ module ActiveRecord
           single_value_from_rows(select_values_forcing_binds(arel, name, binds))
         end
 
-        ActiveRecord::Type.register(:boolean, Type::OracleEnhanced::Boolean, adapter: :oracleenhanced)
-        ActiveRecord::Type.register(:json, Type::OracleEnhanced::Json, adapter: :oracleenhanced)
+        ActiveRecord::Type.register(:boolean, Type::OracleEnhanced::Boolean, adapter: :oracle_enhanced)
+        ActiveRecord::Type.register(:json, Type::OracleEnhanced::Json, adapter: :oracle_enhanced)
     end
   end
 end


### PR DESCRIPTION
Follow https://github.com/rails/rails/pull/41302.

rails/rails#41302 changed the behaviour `adapter_name_from`.

Below are the differences based on that implementation.

## Before

```console
Test3Employee.connection.adapter_name.downcase.to_sym
# => :oracleenhanced
```

## After

```console
Test3Employee.connection_db_config.adapter.to_sym
# => :oracle_enhanced
```

This PR conforms to the new behavior of `adapter_name_from` and
fixes the following build error.

```console
% bundle exec rspec

(snip)

rspec ./spec/active_record/oracle_enhanced/type/boolean_spec.rb:116 #
OracleEnhancedAdapter boolean type detection based on string column
types and names / VARCHAR2 boolean values from ActiveRecord model should
return boolean value from VARCHAR2 boolean column if
emulate_booleans_from_strings is true
rspec ./spec/active_record/oracle_enhanced/type/boolean_spec.rb:141 #
OracleEnhancedAdapter boolean type detection based on string column
types and names / VARCHAR2 boolean values from ActiveRecord model should
return boolean value from VARCHAR2 boolean column if attribute is set to
:boolean
```

https://github.com/rsim/oracle-enhanced/runs/1822500989