### PR TITLE
Fix rename_table for compatibility migrations

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -252,7 +252,7 @@ module ActiveRecord
           rebuild_primary_key_index_to_default_tablespace(table_name, options)
         end
 
-        def rename_table(table_name, new_name) # :nodoc:
+        def rename_table(table_name, new_name, **options) # :nodoc:
           if new_name.to_s.length > DatabaseLimits::IDENTIFIER_MAX_LENGTH
             raise ArgumentError, "New table name '#{new_name}' is too long; the limit is #{DatabaseLimits::IDENTIFIER_MAX_LENGTH} characters"
           end
@@ -261,7 +261,7 @@ module ActiveRecord
           execute "RENAME #{quote_table_name(table_name)} TO #{quote_table_name(new_name)}"
           execute "RENAME #{quote_table_name("#{table_name}_seq")} TO #{default_sequence_name(new_name)}" rescue nil
 
-          rename_table_indexes(table_name, new_name)
+          rename_table_indexes(table_name, new_name, **options)
         end
 
         def drop_table(table_name, **options) # :nodoc:

--- a/spec/active_record/connection_adapters/oracle_enhanced/compatibility_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/compatibility_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+describe "compatibility migrations" do
+  include SchemaSpecHelper
+
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @conn = ActiveRecord::Base.connection
+    schema_define do
+      create_table :test_employees, force: true
+    end
+  end
+
+  after(:all) do
+    schema_define do
+      drop_table :test_employees, if_exists: true
+      drop_table :new_test_employees, if_exists: true
+    end
+  end
+
+  it "should rename table on 7_0 and below" do
+    migration = Class.new(ActiveRecord::Migration[7.0]) {
+      def change
+        rename_table :test_employees, :new_test_employees
+      end
+    }.new
+
+    migration.migrate(:up)
+    expect(@conn.table_exists?(:new_test_employees)).to be_truthy
+    expect(@conn.table_exists?(:test_employees)).not_to be_truthy
+
+    migration.migrate(:down)
+    expect(@conn.table_exists?(:new_test_employees)).not_to be_truthy
+    expect(@conn.table_exists?(:test_employees)).to be_truthy
+  end
+end


### PR DESCRIPTION
👋
This PR fixes the `ArgumentError: wrong number of arguments (given 3, expected 2)` issue when calling `rename_table` with the migration version 7.0 and below.

It looks like ActiveRecord is expecting `rename_table` to include `options` as a parameter when calling `super` [here](https://github.com/rails/rails/blob/7-1-stable/activerecord/lib/active_record/migration/compatibility.rb#L118)