### PR TITLE
Override configure_connection for per-connection session setup

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -173,21 +173,6 @@ module ActiveRecord
             # @raw_connection.setDefaultRowPrefetch(prefetch_rows) if prefetch_rows
           end
 
-          cursor_sharing = config[:cursor_sharing] || "force"
-          exec "alter session set cursor_sharing = #{cursor_sharing}" if cursor_sharing
-
-          # Initialize NLS parameters
-          OracleEnhancedAdapter::DEFAULT_NLS_PARAMETERS.each do |key, default_value|
-            value = config[key] || ENV[key.to_s.upcase] || default_value
-            if value
-              exec "alter session set #{key} = '#{value}'"
-            end
-          end
-
-          OracleEnhancedAdapter::FIXED_NLS_PARAMETERS.each do |key, value|
-            exec "alter session set #{key} = '#{value}'"
-          end
-
           self.autocommit = true
 
           schema = config[:schema] && config[:schema].to_s
@@ -195,7 +180,6 @@ module ActiveRecord
             # default schema owner
             @owner = username.upcase unless username.nil?
           else
-            exec "alter session set current_schema = #{schema}"
             @owner = schema.upcase
           end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -319,14 +319,10 @@ module ActiveRecord
           username = config[:username] && config[:username].to_s
           password = config[:password] && config[:password].to_s
           database = config[:database] && config[:database].to_s
-          schema = config[:schema] && config[:schema].to_s
           host, port = config[:host], config[:port]
           privilege = config[:privilege] && config[:privilege].to_sym
           async = config[:allow_concurrency]
           prefetch_rows = config[:prefetch_rows] || 100
-          cursor_sharing = config[:cursor_sharing] || "force"
-          # get session time_zone from configuration or from TZ environment variable
-          time_zone = config[:time_zone] || ENV["TZ"]
 
           # using a connection string via DATABASE_URL
           connection_string = if host == "connection-string"
@@ -354,25 +350,6 @@ module ActiveRecord
           conn.autocommit = true
           conn.non_blocking = true if async
           conn.prefetch_rows = prefetch_rows
-          conn.exec "alter session set cursor_sharing = #{cursor_sharing}" rescue nil if cursor_sharing
-          if ActiveRecord.default_timezone == :local
-            conn.exec "alter session set time_zone = '#{time_zone}'" unless time_zone.blank?
-          elsif ActiveRecord.default_timezone == :utc
-            conn.exec "alter session set time_zone = '+00:00'"
-          end
-          conn.exec "alter session set current_schema = #{schema}" unless schema.blank?
-
-          # Initialize NLS parameters
-          OracleEnhancedAdapter::DEFAULT_NLS_PARAMETERS.each do |key, default_value|
-            value = config[key] || ENV[key.to_s.upcase] || default_value
-            if value
-              conn.exec "alter session set #{key} = '#{value}'"
-            end
-          end
-
-          OracleEnhancedAdapter::FIXED_NLS_PARAMETERS.each do |key, value|
-            conn.exec "alter session set #{key} = '#{value}'"
-          end
           conn
         end
       end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -234,11 +234,13 @@ module ActiveRecord
       def initialize(config_or_deprecated_connection, deprecated_logger = nil, deprecated_connection_options = nil, deprecated_config = nil) # :nodoc:
         super(config_or_deprecated_connection, deprecated_logger, deprecated_connection_options, deprecated_config)
 
-        @raw_connection = ConnectionAdapters::OracleEnhanced::Connection.create(@config)
+        connect
         @enable_dbms_output = false
         @do_not_prefetch_primary_key = {}
         @columns_cache = {}
         @notice_receiver_sql_warnings = []
+
+        configure_connection
       end
 
       ADAPTER_NAME = "OracleEnhanced"
@@ -455,7 +457,6 @@ module ActiveRecord
       # Reconnects to the database.
       def reconnect!(restore_transactions: false) # :nodoc:
         super
-        _connection.reset!
       rescue OracleEnhanced::ConnectionException => e
         @logger.warn "#{adapter_name} automatic reconnection failed: #{e.message}" if @logger
       end
@@ -712,6 +713,45 @@ module ActiveRecord
         @unconfigured_connection || @raw_connection
       end
 
