### PR TITLE
Remove workaround for jruby-head

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,9 +79,6 @@ jobs:
       - name: Run RSpec
         run: |
           bundle exec rspec
-      - name: Workaround jruby-head failure by removing Gemfile.lock
-        run: |
-          rm Gemfile.lock
       - name: Run bug report templates
         if: "false"
         run: |

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -80,9 +80,6 @@ jobs:
       - name: Run RSpec
         run: |
           bundle exec rspec
-      - name: Workaround jruby-head failure by removing Gemfile.lock
-        run: |
-          rm Gemfile.lock
       - name: Run bug report templates
         if: "false"
         run: |


### PR DESCRIPTION
Revisit when we can resume CI against JRuby.

Refeer to https://github.com/rsim/oracle-enhanced/pull/2035 rubygems/rubygems#3796