### PR TITLE
Add specs for Rails multiple database support and read/write split

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -874,17 +874,17 @@ module ActiveRecord
 
           case _connection.error_code(exception)
           when 1
-            RecordNotUnique.new(message, sql: sql, binds: binds)
+            RecordNotUnique.new(message, sql: sql, binds: binds, connection_pool: @pool)
           when 60
-            Deadlocked.new(message)
+            Deadlocked.new(message, sql: sql, binds: binds, connection_pool: @pool)
           when 900, 904, 942, 955, 1418, 2289, 2449, 17008
-            ActiveRecord::StatementInvalid.new(message, sql: sql, binds: binds)
+            ActiveRecord::StatementInvalid.new(message, sql: sql, binds: binds, connection_pool: @pool)
           when 1400
-            ActiveRecord::NotNullViolation.new(message, sql: sql, binds: binds)
+            ActiveRecord::NotNullViolation.new(message, sql: sql, binds: binds, connection_pool: @pool)
           when 2291, 2292
-            InvalidForeignKey.new(message, sql: sql, binds: binds)
+            InvalidForeignKey.new(message, sql: sql, binds: binds, connection_pool: @pool)
           when 12899
-            ValueTooLong.new(message, sql: sql, binds: binds)
+            ValueTooLong.new(message, sql: sql, binds: binds, connection_pool: @pool)
           else
             super
           end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -803,17 +803,17 @@ module ActiveRecord
 
         case _connection.error_code(exception)
         when 1
-          RecordNotUnique.new(message, sql: sql, binds: binds)
+          RecordNotUnique.new(message, sql: sql, binds: binds, connection_pool: @pool)
         when 60
-          Deadlocked.new(message)
+          Deadlocked.new(message, sql: sql, binds: binds, connection_pool: @pool)
         when 900, 904, 942, 955, 1418, 2289, 2449, 17008
-          ActiveRecord::StatementInvalid.new(message, sql: sql, binds: binds)
+          ActiveRecord::StatementInvalid.new(message, sql: sql, binds: binds, connection_pool: @pool)
         when 1400
-          ActiveRecord::NotNullViolation.new(message, sql: sql, binds: binds)
+          ActiveRecord::NotNullViolation.new(message, sql: sql, binds: binds, connection_pool: @pool)
         when 2291, 2292
-          InvalidForeignKey.new(message, sql: sql, binds: binds)
+          InvalidForeignKey.new(message, sql: sql, binds: binds, connection_pool: @pool)
         when 12899
-          ValueTooLong.new(message, sql: sql, binds: binds)
+          ValueTooLong.new(message, sql: sql, binds: binds, connection_pool: @pool)
         else
           super
         end

--- a/spec/active_record/connection_adapters/oracle_enhanced/multiple_databases_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/multiple_databases_spec.rb
@@ -21,6 +21,7 @@ describe "OracleEnhancedAdapter multiple database support" do
 
     ActiveRecord::Base.connection.create_table :multi_db_primary_employees, force: true do |t|
       t.string :name, limit: 50
+      t.integer :multi_db_remote_employee_id
     end
 
     MultiDbRemoteBase.connection.create_table :multi_db_remote_employees, force: true do |t|
@@ -29,10 +30,12 @@ describe "OracleEnhancedAdapter multiple database support" do
 
     class ::MultiDbPrimaryEmployee < ActiveRecord::Base
       self.table_name = "multi_db_primary_employees"
+      belongs_to :multi_db_remote_employee
     end
 
     class ::MultiDbRemoteEmployee < MultiDbRemoteBase
       self.table_name = "multi_db_remote_employees"
+      has_many :multi_db_primary_employees, foreign_key: :multi_db_remote_employee_id
     end
 
     # A second model inheriting from the same abstract base to test connection sharing
@@ -40,8 +43,8 @@ describe "OracleEnhancedAdapter multiple database support" do
       self.table_name = "multi_db_remote_employees"
     end
 
-    MultiDbPrimaryEmployee.create!(id: 1, name: "Primary Alice")
-    MultiDbPrimaryEmployee.create!(id: 2, name: "Primary Bob")
+    MultiDbPrimaryEmployee.create!(id: 1, name: "Primary Alice", multi_db_remote_employee_id: 1)
+    MultiDbPrimaryEmployee.create!(id: 2, name: "Primary Bob", multi_db_remote_employee_id: 2)
     MultiDbRemoteEmployee.create!(id: 1, name: "Remote Alice")
     MultiDbRemoteEmployee.create!(id: 2, name: "Remote Bob")
   end
@@ -55,6 +58,7 @@ describe "OracleEnhancedAdapter multiple database support" do
     %w[MultiDbPrimaryEmployee MultiDbRemoteEmployee MultiDbRemoteEmployee2 MultiDbRemoteBase].each do |name|
       Object.send(:remove_const, name) if Object.const_defined?(name)
     end
+    ActiveRecord::Base.clear_cache!
   end
 
   # Adapted from test_connected
@@ -96,10 +100,13 @@ describe "OracleEnhancedAdapter multiple database support" do
     expect(MultiDbPrimaryEmployee.count).to eq(2)
   end
 
-  # Adapted from test_transactions_across_databases
-  # The raised RuntimeError propagates out of both transaction blocks, so each
-  # connection rolls back its own transaction on its own — demonstrating that
-  # there is no shared coordinator between the two connections' transactions.
+  # Adapted from test_transactions_across_databases.
+  # Note: because the RuntimeError propagates out of both transaction blocks,
+  # both connections roll back here. This matches the Rails original, but on
+  # its own it cannot distinguish "each connection rolled back independently"
+  # from "one rollback cascaded through a shared coordinator". The
+  # "only the inner remote transaction is rolled back" spec below verifies the
+  # independence property more directly.
   it "transactions are independent per connection" do
     p1 = MultiDbPrimaryEmployee.find(1)
     r1 = MultiDbRemoteEmployee.find(1)
@@ -121,6 +128,29 @@ describe "OracleEnhancedAdapter multiple database support" do
     # Each model's transaction rolled back independently
     expect(MultiDbPrimaryEmployee.find(1).name).to eq("Primary Alice")
     expect(MultiDbRemoteEmployee.find(1).name).to eq("Remote Alice")
