### PR TITLE
Remove `LD_LIBRARY_PATH` from rubocop.yml

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -10,10 +10,6 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
-    env:
-      LD_LIBRARY_PATH: /opt/oracle/instantclient_23_6
-
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby 3.4


### PR DESCRIPTION
This environment variable is not necessary anymore since #2439
