### PR TITLE
CI against Ruby 3.1.2, 3.0.4, and 2.7.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,9 @@ script:
 
 language: ruby
 rvm:
-  - 3.1.1
-  - 3.0.3
-  - 2.7.5
+  - 3.1.2
+  - 3.0.4
+  - 2.7.6
   - ruby-head
   # Rails 7.0 requires Ruby 2.7 or higeher.
   # CI pending until JRuby 9.4 that supports Ruby 2.7 will be released.


### PR DESCRIPTION
These Rubies have been released.

- https://www.ruby-lang.org/en/news/2022/04/12/ruby-3-1-2-released/
- https://www.ruby-lang.org/en/news/2022/04/12/ruby-3-0-4-released/
- https://www.ruby-lang.org/en/news/2022/04/12/ruby-2-7-6-released/