### PR TITLE
Update .travis.yml to run "/ TIMESTAMP WITH TIME ZONE values from ActiveRecord model"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - bundle install
 
 script:
-  - bundle exec rake spec
+  - bundle exec rspec spec/active_record/oracle_enhanced/type/timestamp_spec.rb
 
 language: ruby
 rvm:


### PR DESCRIPTION
This pull request updates .travis.yml to run "/ TIMESTAMP WITH TIME ZONE values from ActiveRecord model" only.

This test has been disabled at test_11g.yml via https://github.com/rsim/oracle-enhanced/pull/2389 Once this test can be run with GitHub Actions, we can disable Travis CI.