### PR TITLE
CI against Ruby 3.0.2 and 2.7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,8 @@ script:
 
 language: ruby
 rvm:
-  - 3.0.1
-  - 2.7.3
+  - 3.0.2
+  - 2.7.4
   - ruby-head
   # Rails 7.0 requires Ruby 2.7 or higeher.
   # CI pending until JRuby 9.4 that supports Ruby 2.7 will be released.


### PR DESCRIPTION
These Rubies have been released.

- https://www.ruby-lang.org/en/news/2021/07/07/ruby-3-0-2-released/
- https://www.ruby-lang.org/en/news/2021/07/07/ruby-2-7-4-released/