### PR TITLE
CI against Ruby 3.3

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Ruby 3.2
+      - name: Set up Ruby 3.3
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.3
       - name: Install required package
         run: |
           sudo apt-get install alien

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
           ./ci/setup_accounts.sh
       - name: Update RubyGems
         run: |
-          gem update --system
+          gem update --system || gem update --system 3.4.22
       - name: Bundle install
         run: |
           bundle install --jobs 4 --retry 3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
         # - jruby,
         # - jruby-head
         ruby: [
+          '3.3',
           '3.2',
           '3.1',
           '3.0',

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Create database user
         run: |
           ./ci/setup_accounts.sh
+      - name: Update RubyGems
+        run: |
+          gem update --system || gem update --system 3.4.22
       - name: Bundle install
         run: |
           bundle install --jobs 4 --retry 3

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -19,6 +19,7 @@ jobs:
         # - jruby,
         # - jruby-head
         ruby: [
+          '3.3',
           '3.2',
           '3.1',
           '3.0',

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ script:
 
 language: ruby
 rvm:
+  - 3.3.0
   - 3.2.2
   - 3.1.4
 


### PR DESCRIPTION
This pull request adds CI against Ruby 3.3

* Ruby 3.3.0 Released
https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/

* Fallback to update RubyGems version to 3.4.22 if update to the latest version fails for Ruby 2.7