+      private def connect
+        @raw_connection = ConnectionAdapters::OracleEnhanced::Connection.create(@config)
+      end
+
+      private def reconnect
+        _connection.reset
+      rescue OracleEnhanced::ConnectionException
+        connect
+      end
+
+      private def configure_connection
+        super
+
+        cursor_sharing = @config[:cursor_sharing] || "force"
+        execute("alter session set cursor_sharing = #{cursor_sharing}", "SCHEMA") if cursor_sharing
+
+        if ORACLE_ENHANCED_CONNECTION == :oci
+          time_zone = @config[:time_zone] || ENV["TZ"]
+          case ActiveRecord.default_timezone
+          when :local
+            execute("alter session set time_zone = '#{time_zone}'", "SCHEMA") unless time_zone.blank?
+          when :utc
+            execute("alter session set time_zone = '+00:00'", "SCHEMA")
+          end
+        end
+
+        schema = @config[:schema].to_s
+        execute("alter session set current_schema = #{schema}", "SCHEMA") unless schema.blank?
+
+        DEFAULT_NLS_PARAMETERS.each do |key, default_value|
+          value = @config[key] || ENV[key.to_s.upcase] || default_value
+          execute("alter session set #{key} = '#{value}'", "SCHEMA") if value
+        end
+
+        FIXED_NLS_PARAMETERS.each do |key, value|
+          execute("alter session set #{key} = '#{value}'", "SCHEMA")
+        end
+      end
+
       class << self
         def native_database_types
           emulate_booleans_from_strings ? NATIVE_DATABASE_TYPES_BOOLEAN_STRINGS : NATIVE_DATABASE_TYPES
@@ -812,12 +852,6 @@ module ActiveRecord
 
         def build_statement_pool
           StatementPool.new(self.class.type_cast_config_to_integer(@config[:statement_limit]))
-        end
-
-        def reconnect
-          _connection.reset # tentative
-        rescue OracleEnhanced::ConnectionException
-          connect
         end
 
         def type_map

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -207,14 +207,14 @@ describe "OracleEnhancedConnection" do
 
     it "should use NLS_TERRITORY environment variable" do
       ENV["NLS_TERRITORY"] = "JAPAN"
-      @conn = ActiveRecord::ConnectionAdapters::OracleEnhanced::Connection.create(CONNECTION_PARAMS)
-      expect(@conn.select("select SYS_CONTEXT('userenv', 'NLS_TERRITORY') as value from dual")).to eq([{ "value" => "JAPAN" }])
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+      expect(ActiveRecord::Base.connection.select_value("select SYS_CONTEXT('userenv', 'NLS_TERRITORY') from dual")).to eq("JAPAN")
     end
 
     it "should use configuration value and ignore NLS_TERRITORY environment variable" do
       ENV["NLS_TERRITORY"] = "AMERICA"
-      @conn = ActiveRecord::ConnectionAdapters::OracleEnhanced::Connection.create(CONNECTION_PARAMS.merge(nls_territory: "INDONESIA"))
-      expect(@conn.select("select SYS_CONTEXT('userenv', 'NLS_TERRITORY') as value from dual")).to eq([{ "value" => "INDONESIA" }])
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(nls_territory: "INDONESIA"))
+      expect(ActiveRecord::Base.connection.select_value("select SYS_CONTEXT('userenv', 'NLS_TERRITORY') from dual")).to eq("INDONESIA")
     end
   end
 
@@ -225,20 +225,48 @@ describe "OracleEnhancedConnection" do
 
     it "should ignore NLS_DATE_FORMAT environment variable" do
       ENV["NLS_DATE_FORMAT"] = "YYYY-MM-DD"
-      @conn = ActiveRecord::ConnectionAdapters::OracleEnhanced::Connection.create(CONNECTION_PARAMS)
-      expect(@conn.select("select SYS_CONTEXT('userenv', 'NLS_DATE_FORMAT') as value from dual")).to eq([{ "value" => "YYYY-MM-DD HH24:MI:SS" }])
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+      expect(ActiveRecord::Base.connection.select_value("select SYS_CONTEXT('userenv', 'NLS_DATE_FORMAT') from dual")).to eq("YYYY-MM-DD HH24:MI:SS")
     end
 
     it "should ignore NLS_DATE_FORMAT configuration value" do
-      @conn = ActiveRecord::ConnectionAdapters::OracleEnhanced::Connection.create(CONNECTION_PARAMS.merge(nls_date_format: "YYYY-MM-DD HH24:MI"))
-      expect(@conn.select("select SYS_CONTEXT('userenv', 'NLS_DATE_FORMAT') as value from dual")).to eq([{ "value" => "YYYY-MM-DD HH24:MI:SS" }])
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(nls_date_format: "YYYY-MM-DD HH24:MI"))
+      expect(ActiveRecord::Base.connection.select_value("select SYS_CONTEXT('userenv', 'NLS_DATE_FORMAT') from dual")).to eq("YYYY-MM-DD HH24:MI:SS")
     end
 
     it "should use default value when NLS_DATE_FORMAT environment variable is not set" do
       ENV["NLS_DATE_FORMAT"] = nil
