### PR TITLE
Use Ubuntu 22.04 (Jammy Jellyfish) at Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: focal
+dist: jammy
 cache: bundler
 
 env:
@@ -16,7 +16,6 @@ env:
     - DATABASE_NAME=XE
     - ORA_SDTZ='Europe/Riga' # Needed as a client parameter
     - TZ='Europe/Riga'       # Needed as a DB Server parameter
-    - "JRUBY_OPTS='--debug --dev -J-Xmx1024M'"
 
 before_install:
   - chmod +x .travis/oracle/download.sh
@@ -33,25 +32,11 @@ install:
 
 script:
   - bundle exec rake spec
-  - rm Gemfile.lock
 
 language: ruby
 rvm:
   - 3.2.2
   - 3.1.4
-  - 3.0.6
-  - 2.7.7
-  - ruby-head
-  # Rails 7.0 requires Ruby 2.7 or higeher.
-  # CI pending until JRuby 9.4 that supports Ruby 2.7 will be released.
-  # https://github.com/jruby/jruby/issues/6464
-  # - jruby-9.4.0
-  # - jruby-head
-
-# matrix:
-#   allow_failures:
-#   - rvm: jruby-9.4.0
-#   - rvm: jruby-head
 
 notifications:
   email: false


### PR DESCRIPTION
- Ruby 3.0 and Ruby 2.7 are dropped because it is not compatible with Ubuntu 22.04 (Jammy Jellyfish) that ships with OpenSSL 3 and OpenSSL 3 support is available only for Ruby 3.1 or higher

Refer to https://bugs.ruby-lang.org/issues/18658
> We decided to not backport openssl-3.x gem into ruby_2_7 and ruby_3_0 branches. Because it affects with OpenSSL 1.0.x.

CI against Oracle Database 11g will be migrated to GitHub Actions via https://github.com/rsim/oracle-enhanced/pull/2327
that runs all Ruby versions supported by Rails main branch, so removing Ruby 2.7 and 3.0 here should be safe.