### PR TITLE
Addres `uninitialized constant TestEmployee::AttributeSignature::Base64`

### DIFF
--- a/spec/active_record/oracle_enhanced/type/custom_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/custom_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "base64"
+
 describe "OracleEnhancedAdapter custom types handling" do
   include SchemaSpecHelper
 


### PR DESCRIPTION
Follow up #2203

This commit addresses these two failures.

```ruby
$ bundle exec rspec ./spec/active_record/oracle_enhanced/type/custom_spec.rb
==> Loading config from ENV or use default
==> Running specs with ruby version 3.1.1
==> Effective ActiveRecord version 7.1.0.alphaFF

Failures:

  1) OracleEnhancedAdapter custom types handling should serialize LOBs when creating a record
     Failure/Error: Base64.encode64 value.raw

     NameError:
       uninitialized constant TestEmployee::AttributeSignature::Base64

                 Base64.encode64 value.raw
                 ^^^^^^
     # ./spec/active_record/oracle_enhanced/type/custom_spec.rb:30:in `serialize'
     # /home/yahonda/src/github.com/rails/rails/activemodel/lib/active_model/attribute.rb:56:in `value_for_database'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:209:in `block in type_casted_binds'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:207:in `map'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:207:in `type_casted_binds'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:96:in `exec_insert'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:167:in `insert'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:22:in `insert'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:90:in `insert'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/persistence.rb:497:in `_insert_record'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/persistence.rb:1117:in `_create_record'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/counter_cache.rb:166:in `_create_record'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/locking/optimistic.rb:79:in `_create_record'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:222:in `_create_record'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/callbacks.rb:461:in `block in _create_record'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:99:in `run_callbacks'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:929:in `_run_create_callbacks'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/callbacks.rb:461:in `_create_record'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/timestamp.rb:108:in `_create_record'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/persistence.rb:1088:in `create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/callbacks.rb:457:in `block in create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:99:in `run_callbacks'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:929:in `_run_save_callbacks'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/callbacks.rb:457:in `create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/timestamp.rb:126:in `create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/persistence.rb:649:in `save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/validations.rb:53:in `save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:302:in `block in save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:354:in `block in with_transaction_returning_status'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:321:in `block in within_new_transaction'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:319:in `within_new_transaction'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:316:in `transaction'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:350:in `with_transaction_returning_status'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:302:in `save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/suppressor.rb:54:in `save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/persistence.rb:55:in `create!'
     # ./spec/active_record/oracle_enhanced/type/custom_spec.rb:70:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:262:in `instance_exec'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:262:in `block in run'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:508:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:465:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:486:in `block in run'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:624:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:486:in `run'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:465:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:508:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:259:in `run'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:644:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:640:in `map'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:640:in `run_examples'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:606:in `run'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `map'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration.rb:2067:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:116:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/reporter.rb:74:in `report'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:115:in `run_specs'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:89:in `run'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.1.1/bin/rspec:25:in `load'
     # /home/yahonda/.rbenv/versions/3.1.1/bin/rspec:25:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/cli/exec.rb:58:in `load'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/cli/exec.rb:58:in `kernel_load'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/cli/exec.rb:23:in `run'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/cli.rb:484:in `exec'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/cli.rb:31:in `dispatch'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/cli.rb:25:in `start'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/exe/bundle:48:in `block in <top (required)>'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/friendly_errors.rb:103:in `with_friendly_errors'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/exe/bundle:36:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.1.1/bin/bundle:25:in `load'
     # /home/yahonda/.rbenv/versions/3.1.1/bin/bundle:25:in `<main>'

  2) OracleEnhancedAdapter custom types handling should serialize LOBs when updating a record
     Failure/Error: Base64.encode64 value.raw

     NameError:
       uninitialized constant TestEmployee::AttributeSignature::Base64

                 Base64.encode64 value.raw
                 ^^^^^^
     # ./spec/active_record/oracle_enhanced/type/custom_spec.rb:30:in `serialize'
     # /home/yahonda/src/github.com/rails/rails/activemodel/lib/active_model/attribute.rb:56:in `value_for_database'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:209:in `block in type_casted_binds'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:207:in `map'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:207:in `type_casted_binds'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:96:in `exec_insert'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:167:in `insert'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:22:in `insert'
     # ./lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:90:in `insert'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/persistence.rb:497:in `_insert_record'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/persistence.rb:1117:in `_create_record'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/counter_cache.rb:166:in `_create_record'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/locking/optimistic.rb:79:in `_create_record'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:222:in `_create_record'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/callbacks.rb:461:in `block in _create_record'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:99:in `run_callbacks'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:929:in `_run_create_callbacks'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/callbacks.rb:461:in `_create_record'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/timestamp.rb:108:in `_create_record'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/persistence.rb:1088:in `create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/callbacks.rb:457:in `block in create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:99:in `run_callbacks'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:929:in `_run_save_callbacks'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/callbacks.rb:457:in `create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/timestamp.rb:126:in `create_or_update'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/persistence.rb:649:in `save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/validations.rb:53:in `save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:302:in `block in save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:354:in `block in with_transaction_returning_status'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:321:in `block in within_new_transaction'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt'
     # /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:319:in `within_new_transaction'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:316:in `transaction'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:350:in `with_transaction_returning_status'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/transactions.rb:302:in `save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/suppressor.rb:54:in `save!'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/persistence.rb:55:in `create!'
     # ./spec/active_record/oracle_enhanced/type/custom_spec.rb:80:in `block (2 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:262:in `instance_exec'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:262:in `block in run'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:508:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:465:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:486:in `block in run'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:624:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:486:in `run'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:465:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:508:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:259:in `run'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:644:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:640:in `map'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:640:in `run_examples'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:606:in `run'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `map'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:121:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/configuration.rb:2067:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:116:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/reporter.rb:74:in `report'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:115:in `run_specs'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:89:in `run'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rspec-core-3.10.1/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.1.1/bin/rspec:25:in `load'
     # /home/yahonda/.rbenv/versions/3.1.1/bin/rspec:25:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/cli/exec.rb:58:in `load'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/cli/exec.rb:58:in `kernel_load'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/cli/exec.rb:23:in `run'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/cli.rb:484:in `exec'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/cli.rb:31:in `dispatch'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/cli.rb:25:in `start'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/exe/bundle:48:in `block in <top (required)>'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/friendly_errors.rb:103:in `with_friendly_errors'
     # /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/exe/bundle:36:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.1.1/bin/bundle:25:in `load'
     # /home/yahonda/.rbenv/versions/3.1.1/bin/bundle:25:in `<main>'

Finished in 2.1 seconds (files took 0.40984 seconds to load)
2 examples, 2 failures

Failed examples:

rspec ./spec/active_record/oracle_enhanced/type/custom_spec.rb:67 # OracleEnhancedAdapter custom types handling should serialize LOBs when creating a record
rspec ./spec/active_record/oracle_enhanced/type/custom_spec.rb:77 # OracleEnhancedAdapter custom types handling should serialize LOBs when updating a record

$
```