### PR TITLE
Add missing default granted permission "ulimited tablespace"

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -227,7 +227,7 @@ module ActiveRecord
       #   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.permissions =
       #   ["create session", "create table", "create view", "create sequence", "create trigger", "ctxapp"]
       cattr_accessor :permissions
-      self.permissions = ["create session", "create table", "create view", "create sequence"]
+      self.permissions = ["unlimited tablespace", "create session", "create table", "create view", "create sequence"]
 
       ##
       # :singleton-method:


### PR DESCRIPTION
The commit 530e4173ee50ca13cd8b69a4c4c5fcb1bb392eb6 introduced the
option to replace the default permissions defined by the adapter
but, mistakenly removed "ulimited tablespace" from the default
list