+  end
+
+  # Directly verifies transaction independence: rolling back the inner remote
+  # transaction (via ActiveRecord::Rollback) must not roll back the outer
+  # primary transaction, since the two connections are separate. If a shared
+  # coordinator were linking them, the primary commit would also be lost and
+  # this spec would fail.
+  it "only the inner remote transaction is rolled back when the primary transaction commits" do
+    p1 = MultiDbPrimaryEmployee.find(1)
+    r1 = MultiDbRemoteEmployee.find(1)
+
+    MultiDbPrimaryEmployee.transaction do
+      p1.update!(name: "Primary Changed")
+      MultiDbRemoteEmployee.transaction do
+        r1.update!(name: "Remote Changed")
+        raise ActiveRecord::Rollback
+      end
+    end
+
+    expect(MultiDbPrimaryEmployee.find(1).name).to eq("Primary Changed")
+    expect(MultiDbRemoteEmployee.find(1).name).to eq("Remote Alice")
+  ensure
+    MultiDbPrimaryEmployee.where(id: 1).update_all(name: "Primary Alice")
   end
 
   # Adapted from base_prevent_writes_test.rb — read/write split via while_preventing_writes
@@ -161,6 +191,24 @@ describe "OracleEnhancedAdapter multiple database support" do
     end
   end
 
+  # Adapted from test "an explain query does not raise if preventing writes"
+  it "an EXPLAIN query does not raise inside while_preventing_writes" do
+    ActiveRecord::Base.while_preventing_writes do
+      expect { MultiDbPrimaryEmployee.where(name: "Primary Alice").explain.inspect }.not_to raise_error
+    end
+  end
+
+  # Adapted from test "an empty transaction does not raise if preventing writes"
+  it "an empty transaction does not raise inside while_preventing_writes" do
+    expect {
+      ActiveRecord::Base.while_preventing_writes do
+        MultiDbPrimaryEmployee.transaction do
+          ActiveRecord::Base.lease_connection.materialize_transactions
+        end
+      end
+    }.not_to raise_error
+  end
+
   # Adapted from test "current_preventing_writes"
   it "current_preventing_writes returns true inside while_preventing_writes" do
     ActiveRecord::Base.while_preventing_writes do
@@ -186,7 +234,10 @@ describe "OracleEnhancedAdapter multiple database support" do
     MultiDbRemoteEmployee.connection_specification_name = original
   end
 
-  # Adapted from test_exception_contains_connection_pool
+  # Adapted from test_exception_contains_connection_pool.
+  # ORA-00904 ("invalid identifier") is the specific error we expect here —
+  # pinning the code ensures the test fails loudly if a different error
+  # (connection failure, pool exhaustion, etc.) masquerades as success.
   it "StatementInvalid error references the correct connection pool" do
     error = nil
     begin
@@ -195,6 +246,70 @@ describe "OracleEnhancedAdapter multiple database support" do
       error = e
     end
     expect(error).not_to be_nil
+    expect(error.message).to match(/ORA-00904/)
     expect(error.connection_pool).to eq(MultiDbRemoteEmployee.lease_connection.pool)
+  end
+
+  # Adapted from test_exception_contains_correct_pool.
+  # ORA-00942 ("table or view does not exist") is the expected error for a
+  # cross-schema SELECT without grants — pinning the code guards against
+  # unrelated failures being accepted by the broader StatementInvalid rescue.
+  it "StatementInvalid error from each connection references its own pool" do
+    primary_conn = MultiDbPrimaryEmployee.lease_connection
+    remote_conn = MultiDbRemoteEmployee.lease_connection
+    expect(primary_conn).not_to eq(remote_conn)
+
+    primary_error = nil
+    begin
+      primary_conn.execute("SELECT * FROM #{DATABASE_REMOTE_USER}.multi_db_remote_employees")
+    rescue ActiveRecord::StatementInvalid => e
+      primary_error = e
+    end
+    expect(primary_error).not_to be_nil
+    expect(primary_error.message).to match(/ORA-00942/)
+    expect(primary_error.connection_pool).to eq(primary_conn.pool)
+
+    remote_error = nil
+    begin
+      remote_conn.execute("SELECT * FROM #{DATABASE_USER}.multi_db_primary_employees")
+    rescue ActiveRecord::StatementInvalid => e
+      remote_error = e
+    end
+    expect(remote_error).not_to be_nil
+    expect(remote_error.message).to match(/ORA-00942/)
+    expect(remote_error.connection_pool).to eq(remote_conn.pool)
+  end
+
+  # Adapted from test_associations
+  it "associations work across connections" do
+    r1 = MultiDbRemoteEmployee.find(1)
+    expect(r1.multi_db_primary_employees.count).to eq(1)
+    p1 = MultiDbPrimaryEmployee.find(1)
+    expect(p1.multi_db_remote_employee.id).to eq(r1.id)
+
+    r2 = MultiDbRemoteEmployee.find(2)
+    expect(r2.multi_db_primary_employees.count).to eq(1)
+    p2 = MultiDbPrimaryEmployee.find(2)
+    expect(p2.multi_db_remote_employee.id).to eq(r2.id)
+  end
+
+  # Adapted from test_associations_should_work_when_model_has_no_connection
+  it "associations work on a model whose connection is inherited from an abstract base" do
+    expect { MultiDbRemoteEmployee.first.multi_db_primary_employees.first }.not_to raise_error
+  end
+
+  # Adapted from test_course_connection_should_survive_reloads
+  it "connection survives model reload" do
+    original = MultiDbRemoteEmployee
+    expect(original.lease_connection).not_to be_nil
+    Object.send(:remove_const, :MultiDbRemoteEmployee)
+    class ::MultiDbRemoteEmployee < MultiDbRemoteBase
+      self.table_name = "multi_db_remote_employees"
+      has_many :multi_db_primary_employees, foreign_key: :multi_db_remote_employee_id
+    end
+    expect(MultiDbRemoteEmployee.lease_connection).not_to be_nil
+  ensure
+    Object.send(:remove_const, :MultiDbRemoteEmployee) if Object.const_defined?(:MultiDbRemoteEmployee)
+    Object.const_set(:MultiDbRemoteEmployee, original) if original
   end
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced/multiple_databases_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/multiple_databases_spec.rb
@@ -21,6 +21,7 @@ describe "OracleEnhancedAdapter multiple database support" do
 
     ActiveRecord::Base.connection.create_table :multi_db_primary_employees, force: true do |t|
       t.string :name, limit: 50
+      t.integer :multi_db_remote_employee_id
     end
 
     MultiDbRemoteBase.connection.create_table :multi_db_remote_employees, force: true do |t|
@@ -29,10 +30,12 @@ describe "OracleEnhancedAdapter multiple database support" do
 
     class ::MultiDbPrimaryEmployee < ActiveRecord::Base
       self.table_name = "multi_db_primary_employees"
