### PR TITLE
CI against JRuby 9.2.17.0 at release61 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ rvm:
   - 2.7.2
   - 2.6.6
   - 2.5.8
-  - jruby-9.2.15.0
+  - jruby-9.2.17.0
   - jruby-head
 
 matrix:


### PR DESCRIPTION
https://www.jruby.org/2021/03/29/jruby-9-2-17-0.html