### PR TITLE
Fix compatibility with Rails 8.0.2.1 - Update Arel visitor inheritance

### DIFF
--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -4,7 +4,7 @@ require_relative "oracle_common"
 
 module Arel # :nodoc: all
   module Visitors
-    class Oracle < Arel::Visitors::ToSql
+    class Oracle < Arel::Visitors::Visitor
       include OracleCommon
 
       private


### PR DESCRIPTION
## Problem
The Oracle Arel visitor fails to load in Rails 8.0.2.1 with the error:

uninitialized constant Arel::Visitors::ToSql (NameError)

This occurs because Rails 8.0.2.1 changed the Arel visitor inheritance chain.

## Root Cause
In Rails 8.0.2.1, `Arel::Visitors::ToSql` now inherits directly from `Arel::Visitors::Visitor` instead of `Arel::Visitors::Reduce`. The oracle_enhanced adapter's Oracle visitor was written expecting the older inheritance structure.

## Solution
Change the Oracle visitor to inherit directly from `Arel::Visitors::Visitor` instead of `Arel::Visitors::ToSql`.

## Changes
- `lib/arel/visitors/oracle.rb`: Line 7 - Change inheritance from `ToSql` to `Visitor`

## Testing
- Tested with Rails 8.0.2.1 and Ruby 3.4.1
- Application boots successfully 
- Database connections work properly

## Compatibility
This change maintains compatibility with the existing Rails 8.0.x series while fixing the 8.0.2.1 specific issue.

Fixes compatibility with Rails 8.0.2.1+