### PR TITLE
all attributes serialized before writing

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -255,11 +255,9 @@ module ActiveRecord
             value = attributes[col.name]
             # changed sequence of next two lines - should check if value is nil before converting to yaml
             next unless value
-            if klass.attribute_types[col.name].is_a? Type::Serialized
-              value = klass.attribute_types[col.name].serialize(value)
-              # value can be nil after serialization because ActiveRecord serializes [] and {} as nil
-              next unless value
-            end
+            value = klass.attribute_types[col.name].serialize(value)
+            # value can be nil after serialization because ActiveRecord serializes [] and {} as nil
+            next unless value
             uncached do
               unless lob_record = select_one(sql = <<~SQL.squish, "Writable Large Object")
                 SELECT #{quote_column_name(col.name)} FROM #{quote_table_name(table_name)}

--- a/spec/active_record/oracle_enhanced/type/custom_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/custom_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+describe "OracleEnhancedAdapter custom types handling" do
+  include SchemaSpecHelper
+
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    schema_define do
+      create_table :test_employees, force: true do |t|
+        t.string    :first_name,  limit: 20
+        t.string    :last_name,   limit: 25
+        t.text      :signature
+      end
+    end
+
+    class TestEmployee < ActiveRecord::Base
+      class AttributeSignature < ActiveRecord::Type::Text
+        def cast(value)
+          case value
+          when Signature
+            value
+          when nil
+            nil
+          else
+            Signature.new(Base64.decode64 value)
+          end
+        end
+
+        def serialize(value)
+          Base64.encode64 value.raw
+        end
+
+        def changed_in_place?(raw_old_value, new_value)
+          new_value != cast(raw_old_value)
+        end
+      end
+
+      class Signature
+        attr_reader :raw
+
+        def initialize(raw_value)
+          @raw = raw_value
+        end
+
+        def to_s
+          "Signature nice string #{raw[0..5]}"
+        end
+
+        def ==(object)
+          raw == object&.raw
+        end
+        alias eql? ==
+      end
+
+      attribute :signature, AttributeSignature.new
+    end
+  end
+
+  after(:all) do
+    schema_define do
+      drop_table :test_employees
+    end
+    Object.send(:remove_const, "TestEmployee")
+    ActiveRecord::Base.clear_cache!
+  end
+
+  it "should serialize LOBs when creating a record" do
+    raw_signature = "peter'ssignature"
+    signature = TestEmployee::Signature.new(raw_signature)
+    @employee = TestEmployee.create!(first_name: "Peter", last_name: "Doe", signature: signature)
+    @employee.reload
+    expect(@employee.signature).to eql(signature)
+    expect(@employee.signature).to_not be(signature)
+    expect(TestEmployee.first.read_attribute_before_type_cast(:signature)).to eq(Base64.encode64 raw_signature)
+  end
+
+  it "should serialize LOBs when updating a record" do
+    raw_signature = "peter'ssignature"
+    signature = TestEmployee::Signature.new(raw_signature)
+    @employee = TestEmployee.create!(first_name: "Peter", last_name: "Doe", signature: TestEmployee::Signature.new("old signature"))
+    @employee.signature = signature
+    @employee.save!
+    @employee.reload
+    expect(@employee.signature).to eql(signature)
+    expect(@employee.signature).to_not be(signature)
+    expect(TestEmployee.first.read_attribute_before_type_cast(:signature)).to eq(Base64.encode64 raw_signature)
+  end
+end


### PR DESCRIPTION
As described in #2200, presently only `ActiveRecord::Type::Serialized`
attributes are serialized before being written to database by `#write_lobs`.

It was introduced with 75ed13e6a7c42024ff4d57642a1a06f2bdfedc99

Any other attributes are just converted to string by `value.to_s`.

My understanding is that all attributes should go through standard serialization regardless their type. Especially any custom attributes.
Otherwise instead of writing whatever serialized form of attribute is, database record would become `"#<MyCustomAttributeType:0x000000000bdb6590>\",\"whaever garbage...` or some other string representation that was not intended to end up inside the database.

With this update all attributes get serilized in the standard way.

/fixes #2200