### PR TITLE
Update link address of Travis from travis.org to travis.com

### DIFF
--- a/RUNNING_TESTS.md
+++ b/RUNNING_TESTS.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/rsim/oracle-enhanced.svg?branch=master)](https://travis-ci.org/rsim/oracle-enhanced)
+[![Build Status](https://app.travis-ci.com/rsim/oracle-enhanced.svg?branch=master)](https://app.travis-ci.com/rsim/oracle-enhanced)
 
 # When and Which tests need to be executed
 


### PR DESCRIPTION
rsim/oracle-enhanced repository was migrated and is now building on travis-ci.com.