### PR TITLE
Remove supports_multi_insert? predicate, inline at formatter call site

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -278,7 +278,21 @@ module ActiveRecord
         def insert_versions_sql(versions) # :nodoc:
           sm_table = quote_table_name(ActiveRecord::Tasks::DatabaseTasks.migration_connection_pool.schema_migration.table_name)
 
-          if supports_multi_insert?
+          # Oracle 10.2 and 11.1 cap the INTO clauses of a multitable
+          # INSERT at 999 target columns per the 10.2 and 11.1 SQL
+          # References; above that the server raises
+          # "ORA-24335: cannot support more than 1000 columns". Each row
+          # contributes one target column here, so a single INSERT ALL
+          # can hold at most 999 rows. The restriction was lifted in
+          # 11.2. rsim/oracle-enhanced#1084 empirically reproduced
+          # ORA-24335 on 10.2.0.5; 11.1 was not retested, but the docs
+          # for 10.2 and 11.1 are identically worded, so keep the
+          # per-statement fallback on 11.1 and earlier as a safety net
+          # so that `rails db:schema:load` still works when
+          # schema_migrations exceeds ~999 rows.
+          #   https://docs.oracle.com/cd/B19306_01/server.102/b14200/statements_9014.htm#i2080134
+          #   https://docs.oracle.com/cd/B28359_01/server.111/b28286/statements_9014.htm#i2080134
+          if database_version.to_s >= [11, 2].to_s
             versions.inject(+"INSERT ALL\n") { |sql, version|
               sql << "INTO #{sm_table} (version) VALUES (#{quote(version)})\n"
             } << "SELECT * FROM DUAL\n"

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_versions_formatter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_versions_formatter.rb
@@ -12,7 +12,7 @@ module ActiveRecord
           sm_table = connection.quote_table_name(connection.pool.schema_migration.table_name)
 
           if versions.is_a?(Array)
-            if connection.supports_multi_insert?
+            if connection.database_version >= "11.2"
               versions.inject(+"INSERT ALL\n") { |sql, version|
                 sql << "INTO #{sm_table} (version) VALUES (#{connection.quote(version)})\n"
               } << "SELECT * FROM DUAL\n"

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -330,10 +330,6 @@ module ActiveRecord
         true
       end
 
-      def supports_multi_insert?
-        database_version.to_s >= [11, 2].to_s
-      end
-
       def supports_virtual_columns?
         database_version.first >= 11
       end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -507,10 +507,6 @@ module ActiveRecord
         true
       end
 
-      def supports_multi_insert?
-        database_version >= "11.2"
-      end
-
       def supports_virtual_columns?
         database_version >= "11"
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -1289,7 +1289,7 @@ end
 
     context "multi insert is supported" do
       it "should loads the migration schema table from insert versions sql" do
