### PR TITLE
Clean up create_oracle_enhanced_users.sql

### DIFF
--- a/spec/support/create_oracle_enhanced_users.sql
+++ b/spec/support/create_oracle_enhanced_users.sql
@@ -11,21 +11,3 @@ CREATE USER oracle_enhanced_schema IDENTIFIED BY oracle_enhanced_schema;
 GRANT unlimited tablespace, create session, create table, create sequence,
 create procedure, create trigger, create view, create materialized view,
 create database link, create synonym, create type, ctxapp TO oracle_enhanced_schema;
-
-CREATE USER arunit IDENTIFIED BY arunit;
-
-GRANT unlimited tablespace, create session, create table, create sequence,
-create procedure, create trigger, create view, create materialized view,
-create database link, create synonym, create type, ctxapp TO arunit;
-
-CREATE USER arunit2 IDENTIFIED BY arunit2;
-
-GRANT unlimited tablespace, create session, create table, create sequence,
-create procedure, create trigger, create view, create materialized view,
-create database link, create synonym, create type, ctxapp TO arunit2;
-
-CREATE USER ruby IDENTIFIED BY oci8;
-GRANT connect, resource, create view,create synonym TO ruby;
-GRANT EXECUTE ON dbms_lock TO ruby;
-GRANT CREATE VIEW TO ruby;
-GRANT unlimited tablespace to ruby;


### PR DESCRIPTION
## Summary
- Remove `ruby` database user and its grants including `GRANT EXECUTE ON dbms_lock` which always fails
- Remove `arunit` and `arunit2` database users that were used by Rails Active Record unit tests which have been removed

## Test plan
- [x] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)