### PR TITLE
unique constraint to also specify index

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -300,7 +300,7 @@ module ActiveRecord
           execute "CREATE #{index_type} INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} (#{quoted_column_names})#{tablespace} #{index_options}"
           if index_type == "UNIQUE"
             unless /\(.*\)/.match?(quoted_column_names)
-              execute "ALTER TABLE #{quote_table_name(table_name)} ADD CONSTRAINT #{quote_column_name(index_name)} #{index_type} (#{quoted_column_names})"
+              execute "ALTER TABLE #{quote_table_name(table_name)} ADD CONSTRAINT #{quote_column_name(index_name)} #{index_type} (#{quoted_column_names}) USING INDEX #{quote_column_name(index_name)}"
             end
           end
         end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -1209,7 +1209,14 @@ end
       schema_define do
         add_index :keyboards, "lower(name)", unique: true, name: :index_keyboards_on_lower_name
       end
-      expect(@would_execute_sql).not_to match(/ALTER +TABLE .* ADD CONSTRAINT .* UNIQUE \(.*\(.*\)\)/)
+      expect(@would_execute_sql).not_to include("ADD CONSTRAINT")
+    end
+
+    it "should add unique constraint only to the index where it was defined" do
+      schema_define do
+        add_index :keyboards, ["name"], unique: true, name: :this_index
+      end
+      expect(@would_execute_sql.lines.last).to match(/ALTER +TABLE .* ADD CONSTRAINT .* UNIQUE \(.*\) USING INDEX "THIS_INDEX";/)
     end
   end
 

--- a/spec/active_record/oracle_enhanced/type/dirty_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/dirty_spec.rb
@@ -125,6 +125,8 @@ describe "OracleEnhancedAdapter dirty object tracking" do
     class << oci_conn
       def write_lob(lob, value, is_binary = false); raise "don't do this'"; end
     end
+    @employee.comments = +"initial"
+    expect(@employee.comments_changed?).to be false
     expect { @employee.save! }.not_to raise_error
     class << oci_conn
       remove_method :write_lob


### PR DESCRIPTION
This patch makes unique constraints to also
specify index name it should affect.

Otherwise it picks the first index that it finds that
contains that column name, even if it is shared with other columns and it
is not unique.

I included in the pull request two other test updates if you don't mind.