### PR TITLE
Install Oracle Instant Client using zip file

### DIFF
--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -26,8 +26,8 @@ jobs:
           '2.7'
         ]
     env:
-      ORACLE_HOME: /usr/lib/oracle/21/client64
-      LD_LIBRARY_PATH: /usr/lib/oracle/21/client64/lib
+      ORACLE_HOME: /opt/oracle/instantclient_21_15
+      LD_LIBRARY_PATH: /opt/oracle/instantclient_21_15
       NLS_LANG: AMERICAN_AMERICA.AL32UTF8
       TNS_ADMIN: ./ci/network/admin
       DATABASE_NAME: XE
@@ -56,19 +56,19 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: Install required package
-        run: |
-          sudo apt-get install alien
       - name: Download Oracle instant client
         run: |
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2110000/oracle-instantclient-basic-21.10.0.0.0-1.x86_64.rpm
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2110000/oracle-instantclient-sqlplus-21.10.0.0.0-1.x86_64.rpm
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2110000/oracle-instantclient-devel-21.10.0.0.0-1.x86_64.rpm
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/2115000/instantclient-basic-linux.x64-21.15.0.0.0dbru.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/2115000/instantclient-sqlplus-linux.x64-21.15.0.0.0dbru.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/2115000/instantclient-sdk-linux.x64-21.15.0.0.0dbru.zip
       - name: Install Oracle instant client
         run: |
-          sudo alien -i oracle-instantclient-basic-21.10.0.0.0-1.x86_64.rpm
-          sudo alien -i oracle-instantclient-sqlplus-21.10.0.0.0-1.x86_64.rpm
-          sudo alien -i oracle-instantclient-devel-21.10.0.0.0-1.x86_64.rpm
+          sudo mkdir -p /opt/oracle/
+          sudo unzip instantclient-basic-linux.x64-21.15.0.0.0dbru.zip -d /opt/oracle
+          sudo unzip -o instantclient-sqlplus-linux.x64-21.15.0.0.0dbru.zip -d /opt/oracle
+          sudo unzip -o instantclient-sdk-linux.x64-21.15.0.0.0dbru.zip -d /opt/oracle
+          echo "/opt/oracle/instantclient_21_15" >> $GITHUB_PATH
+
       - name: Install JDBC Driver
         run: |
           wget -q https://download.oracle.com/otn-pub/otn_software/jdbc/211/ojdbc11.jar -O ./lib/ojdbc11.jar


### PR DESCRIPTION
This commit addresses the following error at https://github.com/rsim/oracle-enhanced/actions/runs/10371233946/job/28711049632#step:7:30

```shell
Run sudo alien -i oracle-instantclient-basic-21.10.0.0.0-1.x86_64.rpm
Warning: Skipping conversion of scripts in package oracle-instantclient-basic: postinst postrm
Warning: Use the --scripts parameter to include the scripts.
	dpkg --no-force-overwrite -i oracle-instantclient-basic_21.10.0.0.0-2_amd64.deb
Selecting previously unselected package oracle-instantclient-basic.
(Reading database ... 267026 files and directories currently installed.)
Preparing to unpack oracle-instantclient-basic_21.10.0.0.0-2_amd64.deb ...
Unpacking oracle-instantclient-basic (21.10.0.0.0-2) ...
Setting up oracle-instantclient-basic (21.10.0.0.0-2) ...
Processing triggers for libc-bin (2.35-0ubuntu3.8) ...
Warning: Skipping conversion of scripts in package oracle-instantclient-sqlplus: postinst postrm
Warning: Use the --scripts parameter to include the scripts.
Unpacking of 'oracle-instantclient-sqlplus-21.10.0.0.0-1.x86_64.rpm' failed at /usr/share/perl5/Alien/Package/Rpm.pm line 168.
Error: Process completed with exit code 2.
```