### PR TITLE
Updates to run tests with activerecord 7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development do
   gem "rubocop-rails", require: false
   gem "rubocop-rspec", require: false
 
-  gem "activerecord",   github: "rails/rails", ref: "8551e64e2411811f26d210601abdba6e13d8798c"
+  gem "activerecord",   github: "rails/rails", tag: "v7.1.3"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do

--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -28,7 +28,7 @@ This adapter is superset of original ActiveRecord Oracle adapter.
     "rubygems_mfa_required" => "true"
   }
 
-  s.add_runtime_dependency("activerecord", ["~> 7.1.0.alpha"])
+  s.add_runtime_dependency("activerecord", ["~> 7.1.0"])
   s.add_runtime_dependency("ruby-plsql", [">= 0.6.0"])
   if /java/.match?(RUBY_PLATFORM)
     s.platform = Gem::Platform.new("java")

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -15,7 +15,7 @@ module ActiveRecord
           log(sql, name, async: async) { @raw_connection.exec(sql) }
         end
 
-        def exec_query(sql, name = "SQL", binds = [], prepare: false, async: false)
+        def internal_exec_query(sql, name = "SQL", binds = [], prepare: false, async: false)
           sql = transform_query(sql)
 
           type_casted_binds = type_casted_binds(binds)


### PR DESCRIPTION
When running the oracle enhanced tests with activerecord v7.1.0 or above I get:

```
==> Effective ActiveRecord version 7.1.3
rake aborted!
NoMethodError: undefined method `database_version' for nil:NilClass (NoMethodError)

        @raw_connection.database_version
                       ^^^^^^^^^^^^^^^^^
/app/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:699:in `get_database_version'
/usr/local/bundle/bundler/gems/rails-9c50861250dd/activerecord/lib/active_record/connection_adapters/schema_cache.rb:374:in `database_version'
/usr/local/bundle/bundler/gems/rails-9c50861250dd/activerecord/lib/active_record/connection_adapters/schema_cache.rb:70:in `database_version'
/usr/local/bundle/bundler/gems/rails-9c50861250dd/activerecord/lib/active_record/connection_adapters/schema_cache.rb:200:in `database_version'
/usr/local/bundle/bundler/gems/rails-9c50861250dd/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:871:in `database_version'
/app/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:307:in `supports_fetch_first_n_rows_and_offset?'
/app/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:271:in `arel_visitor'
/usr/local/bundle/bundler/gems/rails-9c50861250dd/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:159:in `initialize'
/app/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:250:in `initialize'
/app/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:76:in `new'
/app/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:76:in `oracle_enhanced_connection'
/usr/local/bundle/bundler/gems/rails-9c50861250dd/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:676:in `public_send'
/usr/local/bundle/bundler/gems/rails-9c50861250dd/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:676:in `new_connection'
/usr/local/bundle/bundler/gems/rails-9c50861250dd/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:723:in `checkout_new_connection'
/usr/local/bundle/bundler/gems/rails-9c50861250dd/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:702:in `try_to_checkout_new_connection'
/usr/local/bundle/bundler/gems/rails-9c50861250dd/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:654:in `acquire_connection'
/usr/local/bundle/bundler/gems/rails-9c50861250dd/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:353:in `checkout'
/usr/local/bundle/bundler/gems/rails-9c50861250dd/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:182:in `connection'
/usr/local/bundle/bundler/gems/rails-9c50861250dd/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb:246:in `retrieve_connection'
/usr/local/bundle/bundler/gems/rails-9c50861250dd/activerecord/lib/active_record/connection_handling.rb:287:in `retrieve_connection'
/usr/local/bundle/bundler/gems/rails-9c50861250dd/activerecord/lib/active_record/connection_handling.rb:254:in `connection'
/app/rakefile:24:in `block in <top (required)>'
/usr/local/bundle/gems/rake-13.1.0/exe/rake:27:in `<top (required)>'
/usr/local/bin/bundle:25:in `load'
/usr/local/bin/bundle:25:in `<main>'
Tasks: TOP => spec => clear
(See full trace by running task with --trace)
```

Line 24 in the rakefile that is causing the problem is 
`ActiveRecord::Base.connection.execute_structure_dump(ActiveRecord::Base.connection.full_drop)`. This appears to be related to the changes in https://github.com/rails/rails/pull/44576 and https://github.com/rails/rails/pull/44591. We no longer have a `@raw_connection` after calling `ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)` on line 22, so trying work with `ActiveRecord::Base.connection` gives us the nil error.

[3a288c3](https://github.com/umn-asr/oracle-enhanced/commit/3a288c39ab82a699bc329c525696f6df3b5c45e4) addresses the error in starting the tests by:
* change `get_database_version` to use `valid_raw_connection` which will connect if necessary
* setting `self.lock_thread = nil` before the call to `super` in `OracleEnhancedAdapter#initialize`. In super they assign a visitor before `self.lock_thread = nil`. In oracle enhanced assigning a visitor requires a check of `database_version`, which with the new use of `valid_raw_connection` requires `@lock` to be set first.

After those changes, the test start, although with many errors. A couple of the more immediate ones are addressed here as well:

* https://github.com/rails/rails/pull/48229 requires an `internal_exec_query` that is called by the abstract adapter's `exec_query`. Renaming oracle_enhanced's `exec_query` to `internal_exec_query` to address this
* I saw lots of errors with `active?` because `@raw_connection` is nil. Using `valid_raw_connection` in `active?` results in a stack level too deep, so I adapted he postgres adapter's implementation.
