### PR TITLE
Translate lost-connection errors to ActiveRecord::ConnectionFailed

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -118,6 +118,14 @@ module ActiveRecord
       def database_version
         raise NoMethodError, "Not implemented for this raw driver"
       end
+
+      # ORA-00028 your session has been killed
+      # ORA-01012 not logged on
+      # ORA-03113 end-of-file on communication channel
+      # ORA-03114 not connected to ORACLE
+      # ORA-03135 connection lost contact
+      LOST_CONNECTION_ERROR_CODES = [28, 1012, 3113, 3114, 3135] # :nodoc:
+
       class ConnectionException < StandardError # :nodoc:
       end
     end

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -263,7 +263,7 @@ module ActiveRecord
           begin
             yield if block_given?
           rescue Java::JavaSql::SQLException => e
-            raise unless /^(Closed Connection|Io exception:|No more data to read from socket|IO Error:|ORA-03113:|ORA-03114:|ORA-17008:)/.match?(e.message)
+            raise unless lost_connection?(e)
             @active = false
             raise unless should_retry
             should_retry = false
@@ -535,6 +535,17 @@ module ActiveRecord
           else
             nil
           end
+        end
+
+        # JDBC SQLException messages that signal a dropped connection
+        # without a meaningful Oracle error code attached. ORA-17008
+        # (Closed Connection) surfaces as the "Closed Connection" message.
+        LOST_CONNECTION_MESSAGE = /\A(Closed Connection|Io exception:|No more data to read from socket|IO Error:)/
+
+        def lost_connection?(exception)
+          return false unless exception.is_a?(Java::JavaSql::SQLException)
+          LOST_CONNECTION_ERROR_CODES.include?(exception.getErrorCode) ||
+            LOST_CONNECTION_MESSAGE.match?(exception.message)
         end
 
         def get_ruby_value_from_result_set(rset, i, type_name, get_lob_value = true)

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -251,6 +251,10 @@ module ActiveRecord
           end
         end
 
+        def lost_connection?(exception)
+          exception.is_a?(OCIError) && LOST_CONNECTION_ERROR_CODES.include?(exception.code)
+        end
+
         def typecast_result_value(value, get_lob_value)
           case value
           when Integer
@@ -435,13 +439,6 @@ class OCI8EnhancedAutoRecover < DelegateClass(OCI8) # :nodoc:
     end
   end
 
-  # ORA-00028: your session has been killed
-  # ORA-01012: not logged on
-  # ORA-03113: end-of-file on communication channel
-  # ORA-03114: not connected to ORACLE
-  # ORA-03135: connection lost contact
-  LOST_CONNECTION_ERROR_CODES = [ 28, 1012, 3113, 3114, 3135 ] # :nodoc:
-
   # Adds auto-recovery functionality.
   def with_retry(allow_retry: false) # :nodoc:
     should_retry = (allow_retry || self.class.auto_retry?) && autocommit?
@@ -449,7 +446,7 @@ class OCI8EnhancedAutoRecover < DelegateClass(OCI8) # :nodoc:
     begin
       yield
     rescue OCIException => e
-      raise unless e.is_a?(OCIError) && LOST_CONNECTION_ERROR_CODES.include?(e.code)
+      raise unless e.is_a?(OCIError) && ActiveRecord::ConnectionAdapters::OracleEnhanced::LOST_CONNECTION_ERROR_CODES.include?(e.code)
       @active = false
       raise unless should_retry
       should_retry = false

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -799,6 +799,8 @@ module ActiveRecord
       end
 
       def translate_exception(exception, message:, sql:, binds:) # :nodoc:
+        return ActiveRecord::ConnectionFailed.new(message, sql: sql, binds: binds, connection_pool: @pool) if _connection.lost_connection?(exception)
+
         case _connection.error_code(exception)
         when 1
           RecordNotUnique.new(message, sql: sql, binds: binds)

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -475,6 +475,13 @@ describe "OracleEnhancedConnection" do
       @sys_conn.exec "ALTER SYSTEM KILL SESSION '#{sid_serial}' IMMEDIATE"
     end
 
