### PR TITLE
Fix bug report templates for 8.0 stable branch

### DIFF
--- a/.github/workflows/ruby_head.yml
+++ b/.github/workflows/ruby_head.yml
@@ -77,7 +77,6 @@ jobs:
         run: |
           bundle exec rspec
       - name: Run bug report templates
-        if: false
         run: |
           cd guides/bug_report_templates
           ruby active_record_gem.rb

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,6 @@ jobs:
         run: |
           bundle exec rspec
       - name: Run bug report templates
-        if: "false"
         run: |
           cd guides/bug_report_templates
           ruby active_record_gem.rb

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -87,7 +87,6 @@ jobs:
         run: |
           bundle exec rspec
       - name: Run bug report templates
-        if: "false"
         run: |
           cd guides/bug_report_templates
           ruby active_record_gem.rb

--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -7,8 +7,8 @@ gemfile(true) do
 
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-  gem "activerecord", github: "rails/rails", branch: "main"
-  gem "activerecord-oracle_enhanced-adapter",  github: "rsim/oracle-enhanced", branch: "master"
+  gem "activerecord", github: "rails/rails", branch: "8-0-stable"
+  gem "activerecord-oracle_enhanced-adapter",  github: "rsim/oracle-enhanced", branch: "release80"
   gem "minitest"
 
   platforms :ruby do

--- a/guides/bug_report_templates/active_record_gem_spec.rb
+++ b/guides/bug_report_templates/active_record_gem_spec.rb
@@ -7,8 +7,8 @@ gemfile(true) do
 
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-  gem "activerecord", github: "rails/rails", branch: "main"
-  gem "activerecord-oracle_enhanced-adapter",  github: "rsim/oracle-enhanced", branch: "master"
+  gem "activerecord", github: "rails/rails", branch: "8-0-stable"
+  gem "activerecord-oracle_enhanced-adapter",  github: "rsim/oracle-enhanced", branch: "release80"
   gem "rspec", require: "rspec/autorun"
 
   platforms :ruby do


### PR DESCRIPTION
This pull request updates bug report template configuration to be compatible with release80 branch environment and CIs run these files.

