### PR TITLE
Fix dev container: upgrade to Ruby 4.0.2 on Debian 13 (trixie) and add monthly CI

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,8 @@
 FROM mcr.microsoft.com/devcontainers/ruby:1-3.4-bookworm
 
 # Install libaio1 (required for Oracle Instant Client)
-RUN apt-get update && apt-get install -y libaio1 \
+RUN rm -f /etc/apt/sources.list.d/yarn.list \
+    && apt-get update && apt-get install -y libaio1 \
     && rm -rf /var/lib/apt/lists/*
 
 # Create directory structure for Oracle

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,13 +1,15 @@
 FROM mcr.microsoft.com/devcontainers/base:trixie
 
 # Install libaio1t64 and provide a libaio.so.1 symlink for Oracle Instant Client
+# Install rlwrap for readline support in sqlplus
 RUN rm -f /etc/apt/sources.list.d/yarn.list \
     && apt-get update \
-    && apt-get install -y libaio1t64 \
+    && apt-get install -y libaio1t64 rlwrap \
     && rm -rf /var/lib/apt/lists/* \
     && DEB_HOST_MULTIARCH="$(dpkg-architecture -qDEB_HOST_MULTIARCH)" \
     && ln -sf /usr/lib/${DEB_HOST_MULTIARCH}/libaio.so.1t64 \
-              /usr/lib/${DEB_HOST_MULTIARCH}/libaio.so.1
+              /usr/lib/${DEB_HOST_MULTIARCH}/libaio.so.1 \
+    && echo "alias sqlplus='rlwrap sqlplus'" >> /etc/bash.bashrc
 
 # Create directory structure for Oracle
 RUN mkdir -p /opt/oracle

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,13 @@
-FROM mcr.microsoft.com/devcontainers/ruby:1-3.4-bookworm
+FROM mcr.microsoft.com/devcontainers/base:trixie
 
-# Install libaio1 (required for Oracle Instant Client)
+# Install libaio1t64 and provide a libaio.so.1 symlink for Oracle Instant Client
 RUN rm -f /etc/apt/sources.list.d/yarn.list \
-    && apt-get update && apt-get install -y libaio1 \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get update \
+    && apt-get install -y libaio1t64 \
+    && rm -rf /var/lib/apt/lists/* \
+    && DEB_HOST_MULTIARCH="$(dpkg-architecture -qDEB_HOST_MULTIARCH)" \
+    && ln -sf /usr/lib/${DEB_HOST_MULTIARCH}/libaio.so.1t64 \
+              /usr/lib/${DEB_HOST_MULTIARCH}/libaio.so.1
 
 # Create directory structure for Oracle
 RUN mkdir -p /opt/oracle

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,11 @@
   "dockerComposeFile": "docker-compose.yml",
   "service": "app",
   "workspaceFolder": "/workspaces/oracle-enhanced",
+  "features": {
+    "ghcr.io/rails/devcontainer/features/ruby:2": {
+      "version": "4.0.2"
+    }
+  },
   "customizations": {
     "vscode": {
       "extensions": [
@@ -10,7 +15,7 @@
       ]
     }
   },
-  "postCreateCommand": "bundle install",
+  "postCreateCommand": "bash .devcontainer/postCreateCommand.sh",
   "remoteEnv": {
     "DATABASE_NAME": "FREEPDB1",
     "DATABASE_SYS_PASSWORD": "Oracle18",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,6 +15,7 @@
       ]
     }
   },
+  "initializeCommand": "docker pull gvenzl/oracle-free:latest",
   "postCreateCommand": "bash .devcontainer/postCreateCommand.sh",
   "remoteEnv": {
     "DATABASE_NAME": "FREEPDB1",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -22,7 +22,6 @@ services:
       retries: 10
     volumes:
       - oracle-data:/opt/oracle/oradata
-      - ../spec/support/create_oracle_enhanced_users.sql:/container-entrypoint-initdb.d/01-create-users.sql
 
 volumes:
   oracle-data:

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+gem update --system
+bundle install
+
+echo "Waiting for Oracle to be ready..."
+oracle_ready=false
+for i in $(seq 1 30); do
+  if echo "exit" | sqlplus -s "system/${DATABASE_SYS_PASSWORD}@${DATABASE_NAME}" > /dev/null 2>&1; then
+    oracle_ready=true
+    break
+  fi
+  echo "Attempt $i/30 failed, retrying in 10s..."
+  sleep 10
+done
+if [ "$oracle_ready" != "true" ]; then
+  echo "Oracle did not become ready after 30 attempts; aborting container setup." >&2
+  exit 1
+fi
+
+ci/setup_accounts.sh
+
+echo "Dev container setup complete. You are ready to start developing the Oracle Enhanced adapter!"

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,0 +1,25 @@
+name: devcontainer
+
+on:
+  schedule:
+    - cron: "0 6 1 * *"  # 1st of every month at 6:00 AM UTC
+  workflow_dispatch:
+
+env:
+  RUBYOPT: "-w"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Boot dev container and run tests
+        uses: devcontainers/ci@v0.3
+        with:
+          runCmd: |
+            uname -a
+            lsb_release -a
+            ruby --version
+            bundle exec rake spec
+            bundle exec rubocop


### PR DESCRIPTION
## Summary

- Fix dev container build failure caused by an expired Yarn GPG key in the base image (removes \`/etc/apt/sources.list.d/yarn.list\` before \`apt-get update\`)
- Upgrade base image from \`mcr.microsoft.com/devcontainers/ruby:1-3.4-bookworm\` to \`mcr.microsoft.com/devcontainers/base:trixie\` with [ghcr.io/rails/devcontainer/features/ruby:2](https://github.com/rails/devcontainer) (Ruby 4.0.2 via mise)
  - Replace \`libaio1\` with \`libaio1t64\` (renamed in Debian 13 trixie, [Debian Bug #1062218](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1062218)) and add \`libaio.so.1\` symlink for Oracle Instant Client compatibility
  - Extract \`postCreateCommand\` to \`.devcontainer/postCreateCommand.sh\`; the script runs \`gem update --system\`, \`bundle install\`, waits for Oracle to be ready, then runs \`ci/setup_accounts.sh\` to ensure DB users and grants are applied — even when the \`oracle-data\` volume already exists; prints a completion message so first-time users know the environment is ready
  - Remove the \`create_oracle_enhanced_users.sql\` bind mount from \`docker-compose.yml\` — \`ci/setup_accounts.sh\` already handles account setup on every \`postCreate\`, consolidating to a single mechanism used by both CI and the devcontainer
- Install \`rlwrap\` and add \`alias sqlplus='rlwrap sqlplus'\` to \`/etc/bash.bashrc\` for readline support (command history, line editing) in sqlplus sessions
- Add \`initializeCommand\` to pre-pull \`gvenzl/oracle-free:latest\` on the host before the devcontainer build starts, avoiding TLS handshake timeouts during \`docker compose up\`
- Add a monthly GitHub Actions workflow (\`devcontainer.yml\`) to boot the dev container and run \`bundle exec rake spec\` and \`bundle exec rubocop\`, catching issues like GPG key expirations or package renames early; Oracle readiness is handled by \`postCreateCommand.sh\` (run by \`devcontainers/ci\`) so no duplicate wait loop is needed in \`runCmd\`

## Test plan

- [x] Dev container builds and boots successfully with Ruby 4.0.2 on Debian 13 (trixie)
- [x] \`postCreateCommand.sh\` completes: \`gem update --system\`, \`bundle install\`, Oracle ready, \`ci/setup_accounts.sh\` succeeds, completion message printed
- [x] \`alias sqlplus='rlwrap sqlplus'\` is active in VS Code terminal (readline history works)
- [x] \`bundle exec rake spec\` passes (134 examples, 0 failures)
- [x] \`bundle exec rubocop\` passes
- [ ] Monthly CI workflow (\`devcontainer.yml\`) triggers on schedule and can be run manually via \`workflow_dispatch\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)