### PR TITLE
Support RuboCop 1.19.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -34,4 +34,4 @@ jobs:
     - name: Build and run RuboCop
       run: |
         bundle install --jobs 4 --retry 3
-        bundle exec rubocop --parallel
+        bundle exec rubocop

--- a/lib/active_record/connection_adapters/emulation/oracle_adapter.rb
+++ b/lib/active_record/connection_adapters/emulation/oracle_adapter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ActiveRecord::ConnectionAdapters::OracleAdapter < ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter #:nodoc:
+class ActiveRecord::ConnectionAdapters::OracleAdapter < ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter # :nodoc:
   def adapter_name
     "Oracle"
   end

--- a/lib/active_record/connection_adapters/oracle_enhanced/column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 module ActiveRecord
-  module ConnectionAdapters #:nodoc:
+  module ConnectionAdapters # :nodoc:
     module OracleEnhanced
       class Column < ActiveRecord::ConnectionAdapters::Column
         delegate :virtual, to: :sql_type_metadata, allow_nil: true
 
-        def initialize(name, default, sql_type_metadata = nil, null = true, comment: nil) #:nodoc:
+        def initialize(name, default, sql_type_metadata = nil, null = true, comment: nil) # :nodoc:
           super(name, default, sql_type_metadata, null, comment: comment)
         end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   module ConnectionAdapters
     # interface independent methods
     module OracleEnhanced
-      class Connection #:nodoc:
+      class Connection # :nodoc:
         def self.create(config)
           case ORACLE_ENHANCED_CONNECTION
           when :oci
@@ -118,7 +118,7 @@ module ActiveRecord
       def database_version
         raise NoMethodError, "Not implemented for this raw driver"
       end
-      class ConnectionException < StandardError #:nodoc:
+      class ConnectionException < StandardError # :nodoc:
       end
     end
   end

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_limits.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_limits.rb
@@ -9,7 +9,7 @@ module ActiveRecord
         # maximum length of Oracle identifiers
         IDENTIFIER_MAX_LENGTH = 30
 
-        def table_alias_length #:nodoc:
+        def table_alias_length # :nodoc:
           IDENTIFIER_MAX_LENGTH
         end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -164,7 +164,7 @@ module ActiveRecord
 
         alias :exec_delete :exec_update
 
-        def begin_db_transaction #:nodoc:
+        def begin_db_transaction # :nodoc:
           @connection.autocommit = false
         end
 
@@ -183,27 +183,27 @@ module ActiveRecord
           execute "SET TRANSACTION ISOLATION LEVEL  #{transaction_isolation_levels.fetch(isolation)}"
         end
 
-        def commit_db_transaction #:nodoc:
+        def commit_db_transaction # :nodoc:
           @connection.commit
         ensure
           @connection.autocommit = true
         end
 
-        def exec_rollback_db_transaction #:nodoc:
+        def exec_rollback_db_transaction # :nodoc:
           @connection.rollback
         ensure
           @connection.autocommit = true
         end
 
-        def create_savepoint(name = current_savepoint_name) #:nodoc:
+        def create_savepoint(name = current_savepoint_name) # :nodoc:
           execute("SAVEPOINT #{name}", "TRANSACTION")
         end
 
-        def exec_rollback_to_savepoint(name = current_savepoint_name) #:nodoc:
+        def exec_rollback_to_savepoint(name = current_savepoint_name) # :nodoc:
           execute("ROLLBACK TO #{name}", "TRANSACTION")
         end
 
-        def release_savepoint(name = current_savepoint_name) #:nodoc:
+        def release_savepoint(name = current_savepoint_name) # :nodoc:
           # there is no RELEASE SAVEPOINT statement in Oracle
         end
 
@@ -214,7 +214,7 @@ module ActiveRecord
         end
 
         # Inserts the given fixture into the table. Overridden to properly handle lobs.
-        def insert_fixture(fixture, table_name) #:nodoc:
+        def insert_fixture(fixture, table_name) # :nodoc:
           super
 
           if ActiveRecord::Base.pluralize_table_names
@@ -249,7 +249,7 @@ module ActiveRecord
         end
 
         # Writes LOB values from attributes for specified columns
-        def write_lobs(table_name, klass, attributes, columns) #:nodoc:
+        def write_lobs(table_name, klass, attributes, columns) # :nodoc:
           id = quote(attributes[klass.primary_key])
           columns.each do |col|
             value = attributes[col.name]

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -52,7 +52,7 @@ module ActiveRecord
   module ConnectionAdapters
     # JDBC database interface for JRuby
     module OracleEnhanced
