### PR TITLE
Add allow_retry kwarg to execute

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -9,10 +9,10 @@ module ActiveRecord
         # see: abstract/database_statements.rb
 
         # Executes a SQL statement
-        def execute(sql, name = nil, async: false)
+        def execute(sql, name = nil, async: false, allow_retry: false)
           sql = transform_query(sql)
 
-          log(sql, name, async: async) { @raw_connection.exec(sql) }
+          log(sql, name, async: async) { @raw_connection.exec(sql, allow_retry: allow_retry) }
         end
 
         def exec_query(sql, name = "SQL", binds = [], prepare: false, async: false)

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -461,6 +461,11 @@ describe "OracleEnhancedConnection" do
       expect(@conn.exec("SELECT * FROM dual")).not_to be_nil
     end
 
+    it "should reconnect and execute SQL statement if connection is lost and allow_retry is passed" do
+      kill_current_session
+      expect(@conn.exec("SELECT * FROM dual", allow_retry: true)).not_to be_nil
+    end
+
     it "should not reconnect and execute SQL statement if connection is lost and auto retry is disabled" do
       # @conn.auto_retry = false
       ActiveRecord::Base.connection.auto_retry = false


### PR DESCRIPTION
This extends the existing class level auto_retry functionality to optionally allow an allow_retry boolean kwarg to allow retry of specific queries.

This PR preserves the requirement that `autocommit?` be enabled which is the safer choice.

```
  def with_retry(allow_retry: false) # :nodoc:
    should_retry = (allow_retry || self.class.auto_retry?) && autocommit?
```

See issue #2310