### PR TITLE
Test: #2531 after #2535

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -23,7 +23,18 @@ module ActiveRecord
           def describe(name)
             name = name.to_s
             if name.include?("@")
-              raise ArgumentError "db link is not supported"
+              table_part, db_link = name.split("@", 2)
+              real_name = OracleEnhanced::Quoting.valid_table_name?(table_part) ? table_part.upcase : table_part
+              sql = <<~SQL.squish
+                SELECT owner, table_name FROM all_tables@#{db_link} WHERE table_name = :table_name
+                UNION ALL
+                SELECT owner, view_name FROM all_views@#{db_link} WHERE view_name = :table_name
+              SQL
+              if result = _select_one(sql, "CONNECTION", [real_name, real_name])
+                return [result["owner"], result["table_name"]]
+              else
+                raise OracleEnhanced::ConnectionException, %Q{"DESC #{name}" failed; does it exist?}
+              end
             else
               default_owner = @owner
             end

--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -19,51 +19,27 @@ module ActiveRecord
         attr_reader :raw_connection
 
         private
-          # Used always by JDBC connection as well by OCI connection when describing tables over database link
+          # POC: resolve object name via DBMS_UTILITY.NAME_RESOLVE instead of
+          # querying all_tables / all_views / all_synonyms. NAME_RESOLVE follows
+          # private and public synonyms for us, so no manual recursion is needed.
+          # See https://github.com/rsim/oracle-enhanced/pull/2521#issuecomment-4242585736
           def describe(name)
             name = name.to_s
             if name.include?("@")
               raise ArgumentError "db link is not supported"
-            else
-              default_owner = @owner
             end
-            real_name = OracleEnhanced::Quoting.valid_table_name?(name) ? name.upcase : name
-            if real_name.include?(".")
-              table_owner, table_name = real_name.split(".")
+            if OracleEnhanced::Quoting.valid_table_name?(name)
+              _resolve_name(name.upcase)
             else
-              table_owner, table_name = default_owner, real_name
+              # case-preserving (quoted) identifier: wrap each dotted part
+              # in double quotes so DBMS_UTILITY.NAME_RESOLVE doesn't
+              # uppercase it internally.
+              _resolve_name(name.split(".").map { |p| %("#{p}") }.join("."))
             end