-      class JDBCConnection < OracleEnhanced::Connection #:nodoc:
+      class JDBCConnection < OracleEnhanced::Connection # :nodoc:
         attr_accessor :active
         alias :active? :active
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/lob.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/lob.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-module ActiveRecord #:nodoc:
-  module ConnectionAdapters #:nodoc:
-    module OracleEnhanced #:nodoc:
-      module Lob #:nodoc:
+module ActiveRecord # :nodoc:
+  module ConnectionAdapters # :nodoc:
+    module OracleEnhanced # :nodoc:
+      module Lob # :nodoc:
         extend ActiveSupport::Concern
 
         included do

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -26,7 +26,7 @@ module ActiveRecord
   module ConnectionAdapters
     # OCI database interface for MRI
     module OracleEnhanced
-      class OCIConnection < OracleEnhanced::Connection #:nodoc:
+      class OCIConnection < OracleEnhanced::Connection # :nodoc:
         def initialize(config)
           @raw_connection = OCI8EnhancedAutoRecover.new(config, OracleEnhancedOCIFactory)
           # default schema owner
@@ -299,7 +299,7 @@ module ActiveRecord
 
       # The OracleEnhancedOCIFactory factors out the code necessary to connect and
       # configure an Oracle/OCI connection.
-      class OracleEnhancedOCIFactory #:nodoc:
+      class OracleEnhancedOCIFactory # :nodoc:
         DEFAULT_TCP_KEEPALIVE_TIME = 600
 
         def self.new_connection(config)
@@ -375,18 +375,18 @@ end
 # this would be dangerous (as the earlier part of the implied transaction
 # may have failed silently if the connection died) -- so instead the
 # connection is marked as dead, to be reconnected on it's next use.
-#:stopdoc:
-class OCI8EnhancedAutoRecover < DelegateClass(OCI8) #:nodoc:
-  attr_accessor :active #:nodoc:
-  alias :active? :active #:nodoc:
+# :stopdoc:
+class OCI8EnhancedAutoRecover < DelegateClass(OCI8) # :nodoc:
+  attr_accessor :active # :nodoc:
+  alias :active? :active # :nodoc:
 
   cattr_accessor :auto_retry
   class << self
-    alias :auto_retry? :auto_retry #:nodoc:
+    alias :auto_retry? :auto_retry # :nodoc:
   end
   @@auto_retry = false
 
-  def initialize(config, factory) #:nodoc:
+  def initialize(config, factory) # :nodoc:
     @active = true
     @config = config
     @factory = factory
@@ -397,7 +397,7 @@ class OCI8EnhancedAutoRecover < DelegateClass(OCI8) #:nodoc:
   # Checks connection, returns true if active. Note that ping actively
   # checks the connection, while #active? simply returns the last
   # known state.
-  def ping #:nodoc:
+  def ping # :nodoc:
     @connection.exec("select 1 from dual") { |r| nil }
     @active = true
   rescue
@@ -406,7 +406,7 @@ class OCI8EnhancedAutoRecover < DelegateClass(OCI8) #:nodoc:
   end
 
   # Resets connection, by logging off and creating a new connection.
-  def reset! #:nodoc:
+  def reset! # :nodoc:
     logoff rescue nil
     begin
       @connection = @factory.new_connection @config
@@ -423,10 +423,10 @@ class OCI8EnhancedAutoRecover < DelegateClass(OCI8) #:nodoc:
   # ORA-03113: end-of-file on communication channel
   # ORA-03114: not connected to ORACLE
   # ORA-03135: connection lost contact
-  LOST_CONNECTION_ERROR_CODES = [ 28, 1012, 3113, 3114, 3135 ] #:nodoc:
+  LOST_CONNECTION_ERROR_CODES = [ 28, 1012, 3113, 3114, 3135 ] # :nodoc:
 
   # Adds auto-recovery functionality.
-  def with_retry #:nodoc:
+  def with_retry # :nodoc:
     should_retry = self.class.auto_retry? && autocommit?
 
     begin
@@ -441,8 +441,8 @@ class OCI8EnhancedAutoRecover < DelegateClass(OCI8) #:nodoc:
     end
   end
 
-  def exec(sql, *bindvars, &block) #:nodoc:
+  def exec(sql, *bindvars, &block) # :nodoc:
     with_retry { @connection.exec(sql, *bindvars, &block) }
   end
 end
-#:startdoc:
+# :startdoc:

--- a/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
@@ -2,7 +2,7 @@
 
 require "active_support"
 
