### PR TITLE
Make Oracle schema cache aware of primary-key generation strategy

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column.rb
@@ -12,6 +12,18 @@ module ActiveRecord
           @trigger_assigned = trigger_assigned
         end
 
+        def init_with(coder) # :nodoc:
+          super
+          @identity = coder["identity"] unless coder["identity"].nil?
+          @trigger_assigned = coder["trigger_assigned"] unless coder["trigger_assigned"].nil?
+        end
+
+        def encode_with(coder) # :nodoc:
+          super
+          coder["identity"] = @identity
+          coder["trigger_assigned"] = @trigger_assigned
+        end
+
         def virtual?
           virtual
         end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -656,11 +656,7 @@ module ActiveRecord
         return true if table_name.nil?
         table_name = table_name.to_s
         if @prefetch_primary_key_cache[table_name].nil?
-          owner, desc_table_name = resolve_data_source_name(table_name)
-          has_pk                = has_primary_key?(table_name, owner, desc_table_name)
-          has_identity_pk       = supports_identity_columns? && identity_primary_key?(owner, desc_table_name)
-          has_trigger_backed_pk = trigger_backed_primary_key?(owner, desc_table_name)
-          @prefetch_primary_key_cache[table_name] = has_pk && !has_identity_pk && !has_trigger_backed_pk
+          @prefetch_primary_key_cache[table_name] = prefetch_primary_key_from_dictionary(table_name)
         end
         @prefetch_primary_key_cache[table_name]
       end
@@ -1140,6 +1136,14 @@ module ActiveRecord
       ActiveRecord::Type.register(:json, Type::OracleEnhanced::Json, adapter: :oracle_enhanced)
 
       private
+        def prefetch_primary_key_from_dictionary(table_name)
+          owner, desc_table_name = resolve_data_source_name(table_name)
+          has_pk                = has_primary_key?(table_name, owner, desc_table_name)
+          has_identity_pk       = supports_identity_columns? && identity_primary_key?(owner, desc_table_name)
+          has_trigger_backed_pk = trigger_backed_primary_key?(owner, desc_table_name)
+          has_pk && !has_identity_pk && !has_trigger_backed_pk
+        end
+
         AREL_VISITOR_MODES = %i[auto rownum fetch_first].freeze
         private_constant :AREL_VISITOR_MODES
 

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -650,15 +650,14 @@ module ActiveRecord
         SQL
       end
 
-      # Returns true for Oracle adapter (since Oracle requires primary key
-      # values to be pre-fetched before insert). See also #next_sequence_value.
       def prefetch_primary_key?(table_name = nil)
         return true if table_name.nil?
         table_name = table_name.to_s
-        if @prefetch_primary_key_cache[table_name].nil?
-          @prefetch_primary_key_cache[table_name] = prefetch_primary_key_from_dictionary(table_name)
-        end
-        @prefetch_primary_key_cache[table_name]
+        return @prefetch_primary_key_cache[table_name] if @prefetch_primary_key_cache.key?(table_name)
+
+        result = prefetch_primary_key_from_schema_cache(table_name)
+        result = prefetch_primary_key_from_dictionary(table_name) if result.nil?
+        @prefetch_primary_key_cache[table_name] = result
       end
 
       # Returns true when the primary key column of +desc_table_name+ is an
@@ -862,12 +861,6 @@ module ActiveRecord
         # only support single column keys
         pks.size == 1 ? [oracle_downcase(pks.first),
                          oracle_downcase(seqs.first)] : nil
-      end
-
-      # Returns just a table's primary key
-      def primary_key(table_name)
-        pk_and_sequence = pk_and_sequence_for(table_name)
-        pk_and_sequence && pk_and_sequence.first
       end
 
       def has_primary_key?(table_name, owner = nil, desc_table_name = nil) # :nodoc:
@@ -1136,6 +1129,34 @@ module ActiveRecord
       ActiveRecord::Type.register(:json, Type::OracleEnhanced::Json, adapter: :oracle_enhanced)
 
       private
