### PR TITLE
Use `ubuntu-latest` image

### DIFF
--- a/.github/workflows/ruby_head.yml
+++ b/.github/workflows/ruby_head.yml
@@ -44,10 +44,8 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: Install libaio1t64
+      - name: Create symbolic link for libaio library compatibility
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libaio1t64
           sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
       - name: Download Oracle instant client
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,10 +53,8 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: Install libaio1t64
+      - name: Create symbolic link for libaio library compatibility
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libaio1t64
           sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
       - name: Download Oracle instant client
         run: |

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -55,10 +55,8 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: Install libaio1t64
+      - name: Create symbolic link for libaio library compatibility
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libaio1t64
           sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
       - name: Download Oracle instant client
         run: |


### PR DESCRIPTION
https://github.com/actions/runner-images

> mage	YAML Label
> Ubuntu 24.04	ubuntu-latest or ubuntu-24.04

Install the libaio1t64 package and added workaround for the following error.
    
```ruby
sqlplus: error while loading shared libraries: libaio.so.1: cannot open shared object file: No such file or directory
```
Refer to https://bugs.launchpad.net/ubuntu/+source/libaio/+bug/2110672