+      belongs_to :multi_db_remote_employee
     end
 
     class ::MultiDbRemoteEmployee < MultiDbRemoteBase
       self.table_name = "multi_db_remote_employees"
+      has_many :multi_db_primary_employees, foreign_key: :multi_db_remote_employee_id
     end
 
     # A second model inheriting from the same abstract base to test connection sharing
@@ -40,8 +43,8 @@ describe "OracleEnhancedAdapter multiple database support" do
       self.table_name = "multi_db_remote_employees"
     end
 
-    MultiDbPrimaryEmployee.create!(id: 1, name: "Primary Alice")
-    MultiDbPrimaryEmployee.create!(id: 2, name: "Primary Bob")
+    MultiDbPrimaryEmployee.create!(id: 1, name: "Primary Alice", multi_db_remote_employee_id: 1)
+    MultiDbPrimaryEmployee.create!(id: 2, name: "Primary Bob", multi_db_remote_employee_id: 2)
     MultiDbRemoteEmployee.create!(id: 1, name: "Remote Alice")
     MultiDbRemoteEmployee.create!(id: 2, name: "Remote Bob")
   end
@@ -63,6 +66,7 @@ describe "OracleEnhancedAdapter multiple database support" do
       end
       ActiveRecord::Base.clear_cache!
     end
+    ActiveRecord::Base.clear_cache!
   end
 
   # Adapted from test_connected
@@ -104,10 +108,13 @@ describe "OracleEnhancedAdapter multiple database support" do
     expect(MultiDbPrimaryEmployee.count).to eq(2)
   end
 
-  # Adapted from test_transactions_across_databases
-  # The raised RuntimeError propagates out of both transaction blocks, so each
-  # connection rolls back its own transaction on its own — demonstrating that
-  # there is no shared coordinator between the two connections' transactions.
+  # Adapted from test_transactions_across_databases.
+  # Note: because the RuntimeError propagates out of both transaction blocks,
+  # both connections roll back here. This matches the Rails original, but on
+  # its own it cannot distinguish "each connection rolled back independently"
+  # from "one rollback cascaded through a shared coordinator". The
+  # "only the inner remote transaction is rolled back" spec below verifies the
+  # independence property more directly.
   it "transactions are independent per connection" do
     p1 = MultiDbPrimaryEmployee.find(1)
     r1 = MultiDbRemoteEmployee.find(1)
@@ -129,6 +136,29 @@ describe "OracleEnhancedAdapter multiple database support" do
     # Each model's transaction rolled back independently
     expect(MultiDbPrimaryEmployee.find(1).name).to eq("Primary Alice")
     expect(MultiDbRemoteEmployee.find(1).name).to eq("Remote Alice")
+  end
+
+  # Directly verifies transaction independence: rolling back the inner remote
+  # transaction (via ActiveRecord::Rollback) must not roll back the outer
+  # primary transaction, since the two connections are separate. If a shared
+  # coordinator were linking them, the primary commit would also be lost and
+  # this spec would fail.
+  it "only the inner remote transaction is rolled back when the primary transaction commits" do
+    p1 = MultiDbPrimaryEmployee.find(1)
+    r1 = MultiDbRemoteEmployee.find(1)
+
+    MultiDbPrimaryEmployee.transaction do
+      p1.update!(name: "Primary Changed")
+      MultiDbRemoteEmployee.transaction do
+        r1.update!(name: "Remote Changed")
+        raise ActiveRecord::Rollback
+      end
+    end
+
+    expect(MultiDbPrimaryEmployee.find(1).name).to eq("Primary Changed")
+    expect(MultiDbRemoteEmployee.find(1).name).to eq("Remote Alice")
+  ensure
+    MultiDbPrimaryEmployee.where(id: 1).update_all(name: "Primary Alice")
   end
 
   # Adapted from base_prevent_writes_test.rb — read/write split via while_preventing_writes
@@ -169,6 +199,24 @@ describe "OracleEnhancedAdapter multiple database support" do
     end
   end
 
+  # Adapted from test "an explain query does not raise if preventing writes"
+  it "an EXPLAIN query does not raise inside while_preventing_writes" do
+    ActiveRecord::Base.while_preventing_writes do
+      expect { MultiDbPrimaryEmployee.where(name: "Primary Alice").explain.inspect }.not_to raise_error
+    end
+  end
+
+  # Adapted from test "an empty transaction does not raise if preventing writes"
+  it "an empty transaction does not raise inside while_preventing_writes" do
+    expect {
+      ActiveRecord::Base.while_preventing_writes do
+        MultiDbPrimaryEmployee.transaction do
+          ActiveRecord::Base.lease_connection.materialize_transactions
+        end
+      end
+    }.not_to raise_error
+  end
+
   # Adapted from test "current_preventing_writes"
   it "current_preventing_writes returns true inside while_preventing_writes" do
     ActiveRecord::Base.while_preventing_writes do
@@ -194,7 +242,10 @@ describe "OracleEnhancedAdapter multiple database support" do
     MultiDbRemoteEmployee.connection_specification_name = original
   end
 
-  # Adapted from test_exception_contains_connection_pool
+  # Adapted from test_exception_contains_connection_pool.
+  # ORA-00904 ("invalid identifier") is the specific error we expect here —
+  # pinning the code ensures the test fails loudly if a different error
+  # (connection failure, pool exhaustion, etc.) masquerades as success.
   it "StatementInvalid error references the correct connection pool" do
     error = nil
     begin
@@ -203,6 +254,70 @@ describe "OracleEnhancedAdapter multiple database support" do
       error = e
     end
     expect(error).not_to be_nil
+    expect(error.message).to match(/ORA-00904/)
     expect(error.connection_pool).to eq(MultiDbRemoteEmployee.lease_connection.pool)
