### PR TITLE
Add `ruby-oci8` as dependency only for CRuby

### DIFF
--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -26,4 +26,9 @@ This adapter is superset of original ActiveRecord Oracle adapter.
   s.test_files = Dir["spec/**/*"]
   s.add_runtime_dependency("activerecord", ["~> 7.1.0.alpha"])
   s.add_runtime_dependency("ruby-plsql", [">= 0.6.0"])
+  if /java/.match?(RUBY_PLATFORM)
+    s.platform = Gem::Platform.new("java")
+  else
+    s.add_runtime_dependency("ruby-oci8")
+  end
 end


### PR DESCRIPTION
Fix #2238