### PR TITLE
Switch to Arel::Table.name instead of removed alias table_name.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development do
   gem "rubocop-rails", require: false
   gem "rubocop-rspec", require: false
 
-  gem "activerecord",   github: "rails/rails", ref: "436277da88507f9aae0874e62f3e61a8546b9683"
+  gem "activerecord",   github: "rails/rails", ref: "e6da3ebd6c65af23d134a9e01145f26600912008"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development do
   gem "rubocop-rails", require: false
   gem "rubocop-rspec", require: false
 
-  gem "activerecord",   github: "rails/rails", ref: "e6da3ebd6c65af23d134a9e01145f26600912008"
+  gem "activerecord",   github: "rails/rails", ref: "8f780c58ea2a5af17d61ac5858b33ead2c7aa494"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development do
   gem "rubocop-rails", require: false
   gem "rubocop-rspec", require: false
 
-  gem "activerecord",   github: "rails/rails", ref: "8f780c58ea2a5af17d61ac5858b33ead2c7aa494"
+  gem "activerecord",   github: "rails/rails", ref: "59f2b06493bed2c036f6b527e743198416ee1237"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development do
   gem "rubocop-rails", require: false
   gem "rubocop-rspec", require: false
 
-  gem "activerecord",   github: "rails/rails", ref: "0e9267767f19065fa513038253179ad6b05c29ab"
+  gem "activerecord",   github: "rails/rails", ref: "436277da88507f9aae0874e62f3e61a8546b9683"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development do
   gem "rubocop-rails", require: false
   gem "rubocop-rspec", require: false
 
-  gem "activerecord",   github: "rails/rails", ref: "59f2b06493bed2c036f6b527e743198416ee1237"
+  gem "activerecord",   github: "rails/rails", ref: "1d98bc563a8a7faf26238eaaa54a3257a95d644d"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -9,10 +9,10 @@ module ActiveRecord
         # see: abstract/database_statements.rb
 
         # Executes a SQL statement
-        def execute(sql, name = nil, async: false)
+        def execute(sql, name = nil, async: false, allow_retry: false)
           sql = transform_query(sql)
 
-          log(sql, name, async: async) { _connection.exec(sql) }
+          log(sql, name, async: async) { _connection.exec(sql, allow_retry: allow_retry) }
         end
 
         def exec_query(sql, name = "SQL", binds = [], prepare: false, async: false)

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_quoting.rb
@@ -9,19 +9,19 @@ module ActiveRecord
           when ActiveModel::Type::Binary::Data
             lob_value = value == "" ? " " : value
             bind_type = OCI8::BLOB
-            ora_value = bind_type.new(@raw_connection.raw_oci_connection, lob_value)
+            ora_value = bind_type.new(_connection.raw_oci_connection, lob_value)
             ora_value.size = 0 if value == ""
             ora_value
           when Type::OracleEnhanced::Text::Data
             lob_value = value.to_s == "" ? " " : value.to_s
             bind_type = OCI8::CLOB
-            ora_value = bind_type.new(@raw_connection.raw_oci_connection, lob_value)
+            ora_value = bind_type.new(_connection.raw_oci_connection, lob_value)
             ora_value.size = 0 if value.to_s == ""
             ora_value
           when Type::OracleEnhanced::NationalCharacterText::Data
             lob_value = value.to_s == "" ? " " : value.to_s
             bind_type = OCI8::NCLOB
-            ora_value = bind_type.new(@raw_connection.raw_oci_connection, lob_value)
+            ora_value = bind_type.new(_connection.raw_oci_connection, lob_value)
             ora_value.size = 0 if value.to_s == ""
             ora_value
           else

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -49,6 +49,10 @@ module ActiveRecord
         end
       end
 
+      class ColumnDefinition < ActiveRecord::ConnectionAdapters::ColumnDefinition
+        self::OPTION_NAMES.concat([ :as, :sequence_name, :sequence_start_value, :type ])
+      end
+
       class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
         include OracleEnhanced::ColumnMethods
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -276,7 +276,7 @@ module ActiveRecord
         end
 
         def insert_versions_sql(versions) # :nodoc:
-          sm_table = quote_table_name(ActiveRecord::SchemaMigration.table_name)
+          sm_table = quote_table_name(ActiveRecord::Base.connection.schema_migration.table_name)
 
           if supports_multi_insert?
             versions.inject(+"INSERT ALL\n") { |sql, version|

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -53,7 +53,7 @@ module ActiveRecord
         end
 
         def data_source_exists?(table_name)
-          (_owner, _table_name) = @raw_connection.describe(table_name)
+          (_owner, _table_name) = _connection.describe(table_name)
           true
         rescue
           false
@@ -87,7 +87,7 @@ module ActiveRecord
         end
 
         def indexes(table_name) # :nodoc:
-          (_owner, table_name) = @raw_connection.describe(table_name)
+          (_owner, table_name) = _connection.describe(table_name)
           default_tablespace_name = default_tablespace
 
           result = select_all(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name)])