+  end
+
+  # Adapted from test_exception_contains_correct_pool.
+  # ORA-00942 ("table or view does not exist") is the expected error for a
+  # cross-schema SELECT without grants — pinning the code guards against
+  # unrelated failures being accepted by the broader StatementInvalid rescue.
+  it "StatementInvalid error from each connection references its own pool" do
+    primary_conn = MultiDbPrimaryEmployee.lease_connection
+    remote_conn = MultiDbRemoteEmployee.lease_connection
+    expect(primary_conn).not_to eq(remote_conn)
+
+    primary_error = nil
+    begin
+      primary_conn.execute("SELECT * FROM #{DATABASE_REMOTE_USER}.multi_db_remote_employees")
+    rescue ActiveRecord::StatementInvalid => e
+      primary_error = e
+    end
+    expect(primary_error).not_to be_nil
+    expect(primary_error.message).to match(/ORA-00942/)
+    expect(primary_error.connection_pool).to eq(primary_conn.pool)
+
+    remote_error = nil
+    begin
+      remote_conn.execute("SELECT * FROM #{DATABASE_USER}.multi_db_primary_employees")
+    rescue ActiveRecord::StatementInvalid => e
+      remote_error = e
+    end
+    expect(remote_error).not_to be_nil
+    expect(remote_error.message).to match(/ORA-00942/)
+    expect(remote_error.connection_pool).to eq(remote_conn.pool)
+  end
+
+  # Adapted from test_associations
+  it "associations work across connections" do
+    r1 = MultiDbRemoteEmployee.find(1)
+    expect(r1.multi_db_primary_employees.count).to eq(1)
+    p1 = MultiDbPrimaryEmployee.find(1)
+    expect(p1.multi_db_remote_employee.id).to eq(r1.id)
+
+    r2 = MultiDbRemoteEmployee.find(2)
+    expect(r2.multi_db_primary_employees.count).to eq(1)
+    p2 = MultiDbPrimaryEmployee.find(2)
+    expect(p2.multi_db_remote_employee.id).to eq(r2.id)
+  end
+
+  # Adapted from test_associations_should_work_when_model_has_no_connection
+  it "associations work on a model whose connection is inherited from an abstract base" do
+    expect { MultiDbRemoteEmployee.first.multi_db_primary_employees.first }.not_to raise_error
+  end
+
+  # Adapted from test_course_connection_should_survive_reloads
+  it "connection survives model reload" do
+    original = MultiDbRemoteEmployee
+    expect(original.lease_connection).not_to be_nil
+    Object.send(:remove_const, :MultiDbRemoteEmployee)
+    class ::MultiDbRemoteEmployee < MultiDbRemoteBase
+      self.table_name = "multi_db_remote_employees"
+      has_many :multi_db_primary_employees, foreign_key: :multi_db_remote_employee_id
+    end
+    expect(MultiDbRemoteEmployee.lease_connection).not_to be_nil
+  ensure
+    Object.send(:remove_const, :MultiDbRemoteEmployee) if Object.const_defined?(:MultiDbRemoteEmployee)
+    Object.const_set(:MultiDbRemoteEmployee, original) if original
   end
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced/multiple_databases_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/multiple_databases_spec.rb
@@ -123,6 +123,60 @@ describe "OracleEnhancedAdapter multiple database support" do
     expect(MultiDbRemoteEmployee.find(1).name).to eq("Remote Alice")
   end
 
+  # Adapted from base_prevent_writes_test.rb — read/write split via while_preventing_writes
+
+  # Adapted from test "creating a record raises if preventing writes"
+  it "raises ReadOnlyError on INSERT inside while_preventing_writes" do
+    expect {
+      ActiveRecord::Base.while_preventing_writes do
+        MultiDbPrimaryEmployee.create!(name: "Tempbird")
+      end
+    }.to raise_error(ActiveRecord::ReadOnlyError, /Write query attempted while in readonly mode: INSERT/)
+  end
+
+  # Adapted from test "updating a record raises if preventing writes"
+  it "raises ReadOnlyError on UPDATE inside while_preventing_writes" do
+    p1 = MultiDbPrimaryEmployee.find(1)
+    expect {
+      ActiveRecord::Base.while_preventing_writes do
+        p1.update!(name: "Changed")
+      end
+    }.to raise_error(ActiveRecord::ReadOnlyError, /Write query attempted while in readonly mode: UPDATE/)
+  end
+
+  # Adapted from test "deleting a record raises if preventing writes"
+  it "raises ReadOnlyError on DELETE inside while_preventing_writes" do
+    p1 = MultiDbPrimaryEmployee.find(1)
+    expect {
+      ActiveRecord::Base.while_preventing_writes do
+        p1.destroy!
+      end
+    }.to raise_error(ActiveRecord::ReadOnlyError, /Write query attempted while in readonly mode: DELETE/)
+  end
+
+  # Adapted from test "selecting a record does not raise if preventing writes"
+  it "does not raise on SELECT inside while_preventing_writes" do
+    ActiveRecord::Base.while_preventing_writes do
+      expect(MultiDbPrimaryEmployee.where(name: "Primary Alice").first).not_to be_nil
+    end
+  end
+
+  # Adapted from test "current_preventing_writes"
+  it "current_preventing_writes returns true inside while_preventing_writes" do
+    ActiveRecord::Base.while_preventing_writes do
+      expect(ActiveRecord::Base.current_preventing_writes).to be true
+    end
+  end
+
+  # Adapted from test "preventing writes applies to all connections in block"
+  it "while_preventing_writes raises on the remote connection too" do
+    expect {
+      ActiveRecord::Base.while_preventing_writes do
+        MultiDbRemoteEmployee.create!(name: "Tempbird")
+      end
+    }.to raise_error(ActiveRecord::ReadOnlyError, /Write query attempted while in readonly mode: INSERT/)
+  end
+
   # Adapted from test_swapping_the_connection
   it "connection_specification_name can be swapped to point to a different pool" do
     original = MultiDbRemoteEmployee.connection_specification_name

