### PR TITLE
Bump Ruby versions at Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,10 @@ script:
 
 language: ruby
 rvm:
-  - 3.2.1
-  - 3.1.2
-  - 3.0.4
-  - 2.7.6
+  - 3.2.2
+  - 3.1.4
+  - 3.0.6
+  - 2.7.7
   - ruby-head
   # Rails 7.0 requires Ruby 2.7 or higeher.
   # CI pending until JRuby 9.4 that supports Ruby 2.7 will be released.


### PR DESCRIPTION
* Ruby 3.2.2 Released https://www.ruby-lang.org/en/news/2023/03/30/ruby-3-2-2-released/

* Ruby 3.1.4 Released https://www.ruby-lang.org/en/news/2023/03/30/ruby-3-1-4-released/

* Ruby 3.0.6 Released https://www.ruby-lang.org/en/news/2023/03/30/ruby-3-0-6-released/

* Ruby 2.7.7 Released https://www.ruby-lang.org/en/news/2022/11/24/ruby-2-7-7-released/