@@ -368,7 +368,7 @@ module ActiveRecord
         #
         # Will always query database and not index cache.
         def index_name_exists?(table_name, index_name)
-          (_owner, table_name) = @raw_connection.describe(table_name)
+          (_owner, table_name) = _connection.describe(table_name)
           result = select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name), bind_string("index_name", index_name.to_s.upcase)])
             SELECT 1 FROM all_indexes i
             WHERE i.owner = SYS_CONTEXT('userenv', 'current_schema')
@@ -511,7 +511,7 @@ module ActiveRecord
 
         def table_comment(table_name) # :nodoc:
           # TODO
-          (_owner, table_name) = @raw_connection.describe(table_name)
+          (_owner, table_name) = _connection.describe(table_name)
           select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name)])
             SELECT comments FROM all_tab_comments
             WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
@@ -527,7 +527,7 @@ module ActiveRecord
 
         def column_comment(table_name, column_name) # :nodoc:
           # TODO: it  does not exist in Abstract adapter
-          (_owner, table_name) = @raw_connection.describe(table_name)
+          (_owner, table_name) = _connection.describe(table_name)
           select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name), bind_string("column_name", column_name.upcase)])
             SELECT comments FROM all_col_comments
             WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
@@ -555,7 +555,7 @@ module ActiveRecord
 
         # get table foreign keys for schema dump
         def foreign_keys(table_name) # :nodoc:
-          (_owner, desc_table_name) = @raw_connection.describe(table_name)
+          (_owner, desc_table_name) = _connection.describe(table_name)
 
           fk_info = select_all(<<~SQL.squish, "SCHEMA", [bind_string("desc_table_name", desc_table_name)])
             SELECT r.table_name to_table

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -437,7 +437,8 @@ module ActiveRecord
 
       # return raw OCI8 or JDBC connection
       def raw_connection
-        @raw_connection.raw_connection
+        verify!
+        _connection.raw_connection
       end
 
       # Returns true if the connection is active.

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -432,7 +432,7 @@ module ActiveRecord
 
       def auto_retry=(value) # :nodoc:
         @auto_retry = value
-        @raw_connection.auto_retry = value if @raw_connection
+        _connection.auto_retry = value if _connection
       end
 
       # return raw OCI8 or JDBC connection
@@ -446,13 +446,13 @@ module ActiveRecord
         # #active? method is also available, but that simply returns the
         # last known state, which isn't good enough if the connection has
         # gone stale since the last use.
-        @raw_connection.ping
+        _connection.ping
       rescue OracleEnhanced::ConnectionException
         false
       end
 
       def reconnect
-        @raw_connection.reset # tentative
+        _connection.reset # tentative
       rescue OracleEnhanced::ConnectionException
         connect
       end
@@ -460,7 +460,7 @@ module ActiveRecord
       # Reconnects to the database.
       def reconnect! # :nodoc:
         super
-        @raw_connection.reset!
+        _connection.reset!
       rescue OracleEnhanced::ConnectionException => e
         @logger.warn "#{adapter_name} automatic reconnection failed: #{e.message}" if @logger
       end
@@ -478,12 +478,12 @@ module ActiveRecord
       # Disconnects from the database.
       def disconnect! # :nodoc:
         super
-        @raw_connection.logoff rescue nil
+        _connection.logoff rescue nil
       end
 
       def discard!
         super
-        @raw_connection = nil
+        _connection = nil
       end
 
       # use in set_sequence_name to avoid fetching primary key value from sequence
@@ -508,7 +508,7 @@ module ActiveRecord
         table_name = table_name.to_s
         do_not_prefetch = @do_not_prefetch_primary_key[table_name]
         if do_not_prefetch.nil?
-          owner, desc_table_name = @raw_connection.describe(table_name)
+          owner, desc_table_name = _connection.describe(table_name)
           @do_not_prefetch_primary_key[table_name] = do_not_prefetch = !has_primary_key?(table_name, owner, desc_table_name)
         end
         !do_not_prefetch
@@ -577,7 +577,7 @@ module ActiveRecord
       end
 
       def column_definitions(table_name)
-        (owner, desc_table_name) = @raw_connection.describe(table_name)
+        (owner, desc_table_name) = _connection.describe(table_name)
 
         select_all(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("table_name", desc_table_name)])
           SELECT cols.column_name AS name, cols.data_type AS sql_type,
@@ -609,7 +609,7 @@ module ActiveRecord
       # Find a table's primary key and sequence.
       # *Note*: Only primary key is implemented - sequence will be nil.
       def pk_and_sequence_for(table_name, owner = nil, desc_table_name = nil) # :nodoc:
