### PR TITLE
Fix bug report templates for release72 branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,6 @@ jobs:
         run: |
           bundle exec rspec
       - name: Run bug report templates
-        if: "false"
         run: |
           cd guides/bug_report_templates
           ruby active_record_gem.rb

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -85,7 +85,6 @@ jobs:
         run: |
           bundle exec rspec
       - name: Run bug report templates
-        if: "false"
         run: |
           cd guides/bug_report_templates
           ruby active_record_gem.rb

--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -7,8 +7,8 @@ gemfile(true) do
 
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-  gem "activerecord", github: "rails/rails", branch: "main"
-  gem "activerecord-oracle_enhanced-adapter",  github: "rsim/oracle-enhanced", branch: "master"
+  gem "activerecord", github: "rails/rails", branch: "7-2-stable"
+  gem "activerecord-oracle_enhanced-adapter",  github: "rsim/oracle-enhanced", branch: "release72"
   gem "minitest"
 
   platforms :ruby do

--- a/guides/bug_report_templates/active_record_gem_spec.rb
+++ b/guides/bug_report_templates/active_record_gem_spec.rb
@@ -7,8 +7,8 @@ gemfile(true) do
 
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-  gem "activerecord", github: "rails/rails", branch: "main"
-  gem "activerecord-oracle_enhanced-adapter",  github: "rsim/oracle-enhanced", branch: "master"
+  gem "activerecord", github: "rails/rails", branch: "7-2-stable"
+  gem "activerecord-oracle_enhanced-adapter",  github: "rsim/oracle-enhanced", branch: "release72"
   gem "rspec", require: "rspec/autorun"
 
   platforms :ruby do


### PR DESCRIPTION
This pull request updates the bug report template configuration to be compatible with release72 branch environment and CIs run these files.

- With this commit

