### PR TITLE
Support Rails 8.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Rails 7.2 requires Ruby 3.1 or higeher.
+        # Rails 8.0 requires Ruby 3.2 or higeher.
         # CI pending the following matrix until JRuby 9.4 that supports Ruby 2.7 will be released.
         # https://github.com/jruby/jruby/issues/6464
         # - jruby,
@@ -22,7 +22,6 @@ jobs:
           '3.4',
           '3.3',
           '3.2',
-          '3.1',
         ]
     env:
       ORACLE_HOME: /opt/oracle/instantclient_23_8

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Rails 7.2 requires Ruby 3.1 or higeher.
+        # Rails 8.0 requires Ruby 3.2 or higeher.
         # CI pending the following matrix until JRuby 9.4 that supports Ruby 2.7 will be released.
         # https://github.com/jruby/jruby/issues/6464
         # - jruby,
@@ -22,7 +22,6 @@ jobs:
           '3.4',
           '3.3',
           '3.2',
-          '3.1',
         ]
     env:
       ORACLE_HOME: /opt/oracle/instantclient_21_15

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -54,7 +54,7 @@ module ActiveRecord
               end
 
               rows = []
-              if sql =~ /\A\s*SELECT/i # This seems a naive way to detect queries that will have row results.
+              if cursor.select_statement?
                 fetch_options = { get_lob_value: (name != "Writable Large Object") }
                 while row = cursor.fetch(fetch_options)
                   rows << row

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -10,13 +10,13 @@ module ActiveRecord
 
         # Executes a SQL statement
         def execute(sql, name = nil, async: false, allow_retry: false)
-          sql = transform_query(sql)
+          sql = preprocess_query(sql)
 
           log(sql, name, async: async) { _connection.exec(sql, allow_retry: allow_retry) }
         end
 
         def exec_query(sql, name = "SQL", binds = [], prepare: false, async: false, allow_retry: false)
-          sql = transform_query(sql)
+          sql = preprocess_query(sql)
 
           type_casted_binds = type_casted_binds(binds)
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -8,58 +8,79 @@ module ActiveRecord
         #
         # see: abstract/database_statements.rb
 
-        # Executes a SQL statement
-        def execute(sql, name = nil, async: false, allow_retry: false)
-          sql = preprocess_query(sql)
+        READ_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_read_query_regexp(
+          :close, :declare, :fetch, :move, :set, :show
+        ) # :nodoc:
+        private_constant :READ_QUERY
 
-          log(sql, name, async: async) { _connection.exec(sql, allow_retry: allow_retry) }
+        def write_query?(sql) # :nodoc:
+          !READ_QUERY.match?(sql)
+        rescue ArgumentError # Invalid encoding
+          !READ_QUERY.match?(sql.b)
         end
 
-        def exec_query(sql, name = "SQL", binds = [], prepare: false, async: false, allow_retry: false)
+        # Executes a SQL statement
+        def execute(...)
+          super
+        end
+
+        # Low level execution of a SQL statement on the connection returning adapter specific result object.
+        def raw_execute(sql, name = "SQL", binds = [], prepare: false, async: false, allow_retry: false, materialize_transactions: false)
           sql = preprocess_query(sql)
 
           type_casted_binds = type_casted_binds(binds)
+          with_raw_connection(allow_retry: allow_retry, materialize_transactions: materialize_transactions) do |conn|
+            log(sql, name, binds, type_casted_binds, async: async) do
+              cursor = nil
+              cached = false
+              with_retry do
+                if binds.nil? || binds.empty?
+                  cursor = conn.prepare(sql)
+                else
+                  unless @statements.key? sql
+                    @statements[sql] = conn.prepare(sql)
+                  end
 
-          log(sql, name, binds, type_casted_binds, async: async) do
-            cursor = nil
-            cached = false
-            with_retry do
-              if without_prepared_statement?(binds)
-                cursor = _connection.prepare(sql)
-              else
-                unless @statements.key? sql
-                  @statements[sql] = _connection.prepare(sql)
+                  cursor = @statements[sql]
+                  cursor.bind_params(type_casted_binds)
+
+                  cached = true
                 end
-
-                cursor = @statements[sql]
-
-                cursor.bind_params(type_casted_binds)
-
-                cached = true
+                cursor.exec
               end
 
-              cursor.exec
-            end
-
-            if (name == "EXPLAIN") && sql.start_with?("EXPLAIN")
-              res = true
-            else
               columns = cursor.get_col_names.map do |col_name|
                 oracle_downcase(col_name)
               end