-        (owner, desc_table_name) = @raw_connection.describe(table_name)
+        (owner, desc_table_name) = _connection.describe(table_name)
 
         seqs = select_values_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("sequence_name", default_sequence_name(desc_table_name))])
           select us.sequence_name
@@ -651,7 +651,7 @@ module ActiveRecord
       end
 
       def primary_keys(table_name) # :nodoc:
-        (_owner, desc_table_name) = @raw_connection.describe(table_name)
+        (_owner, desc_table_name) = _connection.describe(table_name)
 
         pks = select_values_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("table_name", desc_table_name)])
           SELECT cc.column_name
@@ -696,7 +696,7 @@ module ActiveRecord
       alias index_name_length max_identifier_length
 
       def get_database_version
-        @raw_connection.database_version
+        _connection.database_version
       end
 
       def check_version
@@ -705,6 +705,10 @@ module ActiveRecord
         if version < 10
           raise "Your version of Oracle (#{version}) is too old. Active Record Oracle enhanced adapter supports Oracle >= 10g."
         end
+      end
+
+      private def _connection
+        @unconfigured_connection || @raw_connection
       end
 
       class << self
@@ -773,7 +777,7 @@ module ActiveRecord
       end
 
       def translate_exception(exception, message:, sql:, binds:) # :nodoc:
-        case @raw_connection.error_code(exception)
+        case _connection.error_code(exception)
         when 1
           RecordNotUnique.new(message, sql: sql, binds: binds)
         when 60

--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -96,7 +96,6 @@ module Arel # :nodoc: all
         def visit_Arel_Nodes_HomogeneousIn(o, collector)
           in_clause_length = @connection.in_clause_length
           values = o.casted_values.map { |v| @connection.quote(v) }
-          column_name = quote_table_name(o.table_name) + "." + quote_column_name(o.column_name)
           operator =
             if o.type == :in
               " IN ("
@@ -105,7 +104,7 @@ module Arel # :nodoc: all
             end
 
           if !Array === values || values.length <= in_clause_length
-            collector << column_name
+            visit o.left, collector
             collector << operator
 
             expr =
@@ -127,7 +126,7 @@ module Arel # :nodoc: all
             collector << "("
             values.each_slice(in_clause_length).each_with_index do |valuez, i|
               collector << separator unless i == 0
-              collector << column_name
+              visit o.left, collector
               collector << operator
               collector << valuez.join(",")
               collector << ")"

--- a/lib/arel/visitors/oracle12.rb
+++ b/lib/arel/visitors/oracle12.rb
@@ -49,7 +49,6 @@ module Arel # :nodoc: all
         def visit_Arel_Nodes_HomogeneousIn(o, collector)
           in_clause_length = @connection.in_clause_length
           values = o.casted_values.map { |v| @connection.quote(v) }
-          column_name = quote_table_name(o.table_name) + "." + quote_column_name(o.column_name)
           operator =
             if o.type == :in
               " IN ("
@@ -58,7 +57,7 @@ module Arel # :nodoc: all
             end
 
           if !Array === values || values.length <= in_clause_length
-            collector << column_name
+            visit o.left, collector
             collector << operator
 
             expr =
@@ -80,15 +79,13 @@ module Arel # :nodoc: all
             collector << "("
             values.each_slice(in_clause_length).each_with_index do |valuez, i|
               collector << separator unless i == 0
-              collector << column_name
+              visit o.left, collector
               collector << operator
               collector << valuez.join(",")
               collector << ")"
             end
             collector << ")"
           end
-
-          collector
         end
 
         def visit_Arel_Nodes_UpdateStatement(o, collector)

--- a/lib/arel/visitors/oracle_common.rb
+++ b/lib/arel/visitors/oracle_common.rb
@@ -31,7 +31,7 @@ module Arel # :nodoc: all
         def cached_column_for(attr)
           return unless Arel::Attributes::Attribute === attr
 
-          table = attr.relation.table_name
+          table = attr.relation.name
           return unless schema_cache.columns_hash?(table)
 
           column = attr.name.to_s

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -461,6 +461,11 @@ describe "OracleEnhancedConnection" do
       expect(@conn.exec("SELECT * FROM dual")).not_to be_nil
     end
 
+    it "should reconnect and execute SQL statement if connection is lost and allow_retry is passed" do
+      kill_current_session
+      expect(@conn.exec("SELECT * FROM dual", allow_retry: true)).not_to be_nil
+    end
+
     it "should not reconnect and execute SQL statement if connection is lost and auto retry is disabled" do
       # @conn.auto_retry = false
       ActiveRecord::Base.connection.auto_retry = false

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -241,7 +241,7 @@ describe "OracleEnhancedConnection" do
     end
 
     after(:all) do
