### PR TITLE
Remove ObjectSpace::WeakMap workaround for old JRuby

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -869,19 +869,3 @@ require "active_record/connection_adapters/oracle_enhanced/version"
 module ActiveRecord
   autoload :OracleEnhancedProcedures, "active_record/connection_adapters/oracle_enhanced/procedures"
 end
-
-# Workaround for https://github.com/jruby/jruby/issues/6267
-# Fixed in JRuby 9.3.0.0 or higher via https://github.com/jruby/jruby/pull/6683
-if RUBY_ENGINE == "jruby" && !ObjectSpace::WeakMap.method_defined?(:values)
-  require "jruby"
-
-  class org.jruby::RubyObjectSpace::WeakMap
-    field_reader :map
-  end
-
-  class ObjectSpace::WeakMap
-    def values
-      JRuby.ref(self).map.values.reject(&:nil?)
-    end
-  end
-end


### PR DESCRIPTION
## Summary
- Remove the `ObjectSpace::WeakMap#values` workaround that was needed for JRuby < 9.3 ([jruby/jruby#6267](https://github.com/jruby/jruby/issues/6267))
- Since Rails master requires Ruby 3.3.1+, all JRuby users will use JRuby 10 (Ruby 3.4 compatible) which includes the fix

## Test plan
- [ ] Verify CI passes for both CRuby and JRuby builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)