### PR TITLE
Require 'activerecord', not 'rails' not to attempt to install digest

### DIFF
--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -7,7 +7,7 @@ gemfile(true) do
 
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-  gem "rails", github: "rails/rails", branch: "main"
+  gem "activerecord", github: "rails/rails", branch: "main"
   gem "activerecord-oracle_enhanced-adapter",  github: "rsim/oracle-enhanced", branch: "master"
   gem "minitest"
 

--- a/guides/bug_report_templates/active_record_gem_spec.rb
+++ b/guides/bug_report_templates/active_record_gem_spec.rb
@@ -7,7 +7,7 @@ gemfile(true) do
 
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-  gem "rails", github: "rails/rails", branch: "main"
+  gem "activerecord", github: "rails/rails", branch: "main"
   gem "activerecord-oracle_enhanced-adapter",  github: "rsim/oracle-enhanced", branch: "master"
   gem "rspec", require: "rspec/autorun"
 


### PR DESCRIPTION
While testing #2240, bug report templates fails as follows.
https://github.com/rsim/oracle-enhanced/runs/4769573945?check_suite_focus=true

```
/opt/hostedtoolcache/Ruby/3.0.3/x64/lib/ruby/gems/3.0.0/gems/bundler-2.3.4/lib/bundler/runtime.rb:309:in `check_for_activated_spec!': You have already activated digest 3.0.0, but your Gemfile requires digest 3.1.0. Since digest is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports digest as a default gem. (Gem::LoadError)
```

`digest` gem is required `net-imap`, `net-pop` and `net-smtp` gem for
`actionmailbox` and `actionmailer` since
https://github.com/rails/rails/pull/44083 . To workaround this failure
this commit changes to require `activerecord` in bug report templates.

* Gemfile
```ruby
source "https://rubygems.org"

git_source(:github) { |repo| "https://github.com/#{repo}.git" }

gem "rails", github: "rails/rails", branch: "main"
gem "activerecord-oracle_enhanced-adapter",  github: "rsim/oracle-enhanced", branch: "master"
gem "minitest"

platforms :ruby do
  gem "ruby-oci8"
end
```

* Gemfile.lock
```ruby
$ more Gemfile.lock
GIT
  remote: https://github.com/rails/rails.git
  revision: dc7bb3aa7effda23b2af0ccffa5128747cebee58
  branch: main
  specs:
    actioncable (7.1.0.alpha)
      actionpack (= 7.1.0.alpha)
      activesupport (= 7.1.0.alpha)
      nio4r (~> 2.0)
      websocket-driver (>= 0.6.1)
    actionmailbox (7.1.0.alpha)
      actionpack (= 7.1.0.alpha)
      activejob (= 7.1.0.alpha)
      activerecord (= 7.1.0.alpha)
      activestorage (= 7.1.0.alpha)
      activesupport (= 7.1.0.alpha)
      mail (>= 2.7.1)
      net-imap
      net-pop
      net-smtp
    actionmailer (7.1.0.alpha)
      actionpack (= 7.1.0.alpha)
      actionview (= 7.1.0.alpha)
      activejob (= 7.1.0.alpha)
      activesupport (= 7.1.0.alpha)
      mail (~> 2.5, >= 2.5.4)
      net-imap
      net-pop
      net-smtp
      rails-dom-testing (~> 2.0)
    actionpack (7.1.0.alpha)
      actionview (= 7.1.0.alpha)
      activesupport (= 7.1.0.alpha)
      rack (~> 2.0, >= 2.2.0)
      rack-test (>= 0.6.3)
      rails-dom-testing (~> 2.0)
      rails-html-sanitizer (~> 1.0, >= 1.2.0)
    actiontext (7.1.0.alpha)
      actionpack (= 7.1.0.alpha)
      activerecord (= 7.1.0.alpha)
      activestorage (= 7.1.0.alpha)
      activesupport (= 7.1.0.alpha)
      globalid (>= 0.6.0)
      nokogiri (>= 1.8.5)
    actionview (7.1.0.alpha)
      activesupport (= 7.1.0.alpha)
      builder (~> 3.1)
      erubi (~> 1.4)
      rails-dom-testing (~> 2.0)
      rails-html-sanitizer (~> 1.1, >= 1.2.0)
    activejob (7.1.0.alpha)
      activesupport (= 7.1.0.alpha)
      globalid (>= 0.3.6)
    activemodel (7.1.0.alpha)
      activesupport (= 7.1.0.alpha)
    activerecord (7.1.0.alpha)
      activemodel (= 7.1.0.alpha)
      activesupport (= 7.1.0.alpha)
    activestorage (7.1.0.alpha)
      actionpack (= 7.1.0.alpha)
      activejob (= 7.1.0.alpha)
      activerecord (= 7.1.0.alpha)
      activesupport (= 7.1.0.alpha)
      marcel (~> 1.0)
      mini_mime (>= 1.1.0)
    activesupport (7.1.0.alpha)
      concurrent-ruby (~> 1.0, >= 1.0.2)
      i18n (>= 1.6, < 2)
      minitest (>= 5.1)
      tzinfo (~> 2.0)
    rails (7.1.0.alpha)
      actioncable (= 7.1.0.alpha)
      actionmailbox (= 7.1.0.alpha)
      actionmailer (= 7.1.0.alpha)
      actionpack (= 7.1.0.alpha)
      actiontext (= 7.1.0.alpha)
      actionview (= 7.1.0.alpha)
      activejob (= 7.1.0.alpha)
      activemodel (= 7.1.0.alpha)
      activerecord (= 7.1.0.alpha)
      activestorage (= 7.1.0.alpha)
      activesupport (= 7.1.0.alpha)
      bundler (>= 1.15.0)
      railties (= 7.1.0.alpha)
    railties (7.1.0.alpha)
      actionpack (= 7.1.0.alpha)
      activesupport (= 7.1.0.alpha)
      method_source
      rake (>= 12.2)
      thor (~> 1.0)
      zeitwerk (~> 2.5)

