### PR TITLE
Bump Rails version to https://github.com/rails/rails/commit/0e92677

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development do
   gem "rubocop-rails", require: false
   gem "rubocop-rspec", require: false
 
-  gem "activerecord",   github: "rails/rails", ref: "8551e64e2411811f26d210601abdba6e13d8798c"
+  gem "activerecord",   github: "rails/rails", ref: "0e9267767f19065fa513038253179ad6b05c29ab"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do


### PR DESCRIPTION
This commit bumps Rails version to https://github.com/rails/rails/commit/0e92677

Here is the difference between the current master branch and this commit. https://github.com/rails/rails/compare/8551e64e2411811f26d210601abdba6e13d8798c...0e92677