### PR TITLE
Log username on ORA-01017 authentication failure (OCI and JDBC)

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -146,12 +146,19 @@ module ActiveRecord
             end
 
             begin
-              @raw_connection = java.sql.DriverManager.getConnection(url, properties)
-            rescue
-              # bypass DriverManager to work in cases where ojdbc*.jar
-              # is added to the load path at runtime and not on the
-              # system classpath
-              @raw_connection = ORACLE_DRIVER.connect(url, properties)
+              begin
+                @raw_connection = java.sql.DriverManager.getConnection(url, properties)
+              rescue
+                # bypass DriverManager to work in cases where ojdbc*.jar
+                # is added to the load path at runtime and not on the
+                # system classpath
+                @raw_connection = ORACLE_DRIVER.connect(url, properties)
+              end
+            rescue Java::JavaSql::SQLException => e
+              if e.get_error_code == 1017
+                $stderr.puts "ORA-01017: Authentication failed. username=#{username.inspect} url=#{url.inspect} privilege=#{privilege.inspect}"
+              end
+              raise
             end
 
             # Set session time zone to current time zone

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -354,7 +354,14 @@ module ActiveRecord
           rescue NotImplementedError
           end
 
-          conn = OCI8.new username, password, connection_string, privilege
+          begin
+            conn = OCI8.new username, password, connection_string, privilege
+          rescue OCIError => e
+            if e.code == 1017
+              $stderr.puts "ORA-01017: Authentication failed. username=#{username.inspect} connection_string=#{connection_string.inspect} privilege=#{privilege.inspect}"
+            end
+            raise
+          end
           conn.autocommit = true
           conn.non_blocking = true if async
           conn.prefetch_rows = prefetch_rows


### PR DESCRIPTION
## Summary

- When `OCI8.new` raises ORA-01017 (invalid username/password), print the username, connection string, and privilege to `$stderr` before re-raising
- Equivalent handling for JDBC: when `DriverManager.getConnection` / `ORACLE_DRIVER.connect` fails with `SQLException` error code 1017, print the username, JDBC URL, and privilege to `$stderr`

This makes CI failures caused by misconfigured credentials immediately diagnosable — instead of just seeing `ORA-01017`, you see which username and connection string were attempted.

## Test plan

- [ ] Verify OCI path: connect with wrong password → `ORA-01017: Authentication failed. username="..." connection_string="..." privilege=...` appears on stderr
- [ ] Verify JDBC path (JRuby): same behaviour on wrong-password connection attempt
- [ ] Verify correct credentials still connect successfully (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)