### PR TITLE
Skip tests if database and client versions do not match

### DIFF
--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -36,6 +36,7 @@ jobs:
       DATABASE_HOST: localhost
       DATABASE_PORT: 1521
       DATABASE_VERSION: 11.2.0.2
+      DATABASE_SERVER_AND_CLIENT_VERSION_DO_NOT_MATCH: true
 
     services:
       oracle:

--- a/spec/active_record/oracle_enhanced/type/timestamp_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/timestamp_spec.rb
@@ -35,6 +35,7 @@ describe "OracleEnhancedAdapter timestamp with timezone support" do
   end
 
   describe "/ TIMESTAMP WITH TIME ZONE values from ActiveRecord model" do
+    skip if ENV["DATABASE_SERVER_AND_CLIENT_VERSION_DO_NOT_MATCH"] == "true"
     before(:all) do
       class ::TestEmployee < ActiveRecord::Base
       end


### PR DESCRIPTION
This pull request skips specs if the Oracle server and client versions do not match

https://github.com/rsim/oracle-enhanced/actions/runs/10371897254/job/28713269701?pr=2387
    
```
ActiveRecord::StatementInvalid:
OCIError: ORA-01805: possible error in date/time operation
```