### PR TITLE
Enable `RSpec/RepeatedExample` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -294,3 +294,6 @@ RSpec/EmptyLineAfterSubject:
 
 RSpec/ExcessiveDocstringSpacing:
   Enabled: true
+
+RSpec/RepeatedExample:
+  Enabled: true

--- a/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
@@ -229,20 +229,6 @@ describe "OracleEnhancedAdapter structure dump" do
       dump = ActiveRecord::Base.connection.structure_dump
       expect(dump).to match(/#{comment_sql}/)
     end
-
-    it "should dump table comments" do
-      comment_sql = %Q(COMMENT ON TABLE "TEST_POSTS" IS 'Test posts with ''some'' "quotes"')
-      @conn.execute comment_sql
-      dump = ActiveRecord::Base.connection.structure_dump
-      expect(dump).to match(/#{comment_sql}/)
-    end
-
-    it "should dump column comments" do
-      comment_sql = %Q(COMMENT ON COLUMN "TEST_POSTS"."TITLE" IS 'The title of the post with ''some'' "quotes"')
-      @conn.execute comment_sql
-      dump = ActiveRecord::Base.connection.structure_dump
-      expect(dump).to match(/#{comment_sql}/)
-    end
   end
 
   describe "temporary tables" do


### PR DESCRIPTION
This cop actually finds the actual repeated examples below. So let's
remove them.

```ruby
$ bundle exec rubocop
Inspecting 72 files
....................................................C...................

Offenses:

spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:219:5: C: RSpec/RepeatedExample: Don't repeat examples within an example group.
    it "should dump table comments" do ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:226:5: C: RSpec/RepeatedExample: Don't repeat examples within an example group.
    it "should dump column comments" do ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:233:5: C: RSpec/RepeatedExample: Don't repeat examples within an example group.
    it "should dump table comments" do ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb:240:5: C: RSpec/RepeatedExample: Don't repeat examples within an example group.
    it "should dump column comments" do ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

72 files inspected, 4 offenses detected
$
```