### PR TITLE
Add `ruby-asan` to CI

### DIFF
--- a/.github/workflows/ruby_head.yml
+++ b/.github/workflows/ruby_head.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['head', 'debug']
+        ruby: ['head', 'debug', 'asan']
         yjit-enabled: [0, 1]
     env:
       RUBY_YJIT_ENABLE: ${{ matrix.yjit-enabled }}


### PR DESCRIPTION
This commit adds `ruby-asan` to CI

https://github.com/ruby/setup-ruby

> ruby-asan is the same as ruby-head but with AddressSanitizer (ASan) enabled, helpful for finding memory issues in native extensions.
> Native extensions are automatically compiled with AddressSanitizer when using ruby-asan. ruby-asan is currently only available on ubuntu-24.04.

`ruby-asan` can be added since the CI migrates to the `ubuntu-latest` via #2450