+        def prefetch_primary_key_from_schema_cache(table_name)
+          pk_col = primary_key_column_from_schema_cache(table_name)
+          # Propagate false (cache says no-prefetch) and nil (caller must fall back) as-is.
+          return pk_col unless pk_col.is_a?(OracleEnhanced::Column)
+          !(pk_col.auto_incremented_by_db? || pk_col.auto_populated?)
+        end
+
+        def primary_key_column_from_schema_cache(table_name)
+          return nil unless schema_cache.data_source_exists?(table_name)
+
+          pks = schema_cache.primary_keys(table_name)
+          return false if composite_primary_key?(pks)
+          return false if pks.nil?
+
+          pk_col = schema_cache.columns_hash(table_name)[pks]
+          pk_col if column_with_pk_metadata?(pk_col)
+        end
+
+        def composite_primary_key?(pks)
+          pks.is_a?(Array)
+        end
+
+        def column_with_pk_metadata?(pk_col)
+          pk_col.is_a?(OracleEnhanced::Column) &&
+            pk_col.instance_variable_defined?(:@identity) &&
+            pk_col.instance_variable_defined?(:@trigger_assigned)
+        end
+
         def prefetch_primary_key_from_dictionary(table_name)
           owner, desc_table_name = resolve_data_source_name(table_name)
           has_pk                = has_primary_key?(table_name, owner, desc_table_name)

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_cache_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_cache_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+describe "OracleEnhancedAdapter schema cache" do
+  include SchemaSpecHelper
+
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @conn = ActiveRecord::Base.connection
+    @pool = ActiveRecord::Base.connection_pool
+    schema_define do
+      create_table :test_schema_cache_posts, force: true do |t|
+        t.string :title
+        t.text :body
+        t.timestamps null: false
+      end
+      add_index :test_schema_cache_posts, :title
+    end
+  end
+
+  after(:all) do
+    schema_define do
+      drop_table :test_schema_cache_posts
+    end
+  end
+
+  let(:schema_cache) { @pool.schema_cache }
+
+  describe "columns" do
+    it "returns columns for a table" do
+      columns = schema_cache.columns(@pool, "test_schema_cache_posts")
+      expect(columns).not_to be_empty
+      column_names = columns.map(&:name)
+      expect(column_names).to include("id", "title", "body", "created_at", "updated_at")
+    end
+
+    it "caches columns after first access" do
+      schema_cache.columns(@pool, "test_schema_cache_posts")
+      expect(schema_cache.cached?("test_schema_cache_posts")).to be true
+    end
+  end
+
+  describe "columns_hash" do
+    it "returns a hash of columns indexed by name" do
+      columns_hash = schema_cache.columns_hash(@pool, "test_schema_cache_posts")
+      expect(columns_hash).to be_a(Hash)
+      expect(columns_hash["title"]).not_to be_nil
+      expect(columns_hash["title"].name).to eq("title")
+    end
+  end
+
+  describe "primary_keys" do
+    it "returns the primary key for a table" do
+      pk = schema_cache.primary_keys(@pool, "test_schema_cache_posts")
+      expect(pk).to eq("id")
+    end
+  end
+
+  describe "indexes" do
+    it "returns indexes for a table" do
+      indexes = schema_cache.indexes(@pool, "test_schema_cache_posts")
+      expect(indexes).not_to be_empty
+      index_columns = indexes.map(&:columns).flatten
+      expect(index_columns).to include("title")
+    end
+  end
+
+  describe "data_source_exists?" do
+    it "returns true for an existing table" do
+      expect(schema_cache.data_source_exists?(@pool, "test_schema_cache_posts")).to be true
+    end
+
+    it "returns false for a non-existing table" do
+      expect(schema_cache.data_source_exists?(@pool, "test_nonexistent_table")).to be false
+    end
+  end
+
+  describe "dump and load" do
+    it "can dump and load schema cache" do
+      # Populate cache
+      schema_cache.columns(@pool, "test_schema_cache_posts")
+      schema_cache.primary_keys(@pool, "test_schema_cache_posts")
+      schema_cache.indexes(@pool, "test_schema_cache_posts")
+
+      tmpfile = Tempfile.new(["schema_cache", ".yml"])
+      begin
+        schema_cache.dump_to(tmpfile.path)
+        expect(File.exist?(tmpfile.path)).to be true
+        expect(File.size(tmpfile.path)).to be > 0
+      ensure
+        tmpfile.close
+        tmpfile.unlink
+      end
+    end
+
+    it "produces consistent dump output" do
+      # Populate cache
+      schema_cache.columns(@pool, "test_schema_cache_posts")
+      schema_cache.primary_keys(@pool, "test_schema_cache_posts")
+      schema_cache.indexes(@pool, "test_schema_cache_posts")
+
+      tmpfile1 = Tempfile.new(["schema_cache1", ".yml"])
+      tmpfile2 = Tempfile.new(["schema_cache2", ".yml"])
+      begin
+        schema_cache.dump_to(tmpfile1.path)
+        schema_cache.dump_to(tmpfile2.path)
+
+        dump1 = File.read(tmpfile1.path)
+        dump2 = File.read(tmpfile2.path)
+        expect(dump1).to eq(dump2)
+      ensure
+        tmpfile1.close
+        tmpfile1.unlink
+        tmpfile2.close
+        tmpfile2.unlink
+      end
+    end
+  end
+
+  describe "clear_data_source_cache!" do
+    it "clears cache for a specific table" do
+      schema_cache.columns(@pool, "test_schema_cache_posts")
+      expect(schema_cache.cached?("test_schema_cache_posts")).to be true
+
+      schema_cache.clear_data_source_cache!(@conn, "test_schema_cache_posts")
+      expect(schema_cache.cached?("test_schema_cache_posts")).to be false
+    end
+  end
+
+  describe "version" do
+    it "returns a schema version" do
+      version = schema_cache.version(@pool)
+      expect(version).not_to be_nil
+    end
+  end
+end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_cache_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_cache_spec.rb
@@ -5,8 +5,6 @@ describe "OracleEnhancedAdapter schema cache" do
 
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    @conn = ActiveRecord::Base.connection
-    @pool = ActiveRecord::Base.connection_pool
     schema_define do
       create_table :test_schema_cache_posts, force: true do |t|
         t.string :title
