### PR TITLE
Define adapter type maps statically when possible

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,8 @@ jobs:
           '2.7'
         ]
     env:
-      ORACLE_HOME: /usr/lib/oracle/18.5/client64
-      LD_LIBRARY_PATH: /usr/lib/oracle/18.5/client64/lib
+      ORACLE_HOME: /usr/lib/oracle/21/client64
+      LD_LIBRARY_PATH: /usr/lib/oracle/21/client64/lib
       NLS_LANG: AMERICAN_AMERICA.AL32UTF8
       TNS_ADMIN: ./ci/network/admin
       DATABASE_NAME: XEPDB1
@@ -57,14 +57,14 @@ jobs:
         sudo apt-get install alien
     - name: Download Oracle client
       run: |
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/185000/oracle-instantclient18.5-basic-18.5.0.0.0-3.x86_64.rpm
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/185000/oracle-instantclient18.5-sqlplus-18.5.0.0.0-3.x86_64.rpm
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/185000/oracle-instantclient18.5-devel-18.5.0.0.0-3.x86_64.rpm
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/214000/oracle-instantclient-basic-21.4.0.0.0-1.x86_64.rpm
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/214000/oracle-instantclient-sqlplus-21.4.0.0.0-1.x86_64.rpm
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/214000/oracle-instantclient-devel-21.4.0.0.0-1.x86_64.rpm
     - name: Install Oracle client
       run: |
-        sudo alien -i oracle-instantclient18.5-basic-18.5.0.0.0-3.x86_64.rpm
-        sudo alien -i oracle-instantclient18.5-sqlplus-18.5.0.0.0-3.x86_64.rpm
-        sudo alien -i oracle-instantclient18.5-devel-18.5.0.0.0-3.x86_64.rpm
+        sudo alien -i oracle-instantclient-basic-21.4.0.0.0-1.x86_64.rpm
+        sudo alien -i oracle-instantclient-sqlplus-21.4.0.0.0-1.x86_64.rpm
+        sudo alien -i oracle-instantclient-devel-21.4.0.0.0-1.x86_64.rpm
     - name: Install JDBC Driver
       run: |
         wget -q https://download.oracle.com/otn-pub/otn_software/jdbc/211/ojdbc11.jar -O ./lib/ojdbc11.jar

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -13,11 +13,6 @@ module ActiveRecord
           log(sql, name, async: async) { @connection.exec(sql) }
         end
 
-        def clear_cache! # :nodoc:
-          reload_type_map
-          super
-        end
-
         def exec_query(sql, name = "SQL", binds = [], prepare: false, async: false)
           type_casted_binds = type_casted_binds(binds)
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_quoting.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced
       module JDBCQuoting
-        def _type_cast(value)
+        def type_cast(value)
           case value
           when ActiveModel::Type::Binary::Data
             blob = Java::OracleSql::BLOB.createTemporary(@connection.raw_connection, false, Java::OracleSql::BLOB::DURATION_SESSION)

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_quoting.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced
       module OCIQuoting
-        def _type_cast(value)
+        def type_cast(value)
           case value
           when ActiveModel::Type::Binary::Data
             lob_value = value == "" ? " " : value

--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -111,7 +111,7 @@ module ActiveRecord
           "0"
         end
 
-        def _type_cast(value)
+        def type_cast(value)
           case value
           when Type::OracleEnhanced::TimestampTz::Data, Type::OracleEnhanced::TimestampLtz::Data
             if value.acts_like?(:time)

--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -74,7 +74,7 @@ module ActiveRecord
           s.gsub(/'/, "''")
         end
 
-        def _quote(value) # :nodoc:
+        def quote(value) # :nodoc:
           case value
           when Type::OracleEnhanced::CharacterString::Data then
             "'#{quote_string(value.to_s)}'"


### PR DESCRIPTION
This pull request supports  `Define adapter type maps statically when possible` https://github.com/rails/rails/pull/42773 in Active Record Oracle enhanced adapter. 

Also, to make CI green this pull request needs these additional commits.
* Use Oracle Instant Client 21.4
* Rename `_quote` to `quote`
* Rename `_type_cast` to `type_cast`
