### PR TITLE
Use default_sequence_name to identify sequence when rename a table

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -259,7 +259,7 @@ module ActiveRecord
           schema_cache.clear_data_source_cache!(table_name.to_s)
           schema_cache.clear_data_source_cache!(new_name.to_s)
           execute "RENAME #{quote_table_name(table_name)} TO #{quote_table_name(new_name)}"
-          execute "RENAME #{quote_table_name("#{table_name}_seq")} TO #{default_sequence_name(new_name)}" rescue nil
+          execute "RENAME #{default_sequence_name("#{table_name}")} TO #{default_sequence_name(new_name)}" rescue nil
 
           rename_table_indexes(table_name, new_name)
         end


### PR DESCRIPTION
I encountered a problem when renaming a table with a sequence that has a shortened table name in it to meet the 30 character limit.

Because errors when renaming a sequence are rescued with `nil` i recognized the error after executing the migration on my running test environment.

Example:
Table name: `HERE_IS_MY_LOOONG_TABLE_NAME`
Sequence name: `HERE_IS_MY_LOOONG_TABLE_NA_SEQ`

When executing a rename as follow:
```ruby
rename_table :here_is_my_looong_table_name :short_table_name
```

The adapter try to change a sequence named `HERE_IS_MY_LOOONG_TABLE_NAME_SEQ` instead of `HERE_IS_MY_LOOONG_TABLE_NA_SEQ`