### PR TITLE
Run minimum CI for draft pull requests

### DIFF
--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -2,12 +2,16 @@ name: test_11g
 
 on:
   push:
+    branches:
+      - master
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   schedule:
     - cron: "0 0 * * *"
 
 jobs:
   build:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test_11g_ojdbc11.yml
+++ b/.github/workflows/test_11g_ojdbc11.yml
@@ -2,12 +2,16 @@ name: test_11g_ojdbc11
 
 on:
   push:
+    branches:
+      - master
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   schedule:
     - cron: "0 0 * * *"
 
 jobs:
   build:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
## Summary
- Run minimum CI (`linting`, `rubocop`, `test`) for draft pull requests to shorten the feedback loop during frequent updates
- `test_11g` and `test_11g_ojdbc11` workflows skip draft PRs and run when marked "Ready for review" or on direct pushes to master
- Add `ready_for_review` to `pull_request` activity types so the workflows trigger when a draft PR is marked ready
- Restrict `push` trigger to `master` branch to prevent branch pushes from bypassing the draft check

## Test plan
- [x] Draft PR runs only linting, rubocop, and test workflows
- [x] Marking PR as "Ready for review" triggers test_11g and test_11g_ojdbc11

🤖 Generated with [Claude Code](https://claude.com/claude-code)