### PR TITLE
Enable bug report templates CI step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,6 @@ jobs:
         run: |
           bundle exec rspec
       - name: Run bug report templates
-        if: "false"
         run: |
           cd guides/bug_report_templates
           ruby active_record_gem.rb


### PR DESCRIPTION
## Summary
- Remove `if: "false"` from the "Run bug report templates" step in the test workflow so that bug report templates are executed in CI

## Test plan
- [ ] Verify CI runs the "Run bug report templates" step successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)