### PR TITLE
Address `Style/RedundantRegexpEscape` offense

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -26,7 +26,7 @@ module ActiveRecord
           # if only valid lowercase column characters in name
           when /^[a-z][a-z_0-9$#]*$/
             "\"#{name.upcase}\""
-          when /^[a-z][a-z_0-9$#\-]*$/i
+          when /^[a-z][a-z_0-9$#-]*$/i
             "\"#{name}\""
           # if other characters present then assume that it is expression
           # which should not be quoted


### PR DESCRIPTION
This commit addresses the following offense.

```ruby
$ bundle exec rubocop -a
Inspecting 72 files
...................C....................................................

Offenses:

lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:29:33: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
          when /^[a-z][a-z_0-9$#\-]*$/i
                                ^^

72 files inspected, 1 offense detected, 1 offense corrected
$
```