### PR TITLE
POC: resolve describe() via DBMS_UTILITY.NAME_RESOLVE

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -306,6 +306,25 @@ module ActiveRecord
           @database_version ||= (md = raw_connection.getMetaData) && [md.getDatabaseMajorVersion, md.getDatabaseMinorVersion]
         end
 
+        # Resolve a schema object (table, view, synonym) to [owner, object_name]
+        # in a single round trip via DBMS_UTILITY.NAME_RESOLVE. Private and
+        # public synonyms are chased server-side, and Oracle raises ORA-01775
+        # natively on a looping chain.
+        def name_resolve(name)
+          cs = @raw_connection.prepareCall("BEGIN DBMS_UTILITY.NAME_RESOLVE(?, 0, ?, ?, ?, ?, ?, ?); END;")
+          cs.setString(1, name)
+          cs.registerOutParameter(2, java.sql.Types::VARCHAR) # schema
+          cs.registerOutParameter(3, java.sql.Types::VARCHAR) # part1 (object name)
+          cs.registerOutParameter(4, java.sql.Types::VARCHAR) # part2
+          cs.registerOutParameter(5, java.sql.Types::VARCHAR) # dblink
+          cs.registerOutParameter(6, java.sql.Types::NUMERIC) # part1_type
+          cs.registerOutParameter(7, java.sql.Types::NUMERIC) # object_number
+          cs.execute
+          [cs.getString(2), cs.getString(3)]
+        ensure
+          cs&.close
+        end
+
         class Cursor
           def initialize(connection, raw_statement, exec_sql = nil)
             @raw_connection = connection

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -109,6 +109,31 @@ module ActiveRecord
           Cursor.new(self, @raw_connection.parse(sql))
         end
 
+        # Resolve a schema object (table, view, synonym) to [owner, object_name]
+        # in a single round trip via DBMS_UTILITY.NAME_RESOLVE. Private and
+        # public synonyms are chased server-side, and Oracle raises ORA-01775
+        # natively on a looping chain.
+        def name_resolve(name)
+          cursor = @raw_connection.parse(<<~PLSQL)
+            DECLARE
+              l_part2   VARCHAR2(128);
+              l_dblink  VARCHAR2(128);
+              l_type    NUMBER;
+              l_obj_num NUMBER;
+            BEGIN
+              DBMS_UTILITY.NAME_RESOLVE(:name, 0, :out_schema, :out_name,
+                                        l_part2, l_dblink, l_type, l_obj_num);
+            END;
+          PLSQL
+          cursor.bind_param(":name", name)
+          cursor.bind_param(":out_schema", nil, String, 128)
+          cursor.bind_param(":out_name", nil, String, 128)
+          cursor.exec
+          [cursor[":out_schema"], cursor[":out_name"]]
+        ensure
+          cursor&.close
+        end
+
         class Cursor
           def initialize(connection, raw_cursor)
             @raw_connection = connection

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -735,57 +735,49 @@ module ActiveRecord
           end
 
           # Resolves an Oracle data-source name to its underlying [owner, table_name]
-          # by following synonyms through the catalog. Defaults the schema to
-          # `_connection.owner` (the adapter's configured default schema, taken
-          # from `config[:schema]` or `config[:username]`) when the name is not
-          # schema-qualified. This is distinct from
-          # `SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA')`, which can differ after
-          # `ALTER SESSION SET CURRENT_SCHEMA`.
-          # Raises OracleEnhanced::ConnectionException if the object does not
-          # exist or if synonym resolution produces a looping chain.
+          # via DBMS_UTILITY.NAME_RESOLVE, which chases private and public
+          # synonyms server-side in a single round trip. NAME_RESOLVE raises
+          # ORA-01775 ("looping chain of synonyms") natively on a cycle, which
+          # we let propagate as OracleEnhanced::ConnectionException.
+          #
+          # The PL/SQL call bypasses the adapter's select_one path, so we wrap
+          # it in a sql.active_record SCHEMA notification to keep describe
+          # visible to logging and instrumentation subscribers.
           def resolve_data_source_name(name)