-            sql = <<~SQL.squish
-              SELECT owner, table_name, 'TABLE' name_type
-              FROM all_tables
-              WHERE owner = :table_owner
-                AND table_name = :table_name
-              UNION ALL
-              SELECT owner, view_name table_name, 'VIEW' name_type
-              FROM all_views
-              WHERE owner = :table_owner
-                AND view_name = :table_name
-              UNION ALL
-              SELECT table_owner, table_name, 'SYNONYM' name_type
-              FROM all_synonyms
-              WHERE owner = :table_owner
-                AND synonym_name = :table_name
-              UNION ALL
-              SELECT table_owner, table_name, 'SYNONYM' name_type
-              FROM all_synonyms
-              WHERE owner = 'PUBLIC'
-                AND synonym_name = :real_name
-            SQL
-            if result = _select_one(sql, "CONNECTION", [table_owner, table_name, table_owner, table_name, table_owner, table_name, real_name])
-              case result["name_type"]
-              when "SYNONYM"
-                describe("#{result['owner'] && "#{result['owner']}."}#{result['table_name']}")
-              else
-                [result["owner"], result["table_name"]]
-              end
-            else
-              raise OracleEnhanced::ConnectionException, %Q{"DESC #{name}" failed; does it exist?}
-            end
+          rescue OracleEnhanced::ConnectionException
+            raise
+          rescue => e
+            raise OracleEnhanced::ConnectionException, %Q{"DESC #{name}" failed; does it exist? (#{e.message})}
           end
 
           # Oracle column names by default are case-insensitive, but treated as upcase;

--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -26,17 +26,21 @@ module ActiveRecord
           def describe(name)
             name = name.to_s
             if name.include?("@")
-              raise ArgumentError "db link is not supported"
+              raise ArgumentError, "db link is not supported"
             end
             if OracleEnhanced::Quoting.valid_table_name?(name)
               _resolve_name(name.upcase)
             else
-              # case-preserving (quoted) identifier: wrap each dotted part
-              # in double quotes so DBMS_UTILITY.NAME_RESOLVE doesn't
-              # uppercase it internally.
-              _resolve_name(name.split(".").map { |p| %("#{p}") }.join("."))
+              # Per-part normalization so that e.g. "sys.test_Mixed" becomes
+              # SYS."test_Mixed" — quoting a schema that's actually upcase
+              # internally would make Oracle search for a lowercase schema
+              # and miss it.
+              parts = name.split(".").map do |p|
+                OracleEnhanced::Quoting.valid_table_name?(p) ? p.upcase : %("#{p}")
+              end
+              _resolve_name(parts.join("."))
             end
-          rescue OracleEnhanced::ConnectionException
+          rescue OracleEnhanced::ConnectionException, ArgumentError
             raise
           rescue => e
             raise OracleEnhanced::ConnectionException, %Q{"DESC #{name}" failed; does it exist? (#{e.message})}

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -322,6 +322,23 @@ module ActiveRecord
           @database_version ||= (md = raw_connection.getMetaData) && [md.getDatabaseMajorVersion, md.getDatabaseMinorVersion]
         end
 
+        # POC: call DBMS_UTILITY.NAME_RESOLVE via JDBC CallableStatement with
+        # registered OUT parameters. Returns [schema, object_name].
+        def _resolve_name(name)
+          cs = @raw_connection.prepareCall("BEGIN DBMS_UTILITY.NAME_RESOLVE(?, 0, ?, ?, ?, ?, ?, ?); END;")
+          cs.setString(1, name)
+          cs.registerOutParameter(2, java.sql.Types::VARCHAR) # schema
+          cs.registerOutParameter(3, java.sql.Types::VARCHAR) # part1 (object name)
+          cs.registerOutParameter(4, java.sql.Types::VARCHAR) # part2
+          cs.registerOutParameter(5, java.sql.Types::VARCHAR) # dblink
+          cs.registerOutParameter(6, java.sql.Types::NUMERIC) # part1_type
+          cs.registerOutParameter(7, java.sql.Types::NUMERIC) # object_number
+          cs.execute
+          [cs.getString(2), cs.getString(3)]
+        ensure
+          cs.close rescue nil
+        end
+
         class Cursor
           def initialize(connection, raw_statement, exec_sql = nil)
             @raw_connection = connection

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -101,6 +101,31 @@ module ActiveRecord
           with_retry(allow_retry: allow_retry) { @raw_connection.exec(sql, *bindvars, &block) }
         end
 
+        # POC: call DBMS_UTILITY.NAME_RESOLVE via anonymous PL/SQL block with
+        # OUT binds. Returns [schema, object_name]; synonyms are followed by
+        # the package itself.
+        def _resolve_name(name)
+          plsql = <<~SQL
+            DECLARE
+              l_part2   VARCHAR2(128);
+              l_dblink  VARCHAR2(128);
+              l_type    NUMBER;
+              l_obj_num NUMBER;
+            BEGIN
+              DBMS_UTILITY.NAME_RESOLVE(:name, 0, :out_schema, :out_name,
+                                        l_part2, l_dblink, l_type, l_obj_num);
+            END;
+          SQL
+          cursor = @raw_connection.parse(plsql)
+          cursor.bind_param(":name", name)
+          cursor.bind_param(":out_schema", nil, String, 128)
+          cursor.bind_param(":out_name", nil, String, 128)
+          cursor.exec
+          [cursor[":out_schema"], cursor[":out_name"]]
+        ensure
+          cursor.close rescue nil
+        end
+
         def with_retry(allow_retry: false, &block)
           @raw_connection.with_retry(allow_retry: allow_retry, &block)
         end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -31,8 +31,8 @@ module ActiveRecord
         def table_exists?(table_name)
           table_name = table_name.to_s
           if table_name.include?("@")
-            # db link is not table
-            false
+            # db link tables are not local tables
+            return false
           else
             default_owner = current_schema
           end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -590,6 +590,7 @@ module ActiveRecord
 
       def column_definitions(table_name)
         (owner, desc_table_name) = _connection.describe(table_name)
+        db_link_suffix = table_name.to_s.include?("@") ? "@#{table_name.to_s.split("@", 2).last}" : ""
 
         select_all(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("table_name", desc_table_name)])
           SELECT cols.column_name AS name, cols.data_type AS sql_type,
@@ -603,7 +604,7 @@ module ActiveRecord
                                     NULL) AS limit,
                  DECODE(data_type, 'NUMBER', data_scale, NULL) AS scale,
                  comments.comments as column_comment
-            FROM all_tab_cols cols, all_col_comments comments
+            FROM all_tab_cols#{db_link_suffix} cols, all_col_comments#{db_link_suffix} comments
            WHERE cols.owner      = :owner
              AND cols.table_name = :table_name
              AND cols.hidden_column = 'NO'
@@ -622,10 +623,11 @@ module ActiveRecord
       # *Note*: Only primary key is implemented - sequence will be nil.
       def pk_and_sequence_for(table_name, owner = nil, desc_table_name = nil) # :nodoc:
         (owner, desc_table_name) = _connection.describe(table_name)
+        db_link_suffix = table_name.to_s.include?("@") ? "@#{table_name.to_s.split("@", 2).last}" : ""
 
         seqs = select_values_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("sequence_name", default_sequence_name(desc_table_name))])
           select us.sequence_name
-          from all_sequences us
+          from all_sequences#{db_link_suffix} us
           where us.sequence_owner = :owner
           and us.sequence_name = upper(:sequence_name)
         SQL
@@ -633,7 +635,7 @@ module ActiveRecord
         # changed back from user_constraints to all_constraints for consistency
         pks = select_values_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("table_name", desc_table_name)])
           SELECT cc.column_name
