### PR TITLE
Add `workflow_dispatch` to allow ruby_head action run manually

### DIFF
--- a/.github/workflows/ruby_head.yml
+++ b/.github/workflows/ruby_head.yml
@@ -3,7 +3,7 @@ name: ruby_head
 on:
   schedule:
     - cron: "0 0 * * *"
-
+  workflow_dispatch:
 jobs:
   build:
     name: "ruby-${{ matrix.ruby }}-yjit-enabled: ${{ matrix.yjit-enabled }}"


### PR DESCRIPTION
This pull request adds `workflow_dispatch` to allow ruby_head action run manually.

https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow