### PR TITLE
Add optional argument to reconnect for Rails 7.1+ compatibility

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -467,7 +467,7 @@ module ActiveRecord
       end
 
       # Reconnects to the database.
-      def reconnect!(restore_transactions: true) # :nodoc:
+      def reconnect!(restore_transactions: false) # :nodoc:
         super
         _connection.reset!
       rescue OracleEnhanced::ConnectionException => e

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -467,7 +467,7 @@ module ActiveRecord
       end
 
       # Reconnects to the database.
-      def reconnect! # :nodoc:
+      def reconnect!(restore_transactions: true) # :nodoc:
         super
         _connection.reset!
       rescue OracleEnhanced::ConnectionException => e

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -30,6 +30,12 @@ describe "OracleEnhancedAdapter establish connection" do
     expect(ActiveRecord::Base.connection).to be_active
   end
 
+  it "should be active after reconnection to database with restore_transactions: true" do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    ActiveRecord::Base.connection.reconnect!(restore_transactions: true)
+    expect(ActiveRecord::Base.connection).to be_active
+  end
+
   it "should use database default cursor_sharing parameter value force by default" do
     # Use `SYSTEM_CONNECTION_PARAMS` to query v$parameter
     ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS)


### PR DESCRIPTION
This PR fixes #2432

[`ActiveRecord.connection.verify!`](https://api.rubyonrails.org/v7.1/classes/ActiveRecord/ConnectionAdapters/AbstractAdapter.html#method-i-verify-21) fails on Rails 7.1.0+ when reconnection is needed, because **Rails 7.1 added an optional argument** `restore_transactions: false` to the [`#reconnect!`](https://api.rubyonrails.org/v7.1/classes/ActiveRecord/ConnectionAdapters/AbstractAdapter.html#method-i-reconnect-21) method which is used e.g. inside the [`#verify!`](https://api.rubyonrails.org/v7.1/classes/ActiveRecord/ConnectionAdapters/AbstractAdapter.html#method-i-verify-21)

This change has been implemented in https://github.com/rails/rails/pull/44573 and it appeared in Rails `7.1.0beta1` for the first time.

**Oracle Enhanced Driver Implementation**

https://github.com/rsim/oracle-enhanced/blob/d5b3daf8bdac7578055467329bcb6600114ea47a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb#L470-L475

**Rails 7.1.0beta1 Implementation**

https://github.com/rails/rails/blob/2d7bc98897053658ad904b12e5b19a52b8cc3617/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L560-L565

**Rails 7.1.5.1 Implementation**

https://github.com/rails/rails/blob/14c115b120ed089331ff3dc13f36bd9129ced33d/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L680-L712