### PR TITLE
Use Ruby 3.2 for RuboCop workflow

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Ruby 3.1
+      - name: Set up Ruby 3.2
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: 3.2
       - name: Install required package
         run: |
           sudo apt-get install alien


### PR DESCRIPTION
This pull request uses Ruby 3.2 for RuboCop workflow
Follow-up #2321