### PR TITLE
    Improve MockLogger - level/limited missing method (3)

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_quoting.rb
@@ -9,19 +9,19 @@ module ActiveRecord
           when ActiveModel::Type::Binary::Data
             lob_value = value == "" ? " " : value
             bind_type = OCI8::BLOB
-            ora_value = bind_type.new(@raw_connection.raw_oci_connection, lob_value)
+            ora_value = bind_type.new(_connection.raw_oci_connection, lob_value)
             ora_value.size = 0 if value == ""
             ora_value
           when Type::OracleEnhanced::Text::Data
             lob_value = value.to_s == "" ? " " : value.to_s
             bind_type = OCI8::CLOB
-            ora_value = bind_type.new(@raw_connection.raw_oci_connection, lob_value)
+            ora_value = bind_type.new(_connection.raw_oci_connection, lob_value)
             ora_value.size = 0 if value.to_s == ""
             ora_value
           when Type::OracleEnhanced::NationalCharacterText::Data
             lob_value = value.to_s == "" ? " " : value.to_s
             bind_type = OCI8::NCLOB
-            ora_value = bind_type.new(@raw_connection.raw_oci_connection, lob_value)
+            ora_value = bind_type.new(_connection.raw_oci_connection, lob_value)
             ora_value.size = 0 if value.to_s == ""
             ora_value
           else

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -53,7 +53,7 @@ module ActiveRecord
         end
 
         def data_source_exists?(table_name)
-          (_owner, _table_name) = @raw_connection.describe(table_name)
+          (_owner, _table_name) = _connection.describe(table_name)
           true
         rescue
           false
@@ -87,7 +87,7 @@ module ActiveRecord
         end
 
         def indexes(table_name) # :nodoc:
-          (_owner, table_name) = @raw_connection.describe(table_name)
+          (_owner, table_name) = _connection.describe(table_name)
           default_tablespace_name = default_tablespace
 
           result = select_all(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name)])
@@ -368,7 +368,7 @@ module ActiveRecord
         #
         # Will always query database and not index cache.
         def index_name_exists?(table_name, index_name)
-          (_owner, table_name) = @raw_connection.describe(table_name)
+          (_owner, table_name) = _connection.describe(table_name)
           result = select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name), bind_string("index_name", index_name.to_s.upcase)])
             SELECT 1 FROM all_indexes i
             WHERE i.owner = SYS_CONTEXT('userenv', 'current_schema')
@@ -511,7 +511,7 @@ module ActiveRecord
 
         def table_comment(table_name) # :nodoc:
           # TODO
-          (_owner, table_name) = @raw_connection.describe(table_name)
+          (_owner, table_name) = _connection.describe(table_name)
           select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name)])
             SELECT comments FROM all_tab_comments
             WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
@@ -527,7 +527,7 @@ module ActiveRecord
 
         def column_comment(table_name, column_name) # :nodoc:
           # TODO: it  does not exist in Abstract adapter
-          (_owner, table_name) = @raw_connection.describe(table_name)
+          (_owner, table_name) = _connection.describe(table_name)
           select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name), bind_string("column_name", column_name.upcase)])
             SELECT comments FROM all_col_comments
             WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
@@ -555,7 +555,7 @@ module ActiveRecord
 
         # get table foreign keys for schema dump
         def foreign_keys(table_name) # :nodoc:
-          (_owner, desc_table_name) = @raw_connection.describe(table_name)
+          (_owner, desc_table_name) = _connection.describe(table_name)
 
           fk_info = select_all(<<~SQL.squish, "SCHEMA", [bind_string("desc_table_name", desc_table_name)])
             SELECT r.table_name to_table

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -437,7 +437,8 @@ module ActiveRecord
 
       # return raw OCI8 or JDBC connection
       def raw_connection
-        @raw_connection.raw_connection
+        verify!
+        _connection.raw_connection
       end
 
       # Returns true if the connection is active.

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -432,7 +432,7 @@ module ActiveRecord
 
       def auto_retry=(value) # :nodoc:
         @auto_retry = value
-        @raw_connection.auto_retry = value if @raw_connection
+        _connection.auto_retry = value if _connection
       end
 
       # return raw OCI8 or JDBC connection
@@ -446,13 +446,13 @@ module ActiveRecord
         # #active? method is also available, but that simply returns the
         # last known state, which isn't good enough if the connection has
         # gone stale since the last use.
-        @raw_connection.ping
+        _connection.ping
       rescue OracleEnhanced::ConnectionException
         false
       end
 
       def reconnect
-        @raw_connection.reset # tentative
+        _connection.reset # tentative
       rescue OracleEnhanced::ConnectionException
         connect
       end
@@ -460,7 +460,7 @@ module ActiveRecord
       # Reconnects to the database.
       def reconnect! # :nodoc:
         super
-        @raw_connection.reset!
+        _connection.reset!
       rescue OracleEnhanced::ConnectionException => e
         @logger.warn "#{adapter_name} automatic reconnection failed: #{e.message}" if @logger
       end