@@ -23,25 +21,25 @@ describe "OracleEnhancedAdapter schema cache" do
     end
   end
 
-  let(:schema_cache) { @pool.schema_cache }
+  let(:schema_cache) { ActiveRecord::Base.connection_pool.schema_cache }
 
   describe "columns" do
     it "returns columns for a table" do
-      columns = schema_cache.columns(@pool, "test_schema_cache_posts")
+      columns = schema_cache.columns("test_schema_cache_posts")
       expect(columns).not_to be_empty
       column_names = columns.map(&:name)
       expect(column_names).to include("id", "title", "body", "created_at", "updated_at")
     end
 
     it "caches columns after first access" do
-      schema_cache.columns(@pool, "test_schema_cache_posts")
+      schema_cache.columns("test_schema_cache_posts")
       expect(schema_cache.cached?("test_schema_cache_posts")).to be true
     end
   end
 
   describe "columns_hash" do
     it "returns a hash of columns indexed by name" do
-      columns_hash = schema_cache.columns_hash(@pool, "test_schema_cache_posts")
+      columns_hash = schema_cache.columns_hash("test_schema_cache_posts")
       expect(columns_hash).to be_a(Hash)
       expect(columns_hash["title"]).not_to be_nil
       expect(columns_hash["title"].name).to eq("title")
@@ -50,14 +48,14 @@ describe "OracleEnhancedAdapter schema cache" do
 
   describe "primary_keys" do
     it "returns the primary key for a table" do
-      pk = schema_cache.primary_keys(@pool, "test_schema_cache_posts")
+      pk = schema_cache.primary_keys("test_schema_cache_posts")
       expect(pk).to eq("id")
     end
   end
 
   describe "indexes" do
     it "returns indexes for a table" do
