### PR TITLE
Enabled `RSpec/RepeatedDescription` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -301,5 +301,8 @@ RSpec/EmptyLineAfterSubject:
 RSpec/ExcessiveDocstringSpacing:
   Enabled: true
 
+RSpec/RepeatedDescription:
+  Enabled: true
+
 RSpec/RepeatedExample:
   Enabled: true

--- a/spec/active_record/connection_adapters/oracle_enhanced/dbms_output_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/dbms_output_spec.rb
@@ -47,7 +47,7 @@ describe "OracleEnhancedAdapter logging dbms_output from plsql" do
     expect(@logger.output(:debug)).not_to match(/^DBMS_OUTPUT/)
   end
 
-  it "should log dbms output lines to the rails log" do
+  it "should log dbms output longer lines to the rails log" do
     @conn.enable_dbms_output
 
     expect(@conn.select_all("select more_than_five_characters_long('hi there') is_it_long from dual").to_a).to eq([{ "is_it_long" => 1 }])
@@ -57,7 +57,7 @@ describe "OracleEnhancedAdapter logging dbms_output from plsql" do
     expect(@logger.output(:debug)).to match(/^DBMS_OUTPUT: about to return: 1$/)
   end
 
-  it "should log dbms output lines to the rails log" do
+  it "should log dbms output shorter lines to the rails log" do
     @conn.enable_dbms_output
 
     expect(@conn.select_all("select more_than_five_characters_long('short') is_it_long from dual").to_a).to eq([{ "is_it_long" => 0 }])

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -881,7 +881,7 @@ end
       expect(TestPost.columns_hash["a" * 128]).not_to be_nil
     end
 
-    it "should add lob column with non_default tablespace" do
+    it "should add text type lob column with non_default tablespace" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[:clob] = DATABASE_NON_DEFAULT_TABLESPACE
       schema_define do
         add_column :test_posts, :body, :text
@@ -889,7 +889,7 @@ end
       expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'BODY'")).to eq(DATABASE_NON_DEFAULT_TABLESPACE)
     end
 
-    it "should add lob column with non_default tablespace" do
+    it "should add ntext type lob column with non_default tablespace" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[:nclob] = DATABASE_NON_DEFAULT_TABLESPACE
       schema_define do
         add_column :test_posts, :body, :ntext

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -83,7 +83,7 @@ describe "OracleEnhancedAdapter" do
         expect(@logger.logged(:debug).last).to match(/select .* from all_constraints/im)
       end
 
-      it "should get primary key from database at first time" do
+      it "should get primary key from database at second time without query" do
         expect(TestEmployee.connection.pk_and_sequence_for("test_employees")).to eq(["id", "test_employees_seq"])
         @logger.clear(:debug)
         expect(TestEmployee.connection.pk_and_sequence_for("test_employees")).to eq(["id", "test_employees_seq"])


### PR DESCRIPTION
This pull request enables `RSpec/RepeatedDescription` cop.

These offenses are fixed manually.

```ruby
$ bundle exec rubocop
Inspecting 72 files
...............................................C...C.C..................

Offenses:

spec/active_record/connection_adapters/oracle_enhanced/dbms_output_spec.rb:50:3: C: RSpec/RepeatedDescription: Don't repeat descriptions within an example group.
  it "should log dbms output lines to the rails log" do
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/active_record/connection_adapters/oracle_enhanced/dbms_output_spec.rb:60:3: C: RSpec/RepeatedDescription: Don't repeat descriptions within an example group.
  it "should log dbms output lines to the rails log" do
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb:884:5: C: RSpec/RepeatedDescription: Don't repeat descriptions within an example group.
    it "should add lob column with non_default tablespace" do
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb:892:5: C: RSpec/RepeatedDescription: Don't repeat descriptions within an example group.
    it "should add lob column with non_default tablespace" do
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:81:7: C: RSpec/RepeatedDescription: Don't repeat descriptions within an example group.
      it "should get primary key from database at first time" do
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:86:7: C: RSpec/RepeatedDescription: Don't repeat descriptions within an example group.
      it "should get primary key from database at first time" do
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

72 files inspected, 6 offenses detected
$
```