### PR TITLE
CI against Ruby 3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
         # - jruby,
         # - jruby-head
         ruby: [
+          '3.2',
           '3.1',
           '3.0',
           '2.7',


### PR DESCRIPTION
This pull request adds CI against Ruby 3.2 at GitHub Actions.