### PR TITLE
Run RuboCop in GitHub Actions

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -16,22 +16,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Ruby 3.3
+      - name: Set up Ruby 3.4
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3
-      - name: Download Oracle instant client
-        run: |
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2360000/instantclient-basic-linux.x64-23.6.0.24.10.zip
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2360000/instantclient-sdk-linux.x64-23.6.0.24.10.zip
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2360000/instantclient-sqlplus-linux.x64-23.6.0.24.10.zip
-      - name: Install Oracle instant client
-        run: |
-          sudo unzip instantclient-basic-linux.x64-23.6.0.24.10.zip -d /opt/oracle/
-          sudo unzip -o instantclient-sdk-linux.x64-23.6.0.24.10.zip -d /opt/oracle/
-          sudo unzip -o instantclient-sqlplus-linux.x64-23.6.0.24.10.zip -d /opt/oracle/
-          echo "/opt/oracle/instantclient_23_6" >> $GITHUB_PATH
+          ruby-version: 3.4
       - name: Build and run RuboCop
         run: |
-          bundle install --jobs 4 --retry 3
-          bundle exec rubocop
+          BUNDLE_ONLY=rubocop bundle install --jobs 4 --retry 3
+          BUNDLE_ONLY=rubocop bundle exec rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -8,11 +8,6 @@ group :development do
   gem "rspec"
   gem "rdoc"
   gem "rake"
-  gem "rubocop", require: false
-  gem "rubocop-performance", require: false
-  gem "rubocop-rails", require: false
-  gem "rubocop-rspec", require: false
-
   gem "activerecord",   github: "rails/rails", branch: "7-2-stable"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
@@ -25,4 +20,11 @@ group :development do
     gem "pry"
     gem "pry-nav"
   end
+end
+
+group :rubocop do
+  gem "rubocop", require: false
+  gem "rubocop-performance", require: false
+  gem "rubocop-rails", require: false
+  gem "rubocop-rspec", require: false
 end

--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -46,18 +46,17 @@ module ActiveRecord
           def quote_column_name(name) # :nodoc:
             name = name.to_s
             QUOTED_COLUMN_NAMES[name] ||= if /\A[a-z][a-z_0-9$#]*\Z/.match?(name)
-                                            "\"#{name.upcase}\""
-                                          else
-                                            # remove double quotes which cannot be used inside quoted identifier
-                                            "\"#{name.delete('"')}\""
-                                          end
+              "\"#{name.upcase}\""
+            else
+              # remove double quotes which cannot be used inside quoted identifier
+              "\"#{name.delete('"')}\""
+            end
           end
 
           def quote_table_name(name) # :nodoc:
             name, _link = name.to_s.split("@")
             QUOTED_TABLE_NAMES[name] ||= [name.split(".").map { |n| quote_column_name(n) }].join(".")
           end
-
         end
 
         # This method is used in add_index to identify either column name (which is quoted)
@@ -106,7 +105,6 @@ module ActiveRecord
           object_name = name.include?(".") ? name.split(".").second : name
           !!(object_name =~ /[A-Z]/ && object_name =~ /[a-z]/)
         end
-
 
         def quote_string(s) # :nodoc:
           s.gsub(/'/, "''")

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -63,7 +63,6 @@ require "active_record/type/oracle_enhanced/timestampltz"
 require "active_record/type/oracle_enhanced/character_string"
 
 module ActiveRecord
-
   module ConnectionAdapters # :nodoc:
     # Oracle enhanced adapter will work with both
     # CRuby ruby-oci8 gem (which provides interface to Oracle OCI client)

--- a/lib/arel/visitors/oracle_common.rb
+++ b/lib/arel/visitors/oracle_common.rb
@@ -3,7 +3,6 @@
 module Arel # :nodoc: all
   module Visitors
     module OracleCommon
-
       BIND_BLOCK = proc { |i| ":a#{i}" }
       private_constant :BIND_BLOCK
 

--- a/spec/active_record/connection_adapters/emulation/oracle_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/emulation/oracle_adapter_spec.rb
@@ -10,7 +10,7 @@ describe "OracleEnhancedAdapter emulate OracleAdapter" do
   end
 
   it "should be an OracleAdapter" do
-    @conn = ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(adapter: 'oracle'))
+    @conn = ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(adapter: "oracle"))
     expect(ActiveRecord::Base.connection).not_to be_nil
     expect(ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::OracleAdapter)).to be_truthy
   end


### PR DESCRIPTION
This commit runs RuboCop in GitHub Actions.

- Create `:rubocop` group in Gemfile
Add `BUNDLE_ONLY` available since Bundler 2.3.19
https://github.com/rubygems/rubygems/blob/master/bundler/CHANGELOG.md#2319-july-27-2022
- Use Ruby 3.4
- No need to install Oracle Instant Client to run RuboCop
- Address these offenses as a separate commit

```ruby
$ bundle exec rubocop -a
Inspecting 73 files
...................W.......C..............CC.............................

Offenses:

lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:49:13: C: [Corrected] Layout/IndentationWidth: Use 2 (not 32) spaces for indentation.
                                            "\"#{name.upcase}\""
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:50:43: C: [Corrected] Layout/ElseAlignment: Align else with QUOTED_COLUMN_NAMES[name].
                                          else
                                          ^^^^
lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:51:45: C: [Corrected] Layout/CommentIndentation: Incorrect indentation detected (column 44 instead of 14).
                                            # remove double quotes which cannot be used inside quoted identifier
                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:52:13: C: [Corrected] Layout/IndentationWidth: Use 2 (not 32) spaces for indentation.
                                            "\"#{name.delete('"')}\""
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:53:43: W: [Corrected] Layout/EndAlignment: end at 53, 42 is not aligned with QUOTED_COLUMN_NAMES[name] ||= if at 48, 12.
                                          end
                                          ^^^
lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:60:1: C: [Corrected] Layout/EmptyLinesAroundModuleBody: Extra empty line detected at module body end.
lib/active_record/connection_adapters/oracle_enhanced/quoting.rb:110:1: C: [Corrected] Layout/EmptyLines: Extra blank line detected.
lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:66:1: C: [Corrected] Layout/EmptyLinesAroundModuleBody: Extra empty line detected at module body beginning.
lib/arel/visitors/oracle_common.rb:6:1: C: [Corrected] Layout/EmptyLinesAroundModuleBody: Extra empty line detected at module body beginning.
spec/active_record/connection_adapters/emulation/oracle_adapter_spec.rb:13:86: C: [Corrected] Style/StringLiterals: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
    @conn = ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(adapter: 'oracle'))
                                                                                     ^^^^^^^^

73 files inspected, 10 offenses detected, 10 offenses corrected
$
```