### PR TITLE
Add Gemfile.lock display to CI workflows

### DIFF
--- a/.github/workflows/ruby_head.yml
+++ b/.github/workflows/ruby_head.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Bundle install
         run: |
           bundle install --jobs 4 --retry 3
+      - name: Show Gemfile.lock
+        run: |
+          cat Gemfile.lock
       - name: Run RSpec
         run: |
           bundle exec rspec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Bundle install
         run: |
           bundle install --jobs 4 --retry 3
+      - name: Show Gemfile.lock
+        run: |
+          cat Gemfile.lock
       - name: Run RSpec
         run: |
           bundle exec rspec

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -83,6 +83,9 @@ jobs:
       - name: Bundle install
         run: |
           bundle install --jobs 4 --retry 3
+      - name: Show Gemfile.lock
+        run: |
+          cat Gemfile.lock
       - name: Run RSpec
         run: |
           bundle exec rspec


### PR DESCRIPTION
This pull request shows Gemfile.lock contents in CI logs after bundle install to help debug dependency issues and track resolved gem versions.

🤖 Generated with [Claude Code](https://claude.ai/code)