### PR TITLE
Configure ORA_TZFILE to match Oracle 11g server in CI

### DIFF
--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -36,7 +36,6 @@ jobs:
       DATABASE_HOST: localhost
       DATABASE_PORT: 1521
       DATABASE_VERSION: 11.2.0.2
-      DATABASE_SERVER_AND_CLIENT_VERSION_DO_NOT_MATCH: true
 
     services:
       oracle:
@@ -76,6 +75,19 @@ jobs:
       - name: Install JDBC Driver
         run: |
           wget -q https://download.oracle.com/otn-pub/otn_software/jdbc/23261/ojdbc17.jar -O ./lib/ojdbc17.jar
+      - name: Configure ORA_TZFILE to match Oracle 11g server
+        run: |
+          # Oracle 11g XE uses timezone file v14; Instant Client 21.15 embeds
+          # v35. This mismatch causes ORA-01805 when fetching DATE/TIMESTAMP
+          # values. Copy the v14 files from the 11g container and point the
+          # Instant Client at them via ORA_TZFILE.
+          ORACLE_CONTAINER="${{ job.services.oracle.id }}"
+          sudo mkdir -p "$ORACLE_HOME/oracore/zoneinfo"
+          docker cp "$ORACLE_CONTAINER":/u01/app/oracle/product/11.2.0/xe/oracore/zoneinfo/timezlrg_14.dat /tmp/timezlrg_14.dat
+          docker cp "$ORACLE_CONTAINER":/u01/app/oracle/product/11.2.0/xe/oracore/zoneinfo/timezone_14.dat /tmp/timezone_14.dat
+          sudo mv /tmp/timezlrg_14.dat "$ORACLE_HOME/oracore/zoneinfo/"
+          sudo mv /tmp/timezone_14.dat "$ORACLE_HOME/oracore/zoneinfo/"
+          echo "ORA_TZFILE=timezlrg_14.dat" >> $GITHUB_ENV
       - name: Create database user
         run: |
           ./ci/setup_accounts.sh

--- a/.github/workflows/test_11g_ojdbc11.yml
+++ b/.github/workflows/test_11g_ojdbc11.yml
@@ -32,7 +32,6 @@ jobs:
       DATABASE_HOST: localhost
       DATABASE_PORT: 1521
       DATABASE_VERSION: 11.2.0.2
-      DATABASE_SERVER_AND_CLIENT_VERSION_DO_NOT_MATCH: true
 
     services:
       oracle:
@@ -71,6 +70,19 @@ jobs:
       - name: Install JDBC Driver
         run: |
           wget -q https://download.oracle.com/otn-pub/otn_software/jdbc/23261/ojdbc11.jar -O ./lib/ojdbc11.jar
+      - name: Configure ORA_TZFILE to match Oracle 11g server
+        run: |
+          # Oracle 11g XE uses timezone file v14; Instant Client 21.15 embeds
+          # v35. This mismatch causes ORA-01805 when fetching DATE/TIMESTAMP
+          # values. Copy the v14 files from the 11g container and point the
+          # Instant Client at them via ORA_TZFILE.
+          ORACLE_CONTAINER="${{ job.services.oracle.id }}"
+          sudo mkdir -p "$ORACLE_HOME/oracore/zoneinfo"
+          docker cp "$ORACLE_CONTAINER":/u01/app/oracle/product/11.2.0/xe/oracore/zoneinfo/timezlrg_14.dat /tmp/timezlrg_14.dat
+          docker cp "$ORACLE_CONTAINER":/u01/app/oracle/product/11.2.0/xe/oracore/zoneinfo/timezone_14.dat /tmp/timezone_14.dat
+          sudo mv /tmp/timezlrg_14.dat "$ORACLE_HOME/oracore/zoneinfo/"
+          sudo mv /tmp/timezone_14.dat "$ORACLE_HOME/oracore/zoneinfo/"
+          echo "ORA_TZFILE=timezlrg_14.dat" >> $GITHUB_ENV
       - name: Create database user
         run: |
           ./ci/setup_accounts.sh

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -65,7 +65,7 @@ describe "OracleEnhancedAdapter establish connection" do
   end
 
   it "should not encrypt JDBC network connection" do
