### PR TITLE
Skip the patch for moderm JRuby vers

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -801,7 +801,8 @@ module ActiveRecord
 end
 
 # Workaround for https://github.com/jruby/jruby/issues/6267
-if RUBY_ENGINE == "jruby"
+# This is for older versions of JRuby and not necessary for moderm JRuby (>9) now
+if RUBY_ENGINE == "jruby" && RUBY_VERSION.to_f < 3.0
   require "jruby"
 
   class org.jruby::RubyObjectSpace::WeakMap


### PR DESCRIPTION
By the comment [here](https://github.com/jruby/jruby/issues/6267#issuecomment-2395573502), O believe it's not necessary to apply the patch for moderm JRuby versions.