### PR TITLE
Enable `Style/MapToHash` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -132,6 +132,9 @@ Style/FrozenStringLiteralComment:
   Enabled: true
   EnforcedStyle: always
 
+Style/MapToHash:
+  Enabled: true
+
 Style/RedundantFreeze:
   Enabled: true
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -101,7 +101,7 @@ module ActiveRecord
               _oracle_downcase(col_name)
             end
             row = cursor.fetch
-            columns.each_with_index.map { |x, i| [x, row[i]] }.to_h if row
+            columns.each_with_index.to_h { |x, i| [x, row[i]] } if row
           ensure
             cursor.close
           end


### PR DESCRIPTION
Related to rails/rails#44555

```ruby
$ bundle exec rubocop -A
Inspecting 72 files
.......C................................................................

Offenses:

lib/active_record/connection_adapters/oracle_enhanced/connection.rb:104:37: C: [Corrected] Style/MapToHash: Pass a block to to_h instead of calling map.to_h.
            columns.each_with_index.map { |x, i| [x, row[i]] }.to_h if row
                                    ^^^

72 files inspected, 1 offense detected, 1 offense corrected
$
```