-            FROM all_constraints c, all_cons_columns cc
+            FROM all_constraints#{db_link_suffix} c, all_cons_columns#{db_link_suffix} cc
            WHERE c.owner = :owner
              AND c.table_name = :table_name
              AND c.constraint_type = 'P'

--- a/lib/arel/visitors/oracle_common.rb
+++ b/lib/arel/visitors/oracle_common.rb
@@ -9,6 +9,22 @@ module Arel # :nodoc: all
       def bind_block; BIND_BLOCK; end
 
       private
+        # Oracle db link tables use "table@link" syntax, but the "@link" part must only
+        # appear in the FROM clause. Column qualifiers use just the table name (which Oracle
+        # resolves as the implicit alias for the remote table). Override Arel's table visitor
+        # to emit the "@link" suffix when generating FROM-clause table references.
+        def visit_Arel_Table(o, collector)
+          name = o.name.to_s
+          table_part, link = name.split("@", 2)
+          quoted_name = link ? "#{@connection.quote_table_name(table_part)}@#{link}" : @connection.quote_table_name(name)
+
+          if o.table_alias
+            collector << quoted_name + " " + @connection.quote_table_name(o.table_alias)
+          else
+            collector << quoted_name
+          end
+        end
+
         # Oracle can't compare CLOB columns with standard SQL operators for comparison.
         # We need to replace standard equality for text/binary columns to use DBMS_LOB.COMPARE function.
         # Fixes ORA-00932: inconsistent datatypes: expected - got CLOB

--- a/lib/arel/visitors/oracle_common.rb
+++ b/lib/arel/visitors/oracle_common.rb
@@ -10,9 +10,10 @@ module Arel # :nodoc: all
 
       private
         # Oracle db link tables use "table@link" syntax, but the "@link" part must only
-        # appear in the FROM clause. Column qualifiers use just the table name (which Oracle
-        # resolves as the implicit alias for the remote table). Override Arel's table visitor
-        # to emit the "@link" suffix when generating FROM-clause table references.
+        # appear on table references, not on column qualifiers like table@link.column.
+        # Column qualifiers use just the table name (which Oracle resolves as the implicit
+        # alias for the remote table). Override Arel's table visitor to emit the "@link"
+        # suffix when generating table references, not column qualifiers.
         def visit_Arel_Table(o, collector)
           name = o.name.to_s
           table_part, link = name.split("@", 2)