GIT
  remote: https://github.com/rsim/oracle-enhanced.git
  revision: 38ac75e3696d66d01eca4421e201d73d16885284
  branch: master
  specs:
    activerecord-oracle_enhanced-adapter (7.1.0.alpha)
      activerecord (~> 7.1.0.alpha)
      ruby-plsql (>= 0.6.0)

GEM
  remote: https://rubygems.org/
  specs:
    builder (3.2.4)
    concurrent-ruby (1.1.9)
    crass (1.0.6)
    digest (3.1.0)
    erubi (1.10.0)
    globalid (1.0.0)
      activesupport (>= 5.0)
    i18n (1.8.11)
      concurrent-ruby (~> 1.0)
    io-wait (0.2.1)
    loofah (2.13.0)
      crass (~> 1.0.2)
      nokogiri (>= 1.5.9)
    mail (2.7.1)
      mini_mime (>= 0.1.1)
    marcel (1.0.2)
    method_source (1.0.0)
    mini_mime (1.1.2)
    minitest (5.15.0)
    net-imap (0.2.3)
      digest
      net-protocol
      strscan
    net-pop (0.1.1)
      digest
      net-protocol
      timeout
    net-protocol (0.1.2)
      io-wait
      timeout
    net-smtp (0.3.1)
      digest
      net-protocol
      timeout
    nio4r (2.5.8)
    nokogiri (1.13.0-x86_64-linux)
      racc (~> 1.4)
    racc (1.6.0)
    rack (2.2.3)
    rack-test (1.1.0)
      rack (>= 1.0, < 3)
    rails-dom-testing (2.0.3)
      activesupport (>= 4.2.0)
      nokogiri (>= 1.6)
    rails-html-sanitizer (1.4.2)
      loofah (~> 2.3)
    rake (13.0.6)
    ruby-oci8 (2.2.9)
    ruby-plsql (0.8.0)
    strscan (3.0.1)
    thor (1.2.1)
    timeout (0.2.0)
    tzinfo (2.0.4)
      concurrent-ruby (~> 1.0)
    websocket-driver (0.7.5)
      websocket-extensions (>= 0.1.0)
    websocket-extensions (0.1.5)
    zeitwerk (2.5.3)

PLATFORMS
  x86_64-linux

DEPENDENCIES
  activerecord-oracle_enhanced-adapter!
  minitest
  rails!
  ruby-oci8

BUNDLED WITH
   2.2.32
