### PR TITLE
Use Oracle Instant Client Version 21.11.0.0.0

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -22,15 +22,14 @@ jobs:
           sudo apt-get install alien
       - name: Download Oracle instant client
         run: |
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2110000/oracle-instantclient-basic-21.10.0.0.0-1.x86_64.rpm
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2110000/oracle-instantclient-sqlplus-21.10.0.0.0-1.x86_64.rpm
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2110000/oracle-instantclient-devel-21.10.0.0.0-1.x86_64.rpm
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/2111000/oracle-instantclient-basic-21.11.0.0.0-1.x86_64.rpm
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/2111000/oracle-instantclient-sqlplus-21.11.0.0.0-1.x86_64.rpm
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/2111000/oracle-instantclient-devel-21.11.0.0.0-1.x86_64.rpm
       - name: Install Oracle instant client
         run: |
-          sudo alien -i oracle-instantclient-basic-21.10.0.0.0-1.x86_64.rpm
-          sudo alien -i oracle-instantclient-sqlplus-21.10.0.0.0-1.x86_64.rpm
-          sudo alien -i oracle-instantclient-devel-21.10.0.0.0-1.x86_64.rpm
-
+          sudo alien -i oracle-instantclient-basic-21.11.0.0.0-1.x86_64.rpm
+          sudo alien -i oracle-instantclient-sqlplus-21.11.0.0.0-1.x86_64.rpm
+          sudo alien -i oracle-instantclient-devel-21.11.0.0.0-1.x86_64.rpm
       - name: Build and run RuboCop
         run: |
           bundle install --jobs 4 --retry 3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,14 +59,14 @@ jobs:
           sudo apt-get install alien
       - name: Download Oracle instant client
         run: |
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2110000/oracle-instantclient-basic-21.10.0.0.0-1.x86_64.rpm
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2110000/oracle-instantclient-sqlplus-21.10.0.0.0-1.x86_64.rpm
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2110000/oracle-instantclient-devel-21.10.0.0.0-1.x86_64.rpm
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/2111000/oracle-instantclient-basic-21.11.0.0.0-1.x86_64.rpm
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/2111000/oracle-instantclient-sqlplus-21.11.0.0.0-1.x86_64.rpm
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/2111000/oracle-instantclient-devel-21.11.0.0.0-1.x86_64.rpm
       - name: Install Oracle instant client
         run: |
-          sudo alien -i oracle-instantclient-basic-21.10.0.0.0-1.x86_64.rpm
-          sudo alien -i oracle-instantclient-sqlplus-21.10.0.0.0-1.x86_64.rpm
-          sudo alien -i oracle-instantclient-devel-21.10.0.0.0-1.x86_64.rpm
+          sudo alien -i oracle-instantclient-basic-21.11.0.0.0-1.x86_64.rpm
+          sudo alien -i oracle-instantclient-sqlplus-21.11.0.0.0-1.x86_64.rpm
+          sudo alien -i oracle-instantclient-devel-21.11.0.0.0-1.x86_64.rpm
       - name: Install JDBC Driver
         run: |
           wget -q https://download.oracle.com/otn-pub/otn_software/jdbc/211/ojdbc11.jar -O ./lib/ojdbc11.jar


### PR DESCRIPTION
This pull request uses Oracle Instant Client Version 21.11.0.0.0.

https://www.oracle.com/database/technologies/instant-client/linux-x86-64-downloads.html