--- a/script/benchmark_describe.rb
+++ b/script/benchmark_describe.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+# Benchmark for OracleEnhanced::Connection#describe.
+#
+# Intent: compare the describe() implementations across
+#   - master: UNION ALL over all_tables/all_views/all_synonyms
+#   - PR #2521 branch (add-describe-regression-test): single all_objects query
+#   - poc-dbms-utility-name-resolve: DBMS_UTILITY.NAME_RESOLVE
+#
+# The fixture models the production scenario from #2429: ~1000 objects in
+# the schema (700 tables, 100 views, 100 private synonyms, 100 public
+# synonyms).
+#
+# Usage (from repo root):
+#   bundle exec ruby script/benchmark_describe.rb                 # setup + run + teardown
+#   SKIP_SETUP=1 bundle exec ruby script/benchmark_describe.rb    # reuse previous fixtures
+#   SKIP_TEARDOWN=1 bundle exec ruby script/benchmark_describe.rb # keep fixtures for next run
+#
+# Environment variables honored (same defaults as spec_helper.rb):
+#   DATABASE_NAME, DATABASE_HOST, DATABASE_PORT, DATABASE_USER,
+#   DATABASE_PASSWORD, ITERATIONS, TABLE_COUNT, VIEW_COUNT, SYNONYM_COUNT.
+
+require "bundler/setup"
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+require "oci8" if RUBY_ENGINE == "ruby"
+require "active_record"
+require "active_record/connection_adapters/oracle_enhanced_adapter"
+
+TABLE_COUNT   = Integer(ENV["TABLE_COUNT"]   || 700)
+VIEW_COUNT    = Integer(ENV["VIEW_COUNT"]    || 100)
+SYNONYM_COUNT = Integer(ENV["SYNONYM_COUNT"] || 200) # half private, half public
+ITERATIONS    = Integer(ENV["ITERATIONS"]    || 1)
+SKIP_SETUP    = ENV["SKIP_SETUP"]    == "1"
+SKIP_TEARDOWN = ENV["SKIP_TEARDOWN"] == "1"
+
+ActiveRecord::Base.establish_connection(
+  adapter:  "oracle_enhanced",
+  database: ENV["DATABASE_NAME"]     || "XEPDB1",
+  host:     ENV["DATABASE_HOST"]     || "127.0.0.1",
+  port:     Integer(ENV["DATABASE_PORT"] || 1521),
+  username: ENV["DATABASE_USER"]     || "oracle_enhanced",
+  password: ENV["DATABASE_PASSWORD"] || "oracle_enhanced"
+)
+
+conn  = ActiveRecord::Base.connection
+raw   = conn.instance_variable_get(:@raw_connection) || conn.raw_connection
+owner = (ENV["DATABASE_USER"] || "oracle_enhanced").upcase
+
+def t(label)
+  started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  yield
+  elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+  printf("%-20s %8.2fs\n", label, elapsed)
+end
+
+def safe_exec(conn, sql)
+  conn.execute(sql)
+rescue ActiveRecord::StatementInvalid
+  # idempotent: ignore "already exists" / "does not exist"
+end
+
+table_names   = (1..TABLE_COUNT).map { |i| "bench_tbl_%04d" % i }
+view_names    = (1..VIEW_COUNT).map  { |i| "bench_vw_%04d"  % i }
+priv_syn_half = SYNONYM_COUNT / 2
+pub_syn_half  = SYNONYM_COUNT - priv_syn_half
+priv_synonyms = (1..priv_syn_half).map { |i| "bench_syn_%04d" % i }
+pub_synonyms  = (1..pub_syn_half).map  { |i| "bench_pub_%04d" % i }
+
+unless SKIP_SETUP
+  puts "==> Creating #{TABLE_COUNT} tables, #{VIEW_COUNT} views, " \
+       "#{priv_syn_half} private + #{pub_syn_half} public synonyms"
+  t("create tables") do
+    table_names.each { |n| safe_exec conn, "CREATE TABLE #{n} (id NUMBER)" }
+  end
+  t("create views") do
+    view_names.each_with_index do |vn, i|
+      safe_exec conn, "CREATE VIEW #{vn} AS SELECT * FROM #{table_names[i % TABLE_COUNT]}"
+    end
+  end
+  t("create synonyms") do
+    priv_synonyms.each_with_index do |sn, i|
+      safe_exec conn, "CREATE SYNONYM #{sn} FOR #{table_names[i % TABLE_COUNT]}"
+    end
+    pub_synonyms.each_with_index do |sn, i|
+      safe_exec conn, "CREATE PUBLIC SYNONYM #{sn} FOR #{owner}.#{table_names[i % TABLE_COUNT]}"
+    end
+  end
+end
+
+begin
+  all_names = table_names + view_names + priv_synonyms + pub_synonyms
+
+  # Warm-up pass so dictionary-cache / shared-pool state is primed; the
+  # first describe() after login otherwise dominates wall clock.
+  all_names.first(50).each { |n| raw.send(:describe, n) }
+
+  head_branch = `git rev-parse --abbrev-ref HEAD`.strip
+  head_sha    = `git rev-parse --short HEAD`.strip
+  puts
+  puts "==> branch: #{head_branch} (#{head_sha})"
+  puts "==> fixtures: #{TABLE_COUNT} tables, #{VIEW_COUNT} views, " \
+       "#{priv_syn_half} private synonyms, #{pub_syn_half} public synonyms"
+  puts "==> describe() calls per pass: #{all_names.size}"
+  puts "==> passes: #{ITERATIONS}"
+  puts
+
+  printf("%-20s %10s %10s\n", "case", "wall(s)", "avg(ms)")
+  cases = {
+    "tables"          => table_names,
+    "views"           => view_names,
+    "private synonyms" => priv_synonyms,
+    "public synonyms"  => pub_synonyms,
+    "all mixed"        => all_names.shuffle,
+  }
+  cases.each do |label, names|
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    ITERATIONS.times { names.each { |n| raw.send(:describe, n) } }
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+    per_call_ms = (elapsed * 1000.0) / (ITERATIONS * names.size)
+    printf("%-20s %10.3f %10.3f\n", label, elapsed, per_call_ms)
+  end
+ensure
+  unless SKIP_TEARDOWN
+    puts
+    puts "==> Dropping fixtures"
+    t("drop public syns") { pub_synonyms.each  { |n| safe_exec conn, "DROP PUBLIC SYNONYM #{n}" } }
+    t("drop private syns") { priv_synonyms.each { |n| safe_exec conn, "DROP SYNONYM #{n}" } }
+    t("drop views")        { view_names.each    { |n| safe_exec conn, "DROP VIEW #{n}" } }
+    t("drop tables")       { table_names.each   { |n| safe_exec conn, "DROP TABLE #{n} PURGE" } }
+  end
+end

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -599,6 +599,23 @@ describe "OracleEnhancedConnection" do
       expect(@conn.describe("all_tables")).to eq(["SYS", "ALL_TABLES"])
     end
 