-      Object.send(:remove_const, "Post")
+      Object.send(:remove_const, "Post") if defined?(Post)
       ActiveRecord::Base.clear_cache!
     end
 
@@ -428,7 +428,7 @@ describe "OracleEnhancedConnection" do
 
     before(:all) do
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-      @conn = ActiveRecord::Base.connection.instance_variable_get("@raw_connection")
+      @conn = ActiveRecord::Base.connection.send(:_connection)
       @sys_conn = ActiveRecord::ConnectionAdapters::OracleEnhanced::Connection.create(SYS_CONNECTION_PARAMS)
       schema_define do
         create_table :posts, force: true

--- a/spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb
@@ -81,7 +81,7 @@ describe "Oracle Enhanced adapter database tasks" do
     describe "structure" do
       let(:temp_file) { Tempfile.create(["oracle_enhanced", ".sql"]).path }
       before do
-        ActiveRecord::SchemaMigration.create_table
+        ActiveRecord::Base.connection.schema_migration.create_table
         ActiveRecord::Base.connection.execute "INSERT INTO schema_migrations (version) VALUES ('20150101010000')"
       end
 
@@ -109,7 +109,7 @@ describe "Oracle Enhanced adapter database tasks" do
 
       after do
         File.unlink(temp_file)
-        ActiveRecord::SchemaMigration.drop_table
+        ActiveRecord::Base.connection.schema_migration.drop_table
       end
     end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -330,10 +330,10 @@ describe "OracleEnhancedAdapter schema definition" do
     it "should raise error if too large index name cannot be shortened" do
       if @oracle12cr2_or_higher
         expect(@conn.index_name("test_employees", column: ["first_name", "middle_name", "last_name"])).to eq(
-          ("index_test_employees_on_first_name_and_middle_name_and_last_name"))
+          ("idx_on_first_name_middle_name_last_name_ee1d3958bc"))
       else
         expect(@conn.index_name("test_employees", column: ["first_name", "middle_name", "last_name"])).to eq(
-          "i" + OpenSSL::Digest::SHA1.hexdigest("index_test_employees_on_first_name_and_middle_name_and_last_name")[0, 29]
+          "i" + OpenSSL::Digest::SHA1.hexdigest("idx_on_first_name_middle_name_last_name_ee1d3958bc")[0, 29]
         )
       end
     end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -1228,7 +1228,7 @@ end
     before do
       @conn = ActiveRecord::Base.connection
 
-      ActiveRecord::SchemaMigration.create_table
+      ActiveRecord::Base.connection.schema_migration.create_table
     end
 
     context "multi insert is supported" do
@@ -1256,7 +1256,7 @@ end
     end
 
     after do
-      ActiveRecord::SchemaMigration.drop_table
+      ActiveRecord::Base.connection.schema_migration.drop_table
     end
   end
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
@@ -334,10 +334,9 @@ describe "OracleEnhancedAdapter structure dump" do
     let(:dump) { ActiveRecord::Base.connection.dump_schema_information }
 
     before do
-      ActiveRecord::SchemaMigration.reset_table_name
-      ActiveRecord::SchemaMigration.create_table
+      ActiveRecord::Base.connection.schema_migration.create_table
       versions.each do |i|
-        ActiveRecord::SchemaMigration.create!(version: i)
+        ActiveRecord::Base.connection.schema_migration.create_version(i)
       end
     end
 
@@ -377,7 +376,7 @@ describe "OracleEnhancedAdapter structure dump" do
     end
 
     after do
-      ActiveRecord::SchemaMigration.drop_table
+      ActiveRecord::Base.connection.schema_migration.drop_table
     end
   end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -443,7 +443,7 @@ describe "OracleEnhancedAdapter" do
         end
       end
       class ::TestSerializedColumn < ActiveRecord::Base
-        serialize :serialized, Array
+        serialize :serialized, type: Array
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,6 +57,8 @@ module LoggerSpecHelper
   end
 
   class MockLogger
+    LEVELS = %i[debug info warn error fatal unknown]
+
     attr_reader :flush_count
 
     def initialize
@@ -64,13 +66,22 @@ module LoggerSpecHelper
       @logged = Hash.new { |h, k| h[k] = [] }
     end
 
-    # used in AtiveRecord 2.x
+    # used in ActiveRecord 2.x
     def debug?
       true
     end
 
-    def method_missing(level, message)
-      @logged[level] << message
+    def level
+      0
+    end
+
+    def method_missing(*args)
+      if LEVELS.include?(args[0])
+        level, message  = args
+        @logged[level] << message
+      else
+        super
+      end
     end
 
     def logged(level)


### PR DESCRIPTION
Switch to Arel::Table.name instead of removed alias table_name.

Rails removed the table_name alias to Arel::Table.name
See https://github.com/rails/rails/commit/1d98bc563a8a7faf26238eaaa54a3257a95d644d

Stacked on #2375