-module ActiveRecord #:nodoc:
+module ActiveRecord # :nodoc:
   # Custom create, update, delete methods functionality.
   #
   # Example:
@@ -33,7 +33,7 @@ module ActiveRecord #:nodoc:
   #     end
   #   end
   #
-  module OracleEnhancedProcedures #:nodoc:
+  module OracleEnhancedProcedures # :nodoc:
     module ClassMethods
       # Specify custom create method which should be used instead of Rails generated INSERT statement.
       # Provided block should return ID of new record.
@@ -83,7 +83,7 @@ module ActiveRecord #:nodoc:
       end
     end
 
-    def destroy #:nodoc:
+    def destroy # :nodoc:
       # check if class has custom delete method
       if self.class.custom_delete_method
         # wrap destroy in transaction

--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -8,7 +8,7 @@ module ActiveRecord
         #
         # see: abstract/quoting.rb
 
-        def quote_column_name(name) #:nodoc:
+        def quote_column_name(name) # :nodoc:
           name = name.to_s
           self.class.quoted_column_names[name] ||= if /\A[a-z][a-z_0-9$#]*\Z/.match?(name)
             "\"#{name.upcase}\""
@@ -20,7 +20,7 @@ module ActiveRecord
 
         # This method is used in add_index to identify either column name (which is quoted)
         # or function based index (in which case function expression is not quoted)
-        def quote_column_name_or_expression(name) #:nodoc:
+        def quote_column_name_or_expression(name) # :nodoc:
           name = name.to_s
           case name
           # if only valid lowercase column characters in name
@@ -55,7 +55,7 @@ module ActiveRecord
         # contain letters, digits, _, $ or #
         # can be prefixed with schema name
         # CamelCase table names should be quoted
-        def self.valid_table_name?(name) #:nodoc:
+        def self.valid_table_name?(name) # :nodoc:
           object_name = name.to_s
           !!(object_name =~ VALID_TABLE_NAME && !mixed_case?(object_name))
         end
@@ -65,16 +65,16 @@ module ActiveRecord
           !!(object_name =~ /[A-Z]/ && object_name =~ /[a-z]/)
         end
 
-        def quote_table_name(name) #:nodoc:
+        def quote_table_name(name) # :nodoc:
           name, _link = name.to_s.split("@")
           self.class.quoted_table_names[name] ||= [name.split(".").map { |n| quote_column_name(n) }].join(".")
         end
 
-        def quote_string(s) #:nodoc:
+        def quote_string(s) # :nodoc:
           s.gsub(/'/, "''")
         end
 
-        def _quote(value) #:nodoc:
+        def _quote(value) # :nodoc:
           case value
           when Type::OracleEnhanced::CharacterString::Data then
             "'#{quote_string(value.to_s)}'"
@@ -91,22 +91,22 @@ module ActiveRecord
           end
         end
 
-        def quoted_true #:nodoc:
+        def quoted_true # :nodoc:
           return "'Y'" if emulate_booleans_from_strings
           "1"
         end
 
-        def unquoted_true #:nodoc:
+        def unquoted_true # :nodoc:
           return "Y" if emulate_booleans_from_strings
           "1"
         end
 
-        def quoted_false #:nodoc:
+        def quoted_false # :nodoc:
           return "'N'" if emulate_booleans_from_strings
           "0"
         end
 
-        def unquoted_false #:nodoc:
+        def unquoted_false # :nodoc:
           return "N" if emulate_booleans_from_strings
           "0"
         end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -35,7 +35,7 @@ module ActiveRecord
         end
       end
 
-      class SynonymDefinition < Struct.new(:name, :table_owner, :table_name) #:nodoc:
+      class SynonymDefinition < Struct.new(:name, :table_owner, :table_name) # :nodoc:
       end
 
       class IndexDefinition < ActiveRecord::ConnectionAdapters::IndexDefinition

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-module ActiveRecord #:nodoc:
-  module ConnectionAdapters #:nodoc:
-    module OracleEnhanced #:nodoc:
-      class SchemaDumper < ConnectionAdapters::SchemaDumper #:nodoc:
+module ActiveRecord # :nodoc:
+  module ConnectionAdapters # :nodoc:
+    module OracleEnhanced # :nodoc:
+      class SchemaDumper < ConnectionAdapters::SchemaDumper # :nodoc:
         DEFAULT_PRIMARY_KEY_COLUMN_SPEC = { precision: "38", null: "false" }.freeze
         private_constant :DEFAULT_PRIMARY_KEY_COLUMN_SPEC
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -10,7 +10,7 @@ module ActiveRecord
         #
         # see: abstract/schema_statements.rb
 
-        def tables #:nodoc:
+        def tables # :nodoc:
           select_values(<<~SQL.squish, "SCHEMA")
             SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */
             DECODE(table_name, UPPER(table_name), LOWER(table_name), table_name)
@@ -66,7 +66,7 @@ module ActiveRecord
           SQL
         end
 
-        def materialized_views #:nodoc:
+        def materialized_views # :nodoc:
           select_values(<<~SQL.squish, "SCHEMA")
             SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */
             LOWER(mview_name) FROM all_mviews WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
@@ -86,7 +86,7 @@ module ActiveRecord
            end
         end
 
-        def indexes(table_name) #:nodoc:
+        def indexes(table_name) # :nodoc:
           (_owner, table_name) = @connection.describe(table_name)
           default_tablespace_name = default_tablespace
 
@@ -252,7 +252,7 @@ module ActiveRecord
           rebuild_primary_key_index_to_default_tablespace(table_name, options)
         end
 
-        def rename_table(table_name, new_name) #:nodoc:
+        def rename_table(table_name, new_name) # :nodoc:
           if new_name.to_s.length > DatabaseLimits::IDENTIFIER_MAX_LENGTH
             raise ArgumentError, "New table name '#{new_name}' is too long; the limit is #{DatabaseLimits::IDENTIFIER_MAX_LENGTH} characters"
           end
@@ -264,7 +264,7 @@ module ActiveRecord
           rename_table_indexes(table_name, new_name)
         end
 
-        def drop_table(table_name, **options) #:nodoc:
+        def drop_table(table_name, **options) # :nodoc:
           schema_cache.clear_data_source_cache!(table_name.to_s)
           execute "DROP TABLE #{quote_table_name(table_name)}#{' CASCADE CONSTRAINTS' if options[:force] == :cascade}"
           seq_name = options[:sequence_name] || default_sequence_name(table_name)
@@ -295,7 +295,7 @@ module ActiveRecord
           end
         end
 
-        def add_index(table_name, column_name, **options) #:nodoc:
+        def add_index(table_name, column_name, **options) # :nodoc:
           index_name, index_type, quoted_column_names, tablespace, index_options = add_index_options(table_name, column_name, **options)
           execute "CREATE #{index_type} INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} (#{quoted_column_names})#{tablespace} #{index_options}"
           if index_type == "UNIQUE"
@@ -305,7 +305,7 @@ module ActiveRecord
           end
         end
 
-        def add_index_options(table_name, column_name, comment: nil, **options) #:nodoc:
+        def add_index_options(table_name, column_name, comment: nil, **options) # :nodoc:
           column_names = Array(column_name)
           index_name   = index_name(table_name, column: column_names)
 
@@ -329,7 +329,7 @@ module ActiveRecord
 
         # Remove the given index from the table.
         # Gives warning if index does not exist
-        def remove_index(table_name, column_name = nil, **options) #:nodoc:
+        def remove_index(table_name, column_name = nil, **options) # :nodoc:
           index_name = index_name_for_remove(table_name, column_name, options)
           # TODO: It should execute only when index_type == "UNIQUE"
           execute "ALTER TABLE #{quote_table_name(table_name)} DROP CONSTRAINT #{quote_column_name(index_name)}" rescue nil
@@ -337,7 +337,7 @@ module ActiveRecord
         end
 
         # returned shortened index name if default is too large
-        def index_name(table_name, options) #:nodoc:
+        def index_name(table_name, options) # :nodoc:
           default_name = super(table_name, options).to_s
           # sometimes options can be String or Array with column names
           options = {} unless options.is_a?(Hash)
@@ -377,7 +377,7 @@ module ActiveRecord
           result == 1
         end
 
-        def rename_index(table_name, old_name, new_name) #:nodoc:
+        def rename_index(table_name, old_name, new_name) # :nodoc:
           validate_index_length!(table_name, new_name)
           execute "ALTER INDEX #{quote_column_name(old_name)} rename to #{quote_column_name(new_name)}"
         end
@@ -412,7 +412,7 @@ module ActiveRecord
           OracleEnhanced::ReferenceDefinition.new(ref_name, **options).add_to(update_table_definition(table_name, self))
         end
 
-        def add_column(table_name, column_name, type, **options) #:nodoc:
+        def add_column(table_name, column_name, type, **options) # :nodoc:
           type = aliased_types(type.to_s, type)
           at = create_alter_table table_name
           at.add_column(column_name, type, **options)
@@ -429,14 +429,14 @@ module ActiveRecord
           fallback
         end
 
-        def change_column_default(table_name, column_name, default_or_changes) #:nodoc:
+        def change_column_default(table_name, column_name, default_or_changes) # :nodoc:
           default = extract_new_default_value(default_or_changes)
           execute "ALTER TABLE #{quote_table_name(table_name)} MODIFY #{quote_column_name(column_name)} DEFAULT #{quote(default)}"
         ensure
           clear_table_columns_cache(table_name)
         end
 
-        def change_column_null(table_name, column_name, null, default = nil) #:nodoc:
+        def change_column_null(table_name, column_name, null, default = nil) # :nodoc:
           column = column_for(table_name, column_name)
 
           unless null || default.nil?
@@ -446,7 +446,7 @@ module ActiveRecord
           change_column table_name, column_name, column.sql_type, null: null
         end
 
-        def change_column(table_name, column_name, type, **options) #:nodoc:
+        def change_column(table_name, column_name, type, **options) # :nodoc:
           column = column_for(table_name, column_name)
 
           # remove :null option if its value is the same as current column definition
@@ -470,14 +470,14 @@ module ActiveRecord
           clear_table_columns_cache(table_name)
         end
 
-        def rename_column(table_name, column_name, new_column_name) #:nodoc:
+        def rename_column(table_name, column_name, new_column_name) # :nodoc:
           execute "ALTER TABLE #{quote_table_name(table_name)} RENAME COLUMN #{quote_column_name(column_name)} to #{quote_column_name(new_column_name)}"
           rename_column_indexes(table_name, column_name, new_column_name)
         ensure
           clear_table_columns_cache(table_name)
         end
 
-        def remove_column(table_name, column_name, type = nil, options = {}) #:nodoc:
+        def remove_column(table_name, column_name, type = nil, options = {}) # :nodoc:
           execute "ALTER TABLE #{quote_table_name(table_name)} DROP COLUMN #{quote_column_name(column_name)} CASCADE CONSTRAINTS"
         ensure
           clear_table_columns_cache(table_name)
@@ -507,7 +507,7 @@ module ActiveRecord
           execute "COMMENT ON COLUMN #{quote_table_name(table_name)}.#{quote_column_name(column_name)} IS '#{comment}'"
         end
 
-        def table_comment(table_name) #:nodoc:
+        def table_comment(table_name) # :nodoc:
           # TODO
           (_owner, table_name) = @connection.describe(table_name)
           select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name)])