+    it "should describe table, view, private synonym and public synonym for the same underlying table" do
+      @conn.exec "CREATE TABLE test_describe_all (id NUMBER)" rescue nil
+      @conn.exec "CREATE VIEW test_describe_all_v AS SELECT * FROM test_describe_all" rescue nil
+      @conn.exec "CREATE SYNONYM test_describe_all_syn FOR test_describe_all" rescue nil
+      @conn.exec "CREATE PUBLIC SYNONYM test_describe_all_pub FOR #{@owner}.test_describe_all" rescue nil
+
+      expect(@conn.describe("test_describe_all")).to eq([@owner, "TEST_DESCRIBE_ALL"])
+      expect(@conn.describe("test_describe_all_v")).to eq([@owner, "TEST_DESCRIBE_ALL_V"])
+      expect(@conn.describe("test_describe_all_syn")).to eq([@owner, "TEST_DESCRIBE_ALL"])
+      expect(@conn.describe("test_describe_all_pub")).to eq([@owner, "TEST_DESCRIBE_ALL"])
+    ensure
+      @conn.exec "DROP PUBLIC SYNONYM test_describe_all_pub" rescue nil
+      @conn.exec "DROP SYNONYM test_describe_all_syn" rescue nil
+      @conn.exec "DROP VIEW test_describe_all_v" rescue nil
+      @conn.exec "DROP TABLE test_describe_all" rescue nil
+    end
+
     if defined?(OCI8)
       context "OCI8 adapter" do
         it "should not fallback to SELECT-based logic when querying non-existent table information" do

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -606,10 +606,6 @@ describe "OracleEnhancedConnection" do
       @conn.exec %{DROP TABLE "test_Mixed_Case_Desc"} rescue nil
     end
 