-            visited = Set.new
-            loop do
-              schema, identifier = extract_schema_qualified_name(name)
-              real_name = schema ? "#{schema}.#{identifier}" : identifier
-              owner = schema || _connection.owner
-
-              unless visited.add?([owner, identifier])
-                raise OracleEnhanced::ConnectionException,
-                      %Q{"DESC #{name}" failed; looping chain of synonyms}
-              end
-
-              binds = [
-                bind_string("table_owner", owner),
-                bind_string("table_name", identifier),
-                bind_string("table_owner", owner),
-                bind_string("table_name", identifier),
-                bind_string("table_owner", owner),
-                bind_string("table_name", identifier),
-                bind_string("real_name", real_name),
-              ]
-              result = select_one(<<~SQL.squish, "SCHEMA", binds)
-                SELECT owner, table_name, 'TABLE' name_type
-                FROM all_tables WHERE owner = :table_owner AND table_name = :table_name
-                UNION ALL
-                SELECT owner, view_name table_name, 'VIEW' name_type
-                FROM all_views WHERE owner = :table_owner AND view_name = :table_name
-                UNION ALL
-                SELECT table_owner, table_name, 'SYNONYM' name_type
-                FROM all_synonyms WHERE owner = :table_owner AND synonym_name = :table_name
-                UNION ALL
-                SELECT table_owner, table_name, 'SYNONYM' name_type
-                FROM all_synonyms WHERE owner = 'PUBLIC' AND synonym_name = :real_name
-              SQL
-
-              raise OracleEnhanced::ConnectionException, %Q{"DESC #{name}" failed; does it exist?} unless result
-
-              if result["name_type"] == "SYNONYM"
-                name = "#{result['owner'] && "#{result['owner']}."}#{result['table_name']}"
-              else
-                return [result["owner"], result["table_name"]]
-              end
+            real_name = normalize_name_for_name_resolve(name)
+            instrumenter.instrument(
+              "sql.active_record",
+              sql: "DBMS_UTILITY.NAME_RESOLVE(#{real_name.inspect}, 0, ...)",
+              name: "SCHEMA",
+              connection: self,
+            ) do
+              _connection.name_resolve(real_name)
             end
