### PR TITLE
Disable `truffleruby-head` from our CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,7 @@ jobs:
           '3.2',
           '3.1',
           '3.0',
-          '2.7',
-          'truffleruby-head'
+          '2.7'
         ]
     env:
       ORACLE_HOME: /usr/lib/oracle/21/client64

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -22,8 +22,7 @@ jobs:
           '3.2',
           '3.1',
           '3.0',
-          '2.7',
-          'truffleruby-head'
+          '2.7'
         ]
     env:
       ORACLE_HOME: /usr/lib/oracle/21/client64


### PR DESCRIPTION
because `Run RSpec` did not finish after 5h 55m running. https://github.com/rsim/oracle-enhanced/actions/runs/4963761266/jobs/8883291465