### PR TITLE
Allow-failure CI against jruby-head for release61 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,5 +45,8 @@ rvm:
   - jruby-9.2.15.0
   - jruby-head
 
+matrix:
+  allow_failures:
+  - rvm: jruby-head
 notifications:
     email: false


### PR DESCRIPTION
Related to #2118 .