### PR TITLE
Support use of ojdbc11.jar

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -16,7 +16,8 @@ begin
   # Oracle 11g client ojdbc6.jar is also compatible with Java 1.7
   # Oracle 12c Release 1 client provides ojdbc7.jar
   # Oracle 12c Release 2 client provides ojdbc8.jar
-  ojdbc_jars = %w(ojdbc8.jar ojdbc7.jar ojdbc6.jar)
+  # Oracle 21c provides ojdbc11.jar for Java 11 and above
+  ojdbc_jars = %w(ojdbc11.jar ojdbc8.jar ojdbc7.jar ojdbc6.jar)
 
   if !ENV_JAVA["java.class.path"]&.match?(Regexp.new(ojdbc_jars.join("|")))
     # On Unix environment variable should be PATH, on Windows it is sometimes Path


### PR DESCRIPTION
Oracle provides separate JDBC version for Java 11 and above (ojdbc11.jar).

This change allows application start if only ojdbc11.jar is provided.
It forces usage of ojdbc11.jar instead of ojdbc8.jar if Java 11+ is used and ojdbc11.jar available.