--- a/spec/active_record/connection_adapters/oracle_enhanced/multiple_databases_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/multiple_databases_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+#
+# Tests for Rails multiple database support with oracle_enhanced.
+# Adapted from rails/rails activerecord/test/cases/multiple_db_test.rb
+#
+# Pattern: abstract base class with establish_connection — the programmatic
+# equivalent of connects_to — to connect models to a second Oracle schema.
+
+describe "OracleEnhancedAdapter multiple database support" do
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+
+    # Abstract base class for the remote schema. Defined before any tables are
+    # created so the remote table can be built via its own connection without
+    # rebinding ActiveRecord::Base.
+    class ::MultiDbRemoteBase < ActiveRecord::Base
+      self.abstract_class = true
+      establish_connection REMOTE_CONNECTION_PARAMS
+    end
+
+    ActiveRecord::Base.connection.create_table :multi_db_primary_employees, force: true do |t|
+      t.string :name, limit: 50
+    end
+
+    MultiDbRemoteBase.connection.create_table :multi_db_remote_employees, force: true do |t|
+      t.string :name, limit: 50
+    end
+
+    class ::MultiDbPrimaryEmployee < ActiveRecord::Base
+      self.table_name = "multi_db_primary_employees"
+    end
+
+    class ::MultiDbRemoteEmployee < MultiDbRemoteBase
+      self.table_name = "multi_db_remote_employees"
+    end
+
+    # A second model inheriting from the same abstract base to test connection sharing
+    class ::MultiDbRemoteEmployee2 < MultiDbRemoteBase
+      self.table_name = "multi_db_remote_employees"
+    end
+
+    MultiDbPrimaryEmployee.create!(id: 1, name: "Primary Alice")
+    MultiDbPrimaryEmployee.create!(id: 2, name: "Primary Bob")
+    MultiDbRemoteEmployee.create!(id: 1, name: "Remote Alice")
+    MultiDbRemoteEmployee.create!(id: 2, name: "Remote Bob")
+  end
+
+  after(:all) do
+    if Object.const_defined?(:MultiDbRemoteBase)
+      begin
+        MultiDbRemoteBase.connection.drop_table :multi_db_remote_employees, if_exists: true
+      ensure
+        MultiDbRemoteBase.remove_connection
+      end
+    end
+  ensure
+    begin
+      ActiveRecord::Base.connection.drop_table :multi_db_primary_employees, if_exists: true
+    ensure
+      %w[MultiDbPrimaryEmployee MultiDbRemoteEmployee MultiDbRemoteEmployee2 MultiDbRemoteBase].each do |name|
+        Object.send(:remove_const, name) if Object.const_defined?(name)
+      end
+      ActiveRecord::Base.clear_cache!
+    end
+  end
+
+  # Adapted from test_connected
+  it "both connections are active" do
+    expect(MultiDbPrimaryEmployee.lease_connection).not_to be_nil
+    expect(MultiDbRemoteEmployee.lease_connection).not_to be_nil
+  end
+
+  # Adapted from test_proper_connection
+  it "primary and remote models use different connections" do
+    expect(MultiDbPrimaryEmployee.lease_connection).not_to eq(MultiDbRemoteEmployee.lease_connection)
+    expect(MultiDbPrimaryEmployee.lease_connection).to eq(ActiveRecord::Base.lease_connection)
+  end
+
+  # Adapted from test_connection — subclass shares parent's connection
+  it "two models on the same abstract base share the same connection" do
+    expect(MultiDbRemoteEmployee.lease_connection).to eq(MultiDbRemoteEmployee2.lease_connection)
+    expect(MultiDbRemoteEmployee.lease_connection).not_to eq(MultiDbPrimaryEmployee.lease_connection)
+  end
+
+  # Adapted from test_find
+  it "find works independently on each connection" do
+    p1 = MultiDbPrimaryEmployee.find(1)
+    expect(p1.name).to eq("Primary Alice")
+
+    p2 = MultiDbPrimaryEmployee.find(2)
+    expect(p2.name).to eq("Primary Bob")
+
+    r1 = MultiDbRemoteEmployee.find(1)
+    expect(r1.name).to eq("Remote Alice")
+
+    r2 = MultiDbRemoteEmployee.find(2)
+    expect(r2.name).to eq("Remote Bob")
+  end
+
+  # Adapted from test_count_on_custom_connection
+  it "count works on the remote connection" do
+    expect(MultiDbRemoteEmployee.count).to eq(2)
+    expect(MultiDbPrimaryEmployee.count).to eq(2)
+  end
+
+  # Adapted from test_transactions_across_databases
+  # The raised RuntimeError propagates out of both transaction blocks, so each
+  # connection rolls back its own transaction on its own — demonstrating that
+  # there is no shared coordinator between the two connections' transactions.
+  it "transactions are independent per connection" do
+    p1 = MultiDbPrimaryEmployee.find(1)
+    r1 = MultiDbRemoteEmployee.find(1)
+
+    begin
+      MultiDbPrimaryEmployee.transaction do
+        MultiDbRemoteEmployee.transaction do
+          p1.name = "Typo"
+          r1.name = "Typo"
+          p1.save!
+          r1.save!
+          raise RuntimeError, "rollback"
+        end
+      end
+    rescue RuntimeError
+      # caught
+    end
+
+    # Each model's transaction rolled back independently
+    expect(MultiDbPrimaryEmployee.find(1).name).to eq("Primary Alice")
+    expect(MultiDbRemoteEmployee.find(1).name).to eq("Remote Alice")
+  end
+
+  # Adapted from test_swapping_the_connection
+  it "connection_specification_name can be swapped to point to a different pool" do
+    original = MultiDbRemoteEmployee.connection_specification_name
+    MultiDbRemoteEmployee.connection_specification_name = "ActiveRecord::Base"
+    expect(MultiDbRemoteEmployee.lease_connection).to eq(ActiveRecord::Base.lease_connection)
+  ensure
+    MultiDbRemoteEmployee.connection_specification_name = original
+  end
+
+  # Adapted from test_exception_contains_connection_pool
+  it "StatementInvalid error references the correct connection pool" do
+    error = nil
+    begin
+      MultiDbRemoteEmployee.where(nonexistent_column: "x").first!
+    rescue ActiveRecord::StatementInvalid => e
+      error = e
+    end
+    expect(error).not_to be_nil
+    expect(error.connection_pool).to eq(MultiDbRemoteEmployee.lease_connection.pool)
+  end
+end

