### PR TITLE
Make ActiveRecord's quoted name caches thread-safe on JRuby/TruffleRuby

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -7,10 +7,12 @@ module ActiveRecord
         # QUOTING ==================================================
         #
         # see: abstract/quoting.rb
+        QUOTED_COLUMN_NAMES = Concurrent::Map.new # :nodoc:
+        QUOTED_TABLE_NAMES = Concurrent::Map.new # :nodoc:
 
         def quote_column_name(name) # :nodoc:
           name = name.to_s
-          self.class.quoted_column_names[name] ||= if /\A[a-z][a-z_0-9$#]*\Z/.match?(name)
+          QUOTED_COLUMN_NAMES[name] ||= if /\A[a-z][a-z_0-9$#]*\Z/.match?(name)
             "\"#{name.upcase}\""
           else
             # remove double quotes which cannot be used inside quoted identifier
@@ -67,7 +69,7 @@ module ActiveRecord
 
         def quote_table_name(name) # :nodoc:
           name, _link = name.to_s.split("@")
-          self.class.quoted_table_names[name] ||= [name.split(".").map { |n| quote_column_name(n) }].join(".")
+          QUOTED_TABLE_NAMES[name] ||= [name.split(".").map { |n| quote_column_name(n) }].join(".")
         end
 
         def quote_string(s) # :nodoc:


### PR DESCRIPTION
Refer to rails/rails#48773

```ruby
$ bundle exec rspec ./spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb:234 # OracleEnhancedConnection default_timezone should respect default_timezone = :utc than time_zone setting

==> Loading config from ENV or use default
==> Running specs with ruby version 3.2.2
==> Effective ActiveRecord version 7.0.6
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb"=>[234]}}
F
An error occurred in an `after(:context)` hook.
Failure/Error: Object.send(:remove_const, "Post")

NameError:
  constant Object::Post not defined

Failures:

  1) OracleEnhancedConnection default_timezone should respect default_timezone = :utc than time_zone setting
     Failure/Error: self.class.quoted_table_names[name] ||= [name.split(".").map { |n| quote_column_name(n) }].join(".")

     NoMethodError:
       undefined method `quoted_table_names' for ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter:Class
     # ./lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:70:in `quote_table_name'
     # ./lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:269:in `drop_table'
     # ./lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:233:in `create_table'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/migration.rb:932:in `block in method_missing'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/migration.rb:900:in `block in say_with_time'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/3.2.0/benchmark.rb:296:in `measure'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/migration.rb:900:in `say_with_time'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/migration.rb:921:in `method_missing'
     # ./spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb:221:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:114:in `instance_eval'
     # ./spec/spec_helper.rb:114:in `block (2 levels) in schema_define'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/migration.rb:909:in `suppress_messages'
     # ./spec/spec_helper.rb:113:in `block in schema_define'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/schema.rb:55:in `instance_eval'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/schema.rb:55:in `define'
     # /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/schema.rb:50:in `define'
     # ./spec/spec_helper.rb:112:in `schema_define'
     # ./spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb:220:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.12.2/lib/rspec/core/hooks.rb:365:in `instance_exec'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.12.2/lib/rspec/core/hooks.rb:365:in `run'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.12.2/lib/rspec/core/hooks.rb:529:in `block in run_owned_hooks_for'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.12.2/lib/rspec/core/hooks.rb:528:in `each'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.12.2/lib/rspec/core/hooks.rb:528:in `run_owned_hooks_for'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.12.2/lib/rspec/core/hooks.rb:480:in `run'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.12.2/lib/rspec/core/example_group.rb:553:in `block in run_before_context_hooks'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.12.2/lib/rspec/core/memoized_helpers.rb:208:in `block in isolate_for_context_hook'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.12.2/lib/rspec/core/memoized_helpers.rb:204:in `instance_exec'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.12.2/lib/rspec/core/memoized_helpers.rb:204:in `isolate_for_context_hook'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.12.2/lib/rspec/core/example_group.rb:552:in `run_before_context_hooks'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.12.2/lib/rspec/core/example_group.rb:606:in `run'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.12.2/lib/rspec/core/example_group.rb:608:in `block in run'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.12.2/lib/rspec/core/example_group.rb:608:in `map'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.12.2/lib/rspec/core/example_group.rb:608:in `run'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.12.2/lib/rspec/core/runner.rb:121:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.12.2/lib/rspec/core/runner.rb:121:in `map'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.12.2/lib/rspec/core/runner.rb:121:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.12.2/lib/rspec/core/configuration.rb:2070:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.12.2/lib/rspec/core/runner.rb:116:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.12.2/lib/rspec/core/reporter.rb:74:in `report'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.12.2/lib/rspec/core/runner.rb:115:in `run_specs'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.12.2/lib/rspec/core/runner.rb:89:in `run'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.12.2/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.12.2/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.12.2/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.2.2/bin/rspec:25:in `load'
     # /home/yahonda/.rbenv/versions/3.2.2/bin/rspec:25:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.14/lib/bundler/cli/exec.rb:58:in `load'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.14/lib/bundler/cli/exec.rb:58:in `kernel_load'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.14/lib/bundler/cli/exec.rb:23:in `run'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.14/lib/bundler/cli.rb:492:in `exec'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.14/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.14/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.14/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.14/lib/bundler/cli.rb:34:in `dispatch'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.14/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.14/lib/bundler/cli.rb:28:in `start'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.14/exe/bundle:37:in `block in <top (required)>'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.14/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
     # /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.14/exe/bundle:29:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.2.2/bin/bundle:25:in `load'
     # /home/yahonda/.rbenv/versions/3.2.2/bin/bundle:25:in `<main>'

Finished in 0.38168 seconds (files took 0.42519 seconds to load)
1 example, 1 failure, 1 error occurred outside of examples

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb:234 # OracleEnhancedConnection default_timezone should respect default_timezone = :utc than time_zone setting

$
```