### PR TITLE
CI against Ruby 3.1.1 at Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
 
 language: ruby
 rvm:
-  - 3.1.0
+  - 3.1.1
   - 3.0.3
   - 2.7.5
   - ruby-head


### PR DESCRIPTION
* Ruby 3.1.1 Released
https://www.ruby-lang.org/en/news/2022/02/18/ruby-3-1-1-released/