### PR TITLE
Not running spec/support/alter_system_user_password.sql at GitHub Actions

### DIFF
--- a/ci/setup_accounts.sh
+++ b/ci/setup_accounts.sh
@@ -3,7 +3,6 @@
 set -ev
 
 ${ORACLE_HOME}/bin/sqlplus system/${DATABASE_SYS_PASSWORD}@${DATABASE_NAME} <<SQL
-@@spec/support/alter_system_user_password.sql
 @@spec/support/alter_system_set_open_cursors.sql
 @@spec/support/create_oracle_enhanced_users.sql
 exit


### PR DESCRIPTION
This pull request do not call `spec/support/alter_system_user_password.sql` at GitHub Actions

It is not necessary for GitHub Actions.