### PR TITLE
CI: Add fast-fail: false

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         # Rails 7.0 requires Ruby 2.7 or higeher.
         # CI pending the following matrix until JRuby 9.4 that supports Ruby 2.7 will be released.


### PR DESCRIPTION
Enable running specs on CI against TruffleRuby.