```

```ruby
$ ruby -v
ruby 3.0.3p157 (2021-11-24 revision 3fb7d2cadc) [x86_64-linux]
$ ruby active_record_gem.rb
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
Using concurrent-ruby 1.1.9
Using minitest 5.15.0
Using ruby-plsql 0.8.0
Using bundler 2.2.32
Using ruby-oci8 2.2.9
Using tzinfo 2.0.4
Using i18n 1.8.11
Using activesupport 7.1.0.alpha from https://github.com/rails/rails.git (at /home/yahonda/src/github.com/rails/rails@dc7bb3a)
Using activemodel 7.1.0.alpha from https://github.com/rails/rails.git (at /home/yahonda/src/github.com/rails/rails@dc7bb3a)
Using activerecord 7.1.0.alpha from https://github.com/rails/rails.git (at /home/yahonda/src/github.com/rails/rails@dc7bb3a)
Using activerecord-oracle_enhanced-adapter 7.1.0.alpha from https://github.com/rsim/oracle-enhanced.git (at /home/yahonda/src/github.com/rsim/oracle-enhanced@38ac75e)
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/3.0.0/set.rb:648: warning: already initialized constant Set::InspectKey
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/set-1.0.2/lib/set.rb:815: warning: previous definition of InspectKey was here
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/3.0.0/timeout.rb:26: warning: already initialized constant Timeout::VERSION
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/timeout-0.2.0/lib/timeout.rb:26: warning: previous definition of VERSION was here
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/3.0.0/timeout.rb:52: warning: already initialized constant Timeout::THIS_FILE
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/timeout-0.2.0/lib/timeout.rb:53: warning: previous definition of THIS_FILE was here
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/3.0.0/timeout.rb:53: warning: already initialized constant Timeout::CALLER_OFFSET
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/timeout-0.2.0/lib/timeout.rb:54: warning: previous definition of CALLER_OFFSET was here
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/3.0.0/ipaddr.rb:45: warning: already initialized constant IPAddr::IN4MASK
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/ipaddr-1.2.3/lib/ipaddr.rb:45: warning: previous definition of IN4MASK was here
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/3.0.0/ipaddr.rb:47: warning: already initialized constant IPAddr::IN6MASK
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/ipaddr-1.2.3/lib/ipaddr.rb:47: warning: previous definition of IN6MASK was here
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/3.0.0/ipaddr.rb:49: warning: already initialized constant IPAddr::IN6FORMAT
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/ipaddr-1.2.3/lib/ipaddr.rb:49: warning: previous definition of IN6FORMAT was here
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/3.0.0/ipaddr.rb:52: warning: already initialized constant IPAddr::RE_IPV4ADDRLIKE
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/ipaddr-1.2.3/lib/ipaddr.rb:52: warning: previous definition of RE_IPV4ADDRLIKE was here
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/3.0.0/ipaddr.rb:59: warning: already initialized constant IPAddr::RE_IPV6ADDRLIKE_FULL
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/ipaddr-1.2.3/lib/ipaddr.rb:59: warning: previous definition of RE_IPV6ADDRLIKE_FULL was here
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/3.0.0/ipaddr.rb:71: warning: already initialized constant IPAddr::RE_IPV6ADDRLIKE_COMPRESSED
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/ipaddr-1.2.3/lib/ipaddr.rb:71: warning: previous definition of RE_IPV6ADDRLIKE_COMPRESSED was here
-- create_table(:posts, {:force=>true})
D, [2022-01-12T12:28:02.929250 #310650] DEBUG -- :    (16.0ms)  DROP TABLE "POSTS"
D, [2022-01-12T12:28:02.935228 #310650] DEBUG -- :    (5.7ms)  DROP SEQUENCE "POSTS_SEQ"
D, [2022-01-12T12:28:02.944664 #310650] DEBUG -- :    (9.1ms)  CREATE TABLE "POSTS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY)
D, [2022-01-12T12:28:02.947611 #310650] DEBUG -- :    (2.7ms)  CREATE SEQUENCE "POSTS_SEQ" START WITH 1
   -> 0.3701s
-- create_table(:comments, {:force=>true})
D, [2022-01-12T12:28:03.221825 #310650] DEBUG -- :    (13.7ms)  DROP TABLE "COMMENTS"
D, [2022-01-12T12:28:03.226596 #310650] DEBUG -- :    (4.5ms)  DROP SEQUENCE "COMMENTS_SEQ"
D, [2022-01-12T12:28:03.234699 #310650] DEBUG -- :    (7.8ms)  CREATE TABLE "COMMENTS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY, "POST_ID" NUMBER(38))
D, [2022-01-12T12:28:03.237478 #310650] DEBUG -- :    (2.5ms)  CREATE SEQUENCE "COMMENTS_SEQ" START WITH 1
   -> 0.2898s
D, [2022-01-12T12:28:03.627103 #310650] DEBUG -- :   ActiveRecord::InternalMetadata Load (1.3ms)  SELECT "AR_INTERNAL_METADATA".* FROM "AR_INTERNAL_METADATA" WHERE "AR_INTERNAL_METADATA"."KEY" = :a1 FETCH FIRST :a2 ROWS ONLY  [["key", "environment"], ["LIMIT", 1]]
Run options: --seed 22680

D, [2022-01-12T12:28:05.253594 #310650] DEBUG -- :   Post Create (8.4ms)  INSERT INTO "POSTS" ("ID") VALUES (:a1)  [["id", 1]]
D, [2022-01-12T12:28:06.590645 #310650] DEBUG -- :   Comment Create (4.7ms)  INSERT INTO "COMMENTS" ("ID") VALUES (:a1)  [["id", 1]]
D, [2022-01-12T12:28:06.601376 #310650] DEBUG -- :   Comment Update (3.2ms)  UPDATE "COMMENTS" SET "POST_ID" = :a1 WHERE "COMMENTS"."ID" = :a2  [["post_id", 1], ["id", 1]]
D, [2022-01-12T12:28:06.607107 #310650] DEBUG -- :   Comment Count (3.5ms)  SELECT COUNT(*) FROM "COMMENTS" WHERE "COMMENTS"."POST_ID" = :a1  [["post_id", 1]]
D, [2022-01-12T12:28:06.610485 #310650] DEBUG -- :   Comment Count (2.9ms)  SELECT COUNT(*) FROM "COMMENTS"
D, [2022-01-12T12:28:06.614349 #310650] DEBUG -- :   Comment Load (3.0ms)  SELECT "COMMENTS".* FROM "COMMENTS" ORDER BY "COMMENTS"."ID" ASC FETCH FIRST :a1 ROWS ONLY  [["LIMIT", 1]]
D, [2022-01-12T12:28:06.618792 #310650] DEBUG -- :   Post Load (2.9ms)  SELECT "POSTS".* FROM "POSTS" WHERE "POSTS"."ID" = :a1 FETCH FIRST :a2 ROWS ONLY  [["id", 1], ["LIMIT", 1]]
.

Finished in 2.697890s, 0.3707 runs/s, 1.1120 assertions/s.

1 runs, 3 assertions, 0 failures, 0 errors, 0 skips
$ ruby active_record_gem_spec.rb
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
Using concurrent-ruby 1.1.9
Using ruby-plsql 0.8.0
Using bundler 2.2.32
Using diff-lcs 1.5.0
Using ruby-oci8 2.2.9
Using rspec-support 3.10.3
Using minitest 5.15.0
Using i18n 1.8.11
Using tzinfo 2.0.4
Using rspec-expectations 3.10.1
Using rspec-mocks 3.10.2
Using rspec-core 3.10.1
Using activesupport 7.1.0.alpha from https://github.com/rails/rails.git (at /home/yahonda/src/github.com/rails/rails@dc7bb3a)
Using rspec 3.10.0
Using activemodel 7.1.0.alpha from https://github.com/rails/rails.git (at /home/yahonda/src/github.com/rails/rails@dc7bb3a)
Using activerecord 7.1.0.alpha from https://github.com/rails/rails.git (at /home/yahonda/src/github.com/rails/rails@dc7bb3a)
Using activerecord-oracle_enhanced-adapter 7.1.0.alpha from https://github.com/rsim/oracle-enhanced.git (at /home/yahonda/src/github.com/rsim/oracle-enhanced@38ac75e)
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/3.0.0/set.rb:648: warning: already initialized constant Set::InspectKey
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/set-1.0.2/lib/set.rb:815: warning: previous definition of InspectKey was here
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/3.0.0/timeout.rb:26: warning: already initialized constant Timeout::VERSION
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/timeout-0.2.0/lib/timeout.rb:26: warning: previous definition of VERSION was here
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/3.0.0/timeout.rb:52: warning: already initialized constant Timeout::THIS_FILE
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/timeout-0.2.0/lib/timeout.rb:53: warning: previous definition of THIS_FILE was here
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/3.0.0/timeout.rb:53: warning: already initialized constant Timeout::CALLER_OFFSET
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/timeout-0.2.0/lib/timeout.rb:54: warning: previous definition of CALLER_OFFSET was here
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/3.0.0/ipaddr.rb:45: warning: already initialized constant IPAddr::IN4MASK
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/ipaddr-1.2.3/lib/ipaddr.rb:45: warning: previous definition of IN4MASK was here
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/3.0.0/ipaddr.rb:47: warning: already initialized constant IPAddr::IN6MASK
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/ipaddr-1.2.3/lib/ipaddr.rb:47: warning: previous definition of IN6MASK was here
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/3.0.0/ipaddr.rb:49: warning: already initialized constant IPAddr::IN6FORMAT
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/ipaddr-1.2.3/lib/ipaddr.rb:49: warning: previous definition of IN6FORMAT was here
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/3.0.0/ipaddr.rb:52: warning: already initialized constant IPAddr::RE_IPV4ADDRLIKE
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/ipaddr-1.2.3/lib/ipaddr.rb:52: warning: previous definition of RE_IPV4ADDRLIKE was here
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/3.0.0/ipaddr.rb:59: warning: already initialized constant IPAddr::RE_IPV6ADDRLIKE_FULL
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/ipaddr-1.2.3/lib/ipaddr.rb:59: warning: previous definition of RE_IPV6ADDRLIKE_FULL was here
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/3.0.0/ipaddr.rb:71: warning: already initialized constant IPAddr::RE_IPV6ADDRLIKE_COMPRESSED
/home/yahonda/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/ipaddr-1.2.3/lib/ipaddr.rb:71: warning: previous definition of RE_IPV6ADDRLIKE_COMPRESSED was here
-- create_table(:posts, {:force=>true})
D, [2022-01-12T12:28:13.058660 #310695] DEBUG -- :    (15.9ms)  DROP TABLE "POSTS"
D, [2022-01-12T12:28:13.064292 #310695] DEBUG -- :    (5.4ms)  DROP SEQUENCE "POSTS_SEQ"
D, [2022-01-12T12:28:13.072697 #310695] DEBUG -- :    (8.1ms)  CREATE TABLE "POSTS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY)
D, [2022-01-12T12:28:13.075522 #310695] DEBUG -- :    (2.6ms)  CREATE SEQUENCE "POSTS_SEQ" START WITH 1
   -> 0.3772s
-- create_table(:comments, {:force=>true})
D, [2022-01-12T12:28:13.306499 #310695] DEBUG -- :    (14.1ms)  DROP TABLE "COMMENTS"
D, [2022-01-12T12:28:13.311177 #310695] DEBUG -- :    (4.4ms)  DROP SEQUENCE "COMMENTS_SEQ"
D, [2022-01-12T12:28:13.319282 #310695] DEBUG -- :    (7.8ms)  CREATE TABLE "COMMENTS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY, "POST_ID" NUMBER(38))
D, [2022-01-12T12:28:13.322458 #310695] DEBUG -- :    (3.0ms)  CREATE SEQUENCE "COMMENTS_SEQ" START WITH 1
   -> 0.2469s
D, [2022-01-12T12:28:13.611604 #310695] DEBUG -- :   ActiveRecord::InternalMetadata Load (1.2ms)  SELECT "AR_INTERNAL_METADATA".* FROM "AR_INTERNAL_METADATA" WHERE "AR_INTERNAL_METADATA"."KEY" = :a1 FETCH FIRST :a2 ROWS ONLY  [["key", "environment"], ["LIMIT", 1]]
D, [2022-01-12T12:28:15.227836 #310695] DEBUG -- :   Post Create (8.2ms)  INSERT INTO "POSTS" ("ID") VALUES (:a1)  [["id", 1]]
D, [2022-01-12T12:28:16.585295 #310695] DEBUG -- :   Comment Create (7.0ms)  INSERT INTO "COMMENTS" ("ID") VALUES (:a1)  [["id", 1]]
D, [2022-01-12T12:28:16.593131 #310695] DEBUG -- :   Comment Update (3.5ms)  UPDATE "COMMENTS" SET "POST_ID" = :a1 WHERE "COMMENTS"."ID" = :a2  [["post_id", 1], ["id", 1]]
D, [2022-01-12T12:28:16.601128 #310695] DEBUG -- :   Comment Count (6.1ms)  SELECT COUNT(*) FROM "COMMENTS" WHERE "COMMENTS"."POST_ID" = :a1  [["post_id", 1]]
D, [2022-01-12T12:28:16.606315 #310695] DEBUG -- :   Comment Count (4.3ms)  SELECT COUNT(*) FROM "COMMENTS"
D, [2022-01-12T12:28:16.610908 #310695] DEBUG -- :   Comment Load (3.7ms)  SELECT "COMMENTS".* FROM "COMMENTS" ORDER BY "COMMENTS"."ID" ASC FETCH FIRST :a1 ROWS ONLY  [["LIMIT", 1]]
D, [2022-01-12T12:28:16.615458 #310695] DEBUG -- :   Post Load (3.4ms)  SELECT "POSTS".* FROM "POSTS" WHERE "POSTS"."ID" = :a1 FETCH FIRST :a2 ROWS ONLY  [["id", 1], ["LIMIT", 1]]
.

Finished in 3.92 seconds (files took 0.29977 seconds to load)
1 example, 0 failures

$
```