### PR TITLE
get root cause if something went wrong with jdbc.OracleDriver

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -42,9 +42,9 @@ begin
     java.lang.System.set_property("oracle.net.tns_admin", ENV["TNS_ADMIN"])
   end
 
-rescue LoadError, NameError
+rescue LoadError, NameError => e
   # JDBC driver is unavailable.
-  raise LoadError, "ERROR: ActiveRecord oracle_enhanced adapter could not load Oracle JDBC driver. Please install #{ojdbc_jars.join(' or ') } library."
+  raise LoadError, "ERROR: ActiveRecord oracle_enhanced adapter could not load Oracle JDBC driver. Please install #{ojdbc_jars.join(' or ') } library.\n#{e.class}:#{e.message}"
 end
 
 module ActiveRecord


### PR DESCRIPTION
The original exception cause is hidden up to now if there's an exception while loading JDBC driver

For example providing ojdbc11.jar for Java 1.8 leads to the following error even if a JDBC driver file is provided:

NameError:cannot link Java class oracle.jdbc.OracleDriver oracle/jdbc/OracleDriver has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0