-      indexes = schema_cache.indexes(@pool, "test_schema_cache_posts")
+      indexes = schema_cache.indexes("test_schema_cache_posts")
       expect(indexes).not_to be_empty
       index_columns = indexes.map(&:columns).flatten
       expect(index_columns).to include("title")
@@ -66,20 +64,20 @@ describe "OracleEnhancedAdapter schema cache" do
 
   describe "data_source_exists?" do
     it "returns true for an existing table" do
-      expect(schema_cache.data_source_exists?(@pool, "test_schema_cache_posts")).to be true
+      expect(schema_cache.data_source_exists?("test_schema_cache_posts")).to be true
     end
 
     it "returns false for a non-existing table" do
-      expect(schema_cache.data_source_exists?(@pool, "test_nonexistent_table")).to be false
+      expect(schema_cache.data_source_exists?("test_nonexistent_table")).to be false
     end
   end
 
   describe "dump and load" do
     it "can dump and load schema cache" do
       # Populate cache
-      schema_cache.columns(@pool, "test_schema_cache_posts")
-      schema_cache.primary_keys(@pool, "test_schema_cache_posts")
-      schema_cache.indexes(@pool, "test_schema_cache_posts")
+      schema_cache.columns("test_schema_cache_posts")
+      schema_cache.primary_keys("test_schema_cache_posts")
+      schema_cache.indexes("test_schema_cache_posts")
 
       tmpfile = Tempfile.new(["schema_cache", ".yml"])
       begin
@@ -94,9 +92,9 @@ describe "OracleEnhancedAdapter schema cache" do
 
     it "produces consistent dump output" do
       # Populate cache
-      schema_cache.columns(@pool, "test_schema_cache_posts")
-      schema_cache.primary_keys(@pool, "test_schema_cache_posts")
-      schema_cache.indexes(@pool, "test_schema_cache_posts")
+      schema_cache.columns("test_schema_cache_posts")
+      schema_cache.primary_keys("test_schema_cache_posts")
+      schema_cache.indexes("test_schema_cache_posts")
 
       tmpfile1 = Tempfile.new(["schema_cache1", ".yml"])
       tmpfile2 = Tempfile.new(["schema_cache2", ".yml"])
@@ -118,17 +116,17 @@ describe "OracleEnhancedAdapter schema cache" do
 
   describe "clear_data_source_cache!" do
     it "clears cache for a specific table" do
-      schema_cache.columns(@pool, "test_schema_cache_posts")
+      schema_cache.columns("test_schema_cache_posts")
       expect(schema_cache.cached?("test_schema_cache_posts")).to be true
 
-      schema_cache.clear_data_source_cache!(@conn, "test_schema_cache_posts")
+      schema_cache.clear_data_source_cache!("test_schema_cache_posts")
       expect(schema_cache.cached?("test_schema_cache_posts")).to be false
     end
   end
 
   describe "version" do
     it "returns a schema version" do
-      version = schema_cache.version(@pool)
+      version = schema_cache.version
       expect(version).not_to be_nil
     end
   end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_cache_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_cache_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "tempfile"
