### PR TITLE
Make sure unit tests run successfully before rails/rails#44591 is merged

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development do
   gem "rubocop-rails", require: false
   gem "rubocop-rspec", require: false
 
-  gem "activerecord",   github: "rails/rails", ref: "7fe221d898afe877f282b549bd8bb908ebe1843d"
+  gem "activerecord",   github: "rails/rails", ref: "0e9267767f19065fa513038253179ad6b05c29ab"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do


### PR DESCRIPTION
This pull request ensures unit tests run successfully before rails/rails#44591 is merged. 

It should fail since this commit is merged https://github.com/rails/rails/commit/deec3004d8d85443dc4f3f5fd22ab86b10adb58b then the previous commit https://github.com/rails/rails/commit/0e9267767f19065fa513038253179ad6b05c29ab is used tentatively.