### PR TITLE
Bump required Ruby version to 3.2.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ plugins:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
   DisabledByDefault: true
   SuggestExtensions: false
 

--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.version = version
 
   s.required_rubygems_version = ">= 1.8.11"
-  s.required_ruby_version     = ">= 3.1.0"
+  s.required_ruby_version     = ">= 3.2.0"
   s.license = "MIT"
   s.authors = ["Raimonds Simanovskis"]
   s.description = 'Oracle "enhanced" ActiveRecord adapter contains useful additional methods for working with new and legacy Oracle databases.


### PR DESCRIPTION
## Summary

- Bumps `required_ruby_version` from `>= 3.1.0` to `>= 3.2.0` in the gemspec
- Follows https://github.com/rails/rails/commit/c7b9bb1b73628daf9c9ebd56c63ce3008b31ac6f on the Rails `release81` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)