-      @conn = ActiveRecord::ConnectionAdapters::OracleEnhanced::Connection.create(CONNECTION_PARAMS)
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
       default = ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter::FIXED_NLS_PARAMETERS[:nls_date_format]
-      expect(@conn.select("select SYS_CONTEXT('userenv', 'NLS_DATE_FORMAT') as value from dual")).to eq([{ "value" => default }])
+      expect(ActiveRecord::Base.connection.select_value("select SYS_CONTEXT('userenv', 'NLS_DATE_FORMAT') from dual")).to eq(default)
+    end
+  end
+
+  describe "session settings survive reconnect!" do
+    it "re-applies FIXED_NLS_PARAMETERS after reconnect!" do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+      expected = ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter::FIXED_NLS_PARAMETERS[:nls_date_format]
+      # Taint NLS_DATE_FORMAT on the current session so the post-reconnect
+      # assertion can only pass if configure_connection actively re-applies
+      # FIXED_NLS_PARAMETERS on the fresh physical session.
+      ActiveRecord::Base.connection.execute("ALTER SESSION SET NLS_DATE_FORMAT = 'DD-MON-RRRR'")
+      ActiveRecord::Base.connection.reconnect!
+      expect(ActiveRecord::Base.connection.select_value("select SYS_CONTEXT('userenv', 'NLS_DATE_FORMAT') from dual")).to eq(expected)
+    end
+
+    it "re-applies current_schema after reconnect!" do
+      ActiveRecord::Base.establish_connection(CONNECTION_WITH_SCHEMA_PARAMS)
+      expected = CONNECTION_WITH_SCHEMA_PARAMS[:schema].upcase
+      expect(ActiveRecord::Base.connection.current_schema).to eq(expected)
+      ActiveRecord::Base.connection.reconnect!
+      expect(ActiveRecord::Base.connection.current_schema).to eq(expected)
+    end
+
+    it "re-applies cursor_sharing after reconnect!" do
+      ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS.merge(cursor_sharing: :exact))
+      expect(ActiveRecord::Base.connection.select_value("select value from v$parameter where name = 'cursor_sharing'")).to eq("EXACT")
+      ActiveRecord::Base.connection.reconnect!
+      expect(ActiveRecord::Base.connection.select_value("select value from v$parameter where name = 'cursor_sharing'")).to eq("EXACT")
     end
   end
 


### PR DESCRIPTION
Resolves #2269.

## Summary

Define a private `configure_connection` override on `OracleEnhancedAdapter`, moving NLS parameters, `current_schema`, `cursor_sharing`, and (OCI-only) session `time_zone` out of the OCI/JDBC driver factories.

Since rails/rails#44570, `AbstractAdapter` calls `configure_connection` after `connect` and inside `reconnect!` / `reset!` / `verify!`. Previously the adapter re-applied session setup implicitly by re-running the driver factory inside its own `reset!`, which worked but duplicated the apply on `reconnect!` (driver factory + framework both ran the ALTER SESSIONs) and diverged from the framework convention.

What stays in the driver factory (needs the raw OCI8 / java.sql.Connection):

- OCI: `OCI8.new`, `autocommit`, `non_blocking`, `prefetch_rows`, `tcp_keepalive*`
- JDBC: `DriverManager.getConnection`, `setSessionTimeZone`, `setImplicitCachingEnabled`, `setAutoCommit`, `@owner`

What moves into `configure_connection`:

- `alter session set cursor_sharing`
- `alter session set time_zone` (OCI path only; JDBC uses `setSessionTimeZone`)
- `alter session set current_schema`
- `DEFAULT_NLS_PARAMETERS` and `FIXED_NLS_PARAMETERS`

Also defines private `connect` and `reconnect` so `AbstractAdapter#reconnect!` drives the sequence, drops the now-redundant `_connection.reset!` call at the tail of the adapter's `reconnect!`, and removes the earlier tentative private `def reconnect` that the new override supersedes.

## Behavior

No user-visible behavior change. The same ALTER SESSIONs run on the same raw connection at the same logical moment; they just move from the driver wrapper into the adapter.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb` (CI)
- [x] Full RSpec suite passes on CI
- [x] Confirm NLS/schema/cursor_sharing survive `ActiveRecord::Base.connection.reconnect!` — covered by the new `describe "session settings survive reconnect!"` examples in `connection_spec.rb`. The `NLS_DATE_FORMAT` example taints the current session before calling `reconnect!`, so the post-reconnect assertion can only pass if `configure_connection` actively re-applies the constant on the fresh physical session.