-              rows = []
-              fetch_options = { get_lob_value: (name != "Writable Large Object") }
-              while row = cursor.fetch(fetch_options)
-                rows << row
-              end
-              res = build_result(columns: columns, rows: rows)
-            end
 
-            cursor.close unless cached
-            res
+              rows = []
+              if sql =~ /\A\s*SELECT/i # This seems a naive way to detect queries that will have row results.
+                fetch_options = { get_lob_value: (name != "Writable Large Object") }
+                while row = cursor.fetch(fetch_options)
+                  rows << row
+                end
+              end
+
+              affected_rows_count = cursor.row_count
+
+              cursor.close unless cached
+
+              { columns: columns, rows: rows, affected_rows_count: affected_rows_count }
+            end
           end
         end
-        alias_method :internal_exec_query, :exec_query
+
+        def cast_result(result)
+          if result.nil?
+            ActiveRecord::Result.empty
+          else
+            ActiveRecord::Result.new(result[:columns], result[:rows])
+          end
+        end
+
+        def affected_rows(result)
+          result[:affected_rows_count]
+        end
 
         def supports_explain?
           true
@@ -106,7 +127,7 @@ module ActiveRecord
             cursor = nil
             returning_id_col = returning_id_index = nil
             with_retry do
-              if without_prepared_statement?(binds)
+              if binds.nil? || binds.empty?
                 cursor = _connection.prepare(sql)
               else
                 unless @statements.key?(sql)
@@ -146,7 +167,7 @@ module ActiveRecord
           log(sql, name, binds, type_casted_binds) do
             with_retry do
               cached = false
-              if without_prepared_statement?(binds)
+              if binds.nil? || binds.empty?
                 cursor = _connection.prepare(sql)
               else
                 if @statements.key?(sql)
@@ -287,6 +308,15 @@ module ActiveRecord
             rescue
               @statements.clear
               raise
+            end
+          end
+
+          def handle_warnings(sql)
+            @notice_receiver_sql_warnings.each do |warning|
+              next if warning_ignored?(warning)
+
+              warning.sql = sql
+              ActiveRecord.db_warnings_action.call(warning)
             end
           end
       end

--- a/lib/active_record/connection_adapters/oracle_enhanced/dbms_output.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/dbms_output.rb
@@ -32,7 +32,7 @@ module ActiveRecord
 
       private
         def log(sql, name = "SQL", binds = [], type_casted_binds = [], statement_name = nil, async: false, &block)
-          @instrumenter.instrument(
+          instrumenter.instrument(
             "sql.active_record",
             sql:               sql,
             name:              name,

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -385,6 +385,10 @@ module ActiveRecord
           end
           alias :get_col_names :column_names
 
+          def row_count
+            @raw_statement.getUpdateCount
+          end
+
           def fetch(options = {})
             if @raw_result_set.next
               get_lob_value = options[:get_lob_value]

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -162,6 +162,10 @@ module ActiveRecord
             @raw_cursor.row_count
           end
 
+          def select_statement?
+            @raw_cursor.type == :select_stmt
+          end
+
           def fetch(options = {})
             if row = @raw_cursor.fetch
               get_lob_value = options[:get_lob_value]

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -158,6 +158,10 @@ module ActiveRecord
             @raw_cursor.get_col_names
           end
 
+          def row_count
+            @raw_cursor.row_count
+          end
+
           def fetch(options = {})
             if row = @raw_cursor.fetch
               get_lob_value = options[:get_lob_value]


### PR DESCRIPTION
Building on top of #2424 this adds support for existing oracle_enhanced functionality to Rails 8.0. It may not fully support new Rails 8.0 features; For example there seems to be retry logic in rails now, and the oracle enhanced adapter is still doing its own thing.

- Add `write_query?` implementation (mimicking postgres) to support the ability to prevent writes to a database - https://github.com/rails/rails/commit/f39d72d5267baed1000932831cda98503d1e1047

- Replace the local implementation of execute, exec_query and its alias internal_exec_query with the new interface defined here https://github.com/rails/rails/commit/fd24e5bfc9540fc00764a59ddf39a993bbd63ba2 of `raw_execute`, `cast_result`, and `affected_rows`. To support the affected_rows count this also had to add a `row_count` method to the coi and jdbc cursors.

- without_prepared_statement? was removed https://github.com/rails/rails/commit/2306c10e7a9397f8096e49def97ed47125a4499f

Fixes #2419