### PR TITLE
Lazy load type mappings

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -691,6 +691,12 @@ module ActiveRecord
       end
 
       class << self
+
+          def type_map
+            @type_map ||= Type::TypeMap.new.tap { |m| initialize_type_map(m) }
+            @type_map
+          end
+
         private
           def initialize_type_map(m)
             super
@@ -724,10 +730,9 @@ module ActiveRecord
           end
       end
 
-      TYPE_MAP = Type::TypeMap.new.tap { |m| initialize_type_map(m) }
 
       def type_map
-        TYPE_MAP
+        self.class.type_map
       end
 
       def extract_value_from_default(default)

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -453,6 +453,11 @@ module ActiveRecord
         @logger.warn "#{adapter_name} automatic reconnection failed: #{e.message}" if @logger
       end
 
+      def clear_cache!
+        self.class.clear_type_map!
+        super
+      end
+
       def reset!
         clear_cache!
         super
@@ -691,11 +696,14 @@ module ActiveRecord
       end
 
       class << self
+        def type_map
+          @type_map ||= Type::TypeMap.new.tap { |m| initialize_type_map(m) }
+          @type_map
+        end
 
-          def type_map
-            @type_map ||= Type::TypeMap.new.tap { |m| initialize_type_map(m) }
-            @type_map
-          end
+        def clear_type_map!
+          @type_map = nil
+        end
 
         private
           def initialize_type_map(m)
@@ -729,7 +737,6 @@ module ActiveRecord
             end
           end
       end
-
 
       def type_map
         self.class.type_map

--- a/spec/active_record/oracle_enhanced/type/integer_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/integer_spec.rb
@@ -87,5 +87,12 @@ describe "OracleEnhancedAdapter integer type detection based on attribute settin
       create_employee2
       expect(@employee2.is_manager).to be_a(Integer)
     end
+
+    it "should return Integer value from NUMBER(1) column if emulate_booleans is set to false" do
+      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans = false
+      ActiveRecord::Base.clear_cache!
+      create_employee2
+      expect(@employee2.is_manager).to be_a(Integer)
+    end
   end
 end

--- a/spec/active_record/oracle_enhanced/type/integer_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/integer_spec.rb
@@ -90,6 +90,7 @@ describe "OracleEnhancedAdapter integer type detection based on attribute settin
 
     it "should return Integer value from NUMBER(1) column if emulate_booleans is set to false" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans = false
+      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.clear_cache!
       ActiveRecord::Base.clear_cache!
       create_employee2
       expect(@employee2.is_manager).to be_a(Integer)

--- a/spec/active_record/oracle_enhanced/type/integer_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/integer_spec.rb
@@ -90,7 +90,7 @@ describe "OracleEnhancedAdapter integer type detection based on attribute settin
 
     it "should return Integer value from NUMBER(1) column if emulate_booleans is set to false" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans = false
-      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.clear_cache!
+      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.clear_type_map!
       ActiveRecord::Base.clear_cache!
       create_employee2
       expect(@employee2.is_manager).to be_a(Integer)


### PR DESCRIPTION
This appears to fix issue #2256. I believe it should have the same memory implications as the intention in #2199. The type maps are loaded once when they are first called. Only one instance of the mapping is ever created.

Fortunately this was enough to solve the problem, but if there were a need, this could easily be worked into the clear_cache! API to reset it at a later point in the application just by setting the @type_map to nil.