### PR TITLE
Introduce RuboCop RSpec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 require:
   - rubocop-performance
   - rubocop-rails
+  - rubocop-rspec
 
 AllCops:
   TargetRubyVersion: 2.7
@@ -279,4 +280,17 @@ Performance/DeleteSuffix:
   Enabled: true
 
 Performance/OpenStruct:
+  Enabled: true
+
+# RuboCop RSpec cops
+RSpec/EmptyLineAfterExampleGroup:
+  Enabled: true
+
+RSpec/EmptyLineAfterHook:
+  Enabled: true
+
+RSpec/EmptyLineAfterSubject:
+  Enabled: true
+
+RSpec/ExcessiveDocstringSpacing:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :development do
   gem "rubocop", require: false
   gem "rubocop-performance", require: false
   gem "rubocop-rails", require: false
+  gem "rubocop-rspec", require: false
 
   gem "activerecord",   github: "rails/rails", branch: "main"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -392,7 +392,7 @@ describe "OracleEnhancedConnection" do
       @conn.exec "DROP TABLE test_employees" rescue nil
     end
 
-    it "should execute prepared statement with decimal bind parameter " do
+    it "should execute prepared statement with decimal bind parameter" do
       cursor = @conn.prepare("INSERT INTO test_employees VALUES(:1)")
       type_metadata = ActiveRecord::ConnectionAdapters::SqlTypeMetadata.new(sql_type: "NUMBER", type: :decimal, limit: 10, precision: nil, scale: 2)
       column = ActiveRecord::ConnectionAdapters::OracleEnhanced::Column.new("age", nil, type_metadata, false, comment: nil)

--- a/spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb
@@ -16,6 +16,7 @@ describe "Oracle Enhanced adapter database tasks" do
         ActiveRecord::Tasks::DatabaseTasks.create(new_user_config)
       end
     end
+
     it "creates user" do
       query = "SELECT COUNT(*) FROM dba_users WHERE UPPER(username) = '#{new_user_config[:username].upcase}'"
       expect(ActiveRecord::Base.connection.select_value(query)).to eq(1)
@@ -62,6 +63,7 @@ describe "Oracle Enhanced adapter database tasks" do
 
     describe "drop" do
       before { ActiveRecord::Tasks::DatabaseTasks.drop(config) }
+
       it "drops all tables" do
         expect(ActiveRecord::Base.connection.table_exists?(:test_posts)).to be_falsey
       end
@@ -69,6 +71,7 @@ describe "Oracle Enhanced adapter database tasks" do
 
     describe "purge" do
       before { ActiveRecord::Tasks::DatabaseTasks.purge(config) }
+
       it "drops all tables" do
         expect(ActiveRecord::Base.connection.table_exists?(:test_posts)).to be_falsey
         expect(ActiveRecord::Base.connection.select_value("SELECT COUNT(*) FROM RECYCLEBIN")).to eq(0)
@@ -84,6 +87,7 @@ describe "Oracle Enhanced adapter database tasks" do
 
       describe "structure_dump" do
         before { ActiveRecord::Tasks::DatabaseTasks.structure_dump(config, temp_file) }
+
         it "dumps the database structure to a file without the schema information" do
           contents = File.read(temp_file)
           expect(contents).to include('CREATE TABLE "TEST_POSTS"')
@@ -97,6 +101,7 @@ describe "Oracle Enhanced adapter database tasks" do
           ActiveRecord::Tasks::DatabaseTasks.drop(config)
           ActiveRecord::Tasks::DatabaseTasks.structure_load(config, temp_file)
         end
+
         it "loads the database structure from a file" do
           expect(ActiveRecord::Base.connection.table_exists?(:test_posts)).to be_truthy
         end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -127,6 +127,7 @@ describe "OracleEnhancedAdapter schema dump" do
         remove_foreign_key :test_comments, name: "comments_posts_baz_fooz_fk" rescue nil
       end
     end
+
     after(:all) do
       schema_define do
         drop_table :test_comments, if_exists: true
@@ -383,6 +384,7 @@ describe "OracleEnhancedAdapter schema dump" do
           end
         end
       end
+
       after(:all) do
         if @oracle11g_or_higher
           schema_define do
