### PR TITLE
Bump Ruby versions at Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,9 @@ script:
 
 language: ruby
 rvm:
-  - 3.3.0
-  - 3.2.2
-  - 3.1.4
+  - 3.3.4
+  - 3.2.4
+  - 3.1.6
 
 notifications:
   email: false


### PR DESCRIPTION
This pull request bumps Ruby versions at Travis CI.

https://rubies.travis-ci.org

> Ubuntu 22.04 (x86_64)

https://rubies.travis-ci.org/ubuntu/22.04/x86_64/ruby-3.3.4
https://rubies.travis-ci.org/ubuntu/22.04/x86_64/ruby-3.2.4
 https://rubies.travis-ci.org/ubuntu/22.04/x86_64/ruby-3.1.5