--- a/spec/active_record/connection_adapters/oracle_enhanced/multiple_databases_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/multiple_databases_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+#
+# Tests for Rails multiple database support with oracle_enhanced.
+# Adapted from rails/rails activerecord/test/cases/multiple_db_test.rb
+#
+# Pattern: abstract base class with establish_connection — the programmatic
+# equivalent of connects_to — to connect models to a second Oracle schema.
+
+describe "OracleEnhancedAdapter multiple database support" do
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+
+    # Abstract base class for the remote schema. Defined before any tables are
+    # created so the remote table can be built via its own connection without
+    # rebinding ActiveRecord::Base.
+    class ::MultiDbRemoteBase < ActiveRecord::Base
+      self.abstract_class = true
+      establish_connection REMOTE_CONNECTION_PARAMS
+    end
+
+    ActiveRecord::Base.connection.create_table :multi_db_primary_employees, force: true do |t|
+      t.string :name, limit: 50
+    end
+
+    MultiDbRemoteBase.connection.create_table :multi_db_remote_employees, force: true do |t|
+      t.string :name, limit: 50
+    end
+
+    class ::MultiDbPrimaryEmployee < ActiveRecord::Base
+      self.table_name = "multi_db_primary_employees"
+    end
+
+    class ::MultiDbRemoteEmployee < MultiDbRemoteBase
+      self.table_name = "multi_db_remote_employees"
+    end
+
+    # A second model inheriting from the same abstract base to test connection sharing
+    class ::MultiDbRemoteEmployee2 < MultiDbRemoteBase
+      self.table_name = "multi_db_remote_employees"
+    end
+
+    MultiDbPrimaryEmployee.create!(id: 1, name: "Primary Alice")
+    MultiDbPrimaryEmployee.create!(id: 2, name: "Primary Bob")
+    MultiDbRemoteEmployee.create!(id: 1, name: "Remote Alice")
+    MultiDbRemoteEmployee.create!(id: 2, name: "Remote Bob")
+  end
+
+  after(:all) do
+    if Object.const_defined?(:MultiDbRemoteBase)
+      MultiDbRemoteBase.connection.drop_table :multi_db_remote_employees, if_exists: true
+      MultiDbRemoteBase.remove_connection
+    end
+    ActiveRecord::Base.connection.drop_table :multi_db_primary_employees, if_exists: true
+    %w[MultiDbPrimaryEmployee MultiDbRemoteEmployee MultiDbRemoteEmployee2 MultiDbRemoteBase].each do |name|
+      Object.send(:remove_const, name) if Object.const_defined?(name)
+    end
+  end
+
+  # Adapted from test_connected
+  it "both connections are active" do
+    expect(MultiDbPrimaryEmployee.lease_connection).not_to be_nil
+    expect(MultiDbRemoteEmployee.lease_connection).not_to be_nil
+  end
+
+  # Adapted from test_proper_connection
+  it "primary and remote models use different connections" do
+    expect(MultiDbPrimaryEmployee.lease_connection).not_to eq(MultiDbRemoteEmployee.lease_connection)
+    expect(MultiDbPrimaryEmployee.lease_connection).to eq(ActiveRecord::Base.lease_connection)
+  end
+
+  # Adapted from test_connection — subclass shares parent's connection
+  it "two models on the same abstract base share the same connection" do
+    expect(MultiDbRemoteEmployee.lease_connection).to eq(MultiDbRemoteEmployee2.lease_connection)
+    expect(MultiDbRemoteEmployee.lease_connection).not_to eq(MultiDbPrimaryEmployee.lease_connection)
+  end
+
+  # Adapted from test_find
+  it "find works independently on each connection" do
+    p1 = MultiDbPrimaryEmployee.find(1)
+    expect(p1.name).to eq("Primary Alice")
+
+    p2 = MultiDbPrimaryEmployee.find(2)
+    expect(p2.name).to eq("Primary Bob")
+
+    r1 = MultiDbRemoteEmployee.find(1)
+    expect(r1.name).to eq("Remote Alice")
+
+    r2 = MultiDbRemoteEmployee.find(2)
+    expect(r2.name).to eq("Remote Bob")
+  end
+
+  # Adapted from test_count_on_custom_connection
+  it "count works on the remote connection" do
+    expect(MultiDbRemoteEmployee.count).to eq(2)
+    expect(MultiDbPrimaryEmployee.count).to eq(2)
+  end
+
+  # Adapted from test_transactions_across_databases
+  # The raised RuntimeError propagates out of both transaction blocks, so each
+  # connection rolls back its own transaction on its own — demonstrating that
+  # there is no shared coordinator between the two connections' transactions.
+  it "transactions are independent per connection" do
+    p1 = MultiDbPrimaryEmployee.find(1)
+    r1 = MultiDbRemoteEmployee.find(1)
+
+    begin
+      MultiDbPrimaryEmployee.transaction do
+        MultiDbRemoteEmployee.transaction do
+          p1.name = "Typo"
+          r1.name = "Typo"
+          p1.save!
+          r1.save!
+          raise RuntimeError, "rollback"
+        end
+      end
+    rescue RuntimeError
+      # caught
+    end
+
+    # Each model's transaction rolled back independently
+    expect(MultiDbPrimaryEmployee.find(1).name).to eq("Primary Alice")
+    expect(MultiDbRemoteEmployee.find(1).name).to eq("Remote Alice")
+  end
+
+  # Adapted from test_swapping_the_connection
+  it "connection_specification_name can be swapped to point to a different pool" do
+    original = MultiDbRemoteEmployee.connection_specification_name
+    MultiDbRemoteEmployee.connection_specification_name = "ActiveRecord::Base"
+    expect(MultiDbRemoteEmployee.lease_connection).to eq(ActiveRecord::Base.lease_connection)
+  ensure
+    MultiDbRemoteEmployee.connection_specification_name = original
+  end
+
+  # Adapted from test_exception_contains_connection_pool
+  it "StatementInvalid error references the correct connection pool" do
+    error = nil
+    begin
+      MultiDbRemoteEmployee.where(nonexistent_column: "x").first!
+    rescue ActiveRecord::StatementInvalid => e
+      error = e
+    end
+    expect(error).not_to be_nil
+    expect(error.connection_pool).to eq(MultiDbRemoteEmployee.lease_connection.pool)
+  end
+end

--- a/spec/active_record/connection_adapters/oracle_enhanced/multiple_databases_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/multiple_databases_spec.rb
@@ -131,6 +131,60 @@ describe "OracleEnhancedAdapter multiple database support" do
     expect(MultiDbRemoteEmployee.find(1).name).to eq("Remote Alice")
   end
 