-        skip "Not supported in this database version" unless ActiveRecord::Base.connection.supports_multi_insert?
+        skip "Not supported in this database version" unless ActiveRecord::Base.connection.database_version.to_s >= [11, 2].to_s
 
         expect {
           @conn.execute @conn.insert_versions_sql(versions)
@@ -1301,7 +1301,7 @@ end
 
     context "multi insert is NOT supported" do
       it "should loads the migration schema table from insert versions sql" do
-        skip "Not supported in this database version" if ActiveRecord::Base.connection.supports_multi_insert?
+        skip "Not supported in this database version" if ActiveRecord::Base.connection.database_version.to_s >= [11, 2].to_s
 
         expect {
           versions.each { |version| @conn.execute @conn.insert_versions_sql(version) }

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -1674,9 +1674,9 @@ end
       ActiveRecord::Base.connection_pool.schema_migration.create_table
     end
 
-    context "multi insert is supported" do
+    context "when INSERT ALL accepts 1000+ rows (Oracle 11.2 or later)" do
       it "should loads the migration schema table from insert versions sql" do
-        skip "Not supported in this database version" unless ActiveRecord::Base.lease_connection.supports_multi_insert?
+        skip "Not supported in this database version" unless ActiveRecord::Base.lease_connection.database_version >= "11.2"
 
         expect {
           @conn.execute @conn.send(:insert_versions_sql, versions)
@@ -1686,9 +1686,9 @@ end
       end
     end
 
-    context "multi insert is NOT supported" do
+    context "when INSERT ALL is capped at 999 rows (Oracle older than 11.2)" do
       it "should loads the migration schema table from insert versions sql" do
-        skip "Not supported in this database version" if ActiveRecord::Base.lease_connection.supports_multi_insert?
+        skip "Not supported in this database version" if ActiveRecord::Base.lease_connection.database_version >= "11.2"
 
         expect {
           versions.each { |version| @conn.execute @conn.send(:insert_versions_sql, version) }

--- a/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
@@ -353,7 +353,7 @@ describe "OracleEnhancedAdapter structure dump" do
 
     context "multi insert is supported" do
       it "should dump schema migrations using multi inserts" do
-        skip "Not supported in this database version" unless ActiveRecord::Base.connection.supports_multi_insert?
+        skip "Not supported in this database version" unless ActiveRecord::Base.connection.database_version.to_s >= [11, 2].to_s
 
         expect(dump).to eq <<~SQL
           INSERT ALL
@@ -380,7 +380,7 @@ describe "OracleEnhancedAdapter structure dump" do
       }
 
       it "should dump schema migrations one version per insert" do
-        skip "Not supported in this database version" if ActiveRecord::Base.connection.supports_multi_insert?
+        skip "Not supported in this database version" if ActiveRecord::Base.connection.database_version.to_s >= [11, 2].to_s
 
         expect(dump).to eq insert_statement_per_migration
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
@@ -362,9 +362,9 @@ describe "OracleEnhancedAdapter structure dump" do
       end
     end
 
-    context "multi insert is supported" do
-      it "should dump schema migrations using multi inserts" do
-        skip "Not supported in this database version" unless ActiveRecord::Base.lease_connection.supports_multi_insert?
+    context "when INSERT ALL accepts 1000+ rows (Oracle 11.2 or later)" do
+      it "should dump schema migrations using a single INSERT ALL block" do
+        skip "Not supported in this database version" unless ActiveRecord::Base.lease_connection.database_version >= "11.2"
 
         expect(dump).to eq <<~SQL
           INSERT ALL
@@ -383,7 +383,7 @@ describe "OracleEnhancedAdapter structure dump" do
       end
     end
 
-    context "multi insert is NOT supported" do
+    context "when INSERT ALL is capped at 999 rows (Oracle older than 11.2)" do
       let(:insert_statement_per_migration) {
         1.step(10).map { |i|
           %Q|INSERT INTO "SCHEMA_MIGRATIONS" (version) VALUES ('201601#{sprintf("%02d", i)}000000')|
@@ -391,7 +391,7 @@ describe "OracleEnhancedAdapter structure dump" do
       }
 
       it "should dump schema migrations one version per insert" do
-        skip "Not supported in this database version" if ActiveRecord::Base.lease_connection.supports_multi_insert?
+        skip "Not supported in this database version" if ActiveRecord::Base.lease_connection.database_version >= "11.2"
 
         expect(dump).to eq insert_statement_per_migration
       end


### PR DESCRIPTION
## Summary

- Remove `supports_multi_insert?` from `OracleEnhancedAdapter`. Rails removed it from `AbstractAdapter` years ago (deprecated in rails/rails#32923 in Rails 5.2, removed in rails/rails@cbf43df2 in Rails 6.1) and the adapter's local override was both stale and misnamed -- on this adapter it answered "can a single `INSERT ALL` (multitable insert) hold more than 999 target columns?", not the upstream "supports multi-row VALUES" question (Oracle does not accept multi-row `VALUES` prior to 23c).
- Inline `database_version >= "11.2"` at the formatter's branching point in `lib/active_record/connection_adapters/oracle_enhanced/schema_versions_formatter.rb` -- the only real call site after rsim/oracle-enhanced#2526 moved `INSERT ALL` emission out of `insert_versions_sql` and into `OracleEnhanced::SchemaVersionsFormatter`, which delegated through `connection.supports_multi_insert?` as a temporary stand-in pending this PR.
- Replace the two `supports_multi_insert?` skip-guards in `structure_dump_spec` and `schema_statements_spec` with the same inline predicate. Rename the now-misleading `"multi insert is supported" / "multi insert is NOT supported"` contexts to `"when INSERT ALL accepts 1000+ rows (Oracle 11.2 or later)" / "when INSERT ALL is capped at 999 rows (Oracle older than 11.2)"` so the context describes the actual Oracle behavior under test rather than a predicate name that no longer exists.

## Why

`AbstractAdapter#supports_multi_insert?` was deprecated in rails/rails#32923 / rails/rails@d1a74c1e (2018-05-21, "Bump minimum SQLite version to 3.8" — authored by @yahonda) as part of raising SQLite's minimum so every bundled adapter satisfied the predicate, at which point it stopped carrying information. It was removed in rails/rails@cbf43df2 (2020-05-07, Rails 6.1).

oracle-enhanced kept a local override:

```ruby
def supports_multi_insert?
  database_version >= "11.2"
end
```

which has no analog upstream anymore. The name is also misleading on this adapter: upstream "supports_multi_insert?" meant "supports multi-row `VALUES` syntax", but Oracle does not accept that syntax prior to 23c. The override answers a different question entirely — whether a single `INSERT ALL` (multitable insert) can hold more than 999 target columns.

Following rsim/oracle-enhanced#2526 (formatter pluggability) and rsim/oracle-enhanced#2677 (`OracleEnhancedAdapter::Version` replacing the old `[major, minor]` Array), the predicate has exactly one call site (the formatter) and the comparison form has migrated to `database_version >= "11.2"` (string-based, going through `OracleEnhancedAdapter::Version#<=>`). This PR retires the indirection.

### Why the per-version branching in the formatter is preserved

The 11.2 cutoff is not cosmetic and not about when Oracle introduced `INSERT ALL` (Oracle 9i Release 1, 2001). It encodes a specific multitable-insert restriction documented in the Oracle 10.2 / 11.1 SQL References:

> "In a multitable insert, all of the insert_into_clauses cannot combine to specify more than 999 target columns."
> — Oracle Database 10.2 / 11.1 SQL Reference
>   (Restriction lifted in 11.2 / 12.1.)

Each `schema_migrations` row in the dump contributes one target column to an `INSERT ALL`, so a single `INSERT ALL` can hold at most 999 rows on pre-11.2 Oracle per the docs; beyond that the server raises:

```
ORA-24335: cannot support more than 1000 columns
```

@yahonda reproduced this empirically on Oracle 10.2.0.5 in the rsim/oracle-enhanced#1084 discussion (2016-12-15) with a 1000-row `INSERT ALL`. 11.1 was not retested — the behavior there is known only from the 11.1 SQL Reference — but the docs for 10.2 and 11.1 are identically worded. The fallback path keeps `rails db:schema:load` working on 10.2 / 11.1 once `schema_migrations` exceeds ~999 rows, by emitting one `INSERT` per version joined with SQL\*Plus `/` separators.

oracle-enhanced's gemspec minimum is 11.2+ and the `test_11g` CI job runs 11.2.0.2, so no supported configuration exercises the fallback branch. Still, deleting the fallback would strictly regress `structure.sql` loads on 10.2 (confirmed) and on 11.1 (per Oracle's own documentation) once a project accumulates more than ~999 migrations — niche cases, but real ones the fallback was added to handle. Keep the branching; only drop the predicate Rails no longer exports.

## Behavior change

None. The per-version branching is preserved byte for byte; only the indirection through `supports_multi_insert?` is removed. The gating predicate moves from the adapter to the formatter, in the post-rsim/oracle-enhanced#2677 form `database_version >= "11.2"` (which uses `OracleEnhancedAdapter::Version#<=>` rather than the brittle `Array#to_s` string compare).

## References

- Oracle 10.2 SQL Reference, INSERT: multitable insert restrictions — <https://docs.oracle.com/cd/B19306_01/server.102/b14200/statements_9014.htm#i2080134>
- Oracle 11.1 SQL Reference, INSERT: multitable insert restrictions — <https://docs.oracle.com/cd/B28359_01/server.111/b28286/statements_9014.htm#i2080134>
- Oracle 11.2 SQL Reference (restriction lifted) — <https://docs.oracle.com/cloud/latest/db112/SQLRF/statements_9014.htm#i2080134>
- Oracle 12.1 SQL Reference (restriction lifted) — <https://docs.oracle.com/database/121/SQLRF/statements_9014.htm#i2080134>
- rsim/oracle-enhanced#1084 — "Fix ORA-00933 error when executing `rails db:schema:load`" (origin of the 11.2 gate / 10.2 reproduction of `ORA-24335`)
- rsim/oracle-enhanced#2526 — moved `INSERT ALL` emission into `SchemaVersionsFormatter`, leaving `supports_multi_insert?` with a single (formatter) call site
- rsim/oracle-enhanced#2677 — replaced `database_version`'s Array shape with `OracleEnhancedAdapter::Version` and migrated predicates from `.to_s >= [11, 2].to_s` to `>= "11.2"`
- rails/rails#32923 — Rails deprecation of `supports_multi_insert?`
- rails/rails@cbf43df2 — Rails removal of `supports_multi_insert?` (Rails 6.1)

## Test plan

- [x] No remaining references to `supports_multi_insert?` anywhere in the repo (`grep -rn 'supports_multi_insert' lib spec` returns nothing).
- [x] `bundle exec rubocop` clean on all four touched files.
- [ ] CI green on GitHub Actions (test / test_11g / test_11g_ojdbc11 / Linting / RuboCop).
- [ ] Behavior preserved: same `INSERT ALL ... SELECT * FROM DUAL` output on 11.2+, same per-statement / `/`-separated output on 10.2 / 11.1.
- [ ] Spec skip guards exercise the same code paths they did before, now keyed off the inline predicate.
