### PR TITLE
Additional connect properties for JDBC connection in adapter config

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -135,6 +135,13 @@ module ActiveRecord
             properties.put("defaultRowPrefetch", "#{prefetch_rows}") if prefetch_rows
             properties.put("internal_logon", privilege) if privilege
 
+            if config[:jdbc_connect_properties] # arbitrary additional properties for JDBC connection
+              raise "jdbc_connect_properties should contain an associative array / hash" unless config[:jdbc_connect_properties].is_a? Hash
+              config[:jdbc_connect_properties].each do |key, value|
+                properties.put(key, value)
+              end
+            end
+
             begin
               @raw_connection = java.sql.DriverManager.getConnection(url, properties)
             rescue

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -121,6 +121,12 @@ module ActiveRecord
     # * <tt>:tcp_keepalive</tt> - TCP keepalive is enabled for OCI client, defaults to true
     # * <tt>:tcp_keepalive_time</tt> - TCP keepalive time for OCI client, defaults to 600
     # * <tt>:jdbc_statement_cache_size</tt> - number of cached SQL cursors to keep open, disabled per default (for unpooled JDBC only)
+    # * <tt>:jdbc_connect_properties</tt> - Additional properties for establishing Oracle JDBC connection (for unpooled JDBC only)
+    #   example to require encryption and checksumming for network connection:
+    #     adapter: oracle_enhanced
+    #     jdbc_connect_properties:
+    #       'oracle.net.encryption_client': REQUIRED
+    #       'oracle.net.crypto_checksum_client': REQUIRED
     #
     # Optionals NLS parameters:
     #

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -58,6 +58,20 @@ describe "OracleEnhancedAdapter establish connection" do
     end
   end
 
+  it "should not encrypt JDBC network connection" do
+    if ORACLE_ENHANCED_CONNECTION == :jdbc
+      @conn = ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS)
+      expect(@conn.select("SELECT COUNT(*) Records FROM v$Session_Connect_Info WHERE SID=SYS_CONTEXT('USERENV', 'SID') AND Network_Service_Banner LIKE '%Encryption service adapter%'")).to eq([{ "records" => 0 }])
+    end
+  end
+
+  it "should encrypt JDBC network connection" do
+    if ORACLE_ENHANCED_CONNECTION == :jdbc
+      @conn = ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS.merge(jdbc_connect_properties: { 'oracle.net.encryption_client' => 'REQUESTED' }))
+      expect(@conn.select("SELECT COUNT(*) Records FROM v$Session_Connect_Info WHERE SID=SYS_CONTEXT('USERENV', 'SID') AND Network_Service_Banner LIKE '%Encryption service adapter%'")).to eq([{ "records" => 1 }])
+    end
+  end
+
   it "should connect to database using service_name" do
     ActiveRecord::Base.establish_connection(SERVICE_NAME_CONNECTION_PARAMS)
     expect(ActiveRecord::Base.connection).not_to be_nil

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -60,7 +60,7 @@ describe "OracleEnhancedAdapter establish connection" do
 
   it "should not encrypt JDBC network connection" do
     if ORACLE_ENHANCED_CONNECTION == :jdbc
-      @conn = ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS)
+      @conn = ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS.merge(jdbc_connect_properties: { "oracle.net.encryption_client" => "REJECTED" }))
       expect(@conn.select("SELECT COUNT(*) Records FROM v$Session_Connect_Info WHERE SID=SYS_CONTEXT('USERENV', 'SID') AND Network_Service_Banner LIKE '%Encryption service adapter%'")).to eq([{ "records" => 0 }])
     end
   end

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -67,7 +67,7 @@ describe "OracleEnhancedAdapter establish connection" do
 
   it "should encrypt JDBC network connection" do
     if ORACLE_ENHANCED_CONNECTION == :jdbc
-      @conn = ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS.merge(jdbc_connect_properties: { 'oracle.net.encryption_client' => 'REQUESTED' }))
+      @conn = ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS.merge(jdbc_connect_properties: { "oracle.net.encryption_client" => "REQUESTED" }))
       expect(@conn.select("SELECT COUNT(*) Records FROM v$Session_Connect_Info WHERE SID=SYS_CONTEXT('USERENV', 'SID') AND Network_Service_Banner LIKE '%Encryption service adapter%'")).to eq([{ "records" => 1 }])
     end
   end


### PR DESCRIPTION
Additional connect properties for JDBC connection in adapter config (database.yml).

This allows to configure several additional JDBC connect properties, especially network encryption and network checksumming (like requested in #2058) by:
```
adapter: oracle_enhanced
jdbc_connect_properties:
  'oracle.net.encryption_client': REQUIRED
  'oracle.net.crypto_checksum_client': REQUIRED
```
 