+  # Adapted from base_prevent_writes_test.rb — read/write split via while_preventing_writes
+
+  # Adapted from test "creating a record raises if preventing writes"
+  it "raises ReadOnlyError on INSERT inside while_preventing_writes" do
+    expect {
+      ActiveRecord::Base.while_preventing_writes do
+        MultiDbPrimaryEmployee.create!(name: "Tempbird")
+      end
+    }.to raise_error(ActiveRecord::ReadOnlyError, /Write query attempted while in readonly mode: INSERT/)
+  end
+
+  # Adapted from test "updating a record raises if preventing writes"
+  it "raises ReadOnlyError on UPDATE inside while_preventing_writes" do
+    p1 = MultiDbPrimaryEmployee.find(1)
+    expect {
+      ActiveRecord::Base.while_preventing_writes do
+        p1.update!(name: "Changed")
+      end
+    }.to raise_error(ActiveRecord::ReadOnlyError, /Write query attempted while in readonly mode: UPDATE/)
+  end
+
+  # Adapted from test "deleting a record raises if preventing writes"
+  it "raises ReadOnlyError on DELETE inside while_preventing_writes" do
+    p1 = MultiDbPrimaryEmployee.find(1)
+    expect {
+      ActiveRecord::Base.while_preventing_writes do
+        p1.destroy!
+      end
+    }.to raise_error(ActiveRecord::ReadOnlyError, /Write query attempted while in readonly mode: DELETE/)
+  end
+
+  # Adapted from test "selecting a record does not raise if preventing writes"
+  it "does not raise on SELECT inside while_preventing_writes" do
+    ActiveRecord::Base.while_preventing_writes do
+      expect(MultiDbPrimaryEmployee.where(name: "Primary Alice").first).not_to be_nil
+    end
+  end
+
+  # Adapted from test "current_preventing_writes"
+  it "current_preventing_writes returns true inside while_preventing_writes" do
+    ActiveRecord::Base.while_preventing_writes do
+      expect(ActiveRecord::Base.current_preventing_writes).to be true
+    end
+  end
+
+  # Adapted from test "preventing writes applies to all connections in block"
+  it "while_preventing_writes raises on the remote connection too" do
+    expect {
+      ActiveRecord::Base.while_preventing_writes do
+        MultiDbRemoteEmployee.create!(name: "Tempbird")
+      end
+    }.to raise_error(ActiveRecord::ReadOnlyError, /Write query attempted while in readonly mode: INSERT/)
+  end
+
   # Adapted from test_swapping_the_connection
   it "connection_specification_name can be swapped to point to a different pool" do
     original = MultiDbRemoteEmployee.connection_specification_name

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_isolation_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_isolation_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+#
+# Confirms that the two Oracle schemas (CONNECTION_PARAMS and
+# REMOTE_CONNECTION_PARAMS) are isolated from each other: even when using
+# an explicit schema prefix, a cross-schema SELECT raises ORA-00942 unless
+# a privilege has been explicitly granted.
+#
+# This holds regardless of the underlying topology — same PDB, separate
+# PDBs, or entirely separate databases.
+#
+
+describe "Oracle schema isolation between primary and remote connections" do
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+
+    # Abstract base for the remote schema, so the remote table is created via
+    # its own connection and ActiveRecord::Base never has to be rebound.
+    class ::SchemaIsolationRemoteBase < ActiveRecord::Base
+      self.abstract_class = true
+      establish_connection REMOTE_CONNECTION_PARAMS
+    end
+
+    ActiveRecord::Base.connection.create_table :schema_isolation_primary, force: true do |t|
+      t.string :name, limit: 50
+    end
+
+    SchemaIsolationRemoteBase.connection.create_table :schema_isolation_remote, force: true do |t|
+      t.string :name, limit: 50
+    end
+  end
+
+  after(:all) do
+    if Object.const_defined?(:SchemaIsolationRemoteBase)
+      begin
+        SchemaIsolationRemoteBase.connection.drop_table :schema_isolation_remote, if_exists: true
+      ensure
+        begin
+          SchemaIsolationRemoteBase.remove_connection
+        ensure
+          Object.send(:remove_const, :SchemaIsolationRemoteBase)
+        end
+      end
+    end
+  ensure
+    begin
+      ActiveRecord::Base.connection.drop_table :schema_isolation_primary, if_exists: true
+    ensure
+      ActiveRecord::Base.clear_cache!
+    end
+  end
+
+  # ORA-00942: table or view does not exist
+  # Oracle returns this error for both "no such table" and "no SELECT privilege",
+  # intentionally not distinguishing between the two.
+  it "primary schema cannot directly access a table owned by the remote schema" do
+    expect {
+      ActiveRecord::Base.connection.execute("SELECT * FROM #{DATABASE_REMOTE_USER}.schema_isolation_remote")
+    }.to raise_error(ActiveRecord::StatementInvalid, /ORA-00942/)
+  end
+
+  it "remote schema cannot directly access a table owned by the primary schema" do
+    expect {
+      SchemaIsolationRemoteBase.connection.execute("SELECT * FROM #{DATABASE_USER}.schema_isolation_primary")
+    }.to raise_error(ActiveRecord::StatementInvalid, /ORA-00942/)
+  end
+end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_isolation_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_isolation_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+#
+# Confirms that the two Oracle schemas (CONNECTION_PARAMS and
+# REMOTE_CONNECTION_PARAMS) are isolated from each other: even when using
+# an explicit schema prefix, a cross-schema SELECT raises ORA-00942 unless
+# a privilege has been explicitly granted.
+#
+# This holds regardless of the underlying topology — same PDB, separate
+# PDBs, or entirely separate databases.
+#
+
+describe "Oracle schema isolation between primary and remote connections" do
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+
+    # Abstract base for the remote schema, so the remote table is created via
+    # its own connection and ActiveRecord::Base never has to be rebound.
+    class ::SchemaIsolationRemoteBase < ActiveRecord::Base
+      self.abstract_class = true
+      establish_connection REMOTE_CONNECTION_PARAMS
+    end
+
+    ActiveRecord::Base.connection.create_table :schema_isolation_primary, force: true do |t|
+      t.string :name, limit: 50
+    end
+
+    SchemaIsolationRemoteBase.connection.create_table :schema_isolation_remote, force: true do |t|
+      t.string :name, limit: 50
+    end
+  end
+
+  after(:all) do
+    if Object.const_defined?(:SchemaIsolationRemoteBase)
+      SchemaIsolationRemoteBase.connection.drop_table :schema_isolation_remote, if_exists: true
+      SchemaIsolationRemoteBase.remove_connection
+      Object.send(:remove_const, :SchemaIsolationRemoteBase)
+    end
+    ActiveRecord::Base.connection.drop_table :schema_isolation_primary, if_exists: true
+    ActiveRecord::Base.clear_cache!
+  end
+
+  # ORA-00942: table or view does not exist
+  # Oracle returns this error for both "no such table" and "no SELECT privilege",
+  # intentionally not distinguishing between the two.
+  it "primary schema cannot directly access a table owned by the remote schema" do
+    expect {
+      ActiveRecord::Base.connection.execute("SELECT * FROM #{DATABASE_REMOTE_USER}.schema_isolation_remote")
+    }.to raise_error(ActiveRecord::StatementInvalid, /ORA-00942/)
+  end
+
+  it "remote schema cannot directly access a table owned by the primary schema" do
+    expect {
+      SchemaIsolationRemoteBase.connection.execute("SELECT * FROM #{DATABASE_USER}.schema_isolation_primary")
+    }.to raise_error(ActiveRecord::StatementInvalid, /ORA-00942/)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -198,6 +198,18 @@ SERVICE_NAME_CONNECTION_PARAMS = {
   password: DATABASE_PASSWORD
 }
 
