### PR TITLE
Remove File.exists? workaround for ruby-plsql

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,11 +37,7 @@ require "logger"
 # On JRuby, load the oracle_enhanced adapter first so that the JDBC driver
 # (ojdbc17.jar) is registered with DriverManager before ruby-plsql tries to
 # load it. ruby-plsql only looks for ojdbc6/7.jar and would fail otherwise.
-#
-# File.exists? was removed in Ruby 3.2. Restore it temporarily so that
-# ruby-plsql's JDBC connection code can load under JRuby 10.x (Ruby 3.4).
 require "active_record/connection_adapters/oracle_enhanced_adapter"
-File.singleton_class.alias_method(:exists?, :exist?) unless File.respond_to?(:exists?)
 # ruby-plsql calls ActiveRecord::Base.default_timezone (moved to ActiveRecord
 # module in Rails 7.0). Restore the class-level accessor as a shim.
 unless ActiveRecord::Base.respond_to?(:default_timezone)


### PR DESCRIPTION
## Summary
- Remove the `File.exists?` shim from `spec/spec_helper.rb` that was added as a workaround for ruby-plsql using the removed `File.exists?` method

## Context
`File.exists?` was deprecated in Ruby 2.1 and removed in Ruby 3.2. The `spec/spec_helper.rb` had a workaround aliasing `File.exist?` to `File.exists?` so that ruby-plsql's JDBC connection code could load under JRuby 10.x.

This workaround is no longer needed now that the upstream fix has been applied in rsim/ruby-plsql#267.

## Test plan
- [ ] Verify JRuby CI passes without the shim

🤖 Generated with [Claude Code](https://claude.com/claude-code)