### PR TITLE
CI against JRuby 9.2.15.0 on release61 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ rvm:
   - 2.7.2
   - 2.6.6
   - 2.5.8
-  - jruby-9.2.14.0
+  - jruby-9.2.15.0
   - jruby-head
 
 notifications:


### PR DESCRIPTION
- "JRuby 9.2.15.0 Released"
https://www.jruby.org/2021/02/24/jruby-9-2-15-0.html

The current master branch does not support JRuby yet.