### PR TITLE
Prepare release v6.1.6 [skip ci]

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+## 6.1.6 / 2022-01-21
+
+* Changes and bug fixes
+  * Fix `columns_for_distinct` when using Rails 6.1 [#2249 #2252 rails/rails#31966]
+
 ## 6.1.5 / 2021-12-07
 
 * Changes and bug fixes


### PR DESCRIPTION
The target branch is `release61` directly because the master branch already releases 7.0.z.