### PR TITLE
CI against Ruby 3.0.1 and 2.7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,8 @@ script:
 
 language: ruby
 rvm:
-  - 3.0.0
-  - 2.7.2
+  - 3.0.1
+  - 2.7.3
   - ruby-head
   # Rails 7.0 requires Ruby 2.7 or higeher.
   # CI pending until JRuby 9.4 that supports Ruby 2.7 will be released.


### PR DESCRIPTION
- Ruby 3.0.1 Released
https://www.ruby-lang.org/en/news/2021/04/05/ruby-3-0-1-released/

- Ruby 2.7.3 Released
https://www.ruby-lang.org/en/news/2021/04/05/ruby-2-7-3-released/