### PR TITLE
Address `OracleEnhancedAdapter schema definition add index should raise error if too large index name cannot be shortened` failure

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -330,7 +330,7 @@ describe "OracleEnhancedAdapter schema definition" do
     it "should raise error if too large index name cannot be shortened" do
       if @oracle12cr2_or_higher
         expect(@conn.index_name("test_employees", column: ["first_name", "middle_name", "last_name"])).to eq(
-          ("idx_on_first_name_middle_name_last_name_ee1d3958bc"))
+          ("index_test_employees_on_first_name_and_middle_name_and_last_name"))
       else
         expect(@conn.index_name("test_employees", column: ["first_name", "middle_name", "last_name"])).to eq(
           "i" + OpenSSL::Digest::SHA1.hexdigest("idx_on_first_name_middle_name_last_name_ee1d3958bc")[0, 29]


### PR DESCRIPTION
This pull request addresses the following failure.

```ruby
$ bundle exec rspec ./spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb:330
==> Loading config from ENV or use default
==> Running specs with ruby version 3.3.4
==> Effective ActiveRecord version 7.1.3.4
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb"=>[330]}}
F

Failures:

  1) OracleEnhancedAdapter schema definition add index should raise error if too large index name cannot be shortened
     Failure/Error:
       expect(@conn.index_name("test_employees", column: ["first_name", "middle_name", "last_name"])).to eq(
         ("idx_on_first_name_middle_name_last_name_ee1d3958bc"))

       expected: "idx_on_first_name_middle_name_last_name_ee1d3958bc"
            got: "index_test_employees_on_first_name_and_middle_name_and_last_name"

       (compared using ==)
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-support-3.13.1/lib/rspec/support.rb:110:in `block in <module:Support>'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-support-3.13.1/lib/rspec/support.rb:119:in `notify_failure'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-expectations-3.13.1/lib/rspec/expectations/fail_with.rb:35:in `fail_with'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-expectations-3.13.1/lib/rspec/expectations/handler.rb:38:in `handle_failure'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-expectations-3.13.1/lib/rspec/expectations/handler.rb:56:in `block in handle_matcher'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-expectations-3.13.1/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-expectations-3.13.1/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-expectations-3.13.1/lib/rspec/expectations/expectation_target.rb:65:in `to'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-expectations-3.13.1/lib/rspec/expectations/expectation_target.rb:101:in `to'
     # ./spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb:333:in `block (3 levels) in <top (required)>'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/example.rb:263:in `instance_exec'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/example.rb:263:in `block in run'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/example.rb:511:in `block in with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/example.rb:468:in `block in with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/hooks.rb:486:in `block in run'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/hooks.rb:624:in `run_around_example_hooks_for'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/hooks.rb:486:in `run'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/example.rb:468:in `with_around_example_hooks'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/example.rb:259:in `run'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/example_group.rb:646:in `block in run_examples'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/example_group.rb:642:in `map'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/example_group.rb:642:in `run_examples'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/example_group.rb:607:in `run'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/example_group.rb:608:in `block in run'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/example_group.rb:608:in `map'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/example_group.rb:608:in `run'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/runner.rb:121:in `block (3 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/runner.rb:121:in `map'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/runner.rb:121:in `block (2 levels) in run_specs'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/configuration.rb:2091:in `with_suite_hooks'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/runner.rb:116:in `block in run_specs'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/reporter.rb:74:in `report'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/runner.rb:115:in `run_specs'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/runner.rb:89:in `run'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/runner.rb:71:in `run'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/exe/rspec:4:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.3.4/bin/rspec:25:in `load'
     # /home/yahonda/.rbenv/versions/3.3.4/bin/rspec:25:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/site_ruby/3.3.0/bundler/cli/exec.rb:58:in `load'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/site_ruby/3.3.0/bundler/cli/exec.rb:58:in `kernel_load'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/site_ruby/3.3.0/bundler/cli/exec.rb:23:in `run'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/site_ruby/3.3.0/bundler/cli.rb:455:in `exec'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/site_ruby/3.3.0/bundler/vendor/thor/lib/thor/command.rb:28:in `run'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/site_ruby/3.3.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/site_ruby/3.3.0/bundler/vendor/thor/lib/thor.rb:527:in `dispatch'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/site_ruby/3.3.0/bundler/cli.rb:35:in `dispatch'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/site_ruby/3.3.0/bundler/vendor/thor/lib/thor/base.rb:584:in `start'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/site_ruby/3.3.0/bundler/cli.rb:29:in `start'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.15/exe/bundle:28:in `block in <top (required)>'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/site_ruby/3.3.0/bundler/friendly_errors.rb:117:in `with_friendly_errors'
     # /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.15/exe/bundle:20:in `<top (required)>'
     # /home/yahonda/.rbenv/versions/3.3.4/bin/bundle:25:in `load'
     # /home/yahonda/.rbenv/versions/3.3.4/bin/bundle:25:in `<main>'

Finished in 0.1177 seconds (files took 0.76591 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb:330 # OracleEnhancedAdapter schema definition add index should raise error if too large index name cannot be shortened
$
```

- Oracle Database version tested
```sql
SQL> select * from v$version;

BANNER
---------------------------------------------------------------------------------------------------------------------------------
BANNER_FULL
----------------------------------------------------------------------------------------------------------------------------------------------------------------
BANNER_LEGACY                                                                                                                         CON_ID
--------------------------------------------------------------------------------------------------------------------------------- ----------
Oracle Database 23ai Free Release 23.0.0.0.0 - Develop, Learn, and Run for Free
Oracle Database 23ai Free Release 23.0.0.0.0 - Develop, Learn, and Run for Free
Version 23.5.0.24.07
Oracle Database 23ai Free Release 23.0.0.0.0 - Develop, Learn, and Run for Free                                                            0

SQL>
```