+DATABASE_REMOTE_USER     = config["database"]["remote_user"]     || ENV["DATABASE_REMOTE_USER"]     || "oracle_enhanced_remote"
+DATABASE_REMOTE_PASSWORD = config["database"]["remote_password"] || ENV["DATABASE_REMOTE_PASSWORD"] || "oracle_enhanced_remote"
+
+REMOTE_CONNECTION_PARAMS = {
+  adapter: "oracle_enhanced",
+  database: DATABASE_NAME,
+  host: DATABASE_HOST,
+  port: DATABASE_PORT,
+  username: DATABASE_REMOTE_USER,
+  password: DATABASE_REMOTE_PASSWORD
+}
+
 DATABASE_NON_DEFAULT_TABLESPACE = config["database"]["non_default_tablespace"] || ENV["DATABASE_NON_DEFAULT_TABLESPACE"] || "SYSTEM"
 
 # set default time zone in TZ environment variable

--- a/spec/support/create_oracle_enhanced_users.sql
+++ b/spec/support/create_oracle_enhanced_users.sql
@@ -11,3 +11,9 @@ CREATE USER oracle_enhanced_schema IDENTIFIED BY oracle_enhanced_schema;
 GRANT unlimited tablespace, create session, create table, create sequence,
 create procedure, create trigger, create view, create materialized view,
 create database link, create synonym, create type, ctxapp TO oracle_enhanced_schema;
+
+-- User for Rails multiple database tests.
+CREATE USER oracle_enhanced_remote IDENTIFIED BY oracle_enhanced_remote;
+
+GRANT create session, create table, create sequence, create trigger,
+unlimited tablespace TO oracle_enhanced_remote;

--- a/spec/support/create_oracle_enhanced_users.sql
+++ b/spec/support/create_oracle_enhanced_users.sql
@@ -13,3 +13,9 @@ GRANT unlimited tablespace, create session, create table, create sequence,
 create procedure, create trigger, create view, create materialized view,
 create database link, create synonym, create type, ctxapp,
 create public synonym, drop public synonym TO oracle_enhanced_schema;
+
+-- User for Rails multiple database tests.
+CREATE USER oracle_enhanced_remote IDENTIFIED BY oracle_enhanced_remote;
+
+GRANT create session, create table, create sequence, create trigger,
+unlimited tablespace TO oracle_enhanced_remote;


### PR DESCRIPTION
## Summary

Add specs verifying that oracle_enhanced works with the Rails multiple database API, using two Oracle schemas (users) to simulate separate databases. Also fix `translate_exception` to forward `connection_pool:` for all error types.

## Changes

### New spec files

**`spec/active_record/connection_adapters/oracle_enhanced/multiple_databases_spec.rb`**
Adapted from `rails/rails activerecord/test/cases/multiple_db_test.rb` and `base_prevent_writes_test.rb`.
Uses an abstract base class with `establish_connection` — the programmatic equivalent of `connects_to` — to connect models to a second Oracle schema.

Tests (all passing):
- Both connections are active
- Primary and remote models use different connections
- Two models on the same abstract base share the same connection
- `find` works independently on each connection
- `count` works on the remote connection
- Transactions are independent per connection (nested raise — both roll back)
- **Only the inner remote transaction is rolled back when the primary transaction commits (directly verifies independence via `ActiveRecord::Rollback`)**
- `while_preventing_writes` raises `ReadOnlyError` on INSERT / UPDATE / DELETE
- `while_preventing_writes` does not raise on SELECT
- `current_preventing_writes` returns true inside block
- `while_preventing_writes` raises `ReadOnlyError` on the remote connection too
- `connection_specification_name` can be swapped to point to a different pool
- `StatementInvalid` error references the correct connection pool (pins `ORA-00904`)
- `StatementInvalid` error from each connection references its own pool (pins `ORA-00942`)

**`spec/active_record/connection_adapters/oracle_enhanced/schema_isolation_spec.rb`**
Confirms that the two Oracle schemas cannot access each other's tables directly (verified via ORA-00942), regardless of whether they live in the same PDB or in separate databases.

### Test environment setup

**`spec/support/create_oracle_enhanced_users.sql`** — SQL to create the `oracle_enhanced_remote` user used as the second database.

**`spec/spec_helper.rb`** — Adds `REMOTE_CONNECTION_PARAMS` / `DATABASE_REMOTE_USER` constants.

### Bug fix

**`lib/active_record/connection_adapters/oracle_enhanced_adapter.rb`**
Pass `connection_pool: @pool` in `translate_exception` for all error types, not just `StatementInvalid`. This is required for the `StatementInvalid error references the correct connection pool` test to pass on the remote connection.

## Notes

- `connected_to(database: ...)` was investigated but the `database:` keyword has been removed in current Rails main; the `establish_connection` abstract class pattern is the supported approach.
- In the CI environment both schemas live in the same Oracle Free PDB; the schema isolation spec guards against accidental cross-schema grants.

## Review refinements (squashed in via autosquash)

- `before(:all)`/`after(:all)` in both specs no longer rebind `ActiveRecord::Base`. Dedicated abstract base classes (`MultiDbRemoteBase`, `SchemaIsolationRemoteBase`) are defined first, and remote tables are created/dropped through their connections. Prevents the global `ActiveRecord::Base` connection from being left pointed at the remote schema if setup raises mid-way.
- `after(:all)` calls `MultiDbRemoteBase.remove_connection` instead of `connection_pool.disconnect!` (also removes the pool registration, not just the sessions).
- Added `"only the inner remote transaction is rolled back when the primary transaction commits"` — directly verifies transaction independence by rolling back only one connection via `ActiveRecord::Rollback` and asserting the other commits. The pre-existing "nested raise" test on its own couldn't distinguish "each connection rolled back independently" from "one rollback cascaded through a shared coordinator"; the new spec closes that gap, and the comment on the original spec now cross-references it.
- Pinned Oracle error codes in the two `StatementInvalid`-pool tests (`ORA-00904` for the nonexistent-column case, `ORA-00942` for the cross-schema SELECT) so unrelated errors cannot silently satisfy the broader `StatementInvalid` rescue.
- Renamed `it "associations work when model has no explicit connection (inherits from abstract base)"` to `"associations work on a model whose connection is inherited from an abstract base"` — the model does have a connection (inherited); the old wording was misleading.
- Hardened the "connection survives model reload" test with an `ensure` block that restores the original `MultiDbRemoteEmployee` constant, so the redefined class cannot leak if spec ordering changes.
- Hardened `after(:all)` teardown in both specs so every sequential cleanup step runs inside a nested `ensure` chain. Previously a `drop_table` failure would skip the following `remove_connection` / `Object.remove_const` / `clear_cache!` calls, leaving the remote connection pool attached and stale constants defined for the rest of the suite.
- `create_oracle_enhanced_users.sql` — reworded the `oracle_enhanced_remote` comment to match the actual approach (drop the stale `connected_to` parenthetical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
