### PR TITLE
Test ruby-plsql#239 (bump_oracle_free_23) against master

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :development do
   gem "rdoc"
   gem "rake"
   gem "activerecord",   github: "rails/rails", branch: "8-1-stable"
-  gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
+  gem "ruby-plsql", github: "yahonda/ruby-plsql", branch: "bump_oracle_free_23"
 
   platforms :ruby do
     gem "ruby-oci8",    github: "kubo/ruby-oci8"


### PR DESCRIPTION
Draft PR to run CI against rsim/ruby-plsql#239 ("Bump Oracle to Free 23 and Instant Client to 23.26.1.0.0").

Do not merge — this only repoints the `ruby-plsql` Gemfile source to the PR branch so we can observe CI results on oracle-enhanced `master`.