### PR TITLE
Update primary_key method arguments to fix issue with *args causing wrong number of arguments error

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -219,9 +219,9 @@ module ActiveRecord
           unless create_sequence
             class << td
               attr_accessor :create_sequence
-              def primary_key(*args)
+              def primary_key(name, type = :primary_key, **options)
                 self.create_sequence = true
-                super(*args)
+                super(name, type, **options)
               end
             end
           end


### PR DESCRIPTION
We have found that currently when a migration invokes the primary_key method in `schema_statements.rb` e.g `t.primary_key :zlookupid, :string, limit: 1, null: false`, it causes the following wrong number of arguments error:

> ArgumentError: wrong number of arguments (given 3, expected 1..2)

Based on the use of keyword arguments in the other primary_key method definition in `schema_definitions.rb`, we think that this should be the same in the `schema_statements.rb` definition rather than using `*args` in the definition and `super` call.

We have added a local fix to get around this but wonder if this may be an issue that other's will face.
