### PR TITLE
Require MFA to release

### DIFF
--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -24,6 +24,10 @@ This adapter is superset of original ActiveRecord Oracle adapter.
   s.require_paths = ["lib"]
   s.summary = "Oracle enhanced adapter for ActiveRecord"
   s.test_files = Dir["spec/**/*"]
+  s.metadata = {
+    "rubygems_mfa_required" => "true"
+  }
+
   s.add_runtime_dependency("activerecord", ["~> 7.1.0.alpha"])
   s.add_runtime_dependency("ruby-plsql", [">= 0.6.0"])
   if /java/.match?(RUBY_PLATFORM)


### PR DESCRIPTION
## Summary

Follow up https://github.com/rails/rails/commit/9195b7f and https://github.com/rails/rails/commit/1fde031.

This product can tell gem users that it has been released using MFA.
For example, users can see it with `REQUIRES MFA ACCOUNTS` on the Rails gem page:
https://rubygems.org/gems/rails

It's up to @yahonda as the lead maintainer to decide whether or not to take this.

## Other Information

There are other items that can be set in the `s.metadata`, but that is not the purpose of this PR.