### PR TITLE
Support `build_explain_clause(options = [])`

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -65,7 +65,7 @@ module ActiveRecord
           true
         end
 
-        def explain(arel, binds = [])
+        def explain(arel, binds = [], options = [])
           sql = "EXPLAIN PLAN FOR #{to_sql(arel, binds)}"
           return if /FROM all_/.match?(sql)
           if ORACLE_ENHANCED_CONNECTION == :jdbc
@@ -74,6 +74,11 @@ module ActiveRecord
             exec_query(sql, "EXPLAIN")
           end
           select_values("SELECT * FROM TABLE(DBMS_XPLAN.DISPLAY)", "EXPLAIN").join("\n")
+        end
+
+        def build_explain_clause(options = [])
+          # Oracle does not have anything similar to "EXPLAIN ANALYZE"
+          # https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/EXPLAIN-PLAN.html#GUID-FD540872-4ED3-4936-96A2-362539931BA0
         end
 
         # New method in ActiveRecord 3.1


### PR DESCRIPTION
This commit implements `build_explain_clause(options = [])` that is no-op to remove the warning below because Oracle Database does not support something like `explain analyze` in MySQL.

```ruby
$ bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:356
==> Loading config from ENV or use default
==> Running specs with ruby version 3.3.5
/home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/bundler/gems/rails-cefd9e9942c5/activesupport/lib/active_support/logger_silence.rb:5: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add logger to your Gemfile or gemspec to silence this warning.
==> Effective ActiveRecord version 7.1.4
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb"=>[356]}}
DEPRECATION WARNING: The current database adapter, OracleEnhanced, does not support explain options. To remove this warning, the adapter must implement `build_explain_clause(options = [])`. (called from block (3 levels) in <top (required)> at /home/yahonda/src/github.com/rsim/oracle-enhanced/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:356)
.

Finished in 0.50556 seconds (files took 0.54442 seconds to load)
1 example, 0 failures

$
```

Fix #2394
Refer to https://github.com/rails/rails/pull/47043