### PR TITLE
Prevent from including ojdbc8.jar file to gem file

### DIFF
--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rake"
+
 version = File.read(File.expand_path("../VERSION", __FILE__)).strip
 
 Gem::Specification.new do |s|
@@ -17,7 +19,7 @@ This adapter is superset of original ActiveRecord Oracle adapter.
   s.extra_rdoc_files = [
     "README.md"
   ]
-  s.files = Dir["History.md", "License.txt", "README.md", "VERSION", "lib/**/*"]
+  s.files = FileList["History.md", "License.txt", "README.md", "VERSION", "lib/**/*"].exclude("lib/ojdbc*.jar")
   s.homepage = "http://github.com/rsim/oracle-enhanced"
   s.require_paths = ["lib"]
   s.summary = "Oracle enhanced adapter for ActiveRecord"


### PR DESCRIPTION
Fix #2163

- Without this change - ojdbc8.jar file is included in the gem file.

```
$ cp /usr/lib/oracle/19.8/client64/lib/ojdbc8.jar lib/.
$ bundle exec rake build
activerecord-oracle_enhanced-adapter 7.0.0.alpha built to pkg/activerecord-oracle_enhanced-adapter-7.0.0.alpha.gem.
$ ls -lh pkg/activerecord-oracle_enhanced-adapter-7.0.0.alpha.gem
-rw-rw-r-- 1 yahonda yahonda 4.0M Apr  1 12:14 pkg/activerecord-oracle_enhanced-adapter-7.0.0.alpha.gem
cd pkg
$ gem unpack activerecord-oracle_enhanced-adapter-7.0.0.alpha.gem
Unpacked gem: '/home/yahonda/src/github.com/rsim/oracle-enhanced/pkg/activerecord-oracle_enhanced-adapter-7.0.0.alpha'
$ ls -l activerecord-oracle_enhanced-adapter-7.0.0.alpha/lib/
total 4252
drwxrwxr-x 4 yahonda yahonda    4096 Apr  1 12:14 active_record
-rw-rw-r-- 1 yahonda yahonda     442 Apr  1 12:14 activerecord-oracle_enhanced-adapter.rb
drwxrwxr-x 3 yahonda yahonda    4096 Apr  1 12:14 arel
-rw-r--r-- 1 yahonda yahonda 4340768 Apr  1 12:14 ojdbc8.jar
$
```

- With this change - ojdbc8.jar file is not included in the gem file.

```
$ cp /usr/lib/oracle/19.8/client64/lib/ojdbc8.jar lib/.
$ bundle exec rake build
activerecord-oracle_enhanced-adapter 7.0.0.alpha built to pkg/activerecord-oracle_enhanced-adapter-7.0.0.alpha.gem.
$ ls -lh pkg/activerecord-oracle_enhanced-adapter-7.0.0.alpha.gem
-rw-rw-r-- 1 yahonda yahonda 116K Apr  1 12:22 pkg/activerecord-oracle_enhanced-adapter-7.0.0.alpha.gem
$ cd pkg
$ gem unpack activerecord-oracle_enhanced-adapter-7.0.0.alpha.gem
Unpacked gem: '/home/yahonda/src/github.com/rsim/oracle-enhanced/pkg/activerecord-oracle_enhanced-adapter-7.0.0.alpha'
$ ls -l activerecord-oracle_enhanced-adapter-7.0.0.alpha/lib/
total 12
drwxrwxr-x 4 yahonda yahonda 4096 Apr  1 12:23 active_record
-rw-rw-r-- 1 yahonda yahonda  442 Apr  1 12:23 activerecord-oracle_enhanced-adapter.rb
drwxrwxr-x 3 yahonda yahonda 4096 Apr  1 12:23 arel
$
```