### PR TITLE
Revert "Configure `continue-on-error: true` to run all CI"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,6 @@ jobs:
   build:
 
     runs-on: ubuntu-20.04
-    continue-on-error: true
     strategy:
       matrix:
         # Rails 7.0 requires Ruby 2.7 or higeher.


### PR DESCRIPTION
Reverts rsim/oracle-enhanced#2130

As a side effect, setting `continue-on-error: true` marks the status "Success" even if the Jobs fails .  

Refer to https://github.com/rsim/oracle-enhanced/actions/runs/2606963371