### PR TITLE
Replace slow UNION ALL query with optimized all_objects query

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -758,30 +758,37 @@ module ActiveRecord
               binds = [
                 bind_string("table_owner", owner),
                 bind_string("table_name", identifier),
-                bind_string("table_owner", owner),
-                bind_string("table_name", identifier),
-                bind_string("table_owner", owner),
-                bind_string("table_name", identifier),
                 bind_string("real_name", real_name),
               ]
+              # Single-pass lookup against all_objects, ordered so the first row
+              # is the one the legacy 4-way UNION ALL (all_tables, all_views,
+              # owner synonym, public synonym) would have returned: prefer a
+              # match in the caller's schema over PUBLIC, and within a schema
+              # prefer TABLE over VIEW over SYNONYM.
               result = select_one(<<~SQL.squish, "SCHEMA", binds)
-                SELECT owner, table_name, 'TABLE' name_type
-                FROM all_tables WHERE owner = :table_owner AND table_name = :table_name
-                UNION ALL
-                SELECT owner, view_name table_name, 'VIEW' name_type
-                FROM all_views WHERE owner = :table_owner AND view_name = :table_name
-                UNION ALL
-                SELECT table_owner, table_name, 'SYNONYM' name_type
-                FROM all_synonyms WHERE owner = :table_owner AND synonym_name = :table_name
-                UNION ALL
-                SELECT table_owner, table_name, 'SYNONYM' name_type
-                FROM all_synonyms WHERE owner = 'PUBLIC' AND synonym_name = :real_name
+                SELECT owner, object_name table_name, object_type name_type
+                FROM all_objects
+                WHERE ((owner = :table_owner AND object_name = :table_name)
+                   OR (owner = 'PUBLIC' AND object_name = :real_name))
+                  AND object_type IN ('TABLE', 'VIEW', 'SYNONYM')
+                ORDER BY DECODE(owner, 'PUBLIC', 2, 1),
+                         DECODE(object_type, 'TABLE', 1, 'VIEW', 2, 'SYNONYM', 3)
               SQL
 
               raise OracleEnhanced::ConnectionException, %Q{"DESC #{name}" failed; does it exist?} unless result
 
               if result["name_type"] == "SYNONYM"
-                name = "#{result['owner'] && "#{result['owner']}."}#{result['table_name']}"
+                synonym_binds = [
+                  bind_string("owner", result["owner"]),
+                  bind_string("synonym_name", result["table_name"]),
+                ]
+                syn = select_one(<<~SQL.squish, "SCHEMA", synonym_binds)
+                  SELECT table_owner, table_name
+                  FROM all_synonyms
+                  WHERE owner = :owner AND synonym_name = :synonym_name
+                SQL
+                raise OracleEnhanced::ConnectionException, %Q{"DESC #{name}" failed; does it exist?} unless syn
+                name = "#{syn['table_owner'] && "#{syn['table_owner']}."}#{syn['table_name']}"
               else
                 return [result["owner"], result["table_name"]]
               end

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -734,6 +734,33 @@ describe "OracleEnhancedConnection" do
       expect(resolve("all_tables")).to eq(["SYS", "ALL_TABLES"])
     end
 
