### PR TITLE
CI against Ruby 3.1 at GitHub Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Ruby 3.0
+    - name: Set up Ruby 3.1
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.0
+        ruby-version: 3.1
     - name: Install required package
       run: |
         sudo apt-get install alien

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
         # - jruby,
         # - jruby-head
         ruby: [
+          '3.1',
           '3.0',
           '2.7'
         ]


### PR DESCRIPTION
* Ruby 3.1.0 Released
https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/