### PR TITLE
Address undefined method `to_i' for #<ActiveModel::Attribute::WithCastValue

### DIFF
--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -28,7 +28,7 @@ module Arel # :nodoc: all
 
             collector = super(o, collector)
 
-            if offset.expr.is_a? Nodes::BindParam
+            if offset.expr.type.is_a? ActiveModel::Type::Value
               collector << ") raw_sql_ WHERE rownum <= ("
               collector = visit offset.expr, collector
               collector << " + "
@@ -38,7 +38,7 @@ module Arel # :nodoc: all
               return collector
             else
               collector << ") raw_sql_
-                  WHERE rownum <= #{offset.expr.to_i + limit}
+                  WHERE rownum <= #{offset.expr.value_before_type_cast + limit.value_before_type_cast}
                 )
                 WHERE "
               return visit(offset, collector)


### PR DESCRIPTION
Address undefined method `to_i' for #<ActiveModel::Attribute::WithCastValue

```ruby
$ bundle exec rspec ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:404
==> Loading config from ENV or use default
==> Running specs with ruby version 3.0.1
==> Effective ActiveRecord version 7.0.0.alpha
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb"=>[404]}}
F

Failures:

  1) OracleEnhancedAdapter using offset and limit should return the records starting from offset n with offset(n)
     Failure/Error:
       collector << ") raw_sql_
           WHERE rownum <= #{offset.expr.to_i + limit}

     NoMethodError:
       undefined method `to_i' for #<ActiveModel::Attribute::WithCastValue:0x0000560c802ff318 @name="OFFSET", @value_before_type_cast=0, @type=#<ActiveModel::Type::Value:0x0000560c7f3a8b58 @precision=nil, @scale=nil, @limit=nil>, @original_attribute=nil>
       Did you mean?  to_s
     # ./lib/arel/visitors/oracle.rb:41:in `visit_Arel_Nodes_SelectStatement'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/arel/visitors/visitor.rb:30:in `visit'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/arel/visitors/visitor.rb:11:in `accept'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/arel/visitors/to_sql.rb:18:in `compile'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:28:in `to_sql_and_binds'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:64:in `select_all'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:110:in `select_all'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/querying.rb:51:in `_query_by_sql'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/relation.rb:929:in `block in exec_main_query'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/relation.rb:951:in `skip_query_cache_if_necessary'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/relation.rb:915:in `exec_main_query'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/relation.rb:901:in `block in exec_queries'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/relation.rb:951:in `skip_query_cache_if_necessary'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/relation.rb:895:in `exec_queries'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/relation.rb:685:in `load'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/relation.rb:255:in `records'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/relation.rb:250:in `to_ary'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/relation/finder_methods.rb:562:in `find_nth_with_limit'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/relation/finder_methods.rb:547:in `find_nth'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/relation/finder_methods.rb:148:in `first'
     # ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:406:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:262:in `instance_exec'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:262:in `block in run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:508:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:465:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:486:in `block in run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:624:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:486:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:465:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:508:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:259:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:644:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:640:in `map'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:640:in `run_examples'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:606:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:607:in `block in run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:607:in `map'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:607:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `map'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration.rb:2067:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:116:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/reporter.rb:74:in `report'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:115:in `run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:89:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/rspec:23:in `load'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/rspec:23:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `load'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `kernel_load'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli/exec.rb:28:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli.rb:494:in `exec'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli.rb:30:in `dispatch'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli.rb:24:in `start'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.15/libexec/bundle:49:in `block in <top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/friendly_errors.rb:130:in `with_friendly_errors'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.15/libexec/bundle:37:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/bundle:23:in `load'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/bundle:23:in `<main>'

Finished in 1.49 seconds (files took 0.4446 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:404 # OracleEnhancedAdapter using offset and limit should return the records starting from offset n with offset(n)

$
```

Fix #2158
Related rails/rails#41577
Refer https://github.com/rails/rails/commit/7669dc21967