### PR TITLE
Add loopback database link spec to verify table_name @db_link syntax

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -23,7 +23,18 @@ module ActiveRecord
           def describe(name)
             name = name.to_s
             if name.include?("@")
-              raise ArgumentError "db link is not supported"
+              table_part, db_link = name.split("@", 2)
+              real_name = OracleEnhanced::Quoting.valid_table_name?(table_part) ? table_part.upcase : table_part
+              sql = <<~SQL.squish
+                SELECT owner, table_name FROM all_tables@#{db_link} WHERE table_name = :table_name
+                UNION ALL
+                SELECT owner, view_name FROM all_views@#{db_link} WHERE view_name = :table_name
+              SQL
+              if result = _select_one(sql, "CONNECTION", [real_name, real_name])
+                return [result["owner"], result["table_name"]]
+              else
+                raise OracleEnhanced::ConnectionException, %Q{"DESC #{name}" failed; does it exist?}
+              end
             else
               default_owner = @owner
             end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -31,8 +31,8 @@ module ActiveRecord
         def table_exists?(table_name)
           table_name = table_name.to_s
           if table_name.include?("@")
-            # db link is not table
-            false
+            # db link tables are not local tables
+            return false
           else
             default_owner = current_schema
           end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -590,6 +590,7 @@ module ActiveRecord
 
       def column_definitions(table_name)
         (owner, desc_table_name) = _connection.describe(table_name)
+        db_link_suffix = table_name.to_s.include?("@") ? "@#{table_name.to_s.split("@", 2).last}" : ""
 
         select_all(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("table_name", desc_table_name)])
           SELECT cols.column_name AS name, cols.data_type AS sql_type,
@@ -603,7 +604,7 @@ module ActiveRecord
                                     NULL) AS limit,
                  DECODE(data_type, 'NUMBER', data_scale, NULL) AS scale,
                  comments.comments as column_comment
-            FROM all_tab_cols cols, all_col_comments comments
+            FROM all_tab_cols#{db_link_suffix} cols, all_col_comments#{db_link_suffix} comments
            WHERE cols.owner      = :owner
              AND cols.table_name = :table_name
              AND cols.hidden_column = 'NO'
@@ -622,10 +623,11 @@ module ActiveRecord
       # *Note*: Only primary key is implemented - sequence will be nil.
       def pk_and_sequence_for(table_name, owner = nil, desc_table_name = nil) # :nodoc:
         (owner, desc_table_name) = _connection.describe(table_name)
+        db_link_suffix = table_name.to_s.include?("@") ? "@#{table_name.to_s.split("@", 2).last}" : ""
 
         seqs = select_values_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("sequence_name", default_sequence_name(desc_table_name))])
           select us.sequence_name
-          from all_sequences us
+          from all_sequences#{db_link_suffix} us
           where us.sequence_owner = :owner
           and us.sequence_name = upper(:sequence_name)
         SQL
@@ -633,7 +635,7 @@ module ActiveRecord
         # changed back from user_constraints to all_constraints for consistency
         pks = select_values_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("table_name", desc_table_name)])
           SELECT cc.column_name
-            FROM all_constraints c, all_cons_columns cc
+            FROM all_constraints#{db_link_suffix} c, all_cons_columns#{db_link_suffix} cc
            WHERE c.owner = :owner
              AND c.table_name = :table_name
              AND c.constraint_type = 'P'

--- a/lib/arel/visitors/oracle_common.rb
+++ b/lib/arel/visitors/oracle_common.rb
@@ -9,6 +9,22 @@ module Arel # :nodoc: all
       def bind_block; BIND_BLOCK; end
 
       private
+        # Oracle db link tables use "table@link" syntax, but the "@link" part must only
+        # appear in the FROM clause. Column qualifiers use just the table name (which Oracle
+        # resolves as the implicit alias for the remote table). Override Arel's table visitor
+        # to emit the "@link" suffix when generating FROM-clause table references.
+        def visit_Arel_Table(o, collector)
+          name = o.name.to_s
+          table_part, link = name.split("@", 2)
+          quoted_name = link ? "#{@connection.quote_table_name(table_part)}@#{link}" : @connection.quote_table_name(name)
+
+          if o.table_alias
+            collector << quoted_name + " " + @connection.quote_table_name(o.table_alias)
+          else
+            collector << quoted_name
+          end
+        end
+
         # Oracle can't compare CLOB columns with standard SQL operators for comparison.
         # We need to replace standard equality for text/binary columns to use DBMS_LOB.COMPARE function.
         # Fixes ORA-00932: inconsistent datatypes: expected - got CLOB

