### PR TITLE
Skip specs correctly if `DATABASE_SERVER_AND_CLIENT_VERSION_DO_NOT_MATCH` set to true

### DIFF
--- a/spec/active_record/oracle_enhanced/type/timestamp_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/timestamp_spec.rb
@@ -4,6 +4,7 @@ describe "OracleEnhancedAdapter timestamp with timezone support" do
   include SchemaSpecHelper
 
   before(:all) do
+    skip if ENV["DATABASE_SERVER_AND_CLIENT_VERSION_DO_NOT_MATCH"] == "true"
     if ENV["DATABASE_VERSION"] == "11.2.0.2" && ENV["ORACLE_HOME"] == "/usr/lib/oracle/21/client64"
       skip
     end
@@ -35,7 +36,6 @@ describe "OracleEnhancedAdapter timestamp with timezone support" do
   end
 
   describe "/ TIMESTAMP WITH TIME ZONE values from ActiveRecord model" do
-    skip if ENV["DATABASE_SERVER_AND_CLIENT_VERSION_DO_NOT_MATCH"] == "true"
     before(:all) do
       class ::TestEmployee < ActiveRecord::Base
       end


### PR DESCRIPTION
Skip specs correctly if `DATABASE_SERVER_AND_CLIENT_VERSION_DO_NOT_MATCH` set to true

This commit skips failing specs correctly if `DATABASE_SERVER_AND_CLIENT_VERSION_DO_NOT_MATCH` set to true

Follow up #2389

```ruby
$ export DATABASE_SERVER_AND_CLIENT_VERSION_DO_NOT_MATCH="true"
$ bundle exec rspec ./spec/active_record/oracle_enhanced/type/timestamp_spec.rb
==> Loading config from ENV or use default
==> Running specs with ruby version 3.3.5
/home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/bundler/gems/rails-cefd9e9942c5/activesupport/lib/active_support/logger_silence.rb:5: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add logger to your Gemfile or gemspec to silence this warning.
==> Effective ActiveRecord version 7.1.4
**

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) OracleEnhancedAdapter timestamp with timezone support / TIMESTAMP WITH TIME ZONE values from ActiveRecord model should return Time value from TIMESTAMP columns
     # No reason given
     # ./spec/active_record/oracle_enhanced/type/timestamp_spec.rb:49

  2) OracleEnhancedAdapter timestamp with timezone support / TIMESTAMP WITH TIME ZONE values from ActiveRecord model should return Time value with fractional seconds from TIMESTAMP columns
     # No reason given
     # ./spec/active_record/oracle_enhanced/type/timestamp_spec.rb:63

Finished in 0.00178 seconds (files took 0.53574 seconds to load)
2 examples, 0 failures, 2 pending

$
```