@@ -390,6 +392,7 @@ describe "OracleEnhancedAdapter schema dump" do
           end
         end
       end
+
       it "should dump correctly" do
         output = dump_table_schema "test_names"
         expect(output).not_to match(/t\.index .+FIRST_NAME.+$/)

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -550,6 +550,7 @@ end
       class ::TestPost < ActiveRecord::Base
       end
     end
+
     it "should use default tablespace for clobs" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[:clob] = DATABASE_NON_DEFAULT_TABLESPACE
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[:nclob] = nil
@@ -1157,6 +1158,7 @@ end
         @conn.drop_table :tablespace_tests, if_exists: true
         ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces.delete(:table)
       end
+
       it "should use correct tablespace" do
         ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[:table] = DATABASE_NON_DEFAULT_TABLESPACE
         @conn.create_table :tablespace_tests do |t|
@@ -1171,6 +1173,7 @@ end
         @conn.drop_table :tablespace_tests, if_exists: true
         ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces.delete(:table)
       end
+
       it "should use correct tablespace" do
         @conn.create_table :tablespace_tests, id: false, organization: "INDEX INITRANS 4 COMPRESS 1", tablespace: "bogus" do |t|
           t.integer :id

--- a/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
@@ -9,6 +9,7 @@ describe "OracleEnhancedAdapter structure dump" do
     @oracle11g_or_higher = !! @conn.select_value(
       "select * from product_component_version where product like 'Oracle%' and to_number(substr(version,1,2)) >= 11")
   end
+
   describe "structure dump" do
     before(:each) do
       @conn.create_table :test_posts, force: true do |t|
