### PR TITLE
Address "NoMethodError: undefined method `partial_writes?'"

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
@@ -150,7 +150,7 @@ module ActiveRecord #:nodoc:
               end
             end
             # update just dirty attributes
-            if partial_writes?
+            if partial_updates?
               # Serialized attributes should always be written in case they've been
               # changed in place.
               update_using_custom_method(changed | (attributes.keys & self.class.columns.select { |column| column.is_a?(Type::Serialized) }))


### PR DESCRIPTION
This commit addresses the following failures since rails/rails#42355 .
`DEPRECATION WARNING` have not been fixed yet.

```ruby
$ bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb
==> Loading config from ENV or use default
==> Running specs with ruby version 3.0.1
==> Effective ActiveRecord version 7.0.0.alpha
..FFDEPRECATION WARNING: `ActiveRecord::Base.partial_writes=` is deprecated and will be removed in Rails 7.1. Use `partial_updates=` and `partial_inserts=` instead. (called from block (2 levels) in <top (required)> at /home/yahonda/src/github.com/rsim/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb:214)
FDEPRECATION WARNING: `ActiveRecord::Base.partial_writes=` is deprecated and will be removed in Rails 7.1. Use `partial_updates=` and `partial_inserts=` instead. (called from block (2 levels) in <top (required)> at /home/yahonda/src/github.com/rsim/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb:227)
F....F.DEPRECATION WARNING: `ActiveRecord::Base.partial_writes=` is deprecated and will be removed in Rails 7.1. Use `partial_updates=` and `partial_inserts=` instead. (called from block (2 levels) in <top (required)> at /home/yahonda/src/github.com/rsim/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb:319)
F...

Failures:

  1) OracleEnhancedAdapter custom methods for create, update and destroy should update record
     Failure/Error: if partial_writes?

     NoMethodError:
       undefined method `partial_writes?' for #<TestEmployee id: 3, first_name: "Second", last_name: "Last", hire_date: "2008-06-28", salary: nil, description: "First Last", version: 1, create_time: "2021-06-16", update_time: "2021-06-16", created_at: nil, updated_at: "2021-06-16 13:25:56.171290000 +0000">
       Did you mean?  partial_updates?
     # /home/yahonda/src/github.com/rails/rails/activemodel/lib/active_model/attribute_methods.rb:521:in `method_missing'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:153:in `block in _update_record'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:107:in `run_callbacks'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:141:in `_update_record'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/persistence.rb:957:in `create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/callbacks.rb:457:in `block in create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:99:in `run_callbacks'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:834:in `_run_save_callbacks'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/callbacks.rb:457:in `create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/timestamp.rb:126:in `create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/persistence.rb:540:in `save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/validations.rb:53:in `save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:302:in `block in save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:354:in `block in with_transaction_returning_status'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:316:in `block in transaction'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:310:in `block in within_new_transaction'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:26:in `block (2 levels) in synchronize'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:308:in `within_new_transaction'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:316:in `transaction'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:350:in `with_transaction_returning_status'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:302:in `save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/suppressor.rb:48:in `save!'
     # ./spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb:190:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:262:in `instance_exec'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:262:in `block in run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:508:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:465:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:486:in `block in run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:624:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:486:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:465:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:508:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:259:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:644:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:640:in `map'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:640:in `run_examples'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:606:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `map'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration.rb:2067:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:116:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/reporter.rb:74:in `report'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:115:in `run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:89:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/rspec:23:in `load'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/rspec:23:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `load'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `kernel_load'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli/exec.rb:28:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli.rb:494:in `exec'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli.rb:30:in `dispatch'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli.rb:24:in `start'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.15/libexec/bundle:49:in `block in <top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/friendly_errors.rb:130:in `with_friendly_errors'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.15/libexec/bundle:37:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/bundle:23:in `load'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/bundle:23:in `<main>'

  2) OracleEnhancedAdapter custom methods for create, update and destroy should rollback record when exception is raised in after_update callback
     Failure/Error:
       expect {
         @employee.save
       }.to raise_error("Make the transaction rollback")

       expected Exception with "Make the transaction rollback", got #<NoMethodError: undefined method `partial_writes?' for #<TestEmployee id: 4, first_name: "Second", l...created_at: nil, updated_at: "2021-06-16 13:25:56.603411000 +0000">
       Did you mean?  partial_updates?> with backtrace:
         # /home/yahonda/src/github.com/rails/rails/activemodel/lib/active_model/attribute_methods.rb:521:in `method_missing'
         # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:153:in `block in _update_record'
         # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:107:in `run_callbacks'
         # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:141:in `_update_record'
         # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/persistence.rb:957:in `create_or_update'
         # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/callbacks.rb:457:in `block in create_or_update'
         # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:99:in `run_callbacks'
         # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:834:in `_run_save_callbacks'
         # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/callbacks.rb:457:in `create_or_update'
         # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/timestamp.rb:126:in `create_or_update'
         # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/persistence.rb:507:in `save'
         # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/validations.rb:47:in `save'
         # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:298:in `block in save'
         # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:354:in `block in with_transaction_returning_status'
         # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:316:in `block in transaction'
         # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:310:in `block in within_new_transaction'
         # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:26:in `block (2 levels) in synchronize'
         # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt'
         # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize'
         # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt'
         # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize'
         # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:308:in `within_new_transaction'
         # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:316:in `transaction'
         # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:350:in `with_transaction_returning_status'
         # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:298:in `save'
         # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/suppressor.rb:44:in `save'
         # ./spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb:207:in `block (3 levels) in <top (required)>'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-expectations-3.10.1/lib/rspec/matchers/built_in/raise_error.rb:59:in `matches?'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-expectations-3.10.1/lib/rspec/expectations/handler.rb:51:in `block in handle_matcher'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-expectations-3.10.1/lib/rspec/expectations/handler.rb:27:in `with_matcher'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-expectations-3.10.1/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-expectations-3.10.1/lib/rspec/expectations/expectation_target.rb:65:in `to'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-expectations-3.10.1/lib/rspec/expectations/expectation_target.rb:101:in `to'
         # ./spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb:206:in `block (2 levels) in <top (required)>'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:262:in `instance_exec'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:262:in `block in run'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:508:in `block in with_around_and_singleton_context_hooks'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:465:in `block in with_around_example_hooks'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:486:in `block in run'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:624:in `run_around_example_hooks_for'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:486:in `run'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:465:in `with_around_example_hooks'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:508:in `with_around_and_singleton_context_hooks'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:259:in `run'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:644:in `block in run_examples'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:640:in `map'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:640:in `run_examples'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:606:in `run'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `block (3 levels) in run_specs'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `map'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `block (2 levels) in run_specs'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration.rb:2067:in `with_suite_hooks'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:116:in `block in run_specs'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/reporter.rb:74:in `report'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:115:in `run_specs'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:89:in `run'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:71:in `run'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:45:in `invoke'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/exe/rspec:4:in `<top (required)>'
         # /home/yahonda/.rbenv/versions/3.0.1/bin/rspec:23:in `load'
         # /home/yahonda/.rbenv/versions/3.0.1/bin/rspec:23:in `<top (required)>'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `load'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `kernel_load'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli/exec.rb:28:in `run'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli.rb:494:in `exec'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli.rb:30:in `dispatch'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli.rb:24:in `start'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.15/libexec/bundle:49:in `block in <top (required)>'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/friendly_errors.rb:130:in `with_friendly_errors'
         # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.15/libexec/bundle:37:in `<top (required)>'
         # /home/yahonda/.rbenv/versions/3.0.1/bin/bundle:23:in `load'
         # /home/yahonda/.rbenv/versions/3.0.1/bin/bundle:23:in `<main>'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-support-3.10.2/lib/rspec/support.rb:102:in `block in <module:Support>'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-support-3.10.2/lib/rspec/support.rb:111:in `notify_failure'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-expectations-3.10.1/lib/rspec/expectations/fail_with.rb:35:in `fail_with'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-expectations-3.10.1/lib/rspec/expectations/handler.rb:40:in `handle_failure'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-expectations-3.10.1/lib/rspec/expectations/handler.rb:56:in `block in handle_matcher'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-expectations-3.10.1/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-expectations-3.10.1/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-expectations-3.10.1/lib/rspec/expectations/expectation_target.rb:65:in `to'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-expectations-3.10.1/lib/rspec/expectations/expectation_target.rb:101:in `to'
     # ./spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb:206:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:262:in `instance_exec'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:262:in `block in run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:508:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:465:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:486:in `block in run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:624:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:486:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:465:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:508:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:259:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:644:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:640:in `map'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:640:in `run_examples'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:606:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `map'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration.rb:2067:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:116:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/reporter.rb:74:in `report'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:115:in `run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:89:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/rspec:23:in `load'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/rspec:23:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `load'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `kernel_load'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli/exec.rb:28:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli.rb:494:in `exec'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli.rb:30:in `dispatch'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli.rb:24:in `start'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.15/libexec/bundle:49:in `block in <top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/friendly_errors.rb:130:in `with_friendly_errors'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.15/libexec/bundle:37:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/bundle:23:in `load'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/bundle:23:in `<main>'

  3) OracleEnhancedAdapter custom methods for create, update and destroy should not update record if nothing is changed and partial writes are enabled
     Failure/Error: if partial_writes?

     NoMethodError:
       undefined method `partial_writes?' for #<TestEmployee id: 5, first_name: "First", last_name: "Last", hire_date: "2008-06-28", salary: nil, description: "First Last", version: 1, create_time: "2021-06-16", update_time: "2021-06-16", created_at: nil, updated_at: nil>
       Did you mean?  partial_updates?
     # /home/yahonda/src/github.com/rails/rails/activemodel/lib/active_model/attribute_methods.rb:521:in `method_missing'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:153:in `block in _update_record'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:107:in `run_callbacks'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:141:in `_update_record'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/persistence.rb:957:in `create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/callbacks.rb:457:in `block in create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:99:in `run_callbacks'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:834:in `_run_save_callbacks'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/callbacks.rb:457:in `create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/timestamp.rb:126:in `create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/persistence.rb:540:in `save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/validations.rb:53:in `save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:302:in `block in save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:354:in `block in with_transaction_returning_status'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:316:in `block in transaction'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:310:in `block in within_new_transaction'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:26:in `block (2 levels) in synchronize'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:308:in `within_new_transaction'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:316:in `transaction'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:350:in `with_transaction_returning_status'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:302:in `save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/suppressor.rb:48:in `save!'
     # ./spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb:221:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:262:in `instance_exec'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:262:in `block in run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:508:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:465:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:486:in `block in run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:624:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:486:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:465:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:508:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:259:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:644:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:640:in `map'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:640:in `run_examples'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:606:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `map'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration.rb:2067:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:116:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/reporter.rb:74:in `report'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:115:in `run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:89:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/rspec:23:in `load'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/rspec:23:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `load'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `kernel_load'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli/exec.rb:28:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli.rb:494:in `exec'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli.rb:30:in `dispatch'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli.rb:24:in `start'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.15/libexec/bundle:49:in `block in <top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/friendly_errors.rb:130:in `with_friendly_errors'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.15/libexec/bundle:37:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/bundle:23:in `load'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/bundle:23:in `<main>'

  4) OracleEnhancedAdapter custom methods for create, update and destroy should update record if nothing is changed and partial writes are disabled
     Failure/Error: if partial_writes?

     NoMethodError:
       undefined method `partial_writes?' for #<TestEmployee id: 6, first_name: "First", last_name: "Last", hire_date: "2008-06-28", salary: nil, description: "First Last", version: 1, create_time: "2021-06-16", update_time: "2021-06-16", created_at: nil, updated_at: "2021-06-16 13:25:57.492278000 +0000">
       Did you mean?  partial_updates?
     # /home/yahonda/src/github.com/rails/rails/activemodel/lib/active_model/attribute_methods.rb:521:in `method_missing'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:153:in `block in _update_record'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:107:in `run_callbacks'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:141:in `_update_record'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/persistence.rb:957:in `create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/callbacks.rb:457:in `block in create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:99:in `run_callbacks'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:834:in `_run_save_callbacks'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/callbacks.rb:457:in `create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/timestamp.rb:126:in `create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/persistence.rb:540:in `save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/validations.rb:53:in `save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:302:in `block in save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:354:in `block in with_transaction_returning_status'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:316:in `block in transaction'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:310:in `block in within_new_transaction'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:26:in `block (2 levels) in synchronize'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:308:in `within_new_transaction'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:316:in `transaction'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:350:in `with_transaction_returning_status'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:302:in `save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/suppressor.rb:48:in `save!'
     # ./spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb:234:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:262:in `instance_exec'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:262:in `block in run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:508:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:465:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:486:in `block in run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:624:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:486:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:465:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:508:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:259:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:644:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:640:in `map'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:640:in `run_examples'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:606:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `map'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration.rb:2067:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:116:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/reporter.rb:74:in `report'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:115:in `run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:89:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/rspec:23:in `load'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/rspec:23:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `load'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `kernel_load'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli/exec.rb:28:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli.rb:494:in `exec'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli.rb:30:in `dispatch'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli.rb:24:in `start'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.15/libexec/bundle:49:in `block in <top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/friendly_errors.rb:130:in `with_friendly_errors'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.15/libexec/bundle:37:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/bundle:23:in `load'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/bundle:23:in `<main>'

  5) OracleEnhancedAdapter custom methods for create, update and destroy should set timestamps when updating record
     Failure/Error: if partial_writes?

     NoMethodError:
       undefined method `partial_writes?' for #<TestEmployee id: 11, first_name: "Second", last_name: "Last", hire_date: "2008-06-28", salary: nil, description: "First Last", version: 1, create_time: "2021-06-16", update_time: "2021-06-16", created_at: nil, updated_at: "2021-06-16 13:25:59.854422000 +0000">
       Did you mean?  partial_updates?
     # /home/yahonda/src/github.com/rails/rails/activemodel/lib/active_model/attribute_methods.rb:521:in `method_missing'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:153:in `block in _update_record'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:107:in `run_callbacks'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:141:in `_update_record'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/persistence.rb:957:in `create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/callbacks.rb:457:in `block in create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:99:in `run_callbacks'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:834:in `_run_save_callbacks'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/callbacks.rb:457:in `create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/timestamp.rb:126:in `create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/persistence.rb:540:in `save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/validations.rb:53:in `save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:302:in `block in save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:354:in `block in with_transaction_returning_status'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:316:in `block in transaction'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:310:in `block in within_new_transaction'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:26:in `block (2 levels) in synchronize'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:308:in `within_new_transaction'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:316:in `transaction'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:350:in `with_transaction_returning_status'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:302:in `save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/suppressor.rb:48:in `save!'
     # ./spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb:302:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:262:in `instance_exec'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:262:in `block in run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:508:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:465:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:486:in `block in run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:624:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:486:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:465:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:508:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:259:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:644:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:640:in `map'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:640:in `run_examples'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:606:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `map'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration.rb:2067:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:116:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/reporter.rb:74:in `report'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:115:in `run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:89:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/rspec:23:in `load'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/rspec:23:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `load'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `kernel_load'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli/exec.rb:28:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli.rb:494:in `exec'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli.rb:30:in `dispatch'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli.rb:24:in `start'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.15/libexec/bundle:49:in `block in <top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/friendly_errors.rb:130:in `with_friendly_errors'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.15/libexec/bundle:37:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/bundle:23:in `load'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/bundle:23:in `<main>'

  6) OracleEnhancedAdapter custom methods for create, update and destroy should log update record
     Failure/Error: if partial_writes?

     NoMethodError:
       undefined method `partial_writes?' for #<TestEmployee id: 13, first_name: "First", last_name: "Last", hire_date: "2008-06-28", salary: nil, description: nil, version: nil, create_time: nil, update_time: nil, created_at: "2021-06-16 13:26:00.713252000 +0000", updated_at: "2021-06-16 13:26:00.713252000 +0000">
       Did you mean?  partial_updates?
     # /home/yahonda/src/github.com/rails/rails/activemodel/lib/active_model/attribute_methods.rb:521:in `method_missing'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:153:in `block in _update_record'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:107:in `run_callbacks'
     # ./lib/active_record/connection_adapters/oracle_enhanced/procedures.rb:141:in `_update_record'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/persistence.rb:957:in `create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/callbacks.rb:457:in `block in create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:99:in `run_callbacks'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:834:in `_run_save_callbacks'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/callbacks.rb:457:in `create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/timestamp.rb:126:in `create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/persistence.rb:540:in `save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/validations.rb:53:in `save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:302:in `block in save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:354:in `block in with_transaction_returning_status'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:316:in `block in transaction'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:310:in `block in within_new_transaction'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:26:in `block (2 levels) in synchronize'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:308:in `within_new_transaction'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:316:in `transaction'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:350:in `with_transaction_returning_status'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:302:in `save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/suppressor.rb:48:in `save!'
     # ./spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb:326:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:262:in `instance_exec'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:262:in `block in run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:508:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:465:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:486:in `block in run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:624:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:486:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:465:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:508:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:259:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:644:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:640:in `map'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:640:in `run_examples'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:606:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `map'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration.rb:2067:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:116:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/reporter.rb:74:in `report'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:115:in `run_specs'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:89:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/rspec:23:in `load'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/rspec:23:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `load'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `kernel_load'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli/exec.rb:28:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli.rb:494:in `exec'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli.rb:30:in `dispatch'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/cli.rb:24:in `start'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.15/libexec/bundle:49:in `block in <top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/friendly_errors.rb:130:in `with_friendly_errors'
     # /home/yahonda/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.15/libexec/bundle:37:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/bundle:23:in `load'
     # /home/yahonda/.rbenv/versions/3.0.1/bin/bundle:23:in `<main>'

Finished in 7.87 seconds (files took 0.4069 seconds to load)
16 examples, 6 failures

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb:181 # OracleEnhancedAdapter custom methods for create, update and destroy should update record
rspec ./spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb:195 # OracleEnhancedAdapter custom methods for create, update and destroy should rollback record when exception is raised in after_update callback
rspec ./spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb:213 # OracleEnhancedAdapter custom methods for create, update and destroy should not update record if nothing is changed and partial writes are enabled
rspec ./spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb:226 # OracleEnhancedAdapter custom methods for create, update and destroy should update record if nothing is changed and partial writes are disabled
rspec ./spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb:292 # OracleEnhancedAdapter custom methods for create, update and destroy should set timestamps when updating record
rspec ./spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb:31…