### PR TITLE
Use `debug` gem to replace `byebug`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :development do
 
   platforms :ruby do
     gem "ruby-oci8",    github: "kubo/ruby-oci8"
-    gem "byebug"
+    gem "debug", require: false
   end
 
   platforms :jruby do


### PR DESCRIPTION
debug gem requires Ruby 2.6.0 which is satisified
with Active Record Oracle enhanced adapter master branch which already
requires Ruby 2.7.