--- a/lib/arel/visitors/oracle_common.rb
+++ b/lib/arel/visitors/oracle_common.rb
@@ -10,9 +10,10 @@ module Arel # :nodoc: all
 
       private
         # Oracle db link tables use "table@link" syntax, but the "@link" part must only
-        # appear in the FROM clause. Column qualifiers use just the table name (which Oracle
-        # resolves as the implicit alias for the remote table). Override Arel's table visitor
-        # to emit the "@link" suffix when generating FROM-clause table references.
+        # appear on table references, not on column qualifiers like table@link.column.
+        # Column qualifiers use just the table name (which Oracle resolves as the implicit
+        # alias for the remote table). Override Arel's table visitor to emit the "@link"
+        # suffix when generating table references, not column qualifiers.
         def visit_Arel_Table(o, collector)
           name = o.name.to_s
           table_part, link = name.split("@", 2)

--- a/spec/active_record/connection_adapters/oracle_enhanced/database_link_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/database_link_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+describe "OracleEnhancedAdapter database link" do
+  before(:all) do
+    # Create a table in oracle_enhanced_remote schema by connecting as that user
+    ActiveRecord::Base.establish_connection(REMOTE_CONNECTION_PARAMS)
+    ActiveRecord::Base.connection.create_table :remote_employees, force: true do |t|
+      t.string :name, limit: 50
+    end
+    ActiveRecord::Base.connection.execute("INSERT INTO remote_employees (id, name) VALUES (1, 'Alice')")
+
+    # Create a database link from oracle_enhanced to oracle_enhanced_remote.
+    # Drop first so the spec is safe to re-run if a previous run crashed before teardown.
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @conn = ActiveRecord::Base.connection
+    begin
+      @conn.execute("DROP DATABASE LINK oracle_enhanced_remote_link")
+    rescue ActiveRecord::StatementInvalid => e
+      raise unless e.message.include?("ORA-02024")
+    end
+    @conn.execute(<<~SQL)
+      CREATE DATABASE LINK oracle_enhanced_remote_link
+        CONNECT TO #{DATABASE_REMOTE_USER} IDENTIFIED BY #{DATABASE_REMOTE_PASSWORD}
+        USING '#{DATABASE_HOST}:#{DATABASE_PORT}/#{DATABASE_NAME}'
+    SQL
+
+    class ::RemoteEmployee < ActiveRecord::Base
+      self.table_name = "remote_employees@oracle_enhanced_remote_link"
+    end
+  end
+
+  after(:all) do
+    Object.send(:remove_const, "RemoteEmployee") if defined?(::RemoteEmployee)
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    begin
+      ActiveRecord::Base.connection.execute("DROP DATABASE LINK oracle_enhanced_remote_link")
+    rescue ActiveRecord::StatementInvalid => e
+      raise unless e.message.include?("ORA-02024")
+    end
+    ActiveRecord::Base.establish_connection(REMOTE_CONNECTION_PARAMS)
+    ActiveRecord::Base.connection.drop_table :remote_employees, if_exists: true
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+  end
+
+  it "reads records from a remote table via a database link" do
+    employees = RemoteEmployee.all.to_a
+    expect(employees.size).to eq(1)
+    expect(employees.first.name).to eq("Alice")
+  end
+
+  it "finds a record by primary key via a database link" do
+    employee = RemoteEmployee.find(1)
+    expect(employee.name).to eq("Alice")
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -198,6 +198,18 @@ SERVICE_NAME_CONNECTION_PARAMS = {
   password: DATABASE_PASSWORD
 }
 