+
+describe "OracleEnhancedAdapter schema cache" do
+  include SchemaSpecHelper
+
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    schema_define do
+      create_table :test_schema_cache_posts, force: true do |t|
+        t.string :title
+        t.text :body
+        t.timestamps null: false
+      end
+      add_index :test_schema_cache_posts, :title
+    end
+  end
+
+  after(:all) do
+    schema_define do
+      drop_table :test_schema_cache_posts
+    end
+  end
+
+  let(:schema_cache) { ActiveRecord::Base.connection_pool.schema_cache }
+
+  describe "columns" do
+    it "returns columns for a table" do
+      columns = schema_cache.columns("test_schema_cache_posts")
+      expect(columns).not_to be_empty
+      column_names = columns.map(&:name)
+      expect(column_names).to include("id", "title", "body", "created_at", "updated_at")
+    end
+
+    it "caches columns after first access" do
+      schema_cache.columns("test_schema_cache_posts")
+      expect(schema_cache.cached?("test_schema_cache_posts")).to be true
+    end
+  end
+
+  describe "columns_hash" do
+    it "returns a hash of columns indexed by name" do
+      columns_hash = schema_cache.columns_hash("test_schema_cache_posts")
+      expect(columns_hash).to be_a(Hash)
+      expect(columns_hash["title"]).not_to be_nil
+      expect(columns_hash["title"].name).to eq("title")
+    end
+  end
+
+  describe "primary_keys" do
+    it "returns the primary key for a table" do
+      pk = schema_cache.primary_keys("test_schema_cache_posts")
+      expect(pk).to eq("id")
+    end
+  end
+
+  describe "indexes" do
+    it "returns indexes for a table" do
+      indexes = schema_cache.indexes("test_schema_cache_posts")
+      expect(indexes).not_to be_empty
+      index_columns = indexes.map(&:columns).flatten
+      expect(index_columns).to include("title")
+    end
+  end
+
+  describe "data_source_exists?" do
+    it "returns true for an existing table" do
+      expect(schema_cache.data_source_exists?("test_schema_cache_posts")).to be true
+    end
+
+    it "returns false for a non-existing table" do
+      expect(schema_cache.data_source_exists?("test_nonexistent_table")).to be false
+    end
+  end
+
+  describe "dump and load" do
+    it "can dump and load schema cache" do
+      schema_cache.columns("test_schema_cache_posts")
+      schema_cache.primary_keys("test_schema_cache_posts")
+      schema_cache.indexes("test_schema_cache_posts")
+
+      tmpfile = Tempfile.new(["schema_cache", ".yml"])
+      begin
+        schema_cache.dump_to(tmpfile.path)
+        expect(File.exist?(tmpfile.path)).to be true
+        expect(File.size(tmpfile.path)).to be > 0
+      ensure
+        tmpfile.close
+        tmpfile.unlink
+      end
+    end
+  end
+
+  describe "clear_data_source_cache!" do
+    it "clears cache for a specific table" do
+      schema_cache.columns("test_schema_cache_posts")
+      expect(schema_cache.cached?("test_schema_cache_posts")).to be true
+
+      schema_cache.clear_data_source_cache!("test_schema_cache_posts")
+      expect(schema_cache.cached?("test_schema_cache_posts")).to be false
+    end
+  end
+
+  describe "version" do
+    it "returns a schema version" do
+      version = schema_cache.version
+      expect(version).not_to be_nil
+    end
+  end
+end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_cache_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_cache_spec.rb
@@ -90,6 +90,28 @@ describe "OracleEnhancedAdapter schema cache" do
         tmpfile.unlink
       end
     end
+
+    it "produces consistent dump output" do
+      schema_cache.columns("test_schema_cache_posts")
+      schema_cache.primary_keys("test_schema_cache_posts")
+      schema_cache.indexes("test_schema_cache_posts")
+
+      tmpfile1 = Tempfile.new(["schema_cache1", ".yml"])
+      tmpfile2 = Tempfile.new(["schema_cache2", ".yml"])
+      begin
+        schema_cache.dump_to(tmpfile1.path)
+        schema_cache.dump_to(tmpfile2.path)
+
+        dump1 = File.read(tmpfile1.path)
+        dump2 = File.read(tmpfile2.path)
+        expect(dump1).to eq(dump2)
+      ensure
+        tmpfile1.close
+        tmpfile1.unlink
+        tmpfile2.close
+        tmpfile2.unlink
+      end
+    end
   end
 
   describe "clear_data_source_cache!" do
@@ -106,6 +128,200 @@ describe "OracleEnhancedAdapter schema cache" do
     it "returns a schema version" do
       version = schema_cache.version
       expect(version).not_to be_nil
