### PR TITLE
Avoid extra `BindParam` allocation to generate placeholder in queries

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -79,7 +79,7 @@ module ActiveRecord
         # New method in ActiveRecord 3.1
         # Will add RETURNING clause in case of trigger generated primary keys
         def sql_for_insert(sql, pk, binds)
-          unless pk == false || pk.nil? || pk.is_a?(Array)
+          unless pk == false || pk.nil? || pk.is_a?(Array) || pk.is_a?(String)
             sql = "#{sql} RETURNING #{quote_column_name(pk)} INTO :returning_id"
             (binds = binds.dup) << ActiveRecord::Relation::QueryAttribute.new("returning_id", nil, Type::OracleEnhanced::Integer.new)
           end

--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -10,14 +10,11 @@ module ActiveRecord
 
         def quote_column_name(name) #:nodoc:
           name = name.to_s
-          self.class.quoted_column_names[name] ||= begin
-            # if only valid lowercase column characters in name
-            if /\A[a-z][a-z_0-9$#]*\Z/.match?(name)
-              "\"#{name.upcase}\""
-            else
-              # remove double quotes which cannot be used inside quoted identifier
-              "\"#{name.gsub('"', '')}\""
-            end
+          self.class.quoted_column_names[name] ||= if /\A[a-z][a-z_0-9$#]*\Z/.match?(name)
+            "\"#{name.upcase}\""
+          else
+            # remove double quotes which cannot be used inside quoted identifier
+            "\"#{name.gsub('"', '')}\""
           end
         end
 

--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -192,6 +192,10 @@ module Arel # :nodoc: all
           array
         end
 
+        def visit_ActiveModel_Attribute(o, collector)
+          collector.add_bind(o) { |i| ":a#{i}" }
+        end
+
         def visit_Arel_Nodes_BindParam(o, collector)
           collector.add_bind(o.value) { |i| ":a#{i}" }
         end

--- a/lib/arel/visitors/oracle12.rb
+++ b/lib/arel/visitors/oracle12.rb
@@ -99,6 +99,10 @@ module Arel # :nodoc: all
           super
         end
 
+        def visit_ActiveModel_Attribute(o, collector)
+          collector.add_bind(o) { |i| ":a#{i}" }
+        end
+
         def visit_Arel_Nodes_BindParam(o, collector)
           collector.add_bind(o.value) { |i| ":a#{i}" }
         end


### PR DESCRIPTION
Resolves https://github.com/rsim/oracle-enhanced/issues/2152 and follow https://github.com/rails/rails/pull/41577.

The tests that fail below have not yet been resolved.
https://github.com/rails/rails/commit/6ee96a8f42d6b13bffd46342248f447d9f289288.