+          rescue OracleEnhanced::ConnectionException, ArgumentError
+            raise
+          rescue => e
+            raise OracleEnhanced::ConnectionException,
+                  %Q{"DESC #{name}" failed; does it exist? (#{e.message})}
+          end
+
+          # Normalize a data-source name for DBMS_UTILITY.NAME_RESOLVE.
+          # NAME_RESOLVE uppercases unquoted identifiers, so mixed-case
+          # identifiers like `test_Mixed` must be wrapped in double quotes to
+          # preserve their case. Normalization is per-dotted-part: a valid
+          # unquoted identifier (all upper, no spaces, etc.) is upcased in
+          # place; any other part is wrapped in quotes. This lets
+          # `sys.test_Mixed` become `SYS."test_Mixed"` rather than the
+          # all-quoted `"sys"."test_Mixed"` (which would send Oracle hunting
+          # for a lowercase schema and miss SYS).
+          def normalize_name_for_name_resolve(name)
+            name = name.to_s
+            raise ArgumentError, "db link is not supported" if name.include?("@")
+
+            return name.upcase if OracleEnhanced::Quoting.valid_table_name?(name)
+
+            name.split(".").map do |part|
+              OracleEnhanced::Quoting.valid_table_name?(part) ? part.upcase : %("#{part}")
+            end.join(".")
           end
 
           # Splits "schema.identifier" into its parts, returning [schema, identifier].

--- a/script/benchmark_describe.rb
+++ b/script/benchmark_describe.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+# Benchmark for OracleEnhanced::SchemaStatements#resolve_data_source_name
+# (the method adapters use to resolve a table / view / synonym name to its
+# underlying [owner, object_name] pair -- formerly Connection#describe).
+#
+# Intent: compare the resolve_data_source_name implementations across
+#   - master: UNION ALL over all_tables/all_views/all_synonyms (select_one)
+#   - PR #2521 branch (add-describe-regression-test): single all_objects query
+#   - poc-dbms-utility-name-resolve: DBMS_UTILITY.NAME_RESOLVE
+#
+# The fixture models the production scenario from #2429: ~1000 objects in
+# the schema (700 tables, 100 views, 100 private synonyms, 100 public
+# synonyms).
+#
+# Usage (from repo root):
+#   bundle exec ruby script/benchmark_describe.rb                 # setup + run + teardown
+#   SKIP_SETUP=1 bundle exec ruby script/benchmark_describe.rb    # reuse previous fixtures
+#   SKIP_TEARDOWN=1 bundle exec ruby script/benchmark_describe.rb # keep fixtures for next run
+#
+# Environment variables honored (same defaults as spec_helper.rb):
+#   DATABASE_NAME, DATABASE_HOST, DATABASE_PORT, DATABASE_USER,
+#   DATABASE_PASSWORD, ITERATIONS, TABLE_COUNT, VIEW_COUNT, SYNONYM_COUNT.
+
+require "bundler/setup"
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+require "oci8" if RUBY_ENGINE == "ruby"
+require "active_record"
+require "active_record/connection_adapters/oracle_enhanced_adapter"
+
+TABLE_COUNT   = Integer(ENV["TABLE_COUNT"]   || 700)
+VIEW_COUNT    = Integer(ENV["VIEW_COUNT"]    || 100)
+SYNONYM_COUNT = Integer(ENV["SYNONYM_COUNT"] || 200) # half private, half public
+ITERATIONS    = Integer(ENV["ITERATIONS"]    || 1)
+SKIP_SETUP    = ENV["SKIP_SETUP"]    == "1"
+SKIP_TEARDOWN = ENV["SKIP_TEARDOWN"] == "1"
+
+ActiveRecord::Base.establish_connection(
+  adapter:  "oracle_enhanced",
+  database: ENV["DATABASE_NAME"]     || "XEPDB1",
+  host:     ENV["DATABASE_HOST"]     || "127.0.0.1",
+  port:     Integer(ENV["DATABASE_PORT"] || 1521),
+  username: ENV["DATABASE_USER"]     || "oracle_enhanced",
+  password: ENV["DATABASE_PASSWORD"] || "oracle_enhanced"
+)
+
+conn  = ActiveRecord::Base.connection
+owner = (ENV["DATABASE_USER"] || "oracle_enhanced").upcase
+
+def t(label)
+  started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  yield
+  elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+  printf("%-20s %8.2fs\n", label, elapsed)
+end
+
+def safe_exec(conn, sql)
+  conn.execute(sql)
+rescue ActiveRecord::StatementInvalid
+  # idempotent: ignore "already exists" / "does not exist"
+end
+
+table_names   = (1..TABLE_COUNT).map { |i| "bench_tbl_%04d" % i }
+view_names    = (1..VIEW_COUNT).map  { |i| "bench_vw_%04d"  % i }
+priv_syn_half = SYNONYM_COUNT / 2
+pub_syn_half  = SYNONYM_COUNT - priv_syn_half
+priv_synonyms = (1..priv_syn_half).map { |i| "bench_syn_%04d" % i }
+pub_synonyms  = (1..pub_syn_half).map  { |i| "bench_pub_%04d" % i }
+
+unless SKIP_SETUP
+  puts "==> Creating #{TABLE_COUNT} tables, #{VIEW_COUNT} views, " \
+       "#{priv_syn_half} private + #{pub_syn_half} public synonyms"
+  t("create tables") do
+    table_names.each { |n| safe_exec conn, "CREATE TABLE #{n} (id NUMBER)" }
+  end
+  t("create views") do
+    view_names.each_with_index do |vn, i|
+      safe_exec conn, "CREATE VIEW #{vn} AS SELECT * FROM #{table_names[i % TABLE_COUNT]}"
+    end
+  end
+  t("create synonyms") do
+    priv_synonyms.each_with_index do |sn, i|
+      safe_exec conn, "CREATE SYNONYM #{sn} FOR #{table_names[i % TABLE_COUNT]}"
+    end
+    pub_synonyms.each_with_index do |sn, i|
+      safe_exec conn, "CREATE PUBLIC SYNONYM #{sn} FOR #{owner}.#{table_names[i % TABLE_COUNT]}"
+    end
+  end
+end
+
+begin
+  all_names = table_names + view_names + priv_synonyms + pub_synonyms
+
+  # Warm-up pass so dictionary-cache / shared-pool state is primed; the
+  # first resolve_data_source_name after login otherwise dominates wall clock.
+  all_names.first(50).each { |n| conn.send(:resolve_data_source_name, n) }
+
+  head_branch = `git rev-parse --abbrev-ref HEAD`.strip
+  head_sha    = `git rev-parse --short HEAD`.strip
+  puts
+  puts "==> branch: #{head_branch} (#{head_sha})"
+  puts "==> fixtures: #{TABLE_COUNT} tables, #{VIEW_COUNT} views, " \
+       "#{priv_syn_half} private synonyms, #{pub_syn_half} public synonyms"
+  puts "==> resolve_data_source_name calls per pass: #{all_names.size}"
+  puts "==> passes: #{ITERATIONS}"
+  puts
+
+  printf("%-20s %10s %10s\n", "case", "wall(s)", "avg(ms)")
+  cases = {
+    "tables"          => table_names,
+    "views"           => view_names,
+    "private synonyms" => priv_synonyms,
+    "public synonyms"  => pub_synonyms,
+    "all mixed"        => all_names.shuffle,
+  }
+  cases.each do |label, names|
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    ITERATIONS.times { names.each { |n| conn.send(:resolve_data_source_name, n) } }
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+    per_call_ms = (elapsed * 1000.0) / (ITERATIONS * names.size)
+    printf("%-20s %10.3f %10.3f\n", label, elapsed, per_call_ms)
+  end
+ensure
+  unless SKIP_TEARDOWN
+    puts
+    puts "==> Dropping fixtures"
+    t("drop public syns") { pub_synonyms.each  { |n| safe_exec conn, "DROP PUBLIC SYNONYM #{n}" } }
+    t("drop private syns") { priv_synonyms.each { |n| safe_exec conn, "DROP SYNONYM #{n}" } }
+    t("drop views")        { view_names.each    { |n| safe_exec conn, "DROP VIEW #{n}" } }
+    t("drop tables")       { table_names.each   { |n| safe_exec conn, "DROP TABLE #{n} PURGE" } }
+  end
+end

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -734,12 +734,28 @@ describe "OracleEnhancedConnection" do
       expect(resolve("all_tables")).to eq(["SYS", "ALL_TABLES"])
     end
 
+    # Mixed-case quoted identifiers need per-dotted-part quoting before
+    # reaching DBMS_UTILITY.NAME_RESOLVE: the schema should be upcased and
+    # left unquoted, but the case-preserving table name must be wrapped in
+    # double quotes so Oracle doesn't uppercase it away.
+    it "should resolve a mixed-case quoted table qualified with its owner" do
+      @conn.execute %{CREATE TABLE "test_Mixed_Case_Desc" (id NUMBER)} rescue nil
+      expect(resolve(%{#{@owner}.test_Mixed_Case_Desc})).to eq([@owner, "test_Mixed_Case_Desc"])
+    ensure
+      @conn.execute %{DROP TABLE "test_Mixed_Case_Desc"} rescue nil
+    end
+
+    # DBMS_UTILITY.NAME_RESOLVE chases synonyms server-side, so a circular
+    # chain surfaces as ORA-00980 ("synonym translation is no longer valid")
+    # rather than SQL's ORA-01775 ("looping chain of synonyms"). The thing
+    # that matters either way: no Ruby-side stack overflow, a clean
+    # ConnectionException.
     it "raises when synonym resolution produces a looping chain" do
       @conn.execute "CREATE SYNONYM test_cycle_a FOR test_cycle_b" rescue nil
       @conn.execute "CREATE SYNONYM test_cycle_b FOR test_cycle_a" rescue nil
       expect { resolve("test_cycle_a") }.to raise_error(
         ActiveRecord::ConnectionAdapters::OracleEnhanced::ConnectionException,
-        /looping chain of synonyms/
+        /ORA-00980/
       )
     ensure
       @conn.execute "DROP SYNONYM test_cycle_a" rescue nil
@@ -752,7 +768,7 @@ describe "OracleEnhancedConnection" do
       @conn.execute "CREATE SYNONYM test_cycle_c FOR test_cycle_a" rescue nil
       expect { resolve("test_cycle_a") }.to raise_error(
         ActiveRecord::ConnectionAdapters::OracleEnhanced::ConnectionException,
-        /looping chain of synonyms/
+        /ORA-00980/
       )
     ensure
       @conn.execute "DROP SYNONYM test_cycle_a" rescue nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -205,3 +205,10 @@ DATABASE_NON_DEFAULT_TABLESPACE = config["database"]["non_default_tablespace"] |
 ENV["TZ"] ||= config["timezone"] || "Europe/Riga"
 
 ActiveRecord::Base.logger = ActiveSupport::Logger.new("debug.log", 0, 100 * 1024 * 1024)
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    ActiveRecord::Base.connection.execute("PURGE RECYCLEBIN")
+  end
+end

--- a/spec/support/create_oracle_enhanced_users.sql
+++ b/spec/support/create_oracle_enhanced_users.sql
@@ -4,10 +4,12 @@ CREATE USER oracle_enhanced IDENTIFIED BY oracle_enhanced;
 
 GRANT unlimited tablespace, create session, create table, create sequence,
 create procedure, create trigger, create view, create materialized view,
-create database link, create synonym, create type, ctxapp TO oracle_enhanced;
+create database link, create synonym, create public synonym, create type, ctxapp TO oracle_enhanced;
+GRANT drop public synonym TO oracle_enhanced;
 
 CREATE USER oracle_enhanced_schema IDENTIFIED BY oracle_enhanced_schema;
 
 GRANT unlimited tablespace, create session, create table, create sequence,
 create procedure, create trigger, create view, create materialized view,
-create database link, create synonym, create type, ctxapp TO oracle_enhanced_schema;
+create database link, create synonym, create public synonym, create type, ctxapp TO oracle_enhanced_schema;
+GRANT drop public synonym TO oracle_enhanced_schema;


### PR DESCRIPTION
## Status: open for comparison alongside #2521 / #2560

**Updated 2026-04-21:** this POC, #2521, and #2560 all target the describe
path from different angles. Fresh local benchmarks below on both 23c and
11g make the trade space concrete. The 11g synonym case in particular
surprised me -- #2521 alone leaves it at ~166 ms/call on 11g (vs POC's
~0.28 ms), which is the same ALL_SYNONYMS pain #2560 is trying to work
around with the USER_* fallback.

Not a push to merge -- posted for discussion.

## Summary

POC for the approach @matthewtusker suggested in
https://github.com/rsim/oracle-enhanced/pull/2521#issuecomment-4242585736:
replace the catalog query inside
`SchemaStatements#resolve_data_source_name` (formerly
`OracleEnhanced::Connection#describe`) with a single
`DBMS_UTILITY.NAME_RESOLVE` call. The package resolves private and public
synonyms server-side, so no manual synonym recursion is needed.

Opened as **draft** for discussion alongside #2521 -- not a push to
merge, just runnable code to compare.

## Rebased onto current master

The original POC branch targeted `Connection#describe`, which has since
been removed: #2545 moved describe logic into
`SchemaStatements#resolve_data_source_name`, routed it through
`select_one` for logging / instrumentation / query-cache integration, and
added a `Set`-based iterative synonym loop with cycle detection. This
branch now reapplies NAME_RESOLVE as a driver-level helper
(`OCIConnection#name_resolve` / `JDBCConnection#name_resolve`) that
`resolve_data_source_name` delegates to, with the `sql.active_record`
SCHEMA notification wrapped around the call so the instrumentation
contract introduced by #2545 stays intact.

## Benchmark: master vs PR #2521 vs this POC

CRuby 4.0.2, 900-object fixture (700 tables + 100 views + 100 private
synonyms). Public synonyms left out because the setup requires grants
I haven't applied on my local box yet. Avg ms per
`resolve_data_source_name()` call (lower is better). Commits measured:

- **master** `38907d56` - `select_one` + 4-way UNION ALL across
  `all_tables` / `all_views` / `all_synonyms`.
- **#2521** `ae3e3d2c` - single `all_objects` query with a secondary
  `all_synonyms` lookup when the first hit is a synonym.
- **POC** `2e9f613a` - `DBMS_UTILITY.NAME_RESOLVE` (server-side).

### Oracle 23ai (local gvenzl/oracle-free container)

| case             | master | #2521 | **POC** | POC vs master | POC vs #2521 |
|------------------|-------:|------:|--------:|--------------:|-------------:|
| tables           |  0.599 | 0.256 | **0.136** | 4.4x        | 1.9x         |
| views            |  0.554 | 0.223 | **0.112** | 4.9x        | 2.0x         |
| private synonyms |  1.258 | 0.848 | **0.245** | 5.1x        | 3.5x         |
| all mixed        |  0.661 | 0.297 | **0.118** | 5.6x        | 2.5x         |

### Oracle 11g XE (local gvenzl/oracle-xe:11 container)

| case             |      master |  #2521 | **POC** | POC vs master | POC vs #2521 |
|------------------|------------:|-------:|--------:|--------------:|-------------:|
| tables           |     341.594 |  0.174 | **0.140** |    ~2440x   | 1.2x         |
| views            |     321.016 |  0.128 | **0.107** |    ~3000x   | 1.2x         |
| private synonyms |     659.637 | 165.880 | **0.283** |    ~2330x   | **586x**     |
| all mixed        |     362.161 | 18.386 | **0.139** |    ~2610x   | **132x**     |

The 11g numbers line up with #2560's measurements (668 s / 1399 calls
= ~478 ms/call for the master UNION ALL path). Two 11g-specific
observations worth flagging:

1. **#2521's win on 11g is dramatic for non-synonyms** (~2000x on
   tables/views, ending up essentially on par with POC), because the
   single `all_objects` query sidesteps the UNION-ALL pain that hurt
   master most.
2. **#2521 still leaves the synonym case at ~166 ms/call on 11g** -
   the secondary `all_synonyms` lookup re-enters the ALL_* pain
   #2521's main query escaped. This is structurally the same issue
   #2560's USER_SYNONYMS fallback is trying to fix, just from a
   different direction. POC bypasses it entirely because NAME_RESOLVE
   follows the synonym chain inside the PL/SQL engine and never
   queries a dictionary view from Ruby.

On 23c the differences are consistent with the 11g picture but
compressed by ~1000x because 23c's dictionary views are orders of
magnitude cheaper. Absolute numbers are machine-specific; only the
ratios are meaningful.

## Oracle version support

`DBMS_UTILITY.NAME_RESOLVE` is documented for Oracle 8i (1999), so it's
available on every version this adapter realistically targets in 2026.
See the [Oracle8i Supplied PL/SQL Packages Reference, Release 2 (8.1.6)][8i-doc].

[8i-doc]: https://docs.oracle.com/cd/A87860_01/doc/appdev.817/a76936/dbms_uti.htm

## Implementation notes

Subtleties the spec suite surfaced:

1. `NAME_RESOLVE`'s `context` parameter matters -- `context=1` is PL/SQL
   objects only and raises `ORA-04047` for tables/views. `context=0`
   covers tables, views and synonyms (verified against Oracle 23ai).

2. `NAME_RESOLVE` uppercases unquoted input, so case-preserving (quoted)
   identifiers like `"test_Mixed_Comments"` failed with `ORA-06564`.
   `normalize_name_for_name_resolve` wraps each dotted part in double
   quotes when the original identifier is not upcase-normalized by
   `valid_table_name?`, so `sys.test_Mixed` becomes `SYS."test_Mixed"`
   rather than `"sys"."test_Mixed"`.

3. Circular synonyms surface as `ORA-00980` ("synonym translation is no
   longer valid") from NAME_RESOLVE, not the SQL layer's `ORA-01775`
   ("looping chain of synonyms"). Our `resolve_data_source_name` wraps
   that as an `OracleEnhanced::ConnectionException` -- no Ruby-side stack
   overflow, clean error.

OUT-bind plumbing lives on both the OCI8 path (anonymous PL/SQL block
with named binds) and the JDBC path (`CallableStatement` +
`registerOutParameter`) so it runs on MRI and JRuby alike.

## Trade-offs worth calling out

- **Query cache bypass**: master's `resolve_data_source_name` runs its
  catalog query through `select_one`, which participates in the
  ActiveRecord query cache -- a repeated describe in the same request
  can be effectively free. NAME_RESOLVE is a PL/SQL call and always
  hits the server. The `sql.active_record` event is still emitted (via
  `instrumenter.instrument`), so logging / subscribers see the call,
  but there's no cache layer in front of it.
- **Consistency**: every other lookup in this adapter reads from the
  `all_*` dictionaries. Introducing a `DBMS_UTILITY` call is a style
  break.
- **Readability**: an anonymous PL/SQL block is arguably harder to read
  than the SQL in #2521. That's the main cost to weigh against the
  ~2-3.5x speedup over #2521 on 23c (up to ~600x on 11g synonym paths).
- **Overlap with #2560**: #2560 is an 11g-specific `ALL_*` → `USER_*`
  fallback with three hand-picked swaps and a `same_schema_as_user?`
  helper (explicitly scheduled for removal when 11.2 support drops).
  On the describe path, NAME_RESOLVE subsumes #2560's
  `resolve_data_source_name UNION` bucket (~86% of #2560's 11g
  wall-clock savings) without per-query branching. #2560's wins on
  `synonyms` / `foreign_keys` (~50s on the 11g suite) remain
  complementary -- not touched by this POC.

## Test plan

- [x] `bundle exec rspec` passes on CRuby 4.0.2 (453 examples, 0 failures, 6 pending)
- [x] `bundle exec rspec` passes on JRuby 10.0.5.0 (458 examples, 0 failures, 6 pending)
- [x] Instrumentation regression spec from #2545 stays green (SCHEMA event fires)
- [x] Circular synonym specs updated to match NAME_RESOLVE's ORA-00980 surfacing
- [x] Mixed-case quoted-owner regression spec ported over
- [x] Benchmark script retargeted to `resolve_data_source_name`

Generated with [Claude Code](https://claude.com/claude-code)




