### PR TITLE
update ocale docker image with one that works

### DIFF
--- a/RUNNING_TESTS.md
+++ b/RUNNING_TESTS.md
@@ -43,12 +43,12 @@ If no Oracle database with SYS and SYSTEM user access is available, try the dock
 
 * Pull [docker-oracle-xe-11g](https://hub.docker.com/r/wnameless/oracle-xe-11g/) image from docker hub
   ```sh
-  $ docker pull wnameless/oracle-xe-11g
+  $ docker pull wnameless/oracle-xe-11g-r2
   ```
 
 * Start a Oracle database docker container with mapped ports. Use port `49161` to access the database.
   ```sh
-  $ docker run -d -p 49160:22 -p 49161:1521 wnameless/oracle-xe-11g
+  $ docker run -d -p 49160:22 -p 49161:1521 wnameless/oracle-xe-11g-r2
   ```
 
 * Check connection to the database with `sqlplus`. The user is `system`, the password is `oracle`.


### PR DESCRIPTION
Image changed location because of some licensing hurdles according to image github repo.