### PR TITLE
Remove outdated composite primary key warning

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -641,21 +641,18 @@ module ActiveRecord
              AND cc.constraint_name = c.constraint_name
         SQL
 
-        warn <<~WARNING if pks.count > 1
-          WARNING: Active Record does not support composite primary key.
-
-          #{table_name} has composite primary key. Composite primary key is ignored.
-        WARNING
-
-        # only support single column keys
-        pks.size == 1 ? [oracle_downcase(pks.first),
-                         oracle_downcase(seqs.first)] : nil
+        case pks.size
+        when 0 then nil
+        when 1 then [oracle_downcase(pks.first), oracle_downcase(seqs.first)]
+        else nil
+        end
       end
 
       # Returns just a table's primary key
       def primary_key(table_name)
-        pk_and_sequence = pk_and_sequence_for(table_name)
-        pk_and_sequence && pk_and_sequence.first
+        pk = primary_keys(table_name)
+        pk = pk.first unless pk.size > 1
+        pk
       end
 
       def has_primary_key?(table_name, owner = nil, desc_table_name = nil) # :nodoc:


### PR DESCRIPTION
## Summary

- Active Record has supported composite primary keys natively since Rails 7.1, and oracle-enhanced targets Rails 7.1+ (gemspec pins `~> 8.2.0.alpha`). The warning emitted from `pk_and_sequence_for` (`WARNING: Active Record does not support composite primary key. ... Composite primary key is ignored.`) is no longer accurate.
- Drop the warning. `pk_and_sequence_for` now returns `nil` for composite-PK tables (a single sequence does not apply) and otherwise returns the existing `[pk, sequence]` tuple.
- Align `primary_key(table_name)` with the abstract adapter contract (activerecord `abstract/schema_statements.rb`): delegate to `primary_keys` and return the Array when the PK is composite, the single column otherwise. The adapter already implements `primary_keys` correctly.

## Test plan

- [ ] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/composite_spec.rb`
- [ ] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb`
- [ ] `bundle exec rspec`
- [ ] Confirm no test output contains `WARNING: Active Record does not support composite primary key.`

Generated with [Claude Code](https://claude.com/claude-code)