### PR TITLE
Add `if_exists` option to `remove_index`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -330,6 +330,8 @@ module ActiveRecord
         # Remove the given index from the table.
         # Gives warning if index does not exist
         def remove_index(table_name, column_name = nil, **options) # :nodoc:
+          return if options[:if_exists] && !index_exists?(table_name, column_name, **options)
+
           index_name = index_name_for_remove(table_name, column_name, options)
           # TODO: It should execute only when index_type == "UNIQUE"
           execute "ALTER TABLE #{quote_table_name(table_name)} DROP CONSTRAINT #{quote_column_name(index_name)}" rescue nil


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/38967.

The `if_exists` option has been introduced since Rails 6.1.