+    end
+  end
+
+  describe "prefetch_primary_key? after schema cache reload" do
+    let(:conn) { ActiveRecord::Base.connection }
+
+    it "carries identity / trigger_assigned flags through the YAML round trip" do
+      original = schema_cache.columns("test_schema_cache_posts").find { |c| c.name == "id" }
+      expect(original).not_to be_nil
+
+      yaml = YAML.dump(original)
+      restored = YAML.unsafe_load(yaml)
+
+      expect(restored).to be_a(ActiveRecord::ConnectionAdapters::OracleEnhanced::Column)
+      expect(restored.instance_variable_get(:@identity)).to eq(original.instance_variable_get(:@identity))
+      expect(restored.instance_variable_get(:@trigger_assigned)).to eq(original.instance_variable_get(:@trigger_assigned))
+      expect(restored.auto_incremented_by_db?).to eq(original.auto_incremented_by_db?)
+      expect(restored.auto_populated?).to eq(original.auto_populated?)
+    end
+
+    it "returns true for a sequence-backed primary key without firing catalog SQL" do
+      warm_up_schema_cache_for("test_schema_cache_posts")
+      conn.send(:instance_variable_set, :@prefetch_primary_key_cache, {})
+
+      result, catalog = capture_pk_lookup { conn.prefetch_primary_key?("test_schema_cache_posts") }
+      expect(result).to be true
+      expect(catalog).to be_empty
+    end
+
+    context "with a trigger-backed primary key" do
+      before(:all) do
+        schema_define do
+          create_table :test_schema_cache_legacy_posts, force: true, primary_key_trigger: true do |t|
+            t.string :title
+          end
+        end
+      end
+
+      after(:all) do
+        schema_define do
+          drop_table :test_schema_cache_legacy_posts rescue nil
+        end
+      end
+
+      it "returns false without firing catalog SQL once the column is cached" do
+        warm_up_schema_cache_for("test_schema_cache_legacy_posts")
+        conn.send(:instance_variable_set, :@prefetch_primary_key_cache, {})
+
+        result, catalog = capture_pk_lookup { conn.prefetch_primary_key?("test_schema_cache_legacy_posts") }
+        expect(result).to be false
+        expect(catalog).to be_empty
+      end
+    end
+
+    context "with an identity primary key" do
+      before(:all) do
+        skip "identity columns require Oracle 12c+" unless ActiveRecord::Base.connection.supports_identity_columns?
+        schema_define do
+          create_table :test_schema_cache_identity_posts, force: true, identity: true do |t|
+            t.string :title
+          end
+        end
+      end
+
+      after(:all) do
+        next unless ActiveRecord::Base.connection.supports_identity_columns?
+        schema_define do
+          drop_table :test_schema_cache_identity_posts rescue nil
+        end
+      end
+
+      it "returns false without firing catalog SQL once the column is cached" do
+        warm_up_schema_cache_for("test_schema_cache_identity_posts")
+        conn.send(:instance_variable_set, :@prefetch_primary_key_cache, {})
+
+        result, catalog = capture_pk_lookup { conn.prefetch_primary_key?("test_schema_cache_identity_posts") }
+        expect(result).to be false
+        expect(catalog).to be_empty
+      end
+    end
+
+    context "with a composite primary key" do
+      before(:all) do
+        schema_define do
+          create_table :test_schema_cache_composite, primary_key: ["org_id", "user_id"], force: true do |t|
+            t.integer :org_id, precision: 38, null: false
+            t.integer :user_id, precision: 38, null: false
+            t.string :name
+          end
+        end
+      end
+
+      after(:all) do
+        schema_define do
+          drop_table :test_schema_cache_composite rescue nil
+        end
+      end
+
+      it "returns false without firing catalog SQL once the cache is warmed" do
+        warm_up_schema_cache_for("test_schema_cache_composite")
+        conn.send(:instance_variable_set, :@prefetch_primary_key_cache, {})
+
+        result, catalog = capture_pk_lookup { conn.prefetch_primary_key?("test_schema_cache_composite") }
+        expect(result).to be false
+        expect(catalog).to be_empty
+      end
+    end
+
+    context "with no primary key" do
+      before(:all) do
+        schema_define do
+          create_table :test_schema_cache_no_pk, force: true, id: false do |t|
+            t.string :name
+          end
+        end
+      end
+
+      after(:all) do
+        schema_define do
+          drop_table :test_schema_cache_no_pk rescue nil
+        end
+      end
+
+      it "returns false without firing catalog SQL once the cache is warmed" do
+        warm_up_schema_cache_for("test_schema_cache_no_pk")
+        conn.send(:instance_variable_set, :@prefetch_primary_key_cache, {})
+
+        result, catalog = capture_pk_lookup { conn.prefetch_primary_key?("test_schema_cache_no_pk") }
+        expect(result).to be false
+        expect(catalog).to be_empty
+      end
+    end
+
+    it "preserves Oracle column metadata across full SchemaCache YAML round trip" do
+      warm_up_schema_cache_for("test_schema_cache_posts")
+
+      tmpfile = Tempfile.new(["schema_cache", ".yml"])
+      begin
+        schema_cache.dump_to(tmpfile.path)
+        reloaded = YAML.unsafe_load_file(tmpfile.path)
+
+        cols = reloaded.instance_variable_get(:@columns)["test_schema_cache_posts"]
+        expect(cols).not_to be_nil
+        id_col = cols.find { |c| c.name == "id" }
+        expect(id_col).to be_a(ActiveRecord::ConnectionAdapters::OracleEnhanced::Column)
+        expect(id_col.instance_variable_get(:@identity)).to be(false)
+        expect(id_col.instance_variable_get(:@trigger_assigned)).to be(false)
+      ensure
+        tmpfile.close
+        tmpfile.unlink
+      end
+    end
+
+    def warm_up_schema_cache_for(table_name)
+      cache = ActiveRecord::Base.connection_pool.schema_cache
+      cache.data_source_exists?(table_name)
+      cache.columns(table_name)
+      cache.columns_hash(table_name)
+      cache.primary_keys(table_name)
+    end
+
+    def capture_pk_lookup
+      events = []
+      sub = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        events << payload[:sql]
+      end
+      result = yield
+      catalog = events.grep(/all_constraints|all_sequences|all_tab_identity_cols|all_triggers/i)
+      [result, catalog]
+    ensure
+      ActiveSupport::Notifications.unsubscribe(sub) if sub
+    end
+  end
+
+  describe "primary_key(table_name) for composite-PK tables" do
+    let(:conn) { ActiveRecord::Base.connection }
+
+    before(:all) do
+      schema_define do
+        create_table :test_schema_cache_composite_pk, primary_key: ["org_id", "user_id"], force: true do |t|
+          t.integer :org_id, precision: 38, null: false
+          t.integer :user_id, precision: 38, null: false
+        end
+      end
+    end
+
+    after(:all) do
+      schema_define do
+        drop_table :test_schema_cache_composite_pk rescue nil
+      end
+    end
+
+    it "returns the composite primary key as an Array (Rails default behavior)" do
+      expect(conn.primary_key("test_schema_cache_composite_pk")).to eq(["org_id", "user_id"])
     end
   end
 end