- With this commit
```ruby
$ ruby -v
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +PRISM [x86_64-linux]
$ ruby active_record_gem.rb
Fetching https://github.com/kubo/ruby-oci8.git
Fetching https://github.com/rsim/oracle-enhanced.git
Fetching https://github.com/rails/rails.git
Fetching gem metadata from https://rubygems.org/..........
Resolving dependencies...
-- create_table(:posts, {force: true})
D, [2025-06-29T09:20:53.289823 #1660953] DEBUG -- :    (13.4ms)  DROP TABLE "POSTS"
D, [2025-06-29T09:20:53.294321 #1660953] DEBUG -- :    (4.2ms)  DROP SEQUENCE "POSTS_SEQ"
D, [2025-06-29T09:20:53.300123 #1660953] DEBUG -- :    (5.6ms)  CREATE TABLE "POSTS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY)
D, [2025-06-29T09:20:53.302264 #1660953] DEBUG -- :    (2.0ms)  CREATE SEQUENCE "POSTS_SEQ" START WITH 1
   -> 0.1497s
-- create_table(:comments, {force: true})
D, [2025-06-29T09:20:53.415485 #1660953] DEBUG -- :    (12.6ms)  DROP TABLE "COMMENTS"
D, [2025-06-29T09:20:53.418772 #1660953] DEBUG -- :    (3.0ms)  DROP SEQUENCE "COMMENTS_SEQ"
D, [2025-06-29T09:20:53.423895 #1660953] DEBUG -- :    (4.9ms)  CREATE TABLE "COMMENTS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY, "POST_ID" NUMBER(38))
D, [2025-06-29T09:20:53.425852 #1660953] DEBUG -- :    (1.8ms)  CREATE SEQUENCE "COMMENTS_SEQ" START WITH 1
   -> 0.1235s
D, [2025-06-29T09:20:53.437179 #1660953] DEBUG -- :   ActiveRecord::InternalMetadata Load (0.5ms)  SELECT * FROM (SELECT * FROM "AR_INTERNAL_METADATA" WHERE "AR_INTERNAL_METADATA"."KEY" = :a1 ORDER BY "AR_INTERNAL_METADATA"."KEY" ASC ) WHERE ROWNUM <= 1  [[nil, "environment"]]
Run options: --seed 2150

D, [2025-06-29T09:20:53.973878 #1660953] DEBUG -- :   Post Create (22.2ms)  INSERT INTO "POSTS" ("ID") VALUES (:a1)  [["id", 1]]
D, [2025-06-29T09:20:54.403818 #1660953] DEBUG -- :   Comment Create (17.3ms)  INSERT INTO "COMMENTS" ("ID") VALUES (:a1)  [["id", 1]]
D, [2025-06-29T09:20:54.410472 #1660953] DEBUG -- :   Comment Update (3.0ms)  UPDATE "COMMENTS" SET "POST_ID" = :a1 WHERE "COMMENTS"."ID" = :a2  [["post_id", 1], ["id", 1]]
D, [2025-06-29T09:20:54.414855 #1660953] DEBUG -- :   Comment Count (2.6ms)  SELECT COUNT(*) FROM "COMMENTS" WHERE "COMMENTS"."POST_ID" = :a1  [["post_id", 1]]
D, [2025-06-29T09:20:54.416336 #1660953] DEBUG -- :   Comment Count (1.3ms)  SELECT COUNT(*) FROM "COMMENTS"
D, [2025-06-29T09:20:54.418215 #1660953] DEBUG -- :   Comment Load (1.1ms)  SELECT * FROM (SELECT "COMMENTS".* FROM "COMMENTS" ORDER BY "COMMENTS"."ID" ASC ) WHERE ROWNUM <= :a1  [["LIMIT", 1]]
D, [2025-06-29T09:20:54.420601 #1660953] DEBUG -- :   Post Load (1.7ms)  SELECT "POSTS".* FROM "POSTS" WHERE "POSTS"."ID" = :a1 AND ROWNUM <= :a2   [["id", 1], ["LIMIT", 1]]
.

Finished in 0.955570s, 1.0465 runs/s, 3.1395 assertions/s.

1 runs, 3 assertions, 0 failures, 0 errors, 0 skips
yahonda@myubuntu:~/src/github.com/rsim/oracle-enhanced/guides/bug_report_templates$ ruby active_record_gem_spec.rb
Fetching https://github.com/kubo/ruby-oci8.git
Fetching https://github.com/rsim/oracle-enhanced.git
Fetching https://github.com/rails/rails.git
Fetching gem metadata from https://rubygems.org/..........
Resolving dependencies...
-- create_table(:posts, {force: true})
D, [2025-06-29T09:21:03.308979 #1661232] DEBUG -- :    (15.6ms)  DROP TABLE "POSTS"
D, [2025-06-29T09:21:03.313359 #1661232] DEBUG -- :    (4.1ms)  DROP SEQUENCE "POSTS_SEQ"
D, [2025-06-29T09:21:03.320263 #1661232] DEBUG -- :    (6.4ms)  CREATE TABLE "POSTS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY)
D, [2025-06-29T09:21:03.322988 #1661232] DEBUG -- :    (2.5ms)  CREATE SEQUENCE "POSTS_SEQ" START WITH 1
   -> 0.1535s
-- create_table(:comments, {force: true})
D, [2025-06-29T09:21:03.434660 #1661232] DEBUG -- :    (10.4ms)  DROP TABLE "COMMENTS"
D, [2025-06-29T09:21:03.437557 #1661232] DEBUG -- :    (2.7ms)  DROP SEQUENCE "COMMENTS_SEQ"
D, [2025-06-29T09:21:03.443303 #1661232] DEBUG -- :    (5.5ms)  CREATE TABLE "COMMENTS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY, "POST_ID" NUMBER(38))
D, [2025-06-29T09:21:03.446023 #1661232] DEBUG -- :    (2.5ms)  CREATE SEQUENCE "COMMENTS_SEQ" START WITH 1
   -> 0.1230s
D, [2025-06-29T09:21:03.458293 #1661232] DEBUG -- :   ActiveRecord::InternalMetadata Load (0.5ms)  SELECT * FROM (SELECT * FROM "AR_INTERNAL_METADATA" WHERE "AR_INTERNAL_METADATA"."KEY" = :a1 ORDER BY "AR_INTERNAL_METADATA"."KEY" ASC ) WHERE ROWNUM <= 1  [[nil, "environment"]]
D, [2025-06-29T09:21:03.978427 #1661232] DEBUG -- :   Post Create (27.0ms)  INSERT INTO "POSTS" ("ID") VALUES (:a1)  [["id", 1]]
D, [2025-06-29T09:21:04.399606 #1661232] DEBUG -- :   Comment Create (4.3ms)  INSERT INTO "COMMENTS" ("ID") VALUES (:a1)  [["id", 1]]
D, [2025-06-29T09:21:04.408651 #1661232] DEBUG -- :   Comment Update (3.5ms)  UPDATE "COMMENTS" SET "POST_ID" = :a1 WHERE "COMMENTS"."ID" = :a2  [["post_id", 1], ["id", 1]]
D, [2025-06-29T09:21:04.413675 #1661232] DEBUG -- :   Comment Count (3.3ms)  SELECT COUNT(*) FROM "COMMENTS" WHERE "COMMENTS"."POST_ID" = :a1  [["post_id", 1]]
D, [2025-06-29T09:21:04.415549 #1661232] DEBUG -- :   Comment Count (1.2ms)  SELECT COUNT(*) FROM "COMMENTS"
D, [2025-06-29T09:21:04.416853 #1661232] DEBUG -- :   Comment Load (1.0ms)  SELECT * FROM (SELECT "COMMENTS".* FROM "COMMENTS" ORDER BY "COMMENTS"."ID" ASC ) WHERE ROWNUM <= :a1  [["LIMIT", 1]]
D, [2025-06-29T09:21:04.419228 #1661232] DEBUG -- :   Post Load (1.7ms)  SELECT "POSTS".* FROM "POSTS" WHERE "POSTS"."ID" = :a1 AND ROWNUM <= :a2   [["id", 1], ["LIMIT", 1]]
.

Finished in 1.29 seconds (files took 0.29285 seconds to load)
1 example, 0 failures

yahonda@myubuntu:~/src/github.com/rsim/oracle-enhanced/guides/bug_report_templates$