### PR TITLE
Suppress RuboCop's offense

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -1122,13 +1122,13 @@ end
 
     before(:each) do
       @conn.instance_variable_set :@would_execute_sql, @would_execute_sql = +""
-      class <<@conn
+      class << @conn
         def execute(sql, name = nil); @would_execute_sql << sql << ";\n"; end
       end
     end
 
     after(:each) do
-      class <<@conn
+      class << @conn
         remove_method :execute
       end
       @conn.instance_eval { remove_instance_variable :@would_execute_sql }


### PR DESCRIPTION
Follow up to https://github.com/rubocop/rubocop/pull/9910.

This PR suppresses and corrects the following RuboCop's offense.

```console
% bundle exec rubocop -a
Inspecting 70 files
..................................................C...................

Offenses:

spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb:1125:13:
C: [Corrected] Layout/SpaceAroundOperators: Surrounding space missing for operator <<.
class <<@conn
      ^^
spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb:1131:13:
C: [Corrected] Layout/SpaceAroundOperators: Surrounding space missing for operator <<.
class <<@conn
      ^^

70 files inspected, 2 offenses detected, 2 offenses corrected
```