@@ -523,7 +523,7 @@ module ActiveRecord
           end
         end
 
-        def column_comment(table_name, column_name) #:nodoc:
+        def column_comment(table_name, column_name) # :nodoc:
           # TODO: it  does not exist in Abstract adapter
           (_owner, table_name) = @connection.describe(table_name)
           select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name), bind_string("column_name", column_name.upcase)])
@@ -535,7 +535,7 @@ module ActiveRecord
         end
 
         # Maps logical Rails types to Oracle-specific data types.
-        def type_to_sql(type, limit: nil, precision: nil, scale: nil, **) #:nodoc:
+        def type_to_sql(type, limit: nil, precision: nil, scale: nil, **) # :nodoc:
           # Ignore options for :text, :ntext and :binary columns
           return super(type) if ["text", "ntext", "binary"].include?(type.to_s)
 
@@ -552,7 +552,7 @@ module ActiveRecord
         end
 
         # get table foreign keys for schema dump
-        def foreign_keys(table_name) #:nodoc:
+        def foreign_keys(table_name) # :nodoc:
           (_owner, desc_table_name) = @connection.describe(table_name)
 
           fk_info = select_all(<<~SQL.squish, "SCHEMA", [bind_string("desc_table_name", desc_table_name)])
@@ -596,7 +596,7 @@ module ActiveRecord
 
         # REFERENTIAL INTEGRITY ====================================
 