+DATABASE_REMOTE_USER     = config["database"]["remote_user"]     || ENV["DATABASE_REMOTE_USER"]     || "oracle_enhanced_remote"
+DATABASE_REMOTE_PASSWORD = config["database"]["remote_password"] || ENV["DATABASE_REMOTE_PASSWORD"] || "oracle_enhanced_remote"
+
+REMOTE_CONNECTION_PARAMS = {
+  adapter: "oracle_enhanced",
+  database: DATABASE_NAME,
+  host: DATABASE_HOST,
+  port: DATABASE_PORT,
+  username: DATABASE_REMOTE_USER,
+  password: DATABASE_REMOTE_PASSWORD
+}
+
 DATABASE_NON_DEFAULT_TABLESPACE = config["database"]["non_default_tablespace"] || ENV["DATABASE_NON_DEFAULT_TABLESPACE"] || "SYSTEM"
 
 # set default time zone in TZ environment variable

--- a/spec/support/create_oracle_enhanced_users.sql
+++ b/spec/support/create_oracle_enhanced_users.sql
@@ -11,3 +11,11 @@ CREATE USER oracle_enhanced_schema IDENTIFIED BY oracle_enhanced_schema;
 GRANT unlimited tablespace, create session, create table, create sequence,
 create procedure, create trigger, create view, create materialized view,
 create database link, create synonym, create type, ctxapp TO oracle_enhanced_schema;
+
+-- User for loopback database link tests.
+-- The database link connects back to the same database authenticated as this
+-- user, emulating a remote database without needing an external DB.
+CREATE USER oracle_enhanced_remote IDENTIFIED BY oracle_enhanced_remote;
+
+GRANT create session, create table, create sequence, create trigger,
+unlimited tablespace TO oracle_enhanced_remote;


### PR DESCRIPTION
## Summary

Fix the adapter to support \`self.table_name = "table@db_link"\` end-to-end, and add a database link spec to verify it.

### Root causes

1. **\`describe\` raised unconditionally** — \`connection.rb\` called \`raise ArgumentError "db link is not supported"\` (also syntactically invalid Ruby). Replaced with a real query against \`all_tables@link\` / \`all_views@link\`.

2. **Data dictionary views missed the \`@link\` suffix** — \`column_definitions\`, \`pk_and_sequence_for\`, and related queries in \`oracle_enhanced_adapter.rb\` built SQL from \`all_tab_cols\`, \`all_col_comments\`, \`all_sequences\`, \`all_constraints\`, \`all_cons_columns\` without appending \`@link\`. Added \`db_link_suffix\` derived from the table name.

3. **\`table_exists?\` fell through on db-link names** — the early \`false\` branch was missing \`return\`, so execution continued and \`default_owner\` was set to \`nil\`.

4. **Column qualifiers broke Oracle's db-link parsing (ORA-02084)** — after initially fixing \`quote_table_name\` to include \`@link\`, Arel generated \`"TABLE"@link."COL"\`. Oracle parses the dot after a db-link name as a domain separator, not a column separator. Fix: keep \`quote_table_name\` stripping \`@link\` (used for column refs), and add a \`visit_Arel_Table\` override in \`oracle_common.rb\` that appends \`@link\` only in FROM-clause table references. Oracle's implicit alias for \`"TABLE"@link\` is \`"TABLE"\`, so \`"TABLE"."COL"\` column refs resolve correctly.

### Changes

| File | Change |
|------|--------|
| \`connection.rb\` | \`describe\`: query \`all_tables@link\` / \`all_views@link\` instead of raising |
| \`oracle_enhanced_adapter.rb\` | \`column_definitions\`, \`pk_and_sequence_for\`: append \`@link\` suffix to data-dict views |
| \`schema_statements.rb\` | \`table_exists?\`: add missing \`return false\` for db-link names |
| \`oracle_common.rb\` | \`visit_Arel_Table\`: emit \`@link\` in FROM clause only |
| \`quoting.rb\` | Keep existing behavior (strip \`@link\`); used for column qualifiers |
| \`database_link_spec.rb\` | New database link spec using \`oracle_enhanced_remote_link\` |
| \`create_oracle_enhanced_users.sql\` | Add \`oracle_enhanced_remote\` user |
| \`spec_helper.rb\` | Add \`DATABASE_REMOTE_USER\`, \`REMOTE_CONNECTION_PARAMS\` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)