### PR DESCRIPTION
## Summary

Three commits, each self-contained and green:

1. **`Add schema cache specs`** — baseline `SchemaCache` integration coverage for the Oracle enhanced adapter (`columns`, `columns_hash`, `primary_keys`, `indexes`, `data_source_exists?`, `dump`, `clear_data_source_cache!`, `version`).
2. **`Extract prefetch_primary_key_from_dictionary helper`** — pure refactor: the live data-dictionary lookup moves into a private helper so a schema-cache shortcut can layer on top of it. Behavior unchanged.
3. **`Use schema cache to skip dictionary SQL on prefetch_primary_key?`** — the actual change: teach the schema cache to carry enough Oracle-specific metadata that `prefetch_primary_key?` can answer without hitting the data dictionary.

## What this fixes

Even with a populated schema cache, the **first** `INSERT` against each table in a fresh Rails process used to trigger four data-dictionary round-trips:

```
prefetch_primary_key?
  └─ has_primary_key?
      └─ pk_and_sequence_for          → all_sequences + all_constraints
  └─ identity_primary_key?            → all_tab_identity_cols + all_constraints + all_cons_columns
  └─ trigger_backed_primary_key?      → all_triggers + all_source
```

The adapter's `@prefetch_primary_key_cache` absorbs subsequent calls within a process, but not the first — and the data needed to answer is already present in the schema cache. This PR closes that gap by making the schema cache aware of Oracle's primary-key generation strategy (sequence-backed / identity / trigger-backed).