-    skip "Oracle 11g XE does not support native network encryption" if ENV["DATABASE_SERVER_AND_CLIENT_VERSION_DO_NOT_MATCH"] == "true"
+    skip "Oracle 11g XE does not support native network encryption" if ENV["DATABASE_VERSION"] == "11.2.0.2"
     if ORACLE_ENHANCED_CONNECTION == :jdbc
       ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS.merge(jdbc_connect_properties: { "oracle.net.encryption_client" => "REJECTED" }))
       conn = ActiveRecord::Base.connection.send(:_connection)
@@ -74,7 +74,7 @@ describe "OracleEnhancedAdapter establish connection" do
   end
 
   it "should encrypt JDBC network connection" do
-    skip "Oracle 11g XE does not support native network encryption" if ENV["DATABASE_SERVER_AND_CLIENT_VERSION_DO_NOT_MATCH"] == "true"
+    skip "Oracle 11g XE does not support native network encryption" if ENV["DATABASE_VERSION"] == "11.2.0.2"
     if ORACLE_ENHANCED_CONNECTION == :jdbc
       ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS.merge(jdbc_connect_properties: { "oracle.net.encryption_client" => "REQUESTED" }))
       conn = ActiveRecord::Base.connection.send(:_connection)

--- a/spec/active_record/oracle_enhanced/type/timestamp_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/timestamp_spec.rb
@@ -4,10 +4,6 @@ describe "OracleEnhancedAdapter timestamp with timezone support" do
   include SchemaSpecHelper
 
   before(:all) do
-    skip if ENV["DATABASE_SERVER_AND_CLIENT_VERSION_DO_NOT_MATCH"] == "true"
-    if ENV["DATABASE_VERSION"] == "11.2.0.2" && ENV["ORACLE_HOME"] == "/usr/lib/oracle/21/client64"
-      skip
-    end
     ActiveRecord.default_timezone = :local
     ActiveRecord::Base.establish_connection(CONNECTION_WITH_TIMEZONE_PARAMS)
     @conn = ActiveRecord::Base.connection


### PR DESCRIPTION
## Summary

- Both 11g CI workflows (`test_11g.yml`, `test_11g_ojdbc11.yml`) used `DATABASE_SERVER_AND_CLIENT_VERSION_DO_NOT_MATCH=true` to mask ORA-01805 errors caused by Oracle 11g XE shipping DSTv14 while Instant Client 21.15 embeds v35. Adopt the approach from rsim/ruby-plsql#239: copy the v14 data files out of the running `gvenzl/oracle-xe:11` container into the Instant Client's `oracore/zoneinfo` directory and point the client at them with `ORA_TZFILE`. `ORA_TZFILE` is set to just the basename (`timezlrg_14.dat`) so Instant Client resolves it relative to `$ORACLE_HOME/oracore/zoneinfo/`; the absolute-path form produces `ORA-01804` in sqlplus. This lets the timestamp-with-timezone specs run against 11g instead of being skipped.
- Drop `DATABASE_SERVER_AND_CLIENT_VERSION_DO_NOT_MATCH` from both 11g workflows and remove the corresponding skip in `spec/active_record/oracle_enhanced/type/timestamp_spec.rb`. Also remove the stale `ORACLE_HOME == "/usr/lib/oracle/21/client64"` fallback there — current workflows use `/opt/oracle/instantclient_21_15`, so it never matched.
- Rewire the two JDBC network-encryption skips in `connection_spec.rb` onto `DATABASE_VERSION == "11.2.0.2"`, which is the honest condition — 11g XE genuinely lacks native network encryption regardless of client version.

## Test plan

- [x] `test_11g` workflow: new `Configure ORA_TZFILE to match Oracle 11g server` step succeeds and the timestamp-with-timezone examples run (previously skipped) without ORA-01805.
- [x] `test_11g_ojdbc11` workflow: same as above.
- [x] The two JDBC network-encryption examples in `connection_spec.rb` remain skipped in the 11g jobs with reason "Oracle 11g XE does not support native network encryption".
- [x] `test.yml` (Oracle 23c) is unaffected — it never set the removed env var and does not touch `ORA_TZFILE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)