### PR TITLE
Rename GitHub workflow name from Ruby to RuboCop

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,4 +1,4 @@
-name: Ruby
+name: RuboCop
 
 on:
   push:


### PR DESCRIPTION
This pull request renames GitHub workflow name from Ruby to RuboCop. Renamed the file name as follows.
```
$ git mv ruby.yml rubocop.yml
```