### PR TITLE
Refactor ActiveRecord::QueryLogs hook point

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -10,10 +10,14 @@ module ActiveRecord
 
         # Executes a SQL statement
         def execute(sql, name = nil, async: false)
+          sql = transform_query(sql)
+
           log(sql, name, async: async) { @connection.exec(sql) }
         end
 
         def exec_query(sql, name = "SQL", binds = [], prepare: false, async: false)
+          sql = transform_query(sql)
+
           type_casted_binds = type_casted_binds(binds)
 
           log(sql, name, binds, type_casted_binds, async: async) do


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/43097.

While working on this PR, I noticed a lack of follow up to `execute_batch`.
The resources related to `execute_batch` are:

- https://github.com/rails/rails/commit/0ad70eb2d063cab577a559f6c3d28e787ca1dca8
- https://github.com/rails/rails/commit/21f0855dd6ee624429f92d0a67d5d95fa75ff9cc
- https://github.com/rails/rails/pull/37707

Anyway, following up to `execute_batch` will be a different task than this PR.