-        def disable_referential_integrity(&block) #:nodoc:
+        def disable_referential_integrity(&block) # :nodoc:
           old_constraints = select_all(<<~SQL.squish, "SCHEMA")
             SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ constraint_name, owner, table_name
               FROM all_constraints

--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-module ActiveRecord #:nodoc:
-  module ConnectionAdapters #:nodoc:
-    module OracleEnhanced #:nodoc:
-      module StructureDump #:nodoc:
+module ActiveRecord # :nodoc:
+  module ConnectionAdapters # :nodoc:
+    module OracleEnhanced # :nodoc:
+      module StructureDump # :nodoc:
         # Statements separator used in structure dump to allow loading of structure dump also with SQL*Plus
         STATEMENT_TOKEN = "\n\n/\n\n"
 
-        def structure_dump #:nodoc:
+        def structure_dump # :nodoc:
           sequences = select(<<~SQL.squish, "SCHEMA")
             SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */
             sequence_name, min_value, max_value, increment_by, order_flag, cycle_flag
@@ -60,7 +60,7 @@ module ActiveRecord #:nodoc:
             structure_dump_views
         end
 
-        def structure_dump_column(column) #:nodoc:
+        def structure_dump_column(column) # :nodoc:
           col = +"\"#{column['column_name']}\" #{column['data_type']}"
           if (column["data_type"] == "NUMBER") && !column["data_precision"].nil?
             col << "(#{column['data_precision'].to_i}"
