### PR TITLE
Suppress messages for the "should rename table on 7_0 and below" spec

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/compatibility_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/compatibility_spec.rb
@@ -25,11 +25,15 @@ describe "compatibility migrations" do
       end
     }.new
 
-    migration.migrate(:up)
+    ActiveRecord::Migration.suppress_messages do
+      migration.migrate(:up)
+    end
     expect(@conn.table_exists?(:new_test_employees)).to be_truthy
     expect(@conn.table_exists?(:test_employees)).not_to be_truthy
 
-    migration.migrate(:down)
+    ActiveRecord::Migration.suppress_messages do
+      migration.migrate(:down)
+    end
     expect(@conn.table_exists?(:new_test_employees)).not_to be_truthy
     expect(@conn.table_exists?(:test_employees)).to be_truthy
   end


### PR DESCRIPTION
This commit suppresses the following migration standard output.

```ruby
$ bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/compatibility_spec.rb:21
==> Loading config from ENV or use default
==> Running specs with ruby version 3.4.4
==> Effective ActiveRecord version 8.0.2
Run options: include {locations: {"./spec/active_record/connection_adapters/oracle_enhanced/compatibility_spec.rb" => [21]}}
==  : migrating ===============================================================
-- rename_table(:test_employees, :new_test_employees)
   -> 0.2045s
==  : migrated (0.2045s) ======================================================

==  : reverting ===============================================================
-- rename_table(:new_test_employees, :test_employees)
   -> 0.2033s
==  : reverted (0.2046s) ======================================================

.

Finished in 0.68775 seconds (files took 0.34644 seconds to load)
1 example, 0 failures

$
```

Follow up #2418