### PR TITLE
support LIKE case-insensitive matching

### DIFF
--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative "oracle_common"
+
 module Arel # :nodoc: all
   module Visitors
     class Oracle < Arel::Visitors::ToSql
+      include OracleCommon
+
       private
         def visit_Arel_Nodes_SelectStatement(o, collector)
           o = order_hacks(o)

--- a/lib/arel/visitors/oracle12.rb
+++ b/lib/arel/visitors/oracle12.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative "oracle_common"
+
 module Arel # :nodoc: all
   module Visitors
     class Oracle12 < Arel::Visitors::ToSql
+      include OracleCommon
+
       private
         def visit_Arel_Nodes_SelectStatement(o, collector)
           # Oracle does not allow LIMIT clause with select for update

--- a/lib/arel/visitors/oracle_common.rb
+++ b/lib/arel/visitors/oracle_common.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Arel # :nodoc: all
+  module Visitors
+    module OracleCommon
+      private
+        def visit_Arel_Nodes_Matches(o, collector)
+          if !o.case_sensitive && o.left && o.right
+            o.left = Arel::Nodes::NamedFunction.new("UPPER", [o.left])
+            o.right = Arel::Nodes::NamedFunction.new("UPPER", [o.right])
+          end
+
+          super o, collector
+        end
+    end
+  end
+end

--- a/spec/active_record/oracle_enhanced/type/character_string_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/character_string_spec.rb
@@ -24,6 +24,7 @@ describe "OracleEnhancedAdapter processing CHAR column" do
   end
 
   after(:each) do
+    TestItem.delete_all
     Object.send(:remove_const, "TestItem")
     ActiveRecord::Base.clear_cache!
   end
@@ -39,5 +40,28 @@ describe "OracleEnhancedAdapter processing CHAR column" do
 
     item_reloaded = TestItem.first
     expect(item_reloaded.padded).to eq(str)
+  end
+
+  it "should support case sensitive matching" do
+    TestItem.create!(
+      padded: "First",
+    )
+    TestItem.create!(
+      padded: "first",
+    )
+
+    expect(TestItem.where(TestItem.arel_table[:padded].matches("first%", "\\", true))).to have_attributes(count: 1)
+  end
+
+  it "should support case insensitive matching" do
+    TestItem.create!(
+      padded: "First",
+    )
+    TestItem.create!(
+      padded: "first",
+    )
+
+    expect(TestItem.where(TestItem.arel_table[:padded].matches("first%", "\\", false))).to have_attributes(count: 2)
+    expect(TestItem.where(TestItem.arel_table[:padded].matches("first%"))).to have_attributes(count: 2)
   end
 end


### PR DESCRIPTION
Oracle documentation suggests to use `UPPER()` when case-insensitive search is desired. I have used that here. Without it the comparison is only case-sensitive unlike MySQL and Postgres where it can be one or the other by user choice.

Probably upgrade notes should point out that by default matching is case-insensitive. If anybody used it as case-sensitive without passing the `case_sensitive` parameter to `#matches`, then they can be surprised by this change.