```ruby
$ ruby -v
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +PRISM [x86_64-linux]
yahonda@myubuntu:~/src/github.com/rsim/oracle-enhanced/guides/bug_report_templates$ ruby active_record_gem.rb
Fetching https://github.com/kubo/ruby-oci8.git
Fetching https://github.com/rsim/oracle-enhanced.git
Fetching https://github.com/rails/rails.git
Fetching gem metadata from https://rubygems.org/..........
Resolving dependencies...
-- create_table(:posts, {force: true})
D, [2025-06-29T11:37:40.772561 #1683092] DEBUG -- :    (14.0ms)  DROP TABLE "POSTS"
D, [2025-06-29T11:37:40.777165 #1683092] DEBUG -- :    (4.4ms)  DROP SEQUENCE "POSTS_SEQ"
D, [2025-06-29T11:37:40.783744 #1683092] DEBUG -- :    (6.3ms)  CREATE TABLE "POSTS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY)
D, [2025-06-29T11:37:40.786991 #1683092] DEBUG -- :    (3.1ms)  CREATE SEQUENCE "POSTS_SEQ" START WITH 1
   -> 0.1521s
-- create_table(:comments, {force: true})
D, [2025-06-29T11:37:40.899644 #1683092] DEBUG -- :    (10.6ms)  DROP TABLE "COMMENTS"
D, [2025-06-29T11:37:40.902449 #1683092] DEBUG -- :    (2.6ms)  DROP SEQUENCE "COMMENTS_SEQ"
D, [2025-06-29T11:37:40.908580 #1683092] DEBUG -- :    (5.9ms)  CREATE TABLE "COMMENTS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY, "POST_ID" NUMBER(38))
D, [2025-06-29T11:37:40.911089 #1683092] DEBUG -- :    (2.3ms)  CREATE SEQUENCE "COMMENTS_SEQ" START WITH 1
   -> 0.1240s
D, [2025-06-29T11:37:40.922927 #1683092] DEBUG -- :   ActiveRecord::InternalMetadata Load (0.4ms)  SELECT * FROM (SELECT * FROM "AR_INTERNAL_METADATA" WHERE "AR_INTERNAL_METADATA"."KEY" = :a1 ORDER BY "AR_INTERNAL_METADATA"."KEY" ASC ) WHERE ROWNUM <= 1  [[nil, "environment"]]
Run options: --seed 37326

D, [2025-06-29T11:37:41.437876 #1683092] DEBUG -- :   Post Create (20.8ms)  INSERT INTO "POSTS" ("ID") VALUES (:a1)  [["id", 1]]
D, [2025-06-29T11:37:41.872143 #1683092] DEBUG -- :   Comment Create (18.7ms)  INSERT INTO "COMMENTS" ("ID") VALUES (:a1)  [["id", 1]]
D, [2025-06-29T11:37:41.879265 #1683092] DEBUG -- :   Comment Update (3.3ms)  UPDATE "COMMENTS" SET "POST_ID" = :a1 WHERE "COMMENTS"."ID" = :a2  [["post_id", 1], ["id", 1]]
D, [2025-06-29T11:37:41.884184 #1683092] DEBUG -- :   Comment Count (3.2ms)  SELECT COUNT(*) FROM "COMMENTS" WHERE "COMMENTS"."POST_ID" = :a1  [["post_id", 1]]
D, [2025-06-29T11:37:41.885803 #1683092] DEBUG -- :   Comment Count (1.3ms)  SELECT COUNT(*) FROM "COMMENTS"
D, [2025-06-29T11:37:41.887209 #1683092] DEBUG -- :   Comment Load (1.0ms)  SELECT * FROM (SELECT "COMMENTS".* FROM "COMMENTS" ORDER BY "COMMENTS"."ID" ASC ) WHERE ROWNUM <= :a1  [["LIMIT", 1]]
D, [2025-06-29T11:37:41.889669 #1683092] DEBUG -- :   Post Load (1.8ms)  SELECT "POSTS".* FROM "POSTS" WHERE "POSTS"."ID" = :a1 AND ROWNUM <= :a2   [["id", 1], ["LIMIT", 1]]
.

Finished in 0.960940s, 1.0406 runs/s, 3.1219 assertions/s.

1 runs, 3 assertions, 0 failures, 0 errors, 0 skips
$ ruby active_record_gem_spec.rb
Fetching https://github.com/kubo/ruby-oci8.git
Fetching https://github.com/rsim/oracle-enhanced.git
Fetching https://github.com/rails/rails.git
Fetching gem metadata from https://rubygems.org/..........
Resolving dependencies...
-- create_table(:posts, {force: true})
D, [2025-06-29T11:37:50.523338 #1683370] DEBUG -- :    (15.5ms)  DROP TABLE "POSTS"
D, [2025-06-29T11:37:50.527766 #1683370] DEBUG -- :    (4.2ms)  DROP SEQUENCE "POSTS_SEQ"
D, [2025-06-29T11:37:50.533627 #1683370] DEBUG -- :    (5.6ms)  CREATE TABLE "POSTS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY)
D, [2025-06-29T11:37:50.535643 #1683370] DEBUG -- :    (1.9ms)  CREATE SEQUENCE "POSTS_SEQ" START WITH 1
   -> 0.1516s
-- create_table(:comments, {force: true})
D, [2025-06-29T11:37:50.648552 #1683370] DEBUG -- :    (11.8ms)  DROP TABLE "COMMENTS"
D, [2025-06-29T11:37:50.652595 #1683370] DEBUG -- :    (3.8ms)  DROP SEQUENCE "COMMENTS_SEQ"
D, [2025-06-29T11:37:50.658913 #1683370] DEBUG -- :    (6.0ms)  CREATE TABLE "COMMENTS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY, "POST_ID" NUMBER(38))
D, [2025-06-29T11:37:50.661880 #1683370] DEBUG -- :    (2.7ms)  CREATE SEQUENCE "COMMENTS_SEQ" START WITH 1
   -> 0.1262s
D, [2025-06-29T11:37:50.675137 #1683370] DEBUG -- :   ActiveRecord::InternalMetadata Load (0.5ms)  SELECT * FROM (SELECT * FROM "AR_INTERNAL_METADATA" WHERE "AR_INTERNAL_METADATA"."KEY" = :a1 ORDER BY "AR_INTERNAL_METADATA"."KEY" ASC ) WHERE ROWNUM <= 1  [[nil, "environment"]]
D, [2025-06-29T11:37:51.192344 #1683370] DEBUG -- :   Post Create (20.9ms)  INSERT INTO "POSTS" ("ID") VALUES (:a1)  [["id", 1]]
D, [2025-06-29T11:37:51.623694 #1683370] DEBUG -- :   Comment Create (16.2ms)  INSERT INTO "COMMENTS" ("ID") VALUES (:a1)  [["id", 1]]
D, [2025-06-29T11:37:51.630833 #1683370] DEBUG -- :   Comment Update (3.4ms)  UPDATE "COMMENTS" SET "POST_ID" = :a1 WHERE "COMMENTS"."ID" = :a2  [["post_id", 1], ["id", 1]]
D, [2025-06-29T11:37:51.635778 #1683370] DEBUG -- :   Comment Count (3.3ms)  SELECT COUNT(*) FROM "COMMENTS" WHERE "COMMENTS"."POST_ID" = :a1  [["post_id", 1]]
D, [2025-06-29T11:37:51.638346 #1683370] DEBUG -- :   Comment Count (1.8ms)  SELECT COUNT(*) FROM "COMMENTS"
D, [2025-06-29T11:37:51.639661 #1683370] DEBUG -- :   Comment Load (0.9ms)  SELECT * FROM (SELECT "COMMENTS".* FROM "COMMENTS" ORDER BY "COMMENTS"."ID" ASC ) WHERE ROWNUM <= :a1  [["LIMIT", 1]]
D, [2025-06-29T11:37:51.642065 #1683370] DEBUG -- :   Post Load (1.7ms)  SELECT "POSTS".* FROM "POSTS" WHERE "POSTS"."ID" = :a1 AND ROWNUM <= :a2   [["id", 1], ["LIMIT", 1]]
.

Finished in 1.29 seconds (files took 0.28644 seconds to load)
1 example, 0 failures

$
```