### PR TITLE
Address ORA-01031: insufficient privileges

### DIFF
--- a/ci/setup_accounts.sh
+++ b/ci/setup_accounts.sh
@@ -2,7 +2,7 @@
 
 set -ev
 
-sqlplus system/${DATABASE_SYS_PASSWORD}@${DATABASE_NAME} <<SQL
+sqlplus sys/${DATABASE_SYS_PASSWORD}@${DATABASE_NAME} as sysdba<<SQL
 @@spec/support/alter_system_set_open_cursors.sql
 @@spec/support/create_oracle_enhanced_users.sql
 exit


### PR DESCRIPTION
This pull request addresses the following ORA-01031 error.

```sql
GRANT EXECUTE ON dbms_lock TO ruby
                 *
ERROR at line 1:
ORA-01031: insufficient privileges
Help: https://docs.oracle.com/error-help/db/ora-01031/
```