@@ -75,7 +75,7 @@ module ActiveRecord #:nodoc:
           col
         end
 
-        def structure_dump_virtual_column(column, data_default) #:nodoc:
+        def structure_dump_virtual_column(column, data_default) # :nodoc:
           data_default = data_default.delete('"')
           col = +"\"#{column['column_name']}\" #{column['data_type']}"
           if (column["data_type"] == "NUMBER") && !column["data_precision"].nil?
@@ -89,7 +89,7 @@ module ActiveRecord #:nodoc:
           col << " GENERATED ALWAYS AS (#{data_default}) VIRTUAL"
         end
 
-        def structure_dump_primary_key(table) #:nodoc:
+        def structure_dump_primary_key(table) # :nodoc:
           opts = { name: "", cols: [] }
           pks = select_all(<<~SQL.squish, "SCHEMA")
             SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ a.constraint_name, a.column_name, a.position
@@ -108,7 +108,7 @@ module ActiveRecord #:nodoc:
           opts[:cols].length > 0 ? ",\n CONSTRAINT #{opts[:name]} PRIMARY KEY (#{opts[:cols].join(',')})" : ""
         end
 
-        def structure_dump_unique_keys(table) #:nodoc:
+        def structure_dump_unique_keys(table) # :nodoc:
           keys = {}
           uks = select_all(<<~SQL.squish, "SCHEMA")
             SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ a.constraint_name, a.column_name, a.position
@@ -129,7 +129,7 @@ module ActiveRecord #:nodoc:
           end
         end
 
-        def structure_dump_indexes(table_name) #:nodoc:
+        def structure_dump_indexes(table_name) # :nodoc:
           indexes(table_name).map do |options|
             column_names = options.columns
             options = { name: options.name, unique: options.unique }
@@ -145,7 +145,7 @@ module ActiveRecord #:nodoc:
           end
         end
 
-        def structure_dump_fk_constraints #:nodoc:
+        def structure_dump_fk_constraints # :nodoc:
           foreign_keys = select_all(<<~SQL.squish, "SCHEMA")
             SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ table_name FROM all_tables
             WHERE owner = SYS_CONTEXT('userenv', 'current_schema') ORDER BY 1
@@ -190,7 +190,7 @@ module ActiveRecord #:nodoc:
           join_with_statement_token(comments)
         end
 
-        def foreign_key_definition(to_table, options = {}) #:nodoc:
+        def foreign_key_definition(to_table, options = {}) # :nodoc:
           column_sql = quote_column_name(options[:column] || "#{to_table.to_s.singularize}_id")
           references = options[:references] ? options[:references].first : nil
           references_sql = quote_column_name(options[:primary_key] || references || "id")
@@ -207,7 +207,7 @@ module ActiveRecord #:nodoc:
         end
 
         # Extract all stored procedures, packages, synonyms.
-        def structure_dump_db_stored_code #:nodoc:
+        def structure_dump_db_stored_code # :nodoc:
           structure = []
           all_source = select_all(<<~SQL.squish, "SCHEMA")
             SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ DISTINCT name, type
@@ -239,7 +239,7 @@ module ActiveRecord #:nodoc:
           join_with_statement_token(structure)
         end
 
-        def structure_dump_views #:nodoc:
+        def structure_dump_views # :nodoc:
           structure = []
           views = select_all(<<~SQL.squish, "SCHEMA")
             SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ view_name, text FROM all_views
@@ -251,7 +251,7 @@ module ActiveRecord #:nodoc:
           join_with_statement_token(structure)
         end
 
-        def structure_dump_synonyms #:nodoc:
+        def structure_dump_synonyms # :nodoc:
           structure = []
           synonyms = select_all(<<~SQL.squish, "SCHEMA")
             SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ owner, synonym_name, table_name, table_owner
@@ -265,7 +265,7 @@ module ActiveRecord #:nodoc:
           join_with_statement_token(structure)
         end
 
