### PR TITLE
Support RestartParentTransaction on Oracle

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -151,6 +151,15 @@ module ActiveRecord
           _connection.autocommit = true
         end
 
+        # Rolls back the current transaction and leaves the session ready for
+        # a new one. Unlike exec_rollback_db_transaction, autocommit is left
+        # off: the logical transaction is still active from Rails' point of
+        # view (see RestartParentTransaction), and Oracle implicitly starts a
+        # new transaction on the next DML.
+        def exec_restart_db_transaction # :nodoc:
+          _connection.rollback
+        end
+
         def create_savepoint(name = current_savepoint_name) # :nodoc:
           execute("SAVEPOINT #{name}", "TRANSACTION")
         end

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -102,6 +102,7 @@ module ActiveRecord
 
         def begin_db_transaction # :nodoc:
           _connection.autocommit = false
+          @transaction_isolation = nil
         end
 
         def transaction_isolation_levels
@@ -117,18 +118,30 @@ module ActiveRecord
         def begin_isolated_db_transaction(isolation)
           begin_db_transaction
           execute "SET TRANSACTION ISOLATION LEVEL  #{transaction_isolation_levels.fetch(isolation)}"
+          @transaction_isolation = isolation
         end
 
         def commit_db_transaction # :nodoc:
           _connection.commit
         ensure
           _connection.autocommit = true
+          @transaction_isolation = nil
         end
 
         def exec_rollback_db_transaction # :nodoc:
           _connection.rollback
         ensure
           _connection.autocommit = true
+          @transaction_isolation = nil
+        end
+
+        # Leaves autocommit off (logical txn still alive); re-issues SET TRANSACTION
+        # ISOLATION LEVEL since Oracle drops it on ROLLBACK (Postgres uses ROLLBACK AND CHAIN).
+        def exec_restart_db_transaction # :nodoc:
+          _connection.rollback
+          if @transaction_isolation
+            execute "SET TRANSACTION ISOLATION LEVEL  #{transaction_isolation_levels.fetch(@transaction_isolation)}"
+          end
         end
 
         def create_savepoint(name = current_savepoint_name) # :nodoc:

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -297,6 +297,13 @@ module ActiveRecord
         true
       end
 
+      # Oracle implicitly begins a new transaction on the next DML after a
+      # ROLLBACK, so a nested transaction can be restarted with a single
+      # ROLLBACK round-trip instead of a SAVEPOINT / ROLLBACK TO dance.
+      def supports_restart_db_transaction? # :nodoc:
+        true
+      end
+
       def supports_foreign_keys?
         true
       end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -432,6 +432,10 @@ module ActiveRecord
         true
       end
 
+      def supports_restart_db_transaction? # :nodoc:
+        true
+      end
+
       def supports_foreign_keys?
         true
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -701,6 +701,25 @@ describe "OracleEnhancedAdapter" do
       }.to raise_error(ActiveRecord::Deadlocked)
     end
 
+    # See rails/rails#44526: when the adapter advertises
+    # supports_restart_db_transaction?, an immediately nested transaction
+    # that rolls back restarts the parent via ROLLBACK instead of issuing
+    # a SAVEPOINT / ROLLBACK TO dance.
+    it "advertises supports_restart_db_transaction?" do
+      expect(ActiveRecord::Base.connection.supports_restart_db_transaction?).to be true
+    end
+
+    it "restarts the parent transaction on nested rollback without issuing a SAVEPOINT" do
+      TestPost.transaction do
+        TestPost.transaction(requires_new: true) do
+          TestPost.create!(title: "inner")
+          raise ActiveRecord::Rollback
+        end
+      end
+      expect(TestPost.where(title: "inner").count).to eq 0
+      expect(@logger.logged(:debug).grep(/SAVEPOINT/i)).to be_empty
+    end
+
     after(:all) do
       schema_define do
         drop_table :test_posts

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -694,6 +694,14 @@ describe "OracleEnhancedAdapter" do
       Thread.report_on_exception, @original_report_on_exception = false, Thread.report_on_exception
     end
 
+    before(:each) do
+      set_logger
+    end
+
+    after(:each) do
+      clear_logger
+    end
+
     it "supports with_lock without raising ArgumentError (#2237)" do
       post = TestPost.create!(title: "lock me")
       expect {
@@ -727,6 +735,37 @@ describe "OracleEnhancedAdapter" do
           thread.join
         end
       }.to raise_error(ActiveRecord::Deadlocked)
+    end
+
+    it "advertises supports_restart_db_transaction?" do
+      expect(ActiveRecord::Base.connection.supports_restart_db_transaction?).to be true
+    end
+
+    it "restarts the parent transaction on nested rollback without issuing a SAVEPOINT" do
+      TestPost.transaction do
+        TestPost.transaction(requires_new: true) do
+          TestPost.create!(title: "inner")
+          raise ActiveRecord::Rollback
+        end
+        TestPost.create!(title: "outer")
+      end
+      expect(TestPost.where(title: "inner").count).to eq 0
+      expect(TestPost.where(title: "outer").count).to eq 1
+      sql_log = @logger.logged(:debug)
+      expect(sql_log.grep(/INSERT INTO.*TEST_POSTS/i)).not_to be_empty
+      expect(sql_log.grep(/SAVEPOINT/i)).to be_empty
+    end
+
+    it "re-issues SET TRANSACTION ISOLATION LEVEL after exec_restart_db_transaction" do
+      conn = ActiveRecord::Base.connection
+      conn.begin_isolated_db_transaction(:serializable)
+      begin
+        conn.exec_restart_db_transaction
+        issued = @logger.logged(:debug).grep(/SET TRANSACTION ISOLATION LEVEL\s+SERIALIZABLE/i)
+        expect(issued.size).to eq 2
+      ensure
+        conn.exec_rollback_db_transaction
+      end
     end
 
     after(:all) do


