### PR TITLE
select compatible AR version while developing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source "https://rubygems.org"
 
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
+gemspec
+
 group :development do
   gem "rspec"
   gem "rdoc"


### PR DESCRIPTION
Without this change, running tests locally selects the latest available activerecord version locally. This might be incorrect and confusing as hell.

This change ensures that a supported version of activerecord is selected by bundler. Also it is very standard to have this in Gemfiles.

I hope this doesn't break CI. So I'm submiting anyway and hope it works.