-    it "should raise ArgumentError when the name contains a database link" do
-      expect { @conn.describe("some_table@remote_link") }.to raise_error(ArgumentError)
-    end
-
     it "should describe table, view, private synonym and public synonym for the same underlying table" do
       @conn.exec "CREATE TABLE test_describe_all (id NUMBER)" rescue nil
       @conn.exec "CREATE VIEW test_describe_all_v AS SELECT * FROM test_describe_all" rescue nil

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -599,6 +599,17 @@ describe "OracleEnhancedConnection" do
       expect(@conn.describe("all_tables")).to eq(["SYS", "ALL_TABLES"])
     end
 
+    it "should describe a mixed-case quoted table qualified with its owner" do
+      @conn.exec %{CREATE TABLE "test_Mixed_Case_Desc" (id NUMBER)} rescue nil
+      expect(@conn.describe(%{#{@owner}.test_Mixed_Case_Desc})).to eq([@owner, "test_Mixed_Case_Desc"])
+    ensure
+      @conn.exec %{DROP TABLE "test_Mixed_Case_Desc"} rescue nil
+    end
+
+    it "should raise ArgumentError when the name contains a database link" do
+      expect { @conn.describe("some_table@remote_link") }.to raise_error(ArgumentError)
+    end
+
     it "should describe table, view, private synonym and public synonym for the same underlying table" do
       @conn.exec "CREATE TABLE test_describe_all (id NUMBER)" rescue nil
       @conn.exec "CREATE VIEW test_describe_all_v AS SELECT * FROM test_describe_all" rescue nil

--- a/spec/active_record/connection_adapters/oracle_enhanced/database_link_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/database_link_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+describe "OracleEnhancedAdapter database link" do
+  before(:all) do
+    # Create a table in oracle_enhanced_remote schema by connecting as that user
+    ActiveRecord::Base.establish_connection(REMOTE_CONNECTION_PARAMS)
+    ActiveRecord::Base.connection.create_table :remote_employees, force: true do |t|
+      t.string :name, limit: 50
+    end
+    ActiveRecord::Base.connection.execute("INSERT INTO remote_employees (id, name) VALUES (1, 'Alice')")
+
+    # Create a database link from oracle_enhanced to oracle_enhanced_remote.
+    # Drop first so the spec is safe to re-run if a previous run crashed before teardown.
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @conn = ActiveRecord::Base.connection
+    begin
+      @conn.execute("DROP DATABASE LINK oracle_enhanced_remote_link")
+    rescue ActiveRecord::StatementInvalid => e
+      raise unless e.message.include?("ORA-02024")
+    end
+    @conn.execute(<<~SQL)
+      CREATE DATABASE LINK oracle_enhanced_remote_link
+        CONNECT TO #{DATABASE_REMOTE_USER} IDENTIFIED BY #{DATABASE_REMOTE_PASSWORD}
+        USING '#{DATABASE_HOST}:#{DATABASE_PORT}/#{DATABASE_NAME}'
+    SQL
+
+    class ::RemoteEmployee < ActiveRecord::Base
+      self.table_name = "remote_employees@oracle_enhanced_remote_link"
+    end
+  end
+
+  after(:all) do
+    Object.send(:remove_const, "RemoteEmployee") if defined?(::RemoteEmployee)
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    begin
+      ActiveRecord::Base.connection.execute("DROP DATABASE LINK oracle_enhanced_remote_link")
+    rescue ActiveRecord::StatementInvalid => e
+      raise unless e.message.include?("ORA-02024")
+    end
+    ActiveRecord::Base.establish_connection(REMOTE_CONNECTION_PARAMS)
+    ActiveRecord::Base.connection.drop_table :remote_employees, if_exists: true
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+  end
+
+  it "reads records from a remote table via a database link" do
+    employees = RemoteEmployee.all.to_a
+    expect(employees.size).to eq(1)
+    expect(employees.first.name).to eq("Alice")
+  end
+
+  it "finds a record by primary key via a database link" do
+    employee = RemoteEmployee.find(1)
+    expect(employee.name).to eq("Alice")
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -205,3 +205,10 @@ DATABASE_NON_DEFAULT_TABLESPACE = config["database"]["non_default_tablespace"] |
 ENV["TZ"] ||= config["timezone"] || "Europe/Riga"
 
 ActiveRecord::Base.logger = ActiveSupport::Logger.new("debug.log", 0, 100 * 1024 * 1024)
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    ActiveRecord::Base.connection.execute("PURGE RECYCLEBIN")
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -198,6 +198,18 @@ SERVICE_NAME_CONNECTION_PARAMS = {
   password: DATABASE_PASSWORD
 }
 
+DATABASE_REMOTE_USER     = config["database"]["remote_user"]     || ENV["DATABASE_REMOTE_USER"]     || "oracle_enhanced_remote"
+DATABASE_REMOTE_PASSWORD = config["database"]["remote_password"] || ENV["DATABASE_REMOTE_PASSWORD"] || "oracle_enhanced_remote"
+
+REMOTE_CONNECTION_PARAMS = {
+  adapter: "oracle_enhanced",
+  database: DATABASE_NAME,
+  host: DATABASE_HOST,
+  port: DATABASE_PORT,
+  username: DATABASE_REMOTE_USER,
+  password: DATABASE_REMOTE_PASSWORD
+}
+
 DATABASE_NON_DEFAULT_TABLESPACE = config["database"]["non_default_tablespace"] || ENV["DATABASE_NON_DEFAULT_TABLESPACE"] || "SYSTEM"
 
 # set default time zone in TZ environment variable

--- a/spec/support/create_oracle_enhanced_users.sql
+++ b/spec/support/create_oracle_enhanced_users.sql
@@ -4,10 +4,12 @@ CREATE USER oracle_enhanced IDENTIFIED BY oracle_enhanced;
 
 GRANT unlimited tablespace, create session, create table, create sequence,
 create procedure, create trigger, create view, create materialized view,
-create database link, create synonym, create type, ctxapp TO oracle_enhanced;
+create database link, create synonym, create public synonym, create type, ctxapp TO oracle_enhanced;
+GRANT drop public synonym TO oracle_enhanced;
 
 CREATE USER oracle_enhanced_schema IDENTIFIED BY oracle_enhanced_schema;
 
 GRANT unlimited tablespace, create session, create table, create sequence,
 create procedure, create trigger, create view, create materialized view,
-create database link, create synonym, create type, ctxapp TO oracle_enhanced_schema;
+create database link, create synonym, create public synonym, create type, ctxapp TO oracle_enhanced_schema;
+GRANT drop public synonym TO oracle_enhanced_schema;

--- a/spec/support/create_oracle_enhanced_users.sql
+++ b/spec/support/create_oracle_enhanced_users.sql
@@ -11,3 +11,11 @@ CREATE USER oracle_enhanced_schema IDENTIFIED BY oracle_enhanced_schema;
 GRANT unlimited tablespace, create session, create table, create sequence,
 create procedure, create trigger, create view, create materialized view,
 create database link, create synonym, create type, ctxapp TO oracle_enhanced_schema;
+
+-- User for loopback database link tests.
+-- The database link connects back to the same database authenticated as this
+-- user, emulating a remote database without needing an external DB.
+CREATE USER oracle_enhanced_remote IDENTIFIED BY oracle_enhanced_remote;
+
+GRANT create session, create table, create sequence, create trigger,
+unlimited tablespace TO oracle_enhanced_remote;


### PR DESCRIPTION
Verify PR #2531 (DBMS_UTILITY.NAME_RESOLVE) applies cleanly after PR #2535 (db link support) merges. Conflicts resolved: connection.rb db-link branch preserved; create_oracle_enhanced_users.sql combined both grant sets.