### PR TITLE
Enable `Layout/ClosingParenthesisIndentation` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,9 @@ Layout/CaseIndentation:
 Layout/ClosingHeredocIndentation:
   Enabled: true
 
+Layout/ClosingParenthesisIndentation:
+  Enabled: true
+
 # Align comments with method definitions.
 Layout/CommentIndentation:
   Enabled: true

--- a/lib/active_record/connection_adapters/oracle_enhanced/context_index.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/context_index.rb
@@ -153,14 +153,14 @@ module ActiveRecord
                 (p_rowid IN	      ROWID,
                 p_clob	IN OUT NOCOPY CLOB) IS
                 -- add_context_index_parameters #{(column_names + select_queries).inspect}#{!options.empty? ? +', ' << options.inspect[1..-2] : ''}
-                #{
+              #{
                 selected_columns.map do |cols|
                   cols.map do |col|
                     raise ArgumentError, "Alias #{col} too large, should be 28 or less characters long" unless col.length <= 28
                     "l_#{col} VARCHAR2(32767);\n"
                   end.join
                 end.join
-                } BEGIN
+              } BEGIN
                 FOR r1 IN (
                   SELECT #{quoted_column_names.join(', ')}
                   FROM	 #{quoted_table_name}
@@ -194,7 +194,7 @@ module ActiveRecord
                       "DBMS_LOB.WRITEAPPEND(p_clob, #{col.length + 3}, '</#{col}>');\n"
                     end.join)
                   end.join)
-                  }
+                }
                 END LOOP;
               END;
             SQL

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -669,7 +669,7 @@ module ActiveRecord
                              type_metadata,
                              field["nullable"] == "Y",
                              comment: field["column_comment"]
-                      )
+            )
           end
 
           def fetch_type_metadata(sql_type, virtual = nil)


### PR DESCRIPTION
This pull request enables `Layout/ClosingParenthesisIndentation` cop.

```ruby
$ bundle exec rubocop
Inspecting 70 files
........C..............C..............................................

Offenses:

lib/active_record/connection_adapters/oracle_enhanced/context_index.rb:163:17: C: [Correctable] Layout/ClosingParenthesisIndentation: Indent ) to column 14 (not 16)
                } BEGIN
                ^
lib/active_record/connection_adapters/oracle_enhanced/context_index.rb:197:19: C: [Correctable] Layout/ClosingParenthesisIndentation: Indent ) to column 16 (not 18)
                  }
                  ^
lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:672:23: C: [Correctable] Layout/ClosingParenthesisIndentation: Indent ) to column 12 (not 22)
                      )
                      ^

70 files inspected, 3 offenses detected, 3 offenses auto-correctable
```

Refer https://github.com/rails/rails/commit/d7fce6c996221630cac425c219ce988092fc3405
https://github.com/rubocop/rubocop/blame/master/relnotes/v1.18.0.md#L11