-        def structure_drop #:nodoc:
+        def structure_drop # :nodoc:
           sequences = select_values(<<~SQL.squish, "SCHEMA")
             SELECT/*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */
             sequence_name FROM all_sequences where sequence_owner = SYS_CONTEXT('userenv', 'current_schema') ORDER BY 1
@@ -288,7 +288,7 @@ module ActiveRecord #:nodoc:
           join_with_statement_token(statements)
         end
 
-        def temp_table_drop #:nodoc:
+        def temp_table_drop # :nodoc:
           temporary_tables = select_values(<<~SQL.squish, "SCHEMA")
             SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ table_name FROM all_tables
             WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
@@ -300,7 +300,7 @@ module ActiveRecord #:nodoc:
           join_with_statement_token(statements)
         end
 
-        def full_drop(preserve_tables = false) #:nodoc:
+        def full_drop(preserve_tables = false) # :nodoc:
           s = preserve_tables ? [] : [structure_drop]
           s << temp_table_drop if preserve_tables
           s << drop_sql_for_feature("view")

--- a/lib/active_record/connection_adapters/oracle_enhanced/type_metadata.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/type_metadata.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ActiveRecord
-  module ConnectionAdapters #:nodoc:
+  module ConnectionAdapters # :nodoc:
     module OracleEnhanced
       class TypeMetadata < DelegateClass(ActiveRecord::ConnectionAdapters::SqlTypeMetadata) # :nodoc:
         include Deduplicable

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -63,9 +63,9 @@ require "active_record/type/oracle_enhanced/timestampltz"
 require "active_record/type/oracle_enhanced/character_string"
 
 module ActiveRecord
-  module ConnectionHandling #:nodoc:
+  module ConnectionHandling # :nodoc:
     # Establishes a connection to the database that's used by all Active Record objects.
-    def oracle_enhanced_connection(config) #:nodoc:
+    def oracle_enhanced_connection(config) # :nodoc:
       if config[:emulate_oracle_adapter] == true
         # allows the enhanced adapter to look like the OracleAdapter. Useful to pick up
         # conditionals in the rails activerecord test suite
@@ -79,7 +79,7 @@ module ActiveRecord
     end
   end
 
-  module ConnectionAdapters #:nodoc:
+  module ConnectionAdapters # :nodoc:
     # Oracle enhanced adapter will work with both
     # CRuby ruby-oci8 gem (which provides interface to Oracle OCI client)
     # or with JRuby and Oracle JDBC driver.
@@ -249,7 +249,7 @@ module ActiveRecord
 
       ADAPTER_NAME = "OracleEnhanced"
 
-      def adapter_name #:nodoc:
+      def adapter_name # :nodoc:
         ADAPTER_NAME
       end
 
@@ -273,11 +273,11 @@ module ActiveRecord
         StatementPool.new(self.class.type_cast_config_to_integer(@config[:statement_limit]))
       end
 
-      def supports_savepoints? #:nodoc:
+      def supports_savepoints? # :nodoc:
         true
       end
 
-      def supports_transaction_isolation? #:nodoc:
+      def supports_transaction_isolation? # :nodoc:
         true
       end
 
@@ -360,7 +360,7 @@ module ActiveRecord
         end
       end
 
-      #:stopdoc:
+      # :stopdoc:
       DEFAULT_NLS_PARAMETERS = {
         nls_calendar: nil,
         nls_comp: nil,
@@ -379,13 +379,13 @@ module ActiveRecord
         nls_time_tz_format: nil
       }
 
-      #:stopdoc:
+      # :stopdoc:
       FIXED_NLS_PARAMETERS = {
         nls_date_format: "YYYY-MM-DD HH24:MI:SS",
         nls_timestamp_format: "YYYY-MM-DD HH24:MI:SS:FF6"
       }
 
