### PR TITLE
CI against JRuby 9.2.19.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ rvm:
   - 2.7.2
   - 2.6.6
   - 2.5.8
-  - jruby-9.2.17.0
+  - jruby-9.2.19.0
   - jruby-head
 
 matrix:


### PR DESCRIPTION
* JRuby 9.2.19.0 Released
https://www.jruby.org/2021/06/15/jruby-9-2-19-0.html