### PR TITLE
Remove `OPTIMIZER_FEATURES_ENABLE('11.2.0.2')` hint

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -181,7 +181,7 @@ module ActiveRecord # :nodoc:
           def extract_expression_for_virtual_column(column)
             column_name = column.name
             @connection.select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name.upcase), bind_string("column_name", column_name.upcase)]).inspect
-              select /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ data_default from all_tab_columns
+              select data_default from all_tab_columns
               where owner = SYS_CONTEXT('userenv', 'current_schema')
               and table_name = :table_name
               and column_name = :column_name

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -571,7 +571,7 @@ module ActiveRecord
       # Default tablespace name of current user
       def default_tablespace
         select_value(<<~SQL.squish, "SCHEMA")
-          SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ LOWER(default_tablespace) FROM user_users
+          SELECT LOWER(default_tablespace) FROM user_users
           WHERE username = SYS_CONTEXT('userenv', 'current_schema')
         SQL
       end
@@ -580,7 +580,7 @@ module ActiveRecord
         (owner, desc_table_name) = @raw_connection.describe(table_name)
 
         select_all(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("table_name", desc_table_name)])
-          SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ cols.column_name AS name, cols.data_type AS sql_type,
+          SELECT cols.column_name AS name, cols.data_type AS sql_type,
                  cols.data_default, cols.nullable, cols.virtual_column, cols.hidden_column,
                  cols.data_type_owner AS sql_type_owner,
                  DECODE(cols.data_type, 'NUMBER', data_precision,
@@ -612,7 +612,7 @@ module ActiveRecord
         (owner, desc_table_name) = @raw_connection.describe(table_name)
 
         seqs = select_values_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("sequence_name", default_sequence_name(desc_table_name))])
-          select /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ us.sequence_name
+          select us.sequence_name
           from all_sequences us
           where us.sequence_owner = :owner
           and us.sequence_name = upper(:sequence_name)
@@ -620,7 +620,7 @@ module ActiveRecord
 
         # changed back from user_constraints to all_constraints for consistency
         pks = select_values_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("table_name", desc_table_name)])
-          SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ cc.column_name
+          SELECT cc.column_name
             FROM all_constraints c, all_cons_columns cc
            WHERE c.owner = :owner
              AND c.table_name = :table_name
@@ -654,7 +654,7 @@ module ActiveRecord
         (_owner, desc_table_name) = @raw_connection.describe(table_name)
 
         pks = select_values_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("table_name", desc_table_name)])
-          SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */ cc.column_name
+          SELECT cc.column_name
             FROM all_constraints c, all_cons_columns cc
            WHERE c.owner = SYS_CONTEXT('userenv', 'current_schema')
              AND c.table_name = :table_name
@@ -684,7 +684,7 @@ module ActiveRecord
 
       def temporary_table?(table_name) # :nodoc:
         select_value_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name.upcase)]) == "Y"
-          SELECT /*+ OPTIMIZER_FEATURES_ENABLE('11.2.0.2') */
+          SELECT
           temporary FROM all_tables WHERE table_name = :table_name and owner = SYS_CONTEXT('userenv', 'current_schema')
         SQL
       end


### PR DESCRIPTION
This pull request removes `OPTIMIZER_FEATURES_ENABLE('11.2.0.2')` hint

This hint caused slowness #2179, and I decided to remove this hint.

There are no significant elapsed time changes with/without this hint in our CI:

* With `OPTIMIZER_FEATURES_ENABLE('11.2.0.2')` hint

- test that runs Oracle Database 23c XE
https://github.com/rsim/oracle-enhanced/actions/runs/4963761266/jobs/8883291198?pr=2337

> Finished in 5 minutes 43 seconds (files took 0.70408 seconds to load)

- test_11g that runs Oracle Database 11g XE
https://github.com/rsim/oracle-enhanced/actions/runs/4963761261/jobs/8883291209?pr=2337

> Finished in 17 minutes 39 seconds (files took 0.6625 seconds to load)

* Without `OPTIMIZER_FEATURES_ENABLE('11.2.0.2')` hint

- test that runs Oracle Database 23c XE
https://github.com/rsim/oracle-enhanced/actions/runs/4963590072/jobs/8882971220?pr=2337

> Finished in 5 minutes 45 seconds (files took 0.67993 seconds to load)

- test_11g that runs Oracle Database 11g XE
https://github.com/rsim/oracle-enhanced/actions/runs/4963590070/jobs/8882971277?pr=2337

> Finished in 17 minutes 43 seconds (files took 0.7018 seconds to load)

Fix #2179