### PR TITLE
Bump the minimum Ruby version to 3.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
           ./ci/setup_accounts.sh
       - name: Update RubyGems
         run: |
-          gem update --system || gem update --system 3.4.22
+          gem update --system
       - name: Bundle install
         run: |
           bundle install --jobs 4 --retry 3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ plugins:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.1
   DisabledByDefault: true
   SuggestExtensions: false
 

--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.version = version
 
   s.required_rubygems_version = ">= 1.8.11"
-  s.required_ruby_version     = ">= 2.7.0"
+  s.required_ruby_version     = ">= 3.1.0"
   s.license = "MIT"
   s.authors = ["Raimonds Simanovskis"]
   s.description = 'Oracle "enhanced" ActiveRecord adapter contains useful additional methods for working with new and legacy Oracle databases.


### PR DESCRIPTION
This pull request bumps the minimum Ruby version to 3.1

- Rails 7.2 requires Ruby 3.1 https://github.com/rails/rails/pull/50491
https://guides.rubyonrails.org/7_2_release_notes.html#make-ruby-3-1-the-new-minimum-version

- Remove workaround for Ruby 2.7 https://github.com/rsim/oracle-enhanced/commit/8cb20779687cceb6d0521acbeee1a99a8a25c31e

```ruby
 % ruby -v
ruby 3.1.7p261 (2025-03-26 revision 0a3704f218) [arm64-darwin25]
% gem -v
3.3.27
% bundler -v
Bundler version 2.3.27
% gem update --system
Updating rubygems-update
Fetching rubygems-update-3.6.9.gem
Successfully installed rubygems-update-3.6.9
Parsing documentation for rubygems-update-3.6.9
Installing ri documentation for rubygems-update-3.6.9
Done installing documentation for rubygems-update after 2 seconds
Parsing documentation for rubygems-update-3.6.9
Done installing documentation for rubygems-update after 0 seconds
Installing RubyGems 3.6.9
  Successfully built RubyGem
  Name: bundler
  Version: 2.6.9
  File: bundler-2.6.9.gem
Bundler 2.6.9 installed
RubyGems 3.6.9 installed
Regenerating binstubs
Regenerating plugins
Parsing documentation for rubygems-3.6.9
Installing ri documentation for rubygems-3.6.9

... snip ...
RubyGems system software updated
~ % gem -v
3.6.9
```
- Bump the TargetRubyVersion in .rubocop.yml