### PR TITLE
Added missing method Cursor.select_statement?

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -389,6 +389,13 @@ module ActiveRecord
             @raw_statement.getUpdateCount
           end
 
+          # Is the current statement a SELECT statement?
+          def select_statement?
+            # Only simple SELECT and WITH statements are considered SELECT statements.
+            # because no other valid ojdbc method found to check it.
+            @raw_statement.get_original_sql.strip.match?(/\A\s*(SELECT|WITH)/i)
+          end
+
           def fetch(options = {})
             if @raw_result_set.next
               get_lob_value = options[:get_lob_value]

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -396,10 +396,10 @@ module ActiveRecord
 
             sql = @raw_statement.get_original_sql.strip
 
-            sql.gsub!(/\A\n+/, '')            # remove leading newlines
-            sql.gsub!(/\A\r+/, '')            # remove leading carriage returns
-            sql.gsub!(/--.*$/, '')            # remove single line comments
-            sql.gsub!(/\/\*.*?\*\//m, '')     # Remove multi-line comments (/* ... */)
+            sql.gsub!(/\A\n+/, "")            # remove leading newlines
+            sql.gsub!(/\A\r+/, "")            # remove leading carriage returns
+            sql.gsub!(/--.*$/, "")            # remove single line comments
+            sql.gsub!(/\/\*.*?\*\//m, "")     # Remove multi-line comments (/* ... */)
             sql.match?(/\A\s*(SELECT|WITH)/i)
           end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -393,7 +393,14 @@ module ActiveRecord
           def select_statement?
             # Only simple SELECT and WITH statements are considered SELECT statements.
             # because no other valid ojdbc method found to check it.
-            @raw_statement.get_original_sql.strip.match?(/\A\s*(SELECT|WITH)/i)
+
+            sql = @raw_statement.get_original_sql.strip
+
+            sql.gsub!(/\A\n+/, '')            # remove leading newlines
+            sql.gsub!(/\A\r+/, '')            # remove leading carriage returns
+            sql.gsub!(/--.*$/, '')            # remove single line comments
+            sql.gsub!(/\/\*.*?\*\//m, '')     # Remove multi-line comments (/* ... */)
+            sql.match?(/\A\s*(SELECT|WITH)/i)
           end
 
           def fetch(options = {})


### PR DESCRIPTION
This method was missed for the JDBC implementation of class Cursor

Fixes issue #2470 