### PR DESCRIPTION
## Summary

- Override `supports_restart_db_transaction?` to return `true` (`oracle_enhanced_adapter.rb`), opting Oracle into the `RestartParentTransaction` path introduced in rails/rails#44526.
- Add `exec_restart_db_transaction` (`oracle_enhanced/database_statements.rb`) that issues `_connection.rollback` without flipping autocommit back on. Oracle implicitly starts a new transaction on the next DML, so no explicit `BEGIN` is required — and the logical Rails transaction is still considered active, so we must not touch autocommit the way `exec_rollback_db_transaction` does.
- **Preserve the parent's isolation level across the restart.** Oracle's `SET TRANSACTION ISOLATION LEVEL` is per-transaction and is dropped on `ROLLBACK`. Postgres' `ROLLBACK AND CHAIN` preserves it; bare `ROLLBACK` on Oracle does not. The adapter tracks the parent's isolation level (set in `begin_isolated_db_transaction`, cleared in `begin_db_transaction` / `commit_db_transaction` / `exec_rollback_db_transaction`) and re-issues `SET TRANSACTION ISOLATION LEVEL` immediately after the rollback in `exec_restart_db_transaction`. Without this, `transaction(isolation: :serializable) { transaction(requires_new: true) { raise ActiveRecord::Rollback }; ... }` would silently resume the post-restart work at the session-default isolation while Rails still believed the parent's isolation was intact.
- Add three specs under the existing `"Transaction"` describe:
  - One asserts `supports_restart_db_transaction?` is `true` (Rails picks `RestartParentTransaction` independent of this flag, so the assertion is the only direct check that the override is wired up).
  - One nests `transaction(requires_new: true)` inside an outer `transaction do ... end` *before* any parent DML (so the parent is `restartable?`), raises `ActiveRecord::Rollback` in the inner block, then issues another DML in the outer block. It asserts: (a) the inner row did not persist, (b) the outer row persisted after the restart — proving the parent transaction stayed alive, i.e. leaving autocommit off was correct — and (c) no `SAVEPOINT` SQL was logged, i.e. `RestartParentTransaction` was selected over `SavepointTransaction`.
  - One drives the adapter methods directly: `begin_isolated_db_transaction(:serializable)` followed by `exec_restart_db_transaction`, asserting that `SET TRANSACTION ISOLATION LEVEL SERIALIZABLE` is logged twice (once at the original begin, once at the restart).

## Note

This PR represents the **opt-in / `supports_restart_db_transaction? = true`** approach with adapter-side isolation tracking. A simpler **opt-out / `false`** alternative — relying on Rails' built-in fallback (`rollback_db_transaction + materialize!`) which already preserves isolation via `materialize!` — is being explored in a separate PR.

## Why

Rails' `RestartParentTransaction` (rails/rails#44526) makes immediately-nested transactions cheaper: entry and commit are no-ops, and rollback is one `exec_restart_db_transaction` call on the parent. Postgres uses `ROLLBACK AND CHAIN`; MySQL 8+ opts in too. Oracle has been riding the default-`false` fallback and taking the SAVEPOINT round-trip on every nested transaction.

Oracle does not have `ROLLBACK AND CHAIN`, but it doesn't need it: after `ROLLBACK`, the next DML implicitly begins a new transaction. So the semantic intent of 44526 is naturally satisfied by a bare `ROLLBACK`, saving one `SAVEPOINT` and one `ROLLBACK TO` round-trip per eligible nested transaction — provided the isolation level is also re-issued, which this PR does.

`RestartParentTransaction` is only selected when the parent transaction is still `restartable?` (joinable and not yet dirty). Once the parent has executed DML, Rails falls back to `SavepointTransaction` automatically, so existing savepoint-based behaviour is unchanged for the non-immediate-nesting case.

Closes #2270.

## Test plan

- [x] New specs pass locally against Oracle Database 23ai Free.
- [x] Full rspec suite green locally.
- [x] `bundle exec rubocop` clean.
- [x] CI green at 1591a27a.
- [x] `exec_restart_db_transaction` is **only** wired to the `RestartParentTransaction` path (Rails calls it via `parent.restart`); it does not touch the existing `exec_rollback_db_transaction` / savepoint code paths.
- [x] Autocommit handling: `exec_restart_db_transaction` deliberately does *not* set `autocommit = true` (unlike `exec_rollback_db_transaction`), because the logical transaction is expected to stay open from Rails' point of view.
- [x] Isolation level: re-issued after rollback so the implicitly-started next transaction inherits the parent's setting.
