### PR TITLE
Update add_timestamps to support 7.1

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -622,6 +622,13 @@ module ActiveRecord
           OracleEnhanced::AlterTable.new create_table_definition(name)
         end
 
+        def add_timestamps(table_name, **options)
+          fragments = add_timestamps_for_alter(table_name, **options)
+          fragments.each do |fragment|
+            execute "ALTER TABLE #{quote_table_name(table_name)} #{fragment}"
+          end
+        end
+
         def update_table_definition(table_name, base)
           OracleEnhanced::Table.new(table_name, base)
         end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -387,6 +387,33 @@ describe "OracleEnhancedAdapter schema definition" do
   end
 end
 
+  describe "add timestamps" do
+    before(:each) do
+      @conn = ActiveRecord::Base.connection
+      schema_define do
+        create_table :test_employees, force: true
+      end
+    end
+
+    after(:each) do
+      schema_define do
+        drop_table :test_employees, if_exists: true
+      end
+    end
+
+    it "should add created_at and updated_at" do
+      class ::TestEmployee < ActiveRecord::Base; end
+
+      expect do
+        @conn.add_timestamps("test_employees")
+      end.not_to raise_error
+
+      TestEmployee.reset_column_information
+      expect(TestEmployee.columns_hash["created_at"]).not_to be_nil
+      expect(TestEmployee.columns_hash["updated_at"]).not_to be_nil
+    end
+  end
+
   describe "ignore options for LOB columns" do
     after(:each) do
       schema_define do


### PR DESCRIPTION
👋
This PR fixes an issue where ActiveRecord 7.1 no longer creates valid oracle sql when using `add_timestamps` and raises `OCIError: ORA-01735: invalid ALTER TABLE option`