@@ -243,10 +244,12 @@ describe "OracleEnhancedAdapter structure dump" do
       expect(dump).to match(/#{comment_sql}/)
     end
   end
+
   describe "temporary tables" do
     after(:all) do
       @conn.drop_table :test_comments, if_exists: true
     end
+
     it "should dump correctly" do
       @conn.create_table :test_comments, temporary: true, id: false do |t|
         t.integer :post_id
@@ -261,26 +264,32 @@ describe "OracleEnhancedAdapter structure dump" do
     before(:each) do
       @conn.execute sql
     end
+
     after(:each) do
       @conn.execute "drop SEQUENCE \"#{sequence_name}\""
     end
+
     subject do
       ActiveRecord::Base.connection.structure_dump
     end
+
     context "default sequence" do
       let(:sql) { "CREATE SEQUENCE \"#{sequence_name}\"" }
       it { is_expected.to_not match(%r{CREATE SEQUENCE "#{sequence_name}" MAXVALUE \d+ MINVALUE \d+ NOORDER NOCYCLE}) }
     end
+
     context "noorder" do
       let(:sql) { "CREATE SEQUENCE \"#{sequence_name}\" NOORDER" }
       it { is_expected.to include("NOORDER") }
       it { is_expected.to_not include(" ORDER") }
     end
+
     context "order" do
       let(:sql) { "CREATE SEQUENCE \"#{sequence_name}\" ORDER" }
       it { is_expected.to include(" ORDER") }
       it { is_expected.to_not include("NOORDER") }
     end
+
     context "min max values" do
       let(:sql) { "CREATE SEQUENCE \"#{sequence_name}\" MINVALUE 7 MAXVALUE 444" }
       it { is_expected.to include("MINVALUE 7") }
@@ -317,6 +326,7 @@ describe "OracleEnhancedAdapter structure dump" do
         t.string :foo
       end
     end
+
     it "should dump drop sql for just temp tables" do
       dump = @conn.temp_table_drop
       expect(dump).to match(/DROP TABLE "TEMP_TBL"/)
@@ -444,6 +454,7 @@ describe "OracleEnhancedAdapter structure dump" do
         create or replace type full_drop_test_type as table of number
       SQL
     end
+
     after(:each) do
       @conn.drop_table :full_drop_test
       @conn.drop_table :full_drop_test_temp
@@ -455,6 +466,7 @@ describe "OracleEnhancedAdapter structure dump" do
       @conn.execute "DROP PROCEDURE FULL_DROP_TEST_PROCEDURE" rescue nil
       @conn.execute "DROP TYPE FULL_DROP_TEST_TYPE" rescue nil
     end
+
     it "should contain correct sql" do
       drop = @conn.full_drop
       expect(drop).to match(/DROP TABLE "FULL_DROP_TEST" CASCADE CONSTRAINTS/)

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -129,6 +129,7 @@ describe "OracleEnhancedAdapter" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[:clob] = "UNUSED"
       @conn = ActiveRecord::Base.connection
     end
+
     after(:all) do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces = {}
     end
@@ -136,6 +137,7 @@ describe "OracleEnhancedAdapter" do
     after(:each) do
       @conn.drop_table :foos, if_exists: true
     end
+
     it "should create ok" do
       @conn.create_table :foos, temporary: true, id: false do |t|
         t.integer :id
@@ -648,7 +650,7 @@ describe "OracleEnhancedAdapter" do
       expect(@logger.logged(:debug).last).to match(/\["table_name", "TEST_POSTS"\]/)
     end
 
-    it "should not raise missing IN/OUT parameter like issue 1678 " do
+    it "should not raise missing IN/OUT parameter like issue 1678" do
       # "to_sql" enforces unprepared_statement including dictionary access SQLs
       expect { User.joins(:group).to_sql }.not_to raise_exception
     end
@@ -721,12 +723,14 @@ describe "OracleEnhancedAdapter" do
         end
       end
     end
+
     after(:all) do
       schema_define do
         drop_table :table_with_name_thats_just_ok,
           sequence_name: "suitably_short_seq" rescue nil
       end
     end
+
     it "should create table with custom sequence name" do
       expect(@conn.select_value("select suitably_short_seq.nextval from dual")).to eq(1)
     end
@@ -767,7 +771,7 @@ describe "OracleEnhancedAdapter" do
       expect(post.explain).to include("|  TABLE ACCESS FULL| TEST_POSTS |")
     end
 
-    it "should explain considers hints with /*+ */ " do
+    it "should explain considers hints with /*+ */" do
       post = TestPost.optimizer_hints("/*+ FULL (\"TEST_POSTS\") */")
       post = post.where(id: 1)
       expect(post.explain).to include("|  TABLE ACCESS FULL| TEST_POSTS |")


### PR DESCRIPTION
Enabled these "style" cops for now.

```
RSpec/EmptyLineAfterExampleGroup
RSpec/EmptyLineAfterHook
RSpec/EmptyLineAfterSubject
RSpec/HooksBeforeExamples
```

```ruby
$ bundle exec rubocop -a
Inspecting 72 files
...........................................C..C...CCCC..................

Offenses:

spec/active_record/connection_adapters/emulation/oracle_adapter_spec.rb:17:3: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after after.
  end
  ^^^
spec/active_record/connection_adapters/emulation/oracle_adapter_spec.rb:18:3: C: [Corrected] RSpec/HooksBeforeExamples: Move after above the examples in the group.
  after(:all) do ...
  ^^^^^^^^^^^^^^
spec/active_record/connection_adapters/emulation/oracle_adapter_spec.rb:23:1: C: [Corrected] Layout/EmptyLinesAroundBlockBody: Extra empty line detected at block body end.
spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb:18:5: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after before.
    end
    ^^^
spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb:22:5: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after after.
    end
    ^^^
spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb:28:5: C: [Corrected] RSpec/HooksBeforeExamples: Move after above the examples in the group.
    after do ...
    ^^^^^^^^
spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb:64:7: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after before.
      before { ActiveRecord::Tasks::DatabaseTasks.drop(config) }
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb:68:5: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after after.
    end
    ^^^
spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb:71:7: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after before.
      before { ActiveRecord::Tasks::DatabaseTasks.purge(config) }
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb:86:9: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after before.
        before { ActiveRecord::Tasks::DatabaseTasks.structure_dump(config, temp_file) }
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb:96:7: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after after.
      end
      ^^^
spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb:99:9: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after before.
        end
        ^^^
spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb:105:7: C: [Corrected] RSpec/HooksBeforeExamples: Move after above the examples in the group.
      after do ...
      ^^^^^^^^
spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb:111:5: C: [Corrected] RSpec/HooksBeforeExamples: Move after above the examples in the group.
    after do ...
    ^^^^^^^^
spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb:118:1: C: [Corrected] Layout/EmptyLinesAroundBlockBody: Extra empty line detected at block body end.
spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb:120:1: C: [Corrected] Layout/EmptyLinesAroundBlockBody: Extra empty line detected at block body end.
spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb:129:5: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after after.
    end
    ^^^
spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb:385:7: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after before.
      end
      ^^^
spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb:392:7: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after after.
      end
      ^^^
spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb:481:5: C: [Corrected] RSpec/HooksBeforeExamples: Move after above the examples in the group.
    after do ...
    ^^^^^^^^
spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb:486:5: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after after.
    end
    ^^^
spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb:490:1: C: [Corrected] Layout/EmptyLinesAroundBlockBody: Extra empty line detected at block body end.
spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb:552:5: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after before.
    end
    ^^^
spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb:559:5: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after after.
    end
    ^^^
spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb:601:5: C: [Corrected] RSpec/HooksBeforeExamples: Move after above the examples in the group.
    after do ...
    ^^^^^^^^
spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb:607:1: C: [Corrected] Layout/EmptyLinesAroundBlockBody: Extra empty line detected at block body end.
spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb:624:5: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after after.
    end
    ^^^
spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb:647:5: C: [Corrected] RSpec/HooksBeforeExamples: Move after above the examples in the group.
    after do ...
    ^^^^^^^^
spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb:654:1: C: [Corrected] Layout/EmptyLinesAroundBlockBody: Extra empty line detected at block body end.
spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb:1159:7: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after after.
      end
      ^^^
spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb:1173:7: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after after.
      end
      ^^^
spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb:1229:5: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after after.
    end
    ^^^
spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb:1248:5: C: [Corrected] RSpec/HooksBeforeExamples: Move after above the examples in the group.
    after do ...
    ^^^^^^^^
spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb:1253:1: C: [Corrected] Layout/EmptyLinesAroundBlockBody: Extra empty line detected at block body end.
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:11:3: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after before.
  end
  ^^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:245:3: C: [Corrected] RSpec/EmptyLineAfterExampleGroup: Add an empty line after describe.
  end
  ^^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:249:5: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after after.
    end
    ^^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:263:5: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after before.
    end
    ^^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:266:5: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after after.
    end
    ^^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:269:5: C: [Corrected] RSpec/EmptyLineAfterSubject: Add an empty line after subject.
    end
    ^^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:273:5: C: [Corrected] RSpec/EmptyLineAfterExampleGroup: Add an empty line after context.
    end
    ^^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:278:5: C: [Corrected] RSpec/EmptyLineAfterExampleGroup: Add an empty line after context.
    end
    ^^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:283:5: C: [Corrected] RSpec/EmptyLineAfterExampleGroup: Add an empty line after context.
    end
    ^^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:319:5: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after before.
    end
    ^^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:325:5: C: [Corrected] RSpec/HooksBeforeExamples: Move after above the examples in the group.
    after(:each) do ...
    ^^^^^^^^^^^^^^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:333:5: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after after.
    end
    ^^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:360:5: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after after.
    end
    ^^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:383:5: C: [Corrected] RSpec/HooksBeforeExamples: Move after above the examples in the group.
    after do ...
    ^^^^^^^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:395:1: C: [Corrected] Layout/EmptyLinesAroundBlockBody: Extra empty line detected at block body end.
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:446:5: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after before.
    end
    ^^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:457:5: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after after.
    end
    ^^^
spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:131:5: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after before.
    end
    ^^^
spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:138:5: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after after.
    end
    ^^^
spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:684:5: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after after.
    end
    ^^^
spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:703:5: C: [Corrected] RSpec/HooksBeforeExamples: Move after above the examples in the group.
    after(:all) do ...
    ^^^^^^^^^^^^^^
spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:712:1: C: [Corrected] Layout/EmptyLinesAroundBlockBody: Extra empty line detected at block body end.
spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:723:5: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after before.
    end
    ^^^
spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:729:5: C: [Corrected] RSpec/EmptyLineAfterHook: Add an empty line after after.
    end
    ^^^

72 files inspected, 58 offenses detected, 58 offenses corrected
$
```