### PR TITLE
Bump Ruby versions at Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,9 @@ script:
 
 language: ruby
 rvm:
-  - 3.3.5
-  - 3.2.4
-  - 3.1.6
+  - 3.4.4
+  - 3.3.8
+  - 3.2.8
 
 notifications:
   email: false


### PR DESCRIPTION
This pull request updates Ruby versions at Travis CI, adding Ruby 3.4 and dropping Ruby 3.1.

https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#ruby-versions
> Rails 8.0 requires Ruby 3.2.0 or newer.

https://rubies.travis-ci.org/
> Ubuntu 22.04 (x86_64)

https://rubies.travis-ci.org/ubuntu/22.04/x86_64/ruby-3.4.4
https://rubies.travis-ci.org/ubuntu/22.04/x86_64/ruby-3.3.8
https://rubies.travis-ci.org/ubuntu/22.04/x86_64/ruby-3.2.8