+    # Exercises all five catalog paths (table, view, materialized view,
+    # private synonym, public synonym) for one underlying table in a single
+    # run. The individual cases above use disjoint fixtures; this one proves
+    # the DECODE-ordered all_objects lookup + synonym follow-through stays
+    # consistent when a private and a public synonym to the same table
+    # coexist, and that a materialized view created on the same base table
+    # resolves to the MV name (not the base table) as a sibling data source.
+    it "resolves table, view, materialized view, private synonym and public synonym for the same underlying table" do
+      @conn.execute "CREATE TABLE test_describe_all (id NUMBER)" rescue nil
+      @conn.execute "CREATE VIEW test_describe_all_v AS SELECT * FROM test_describe_all" rescue nil
+      @conn.execute "CREATE MATERIALIZED VIEW test_describe_all_mv AS SELECT * FROM test_describe_all" rescue nil
+      @conn.execute "CREATE SYNONYM test_describe_all_syn FOR test_describe_all" rescue nil
+      @conn.execute "CREATE PUBLIC SYNONYM test_describe_all_pub FOR #{@owner}.test_describe_all" rescue nil
+
+      expect(resolve("test_describe_all")).to eq([@owner, "TEST_DESCRIBE_ALL"])
+      expect(resolve("test_describe_all_v")).to eq([@owner, "TEST_DESCRIBE_ALL_V"])
+      expect(resolve("test_describe_all_mv")).to eq([@owner, "TEST_DESCRIBE_ALL_MV"])
+      expect(resolve("test_describe_all_syn")).to eq([@owner, "TEST_DESCRIBE_ALL"])
+      expect(resolve("test_describe_all_pub")).to eq([@owner, "TEST_DESCRIBE_ALL"])
+    ensure
+      @conn.execute "DROP PUBLIC SYNONYM test_describe_all_pub" rescue nil
+      @conn.execute "DROP SYNONYM test_describe_all_syn" rescue nil
+      @conn.execute "DROP MATERIALIZED VIEW test_describe_all_mv" rescue nil
+      @conn.execute "DROP VIEW test_describe_all_v" rescue nil
+      @conn.execute "DROP TABLE test_describe_all" rescue nil
+    end
+
     it "raises when synonym resolution produces a looping chain" do
       @conn.execute "CREATE SYNONYM test_cycle_a FOR test_cycle_b" rescue nil
       @conn.execute "CREATE SYNONYM test_cycle_b FOR test_cycle_a" rescue nil

--- a/spec/support/create_oracle_enhanced_users.sql
+++ b/spec/support/create_oracle_enhanced_users.sql
@@ -4,10 +4,12 @@ CREATE USER oracle_enhanced IDENTIFIED BY oracle_enhanced;
 
 GRANT unlimited tablespace, create session, create table, create sequence,
 create procedure, create trigger, create view, create materialized view,
-create database link, create synonym, create type, ctxapp TO oracle_enhanced;
+create database link, create synonym, create type, ctxapp,
+create public synonym, drop public synonym TO oracle_enhanced;
 
 CREATE USER oracle_enhanced_schema IDENTIFIED BY oracle_enhanced_schema;
 
 GRANT unlimited tablespace, create session, create table, create sequence,
 create procedure, create trigger, create view, create materialized view,
-create database link, create synonym, create type, ctxapp TO oracle_enhanced_schema;
+create database link, create synonym, create type, ctxapp,
+create public synonym, drop public synonym TO oracle_enhanced_schema;


### PR DESCRIPTION
## Summary
- Replace the 4-way `UNION ALL` query across `all_tables`, `all_views`, and `all_synonyms` inside `OracleEnhanced::SchemaStatements#resolve_data_source_name` with a single `all_objects` query for the common TABLE/VIEW lookup path.
- Resolve synonym targets via a second `all_synonyms` query only when a synonym is found.
- `ORDER BY DECODE(...)` preserves the legacy lookup priority (owner table, owner view, owner synonym, public synonym) in the single-pass query.
- Add a regression spec covering table, view, materialized view, private synonym, and public synonym resolution for one underlying table.
- Grant `CREATE/DROP PUBLIC SYNONYM` to test users so the new spec can run from a fresh setup.

## Motivation
The original `UNION ALL` query causes ~2s delays in production (see #2429). This replaces it with a single `all_objects` query, which is significantly faster for the common TABLE/VIEW path. Based on the approach suggested in #2467.

## Note on rebase
Rebased onto current `master` (past #2545 "Move describe to schema_statements as resolve_data_source_name"). The optimization now lives in `OracleEnhanced::SchemaStatements#resolve_data_source_name` rather than the former `Connection#describe`. Upstream's iterative loop and `Set`-based synonym cycle guard are preserved; the catalog lookup still goes through `select_one(..., "SCHEMA", ...)` so it participates in instrumentation and the query cache.

## Test plan
- [x] Local `bundle exec rspec .../connection_spec.rb` — 77 examples, 0 failures, 1 pending (JDBC-only).
- [x] `resolve_data_source_name` block — 14 examples, 0 failures (includes the new combined regression).
- [x] `bundle exec rubocop` clean on both Ruby files.
- [x] Copilot CLI review (upstream/master..HEAD) — no actionable findings.
- [x] Verified materialized views are still found (backing table appears as `TABLE` in `all_objects`); combined regression spec now covers this case explicitly.

Co-Authored-By: N.lohitha <lohithavarma36@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

