### PR TITLE
Suppress DEPRECATION WARNING by setting ActiveRecord::Base.destroy_all_in_batches = true

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb
@@ -185,6 +185,8 @@ describe "OracleEnhancedAdapter context index" do
 
   describe "on multiple tables" do
     before(:all) do
+      @old_destroy_all_in_batches = ActiveRecord::Base.destroy_all_in_batches
+      ActiveRecord::Base.destroy_all_in_batches = true
       @conn = ActiveRecord::Base.connection
       create_tables
       class ::Post < ActiveRecord::Base
@@ -201,6 +203,7 @@ describe "OracleEnhancedAdapter context index" do
       Object.send(:remove_const, "Comment")
       Object.send(:remove_const, "Post")
       ActiveRecord::Base.clear_cache!
+      ActiveRecord::Base.destroy_all_in_batches = @old_destroy_all_in_batches
     end
 
     after(:each) do


### PR DESCRIPTION
This pull request suppresses these deprecation warnings.

```ruby
$ bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb
==> Loading config from ENV or use default
==> Running specs with ruby version 3.0.1
==> Effective ActiveRecord version 7.0.0.alpha
..........DEPRECATION WARNING: As of Rails 7.1, destroy_all will no longer return the collection of objects that were destroyed. To transition to the new behaviour set the following in an initializer: Rails.application.config.active_record.destroy_all_in_batches = true (called from block (3 levels) in <top (required)> at /home/yahonda/src/github.com/rsim/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb:209)
.DEPRECATION WARNING: As of Rails 7.1, destroy_all will no longer return the collection of objects that were destroyed. To transition to the new behaviour set the following in an initializer: Rails.application.config.active_record.destroy_all_in_batches = true (called from block (3 levels) in <top (required)> at /home/yahonda/src/github.com/rsim/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb:209)
.DEPRECATION WARNING: As of Rails 7.1, destroy_all will no longer return the collection of objects that were destroyed. To transition to the new behaviour set the following in an initializer: Rails.application.config.active_record.destroy_all_in_batches = true (called from block (3 levels) in <top (required)> at /home/yahonda/src/github.com/rsim/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb:209)
...........

Finished in 32.32 seconds (files took 0.40705 seconds to load)
23 examples, 0 failures

$
```

Refer rails/rails#40445