### PR TITLE
Fix columns_for_distinct when using Rails 6.1

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -662,7 +662,7 @@ module ActiveRecord
           }.reject(&:blank?).map.with_index { |column, i|
             "FIRST_VALUE(#{column}) OVER (PARTITION BY #{columns} ORDER BY #{column}) AS alias_#{i}__"
           }
-        [super, *order_columns].join(", ")
+        (order_columns << super).join(", ")
       end
 
       def temporary_table?(table_name) # :nodoc:


### PR DESCRIPTION
Running `ARCONN=oracle bundle exec ruby -Itest ./test/cases/finder_test.rb -n test_find_with_order_on_included_associations_with_construct_finder_sql_for_association_limiting_and_is_distinct` in Rails 6.1.4.4 will result in an error.

```
ARCONN=oracle bundle exec ruby -Itest ./test/cases/finder_test.rb -n test_find_with_order_on_included_associations_with_construct_finder_sql_for_association_limiting_and_is_distinct
Using oracle
Warning: NLS_LANG is not set. fallback to US7ASCII.
Run options: -n test_find_with_order_on_included_associations_with_construct_finder_sql_for_association_limiting_and_is_distinct --seed 32511

# Running:

F

Failure:
FinderTest#test_find_with_order_on_included_associations_with_construct_finder_sql_for_association_limiting_and_is_distinct [./test/cases/finder_test.rb:1503]:
Expected: 2
  Actual: 1

rails test ./test/cases/finder_test.rb:1502

Finished in 1.275346s, 0.7841 runs/s, 0.7841 assertions/s.
1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
```

Fixing the return value of `columns_for_distinct` causes the test to pass.
This is a fix for the change to PostgreSQL and MySQL adapters in Rails 6.0. https://github.com/rails/rails/pull/31966

The reason why the tests for  `ARCONN=oracle bundle exec ruby -Itest ./test/cases/finder_test.rb -n test_find_with_order_on_included_associations_with_construct_finder_sql_for_association_limiting_and_is_distinct` don't pass is because of a fix in finder_methods.rb in Rails 6.1.
https://github.com/rails/rails/commit/2ad2425fd3b3a58e937f97b1fa05306c4d3166ae