### PR TITLE
Address `FrozenError (can't modify frozen Hash):` error

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -98,6 +98,8 @@ module ActiveRecord
               @raw_connection = @raw_connection.underlying_connection
             end
 
+            # Workaround FrozenError (can't modify frozen Hash):
+            config = config.dup
             config[:driver] ||= @raw_connection.meta_data.connection.java_class.name
             username = @raw_connection.meta_data.user_name
           else


### PR DESCRIPTION
This pull request unfreeze config object to workaround the error
with JNDI connection.

As of right now Oracle enhanced adapter master branch does not
support JRuby and no JNDI specs are available this commit does not have
any tests. Instead this change has been verified by the reporter.

Fix #2139