## How

- Serialize `OracleEnhanced::Column`'s `@identity` and `@trigger_assigned` flags via `init_with` / `encode_with`, so they survive the `schema_cache.yml` YAML round trip. Rails' base `Column#init_with` only knows the standard fields, so these Oracle-specific extras silently dropped before this PR.
- `init_with` deliberately leaves the ivars **undefined** when the YAML payload predates these keys (old dumps); the schema-cache shortcut detects that and falls through to the live-dictionary lookup, instead of being mis-classified as `@identity = false`.
- `prefetch_primary_key?` now dispatches inline: schema cache first via `prefetch_primary_key_from_schema_cache`, falling back to `prefetch_primary_key_from_dictionary` (the helper extracted in commit 2) when the cache lacks the metadata.
- `prefetch_primary_key_from_schema_cache` derives the answer from `OracleEnhanced::Column#auto_incremented_by_db?` (= identity) and `auto_populated?` (= identity, trigger, or any server-side default), using the on-column flags hydrated from the cache. Returns `false` when the cache definitively says "no PK" or "composite PK", `nil` only when the metadata is missing.
- Drop the `primary_key(table_name)` override that called `pk_and_sequence_for`. Rails' AbstractAdapter default routes through `primary_keys` (plural), which is wrapped by `SchemaCache` and therefore cached after a single lookup.

## Behavior change in `primary_key(table_name)` (composite PK only)

For tables with a composite primary key — and only those — the return value of `connection.primary_key(table_name)` changes:

| | before | after |
|---|---|---|
| single PK | `"id"` | `"id"` |
| composite PK | `nil` + stderr warning | `["col_a", "col_b"]` (Array — Rails default) |
| no PK | `nil` | `nil` |

The new behavior matches Rails 8.x's native composite-primary-key support; the old behavior was a leftover from when composite PKs weren't first-class in ActiveRecord. Single-PK tables (the overwhelming majority of users) are unaffected. See #2648 for the broader composite-PK work; this PR chips off the `primary_key(table_name)` corner.

## Verified end-to-end

Pointed a Rails 8.2.alpha app at this branch with a fresh `db:schema:cache:dump` and ran a CRUD round (`create! → find_by → update! → destroy!`):

| | before | after |
|---|---|---|
| `pk_and_sequence_for` SQL on first `Model.create!` | `all_sequences` + `all_constraints` (2) | 0 |
| `identity_primary_key?` SQL on first `Model.create!` | `all_tab_identity_cols` join (1) | 0 |
| `trigger_backed_primary_key?` SQL on first `Model.create!` | `all_triggers` + `all_source` (1) | 0 |

The only remaining catalog round-trip is Rails' boot-time `SchemaMigration#table_exists?`, which is one-shot per connection — out of scope.

## Spec coverage

`schema_cache_spec.rb` adds a `prefetch_primary_key? after schema cache reload` describe block covering all three PK flavours:

- **Sequence-backed (Rails-managed) PK** — asserts `prefetch_primary_key?` returns `true` with no `all_constraints` / `all_sequences` / `all_tab_identity_cols` / `all_triggers` SQL fired.
- **Trigger-backed PK** (`create_table ..., primary_key_trigger: true`) — asserts `prefetch_primary_key?` returns `false` with no dictionary SQL fired.
- **Identity PK** (`create_table ..., identity: true`) — asserts the same; skipped on Oracle < 12c.
- **YAML round trip** — asserts an `OracleEnhanced::Column` carries `@identity` / `@trigger_assigned` through `YAML.dump` / `YAML.unsafe_load`.

The `produces consistent dump output` assertion lives in commit 3 (rather than commit 1) because its determinism depends on the `encode_with` / `init_with` symmetry added there.

## Test plan

- [x] All 15 specs in `schema_cache_spec.rb` pass locally against Oracle Database 23ai Free.
- [x] `bundle exec rubocop` clean.
- [x] End-to-end Rails 8.2.alpha app verified.
- [x] CI green.