@@ -478,12 +478,12 @@ module ActiveRecord
       # Disconnects from the database.
       def disconnect! # :nodoc:
         super
-        @raw_connection.logoff rescue nil
+        _connection.logoff rescue nil
       end
 
       def discard!
         super
-        @raw_connection = nil
+        _connection = nil
       end
 
       # use in set_sequence_name to avoid fetching primary key value from sequence
@@ -508,7 +508,7 @@ module ActiveRecord
         table_name = table_name.to_s
         do_not_prefetch = @do_not_prefetch_primary_key[table_name]
         if do_not_prefetch.nil?
-          owner, desc_table_name = @raw_connection.describe(table_name)
+          owner, desc_table_name = _connection.describe(table_name)
           @do_not_prefetch_primary_key[table_name] = do_not_prefetch = !has_primary_key?(table_name, owner, desc_table_name)
         end
         !do_not_prefetch
@@ -577,7 +577,7 @@ module ActiveRecord
       end
 
       def column_definitions(table_name)
-        (owner, desc_table_name) = @raw_connection.describe(table_name)
+        (owner, desc_table_name) = _connection.describe(table_name)
 
         select_all(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("table_name", desc_table_name)])
           SELECT cols.column_name AS name, cols.data_type AS sql_type,
@@ -609,7 +609,7 @@ module ActiveRecord
       # Find a table's primary key and sequence.
       # *Note*: Only primary key is implemented - sequence will be nil.
       def pk_and_sequence_for(table_name, owner = nil, desc_table_name = nil) # :nodoc:
-        (owner, desc_table_name) = @raw_connection.describe(table_name)
+        (owner, desc_table_name) = _connection.describe(table_name)
 
         seqs = select_values_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("sequence_name", default_sequence_name(desc_table_name))])
           select us.sequence_name
@@ -651,7 +651,7 @@ module ActiveRecord
       end
 
       def primary_keys(table_name) # :nodoc:
-        (_owner, desc_table_name) = @raw_connection.describe(table_name)
+        (_owner, desc_table_name) = _connection.describe(table_name)
 
         pks = select_values_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("table_name", desc_table_name)])
           SELECT cc.column_name
@@ -696,7 +696,7 @@ module ActiveRecord
       alias index_name_length max_identifier_length
 
       def get_database_version
-        @raw_connection.database_version
+        _connection.database_version
       end
 
       def check_version
@@ -705,6 +705,10 @@ module ActiveRecord
         if version < 10
           raise "Your version of Oracle (#{version}) is too old. Active Record Oracle enhanced adapter supports Oracle >= 10g."
         end
+      end
+
+      private def _connection
+        @unconfigured_connection || @raw_connection
       end
 
       class << self
@@ -773,7 +777,7 @@ module ActiveRecord
       end
 
       def translate_exception(exception, message:, sql:, binds:) # :nodoc:
-        case @raw_connection.error_code(exception)
+        case _connection.error_code(exception)
         when 1
           RecordNotUnique.new(message, sql: sql, binds: binds)
         when 60

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -241,7 +241,7 @@ describe "OracleEnhancedConnection" do
     end
 
     after(:all) do
-      Object.send(:remove_const, "Post")
+      Object.send(:remove_const, "Post") if defined?(Post)
       ActiveRecord::Base.clear_cache!
     end
 
@@ -428,7 +428,7 @@ describe "OracleEnhancedConnection" do
 
     before(:all) do
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-      @conn = ActiveRecord::Base.connection.instance_variable_get("@raw_connection")
+      @conn = ActiveRecord::Base.connection.send(:_connection)
       @sys_conn = ActiveRecord::ConnectionAdapters::OracleEnhanced::Connection.create(SYS_CONNECTION_PARAMS)
       schema_define do
         create_table :posts, force: true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,6 +57,8 @@ module LoggerSpecHelper
   end
 
   class MockLogger
+    LEVELS = %i[debug info warn error fatal unknown]
+
     attr_reader :flush_count
 
     def initialize
@@ -64,13 +66,22 @@ module LoggerSpecHelper
       @logged = Hash.new { |h, k| h[k] = [] }
     end
 
-    # used in AtiveRecord 2.x
+    # used in ActiveRecord 2.x
     def debug?
       true
     end
 
-    def method_missing(level, message)
-      @logged[level] << message
+    def level
+      0
+    end
+
+    def method_missing(*args)
+      if LEVELS.include?(args[0])
+        level, message  = args
+        @logged[level] << message
+      else
+        super
+      end
     end
 
     def logged(level)


### PR DESCRIPTION
Improve MockLogger - level/limited missing method

Rails commit bd19d1baf1 [1] added a check of logger.level which was not
supported by the MockLogger.

This commit adds a mock level method. And limits the missing_method to
respond only to logging calls, so any other calls will raise a
NoMethodError to make future debugging easier.

[1]
https://github.com/rails/rails/commit/bd19d1baf1cb006f3e9f16afac1c7b4e693f111c

Stacked on #2368