+    def connection_id_from_server(conn)
+      audsid = conn.select("SELECT userenv('sessionid') audsid FROM dual").first["audsid"]
+      @sys_conn.select("SELECT s.sid||','||s.serial# sid_serial
+          FROM   v$session s
+          WHERE  audsid = '#{audsid}'").first["sid_serial"]
+    end
+
     it "should reconnect and execute SQL statement if connection is lost and auto retry is enabled" do
       # @conn.auto_retry = true
       ActiveRecord::Base.connection.auto_retry = true
@@ -485,6 +492,21 @@ describe "OracleEnhancedConnection" do
     it "should reconnect and execute SQL statement if connection is lost and allow_retry is passed" do
       kill_current_session
       expect(@conn.exec("SELECT * FROM dual", allow_retry: true)).not_to be_nil
+    end
+
+    # Regression test ported from rails/rails#46273, which only covers
+    # Mysql2 and PostgreSQL in the Rails repository.
+    it "adapter #execute is retryable when allow_retry: true is passed" do
+      previous_auto_retry = ActiveRecord::Base.connection.auto_retry
+      ActiveRecord::Base.connection.auto_retry = false
+      begin
+        initial_connection_id = connection_id_from_server(@conn)
+        kill_current_session
+        expect { ActiveRecord::Base.connection.execute("SELECT 1 FROM dual", allow_retry: true) }.not_to raise_error
+        expect(connection_id_from_server(@conn)).not_to eq(initial_connection_id)
+      ensure
+        ActiveRecord::Base.connection.auto_retry = previous_auto_retry
+      end
     end
 
     it "should not reconnect and execute SQL statement if connection is lost and auto retry is disabled" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,11 +37,7 @@ require "logger"
 # On JRuby, load the oracle_enhanced adapter first so that the JDBC driver
 # (ojdbc17.jar) is registered with DriverManager before ruby-plsql tries to
 # load it. ruby-plsql only looks for ojdbc6/7.jar and would fail otherwise.
-#
-# File.exists? was removed in Ruby 3.2. Restore it temporarily so that
-# ruby-plsql's JDBC connection code can load under JRuby 10.x (Ruby 3.4).
 require "active_record/connection_adapters/oracle_enhanced_adapter"
-File.singleton_class.alias_method(:exists?, :exist?) unless File.respond_to?(:exists?)
 # ruby-plsql calls ActiveRecord::Base.default_timezone (moved to ActiveRecord
 # module in Rails 7.0). Restore the class-level accessor as a shim.
 unless ActiveRecord::Base.respond_to?(:default_timezone)


### PR DESCRIPTION
## Summary

- Translate Oracle lost-connection errors (ORA-00028 / 01012 / 03113 / 03114 / 03135 for OCI, equivalent JDBC SQLException codes + a fallback regex for code-less disconnect strings) to `ActiveRecord::ConnectionFailed` in `translate_exception`.
- Add a shared `LOST_CONNECTION_ERROR_CODES` list on the `OracleEnhanced` module and a `lost_connection?(exception)` predicate on both `OCIConnection` and `JDBCConnection`; refactor JDBC `with_retry`'s inline regex to share it.
- Port the `#execute is retryable` regression test from rails/rails#46273 (which only covers Mysql2/PostgreSQL upstream) to our suite, and strengthen it with the Rails `adapter_test.rb` pattern of asserting the server-side session id (sid,serial# via v$session) actually changes after the retry — so the test proves a new Oracle session was established, not just that no error was raised.

## Why

Without this, `ActiveRecord::Base.connection.execute(sql, allow_retry: true)` — the API added in rails/rails#46273 — does not actually retry against Oracle. `AbstractAdapter#with_raw_connection` only retries when the wrapped exception is `ActiveRecord::ConnectionFailed`, so lost-connection errors were bubbling up as plain `StatementInvalid` and the retry path never fired.

Closes #2310.

## Test plan

- [x] New regression test passes with the lib changes
- [x] Same test fails without the lib changes (verified: `StatementInvalid: ORA-03113: end-of-file on communication channel`)
- [x] Full local rspec suite passes against Oracle Database 23ai Free (422 examples, 0 failures, 6 pre-existing pending)
- [x] CI green on test_11g, test_11g_ojdbc11, Linting