### PR TITLE
Address `OracleEnhancedAdapter schema definition add index should raise error if too large index name cannot be shortened` failure against Oracle Database 11g

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -333,7 +333,7 @@ describe "OracleEnhancedAdapter schema definition" do
           ("index_test_employees_on_first_name_and_middle_name_and_last_name"))
       else
         expect(@conn.index_name("test_employees", column: ["first_name", "middle_name", "last_name"])).to eq(
-          "i" + OpenSSL::Digest::SHA1.hexdigest("idx_on_first_name_middle_name_last_name_ee1d3958bc")[0, 29]
+          "i" + OpenSSL::Digest::SHA1.hexdigest("index_test_employees_on_first_name_and_middle_name_and_last_name")[0, 29]
         )
       end
     end


### PR DESCRIPTION
This pull request addresses the following failure against Oracle Database 11g.

```ruby
$ rspec ./spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb:330 # OracleEnhancedAdapter schema definition add index should raise error if too large index name cannot be shortened
...
Failures:

  1) OracleEnhancedAdapter schema definition add index should raise error if too large index name cannot be shortened
     Failure/Error:
       expect(@conn.index_name("test_employees", column: ["first_name", "middle_name", "last_name"])).to eq(
         "i" + OpenSSL::Digest::SHA1.hexdigest("idx_on_first_name_middle_name_last_name_ee1d3958bc")[0, 29]
       )

       expected: "i2ca2fb0a38640050a52ea38bdb505"
            got: "ic7f03de8c2dfa78428f6cd097f2bf"

       (compared using ==)
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-support-3.13.1/lib/rspec/support.rb:110:in `block in <module:Support>'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-support-3.13.1/lib/rspec/support.rb:119:in `notify_failure'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-expectations-3.13.3/lib/rspec/expectations/fail_with.rb:35:in `fail_with'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-expectations-3.13.3/lib/rspec/expectations/handler.rb:37:in `handle_failure'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-expectations-3.13.3/lib/rspec/expectations/handler.rb:55:in `block in handle_matcher'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-expectations-3.13.3/lib/rspec/expectations/handler.rb:26:in `with_matcher'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-expectations-3.13.3/lib/rspec/expectations/handler.rb:47:in `handle_matcher'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-expectations-3.13.3/lib/rspec/expectations/expectation_target.rb:65:in `to'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-expectations-3.13.3/lib/rspec/expectations/expectation_target.rb:101:in `to'
     # ./spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb:335:in `block (3 levels) in <top (required)>'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/lib/rspec/core/example.rb:263:in `instance_exec'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/lib/rspec/core/example.rb:263:in `block in run'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/lib/rspec/core/example.rb:511:in `block in with_around_and_singleton_context_hooks'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/lib/rspec/core/example.rb:468:in `block in with_around_example_hooks'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/lib/rspec/core/hooks.rb:486:in `block in run'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/lib/rspec/core/hooks.rb:624:in `run_around_example_hooks_for'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/lib/rspec/core/hooks.rb:486:in `run'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/lib/rspec/core/example.rb:468:in `with_around_example_hooks'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/lib/rspec/core/example.rb:259:in `run'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/lib/rspec/core/example_group.rb:646:in `block in run_examples'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/lib/rspec/core/example_group.rb:642:in `map'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/lib/rspec/core/example_group.rb:642:in `run_examples'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/lib/rspec/core/example_group.rb:607:in `run'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/lib/rspec/core/example_group.rb:608:in `block in run'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/lib/rspec/core/example_group.rb:608:in `map'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/lib/rspec/core/example_group.rb:608:in `run'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/lib/rspec/core/runner.rb:121:in `block (3 levels) in run_specs'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/lib/rspec/core/runner.rb:121:in `map'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/lib/rspec/core/runner.rb:121:in `block (2 levels) in run_specs'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/lib/rspec/core/configuration.rb:2092:in `with_suite_hooks'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/lib/rspec/core/runner.rb:116:in `block in run_specs'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/lib/rspec/core/reporter.rb:74:in `report'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/lib/rspec/core/runner.rb:115:in `run_specs'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/lib/rspec/core/runner.rb:89:in `run'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/lib/rspec/core/runner.rb:71:in `run'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/lib/rspec/core/runner.rb:45:in `invoke'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.13.1/exe/rspec:4:in `<top (required)>'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/bin/rspec:25:in `load'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/bin/rspec:25:in `<top (required)>'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/site_ruby/3.0.0/bundler/cli/exec.rb:58:in `load'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/site_ruby/3.0.0/bundler/cli/exec.rb:58:in `kernel_load'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/site_ruby/3.0.0/bundler/cli/exec.rb:23:in `run'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/site_ruby/3.0.0/bundler/cli.rb:455:in `exec'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/site_ruby/3.0.0/bundler/vendor/thor/lib/thor/command.rb:28:in `run'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/site_ruby/3.0.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/site_ruby/3.0.0/bundler/vendor/thor/lib/thor.rb:527:in `dispatch'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/site_ruby/3.0.0/bundler/cli.rb:35:in `dispatch'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/site_ruby/3.0.0/bundler/vendor/thor/lib/thor/base.rb:584:in `start'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/site_ruby/3.0.0/bundler/cli.rb:29:in `start'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/bundler-2.5.19/exe/bundle:28:in `block in <top (required)>'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/site_ruby/3.0.0/bundler/friendly_errors.rb:117:in `with_friendly_errors'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/lib/ruby/gems/3.0.0/gems/bundler-2.5.19/exe/bundle:20:in `<top (required)>'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/bin/bundle:25:in `load'
     # /opt/hostedtoolcache/Ruby/3.0.7/x64/bin/bundle:25:in `<main>'
```