-      #:stopdoc:
+      # :stopdoc:
       NATIVE_DATABASE_TYPES = {
         primary_key: "NUMBER(38) NOT NULL PRIMARY KEY",
         string: { name: "VARCHAR2", limit: 255 },
@@ -409,9 +409,9 @@ module ActiveRecord
       NATIVE_DATABASE_TYPES_BOOLEAN_STRINGS = NATIVE_DATABASE_TYPES.dup.merge(
         boolean: { name: "VARCHAR2", limit: 1 }
       )
-      #:startdoc:
+      # :startdoc:
 
-      def native_database_types #:nodoc:
+      def native_database_types # :nodoc:
         emulate_booleans_from_strings ? NATIVE_DATABASE_TYPES_BOOLEAN_STRINGS : NATIVE_DATABASE_TYPES
       end
 
@@ -421,10 +421,10 @@ module ActiveRecord
       # If SQL statement fails due to lost connection then reconnect
       # and retry SQL statement if autocommit mode is enabled.
       # By default this functionality is disabled.
-      attr_reader :auto_retry #:nodoc:
+      attr_reader :auto_retry # :nodoc:
       @auto_retry = false
 
-      def auto_retry=(value) #:nodoc:
+      def auto_retry=(value) # :nodoc:
         @auto_retry = value
         @connection.auto_retry = value if @connection
       end
@@ -435,7 +435,7 @@ module ActiveRecord
       end
 
       # Returns true if the connection is active.
-      def active? #:nodoc:
+      def active? # :nodoc:
         # Pings the connection to check if it's still good. Note that an
         # #active? method is also available, but that simply returns the
         # last known state, which isn't good enough if the connection has
@@ -446,7 +446,7 @@ module ActiveRecord
       end
 
       # Reconnects to the database.
-      def reconnect! #:nodoc:
+      def reconnect! # :nodoc:
         super
         @connection.reset!
       rescue OracleEnhanced::ConnectionException => e
@@ -459,7 +459,7 @@ module ActiveRecord
       end
 
       # Disconnects from the database.
-      def disconnect! #:nodoc:
+      def disconnect! # :nodoc:
         super
         @connection.logoff rescue nil
       end
@@ -497,7 +497,7 @@ module ActiveRecord
         !do_not_prefetch
       end
 
-      def reset_pk_sequence!(table_name, primary_key = nil, sequence_name = nil) #:nodoc:
+      def reset_pk_sequence!(table_name, primary_key = nil, sequence_name = nil) # :nodoc:
         return nil unless data_source_exists?(table_name)
         unless primary_key && sequence_name
           # *Note*: Only primary key is implemented - sequence will be nil.
@@ -591,7 +591,7 @@ module ActiveRecord
 
       # Find a table's primary key and sequence.
       # *Note*: Only primary key is implemented - sequence will be nil.
-      def pk_and_sequence_for(table_name, owner = nil, desc_table_name = nil) #:nodoc:
+      def pk_and_sequence_for(table_name, owner = nil, desc_table_name = nil) # :nodoc:
         (owner, desc_table_name) = @connection.describe(table_name)
 
         seqs = select_values_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("sequence_name", default_sequence_name(desc_table_name))])
@@ -629,7 +629,7 @@ module ActiveRecord
         pk_and_sequence && pk_and_sequence.first
       end
 
-      def has_primary_key?(table_name, owner = nil, desc_table_name = nil) #:nodoc:
+      def has_primary_key?(table_name, owner = nil, desc_table_name = nil) # :nodoc:
         !pk_and_sequence_for(table_name, owner, desc_table_name).nil?
       end
 
@@ -649,7 +649,7 @@ module ActiveRecord
         pks.map { |pk| oracle_downcase(pk) }
       end
 
-      def columns_for_distinct(columns, orders) #:nodoc:
+      def columns_for_distinct(columns, orders) # :nodoc:
         # construct a valid columns name for DISTINCT clause,
         # ie. one that includes the ORDER BY columns, using FIRST_VALUE such that
         # the inclusion of these columns doesn't invalidate the DISTINCT
@@ -665,7 +665,7 @@ module ActiveRecord
         [super, *order_columns].join(", ")
       end
 
-      def temporary_table?(table_name) #:nodoc:
+      def temporary_table?(table_name) # :nodoc:
         select_value_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name.upcase)]) == "Y"
           SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */
           temporary FROM all_tables WHERE table_name = :table_name and owner = SYS_CONTEXT('userenv', 'current_schema')
@@ -731,7 +731,7 @@ module ActiveRecord
           end
         end
 
-        def extract_limit(sql_type) #:nodoc:
+        def extract_limit(sql_type) # :nodoc:
           case sql_type
           when /^bigint/i
             19
@@ -740,7 +740,7 @@ module ActiveRecord
           end
         end
 
-        def translate_exception(exception, message:, sql:, binds:) #:nodoc:
+        def translate_exception(exception, message:, sql:, binds:) # :nodoc:
           case @connection.error_code(exception)
           when 1
             RecordNotUnique.new(message, sql: sql, binds: binds)


### PR DESCRIPTION
https://github.com/rubocop/rubocop/releases/tag/v1.19.0

* Disable parallel option since it is enabled by default since RuboCop 1.19.0

* Make Layout/LeadingCommentSpace aware of #:nodoc
https://github.com/rubocop/rubocop/pull/9964
