### PR TITLE
Mark History.md as no longer updated and point to GitHub releases

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+This file is no longer being updated. For the latest updates and release information, please see: https://github.com/rsim/oracle-enhanced/releases
+
 ## 7.2.0 / 2025-06-23
 
 * Changes and bug fixes


### PR DESCRIPTION
This pull request marks History.md as no longer updated and points to GitHub releases, as maintaining both is redundant.