### PR TITLE
Use longer identifiers by default on Oracle 12.2+

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_limits.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_limits.rb
@@ -4,22 +4,25 @@ module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced
       module DatabaseLimits
-        # maximum length of Oracle identifiers
-        IDENTIFIER_MAX_LENGTH = 30
-
-        def table_alias_length # :nodoc:
-          IDENTIFIER_MAX_LENGTH
-        end
-
-        # the maximum length of an index name
-        # supported by this database
-        def index_name_length
-          IDENTIFIER_MAX_LENGTH
+        # Keep the legacy constant available via direct access while steering
+        # callers toward the dynamic, connection-specific max_identifier_length.
+        # A deprecated constant proxy does not fit here because the replacement
+        # is a method, not another constant.
+        def self.const_missing(name)
+          if name == :IDENTIFIER_MAX_LENGTH
+            OracleEnhanced.deprecator.deprecation_warning(
+              "ActiveRecord::ConnectionAdapters::OracleEnhanced::DatabaseLimits::IDENTIFIER_MAX_LENGTH",
+              "use `max_identifier_length` instead"
+            )
+            30
+          else
+            super
+          end
         end
 
         # the maximum length of a sequence name
         def sequence_name_length
-          IDENTIFIER_MAX_LENGTH
+          max_identifier_length
         end
 
         # To avoid ORA-01795: maximum number of expressions in a list is 1000

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_limits.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_limits.rb
@@ -4,22 +4,29 @@ module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced
       module DatabaseLimits
-        # maximum length of Oracle identifiers
-        IDENTIFIER_MAX_LENGTH = 30
-
-        def table_alias_length # :nodoc:
-          IDENTIFIER_MAX_LENGTH
-        end
-
-        # the maximum length of an index name
-        # supported by this database
-        def index_name_length
-          IDENTIFIER_MAX_LENGTH
+        # Keep the legacy constant available via direct access while steering
+        # callers toward the dynamic, connection-specific max_identifier_length.
+        # A deprecated constant proxy does not fit here because the replacement
+        # is a method, not another constant.
+        #
+        # Note: direct reads (+DatabaseLimits::IDENTIFIER_MAX_LENGTH+) still work;
+        # reflection APIs (+const_defined?+, +defined?+, +.constants+) do not see
+        # it because nothing is actually declared.
+        def self.const_missing(name)
+          if name == :IDENTIFIER_MAX_LENGTH
+            OracleEnhanced.deprecator.deprecation_warning(
+              "ActiveRecord::ConnectionAdapters::OracleEnhanced::DatabaseLimits::IDENTIFIER_MAX_LENGTH",
+              "use `max_identifier_length` instead"
+            )
+            30
+          else
+            super
+          end
         end
 
         # the maximum length of a sequence name
         def sequence_name_length
-          IDENTIFIER_MAX_LENGTH
+          max_identifier_length
         end
 
         # To avoid ORA-01795: maximum number of expressions in a list is 1000

--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -110,7 +110,9 @@ module ActiveRecord
             max_identifier_length = 30
           end
           object_name = name.to_s
+          # Grammar only: no length bound here; `\w` is ASCII-only so non-ASCII letters after the first character are rejected (stricter than Oracle on AL32UTF8).
           return false unless /\A(?:[[:alpha:]][\w$#]*\.)?[[:alpha:]][\w$#]*\Z/.match?(object_name)
+          # Byte limit is enforced per component — Oracle applies the limit to each identifier, not to the full `schema.table` string.
           return false unless object_name.split(".").all? { |part| part.bytesize <= max_identifier_length }
           !mixed_case?(object_name)
         end

--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -76,33 +76,31 @@ module ActiveRecord
           end
         end
 
-        # Names must be from 1 to 30 bytes long with these exceptions:
-        # * Names of databases are limited to 8 bytes.
-        # * Names of database links can be as long as 128 bytes.
-        #
-        # Nonquoted identifiers cannot be Oracle Database reserved words
-        #
-        # Nonquoted identifiers must begin with an alphabetic character from
-        # your database character set
-        #
-        # Nonquoted identifiers can contain only alphanumeric characters from
-        # your database character set and the underscore (_), dollar sign ($),
-        # and pound sign (#).
-        # Oracle strongly discourages you from using $ and # in nonquoted identifiers.
-        NONQUOTED_OBJECT_NAME = /[[:alpha:]][\w$#]{0,29}/
-        VALID_TABLE_NAME = /\A(?:#{NONQUOTED_OBJECT_NAME}\.)?#{NONQUOTED_OBJECT_NAME}\Z/
+        # Nonquoted Oracle identifiers must begin with an alphabetic
+        # character from the database character set and may contain only
+        # alphanumerics plus +_+, +$+, and +#+. Oracle strongly discourages
+        # +$+ and +#+ in nonquoted names. Byte limits depend on the
+        # identifier class: 30 bytes on pre-12.2 databases, 128 bytes on
+        # 12.2+ for schema objects; Oracle enforces the limit per
+        # identifier (per component of a +schema.name+ pair), not on the
+        # full qualified string. Mixed-case names are rejected here so
+        # callers quote them explicitly.
 
-        # unescaped table name should start with letter and
-        # contain letters, digits, _, $ or #
-        # can be prefixed with schema name
-        # CamelCase table names should be quoted
-        # The +max_identifier_length+ argument is the byte limit Oracle
-        # enforces for the connection (30 on pre-12.2, 128 on 12.2+). The
-        # grammar regex itself no longer encodes a length bound; bytesize
-        # is checked separately per component because Oracle applies the
-        # limit to each identifier, not to the full +schema.table+ string.
-        # Omitting the argument is deprecated and falls back to the legacy
-        # 30 byte bound with a warning.
+        # Returns true when +name+ is a valid unquoted Oracle schema-object
+        # name (optionally schema-qualified as +schema.name+). The
+        # +max_identifier_length+ bound is applied per component because
+        # Oracle enforces the byte limit on each identifier, not on the
+        # full +schema.table+ string. Omitting the argument is deprecated
+        # and falls back to the legacy 30 byte bound with a warning.
+        #
+        # The grammar regex has mixed Unicode semantics: +[[:alpha:]]+
+        # accepts Unicode letters as the first character but +\w+ stays
+        # ASCII-only, so any non-ASCII character beyond the first position
+        # is rejected. Oracle itself accepts database-character-set letters
+        # throughout unquoted identifiers on AL32UTF8, so this is stricter
+        # than Oracle. A future change could add the +/u+ flag or use
+        # +[[:word:]]+; for now the bytesize check is preserved as the
+        # intended byte boundary for when the grammar is relaxed.
         def self.valid_table_name?(name, max_identifier_length: nil) # :nodoc:
           if max_identifier_length.nil?
             OracleEnhanced.deprecator.deprecation_warning(
@@ -120,6 +118,33 @@ module ActiveRecord
         def self.mixed_case?(name)
           object_name = name.include?(".") ? name.split(".").second : name
           !!(object_name =~ /[A-Z]/ && object_name =~ /[a-z]/)
+        end
+
+        # Deprecated. +NONQUOTED_OBJECT_NAME+ and +VALID_TABLE_NAME+ are
+        # resolved here so external references keep their pre-deprecation
+        # values (30 byte grammar) with a warning routed through the shared
+        # deprecator. New code should use +valid_table_name?+.
+        #
+        # Note: direct reads (+Quoting::VALID_TABLE_NAME+) still work; reflection
+        # APIs (+const_defined?+, +defined?+, +.constants+) do not see these
+        # names because nothing is actually declared.
+        def self.const_missing(name)
+          case name
+          when :NONQUOTED_OBJECT_NAME
+            OracleEnhanced.deprecator.deprecation_warning(
+              "ActiveRecord::ConnectionAdapters::OracleEnhanced::Quoting::NONQUOTED_OBJECT_NAME",
+              "use `valid_table_name?` instead"
+            )
+            /[[:alpha:]][\w$#]{0,29}/
+          when :VALID_TABLE_NAME
+            OracleEnhanced.deprecator.deprecation_warning(
+              "ActiveRecord::ConnectionAdapters::OracleEnhanced::Quoting::VALID_TABLE_NAME",
+              "use `valid_table_name?` instead"
+            )
+            /\A(?:[[:alpha:]][\w$#]{0,29}\.)?[[:alpha:]][\w$#]{0,29}\Z/
+          else
+            super
+          end
         end
 
         def quote_string(s) # :nodoc:

--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -96,9 +96,25 @@ module ActiveRecord
         # contain letters, digits, _, $ or #
         # can be prefixed with schema name
         # CamelCase table names should be quoted
-        def self.valid_table_name?(name) # :nodoc:
+        # The +max_identifier_length+ argument is the byte limit Oracle
+        # enforces for the connection (30 on pre-12.2, 128 on 12.2+). The
+        # grammar regex itself no longer encodes a length bound; bytesize
+        # is checked separately per component because Oracle applies the
+        # limit to each identifier, not to the full +schema.table+ string.
+        # Omitting the argument is deprecated and falls back to the legacy
+        # 30 byte bound with a warning.
+        def self.valid_table_name?(name, max_identifier_length: nil) # :nodoc:
+          if max_identifier_length.nil?
+            OracleEnhanced.deprecator.deprecation_warning(
+              "ActiveRecord::ConnectionAdapters::OracleEnhanced::Quoting.valid_table_name? called without `max_identifier_length:`",
+              "pass `max_identifier_length:` explicitly; the implicit 30 byte default will be removed"
+            )
+            max_identifier_length = 30
+          end
           object_name = name.to_s
-          !!(object_name =~ VALID_TABLE_NAME && !mixed_case?(object_name))
+          return false unless /\A(?:[[:alpha:]][\w$#]*\.)?[[:alpha:]][\w$#]*\Z/.match?(object_name)
+          return false unless object_name.split(".").all? { |part| part.bytesize <= max_identifier_length }
+          !mixed_case?(object_name)
         end
 
         def self.mixed_case?(name)

--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -76,20 +76,27 @@ module ActiveRecord
           end
         end
 
-        # Names must be from 1 to 30 bytes long with these exceptions:
+        # Grammar check for nonquoted Oracle identifiers. This regex decides
+        # whether a name looks like a bare (unquoted) Oracle identifier so
+        # `valid_table_name?` / `Connection#describe` can upcase it; it does
+        # not enforce the actual byte limit.
+        #
+        # The real limit is enforced by Oracle itself:
+        # 30 bytes on 12.1 and lower, 128 bytes on 12.2 and higher. The upper
+        # bound in the regex is set to the larger of the two (128) so the
+        # same constant works for both; on pre-12.2 databases a 31..128 byte
+        # name matches this regex but Oracle will reject it at execution
+        # (ORA-00972). Keeping one regex avoids threading a
+        # `supports_longer_identifier?` flag through every call site.
+        #
         # * Names of databases are limited to 8 bytes.
         # * Names of database links can be as long as 128 bytes.
         #
-        # Nonquoted identifiers cannot be Oracle Database reserved words
-        #
-        # Nonquoted identifiers must begin with an alphabetic character from
-        # your database character set
-        #
-        # Nonquoted identifiers can contain only alphanumeric characters from
-        # your database character set and the underscore (_), dollar sign ($),
-        # and pound sign (#).
-        # Oracle strongly discourages you from using $ and # in nonquoted identifiers.
-        NONQUOTED_OBJECT_NAME = /[[:alpha:]][\w$#]{0,29}/
+        # Nonquoted identifiers cannot be Oracle Database reserved words.
+        # They must begin with an alphabetic character from your database
+        # character set, and contain only alphanumeric characters plus _ ,
+        # $ , and #. Oracle strongly discourages $ and # in nonquoted names.
+        NONQUOTED_OBJECT_NAME = /[[:alpha:]][\w$#]{0,127}/
         VALID_TABLE_NAME = /\A(?:#{NONQUOTED_OBJECT_NAME}\.)?#{NONQUOTED_OBJECT_NAME}?\Z/
 
         # unescaped table name should start with letter and

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -36,7 +36,7 @@ module ActiveRecord
           else
             default_owner = current_schema
           end
-          real_name = OracleEnhanced::Quoting.valid_table_name?(table_name) ?
+          real_name = OracleEnhanced::Quoting.valid_table_name?(table_name, max_identifier_length: max_identifier_length) ?
             table_name.upcase : table_name
           if real_name.include?(".")
             table_owner, table_name = real_name.split(".")
@@ -253,8 +253,8 @@ module ActiveRecord
         end
 
         def rename_table(table_name, new_name, **options) # :nodoc:
-          if new_name.to_s.length > DatabaseLimits::IDENTIFIER_MAX_LENGTH
-            raise ArgumentError, "New table name '#{new_name}' is too long; the limit is #{DatabaseLimits::IDENTIFIER_MAX_LENGTH} characters"
+          if new_name.to_s.bytesize > max_identifier_length
+            raise ArgumentError, "New table name '#{new_name}' is too long; the limit is #{max_identifier_length} bytes"
           end
           schema_cache.clear_data_source_cache!(table_name.to_s)
           schema_cache.clear_data_source_cache!(new_name.to_s)
@@ -803,7 +803,7 @@ module ActiveRecord
             string = string.to_s
             raise ArgumentError, "db link is not supported" if string.include?("@")
 
-            string = string.upcase if OracleEnhanced::Quoting.valid_table_name?(string)
+            string = string.upcase if OracleEnhanced::Quoting.valid_table_name?(string, max_identifier_length: max_identifier_length)
             schema, identifier = string.split(".") if string.include?(".")
             [schema, identifier || string]
           end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -253,8 +253,8 @@ module ActiveRecord
         end
 
         def rename_table(table_name, new_name, **options) # :nodoc:
-          if new_name.to_s.length > DatabaseLimits::IDENTIFIER_MAX_LENGTH
-            raise ArgumentError, "New table name '#{new_name}' is too long; the limit is #{DatabaseLimits::IDENTIFIER_MAX_LENGTH} characters"
+          if new_name.to_s.bytesize > max_identifier_length
+            raise ArgumentError, "New table name '#{new_name}' is too long; the limit is #{max_identifier_length} bytes"
           end
           schema_cache.clear_data_source_cache!(table_name.to_s)
           schema_cache.clear_data_source_cache!(new_name.to_s)

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -199,14 +199,48 @@ module ActiveRecord
 
       ##
       # :singleton-method:
-      # By default, OracleEnhanced adapter will use longer 128 bytes identifier
-      # if database version is Oracle 12.2 or higher.
-      # If you wish to use shorter 30 byte identifier with Oracle Database supporting longer identifier
-      # you can add the following line to your initializer file:
+      # Controls the identifier length used by the adapter.
       #
-      #   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.use_shorter_identifier = true
-      cattr_accessor :use_shorter_identifier
-      self.use_shorter_identifier = false
+      # * +false+ (default) — use 128 byte identifiers on Oracle 12.2+, and
+      #   silently fall back to 30 bytes on older databases.
+      # * +true+ — force the legacy 30 byte limit, even on 12.2+.
+      #
+      # Can be set globally in an initializer:
+      #
+      #   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.use_legacy_identifier_length = true
+      #
+      # or per connection via database.yml:
+      #
+      #   production:
+      #     adapter: oracle_enhanced
+      #     use_legacy_identifier_length: true
+      cattr_accessor :use_legacy_identifier_length
+      self.use_legacy_identifier_length = false
+
+      # Deprecated alias for +use_legacy_identifier_length+.
+      def self.use_shorter_identifier
+        OracleEnhanced.deprecator.deprecation_warning(
+          "ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.use_shorter_identifier",
+          "use `use_legacy_identifier_length` instead"
+        )
+        use_legacy_identifier_length
+      end
+
+      def self.use_shorter_identifier=(value)
+        OracleEnhanced.deprecator.deprecation_warning(
+          "ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.use_shorter_identifier=",
+          "use `use_legacy_identifier_length=` instead"
+        )
+        self.use_legacy_identifier_length = value
+      end
+
+      def use_shorter_identifier
+        self.class.use_shorter_identifier
+      end
+
+      def use_shorter_identifier=(value)
+        self.class.use_shorter_identifier = value
+      end
 
       ##
       # :singleton-method:
@@ -370,12 +404,13 @@ module ActiveRecord
         false
       end
 
-      def supports_longer_identifier?
-        if !use_shorter_identifier && database_version.to_s >= [12, 2].to_s
-          true
+      def supports_longer_identifier? # :nodoc:
+        use_legacy = if @config.key?(:use_legacy_identifier_length)
+          ActiveModel::Type::Boolean.new.cast(@config[:use_legacy_identifier_length])
         else
-          false
+          self.class.use_legacy_identifier_length
         end
+        !use_legacy && Gem::Version.new(database_version.join(".")) >= Gem::Version.new("12.2")
       end
 
       # :stopdoc:

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -199,14 +199,48 @@ module ActiveRecord
 
       ##
       # :singleton-method:
-      # By default, OracleEnhanced adapter will use longer 128 bytes identifier
-      # if database version is Oracle 12.2 or higher.
-      # If you wish to use shorter 30 byte identifier with Oracle Database supporting longer identifier
-      # you can add the following line to your initializer file:
+      # Controls the identifier length used by the adapter.
       #
-      #   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.use_shorter_identifier = true
-      cattr_accessor :use_shorter_identifier
-      self.use_shorter_identifier = false
+      # * +false+ (default) — use 128 byte identifiers on Oracle 12.2+, and
+      #   silently fall back to 30 bytes on older databases.
+      # * +true+ — force the legacy 30 byte limit, even on 12.2+.
+      #
+      # Can be set globally in an initializer:
+      #
+      #   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.use_legacy_identifier_length = true
+      #
+      # or per connection via database.yml:
+      #
+      #   production:
+      #     adapter: oracle_enhanced
+      #     use_legacy_identifier_length: true
+      cattr_accessor :use_legacy_identifier_length
+      self.use_legacy_identifier_length = false
+
+      # Deprecated alias for +use_legacy_identifier_length+.
+      def self.use_shorter_identifier
+        OracleEnhanced.deprecator.deprecation_warning(
+          "ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.use_shorter_identifier",
+          "use `use_legacy_identifier_length` instead"
+        )
+        use_legacy_identifier_length
+      end
+
+      def self.use_shorter_identifier=(value)
+        OracleEnhanced.deprecator.deprecation_warning(
+          "ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.use_shorter_identifier=",
+          "use `use_legacy_identifier_length=` instead"
+        )
+        self.use_legacy_identifier_length = value
+      end
+
+      def use_shorter_identifier
+        self.class.use_shorter_identifier
+      end
+
+      def use_shorter_identifier=(value)
+        self.class.use_shorter_identifier = value
+      end
 
       ##
       # :singleton-method:
@@ -360,12 +394,14 @@ module ActiveRecord
         false
       end
 
-      def supports_longer_identifier?
-        if !use_shorter_identifier && database_version.to_s >= [12, 2].to_s
-          true
+      def supports_longer_identifier? # :nodoc:
+        per_connection = @config[:use_legacy_identifier_length] if @config.key?(:use_legacy_identifier_length)
+        use_legacy = if per_connection.nil?
+          self.class.use_legacy_identifier_length
         else
-          false
+          ActiveModel::Type::Boolean.new.cast(per_connection)
         end
+        !use_legacy && Gem::Version.new(database_version.join(".")) >= Gem::Version.new("12.2")
       end
 
       # :stopdoc:

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -396,12 +396,12 @@ module ActiveRecord
 
       def supports_longer_identifier? # :nodoc:
         per_connection = @config[:use_legacy_identifier_length] if @config.key?(:use_legacy_identifier_length)
-        use_legacy = if per_connection.nil?
+        use_legacy_length = if per_connection.nil?
           self.class.use_legacy_identifier_length
         else
           ActiveModel::Type::Boolean.new.cast(per_connection)
         end
-        !use_legacy && Gem::Version.new(database_version.join(".")) >= Gem::Version.new("12.2")
+        !use_legacy_length && Gem::Version.new(database_version.join(".")) >= Gem::Version.new("12.2")
       end
 
       # :stopdoc:

--- a/spec/active_record/connection_adapters/oracle_enhanced/identifier_length_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/identifier_length_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+describe "OracleEnhancedAdapter identifier length configuration" do
+  let(:adapter_class) { ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter }
+
+  before(:each) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+  end
+
+  after(:each) do
+    adapter_class.use_legacy_identifier_length = false
+    ActiveRecord::Base.remove_connection
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+  end
+
+  describe "use_shorter_identifier" do
+    it "is deprecated when assigned and delegates to use_legacy_identifier_length" do
+      expect {
+        adapter_class.use_shorter_identifier = true
+      }.to output(/use_shorter_identifier.* is deprecated/).to_stderr
+
+      expect(adapter_class.use_legacy_identifier_length).to be(true)
+    end
+
+    it "is deprecated when read and reflects use_legacy_identifier_length" do
+      adapter_class.use_legacy_identifier_length = true
+
+      expect {
+        expect(adapter_class.use_shorter_identifier).to be(true)
+      }.to output(/use_shorter_identifier.* is deprecated/).to_stderr
+    end
+  end
+
+  describe "supports_longer_identifier?" do
+    it "honors global use_legacy_identifier_length" do
+      adapter_class.use_legacy_identifier_length = true
+      ActiveRecord::Base.remove_connection
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+      conn = ActiveRecord::Base.connection
+
+      expect(conn.supports_longer_identifier?).to be(false)
+      expect(conn.max_identifier_length).to eq(30)
+    end
+
+    it "honors per-connection use_legacy_identifier_length" do
+      ActiveRecord::Base.remove_connection
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(use_legacy_identifier_length: true))
+      conn = ActiveRecord::Base.connection
+
+      expect(conn.supports_longer_identifier?).to be(false)
+      expect(conn.max_identifier_length).to eq(30)
+    end
+
+    it "per-connection config overrides global (legacy locally, longer globally)" do
+      adapter_class.use_legacy_identifier_length = false
+      ActiveRecord::Base.remove_connection
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(use_legacy_identifier_length: true))
+      conn = ActiveRecord::Base.connection
+
+      expect(conn.supports_longer_identifier?).to be(false)
+    end
+
+    it "per-connection config overrides global (longer locally, legacy globally)" do
+      adapter_class.use_legacy_identifier_length = true
+      ActiveRecord::Base.remove_connection
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(use_legacy_identifier_length: false))
+      conn = ActiveRecord::Base.connection
+
+      if Gem::Version.new(conn.database_version.join(".")) >= Gem::Version.new("12.2")
+        expect(conn.supports_longer_identifier?).to be(true)
+        expect(conn.max_identifier_length).to eq(128)
+      else
+        expect(conn.supports_longer_identifier?).to be(false)
+        expect(conn.max_identifier_length).to eq(30)
+      end
+    end
+
+    it "silently falls back to 30-byte identifiers on a pre-12.2 database" do
+      conn = ActiveRecord::Base.connection
+      allow(conn).to receive(:database_version).and_return([11, 2])
+      expect(conn.supports_longer_identifier?).to be(false)
+      expect(conn.max_identifier_length).to eq(30)
+    end
+  end
+
+  describe "IDENTIFIER_MAX_LENGTH deprecation" do
+    it "flows through OracleEnhanced.deprecator with the gem name and horizon" do
+      expect {
+        ActiveRecord::ConnectionAdapters::OracleEnhanced::DatabaseLimits::IDENTIFIER_MAX_LENGTH
+      }.to output(/IDENTIFIER_MAX_LENGTH is deprecated.*activerecord-oracle_enhanced-adapter.*a future version/m).to_stderr
+    end
+  end
+end

--- a/spec/active_record/connection_adapters/oracle_enhanced/identifier_length_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/identifier_length_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+describe "OracleEnhancedAdapter identifier length configuration" do
+  let(:adapter_class) { ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter }
+
+  before(:each) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+  end
+
+  after(:each) do
+    adapter_class.use_legacy_identifier_length = false
+    ActiveRecord::Base.remove_connection
+  end
+
+  describe "use_shorter_identifier" do
+    it "is deprecated when assigned and delegates to use_legacy_identifier_length" do
+      expect {
+        adapter_class.use_shorter_identifier = true
+      }.to output(/use_shorter_identifier.* is deprecated/).to_stderr
+
+      expect(adapter_class.use_legacy_identifier_length).to be(true)
+    end
+
+    it "is deprecated when read and reflects use_legacy_identifier_length" do
+      adapter_class.use_legacy_identifier_length = true
+
+      expect {
+        expect(adapter_class.use_shorter_identifier).to be(true)
+      }.to output(/use_shorter_identifier.* is deprecated/).to_stderr
+    end
+  end
+
+  describe "supports_longer_identifier?" do
+    it "honors global use_legacy_identifier_length" do
+      adapter_class.use_legacy_identifier_length = true
+      ActiveRecord::Base.remove_connection
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+      conn = ActiveRecord::Base.connection
+
+      expect(conn.supports_longer_identifier?).to be(false)
+      expect(conn.max_identifier_length).to eq(30)
+    end
+
+    it "honors per-connection use_legacy_identifier_length" do
+      ActiveRecord::Base.remove_connection
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(use_legacy_identifier_length: true))
+      conn = ActiveRecord::Base.connection
+
+      expect(conn.supports_longer_identifier?).to be(false)
+      expect(conn.max_identifier_length).to eq(30)
+    end
+
+    it "per-connection config overrides global (legacy locally, longer globally)" do
+      adapter_class.use_legacy_identifier_length = false
+      ActiveRecord::Base.remove_connection
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(use_legacy_identifier_length: true))
+      conn = ActiveRecord::Base.connection
+
+      expect(conn.supports_longer_identifier?).to be(false)
+    end
+
+    it "per-connection config overrides global (longer locally, legacy globally)" do
+      adapter_class.use_legacy_identifier_length = true
+      ActiveRecord::Base.remove_connection
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(use_legacy_identifier_length: false))
+      conn = ActiveRecord::Base.connection
+
+      if Gem::Version.new(conn.database_version.join(".")) >= Gem::Version.new("12.2")
+        expect(conn.supports_longer_identifier?).to be(true)
+        expect(conn.max_identifier_length).to eq(128)
+      else
+        expect(conn.supports_longer_identifier?).to be(false)
+        expect(conn.max_identifier_length).to eq(30)
+      end
+    end
+
+    it "silently falls back to 30-byte identifiers on a pre-12.2 database" do
+      conn = ActiveRecord::Base.connection
+      allow(conn).to receive(:database_version).and_return([11, 2])
+      expect(conn.supports_longer_identifier?).to be(false)
+      expect(conn.max_identifier_length).to eq(30)
+    end
+
+    it "falls back to the global setting when the per-connection value is nil" do
+      adapter_class.use_legacy_identifier_length = true
+      ActiveRecord::Base.remove_connection
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(use_legacy_identifier_length: nil))
+      conn = ActiveRecord::Base.connection
+
+      expect(conn.supports_longer_identifier?).to be(false)
+      expect(conn.max_identifier_length).to eq(30)
+    end
+  end
+
+  describe "IDENTIFIER_MAX_LENGTH deprecation" do
+    it "flows through OracleEnhanced.deprecator with the gem name and horizon" do
+      expect {
+        ActiveRecord::ConnectionAdapters::OracleEnhanced::DatabaseLimits::IDENTIFIER_MAX_LENGTH
+      }.to output(/IDENTIFIER_MAX_LENGTH is deprecated.*activerecord-oracle_enhanced-adapter.*a future version/m).to_stderr
+    end
+  end
+end

--- a/spec/active_record/connection_adapters/oracle_enhanced/quoting_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/quoting_spec.rb
@@ -66,60 +66,83 @@ describe "OracleEnhancedAdapter quoting" do
       @adapter = ActiveRecord::ConnectionAdapters::OracleEnhanced::Quoting
     end
 
+    def valid?(name, max_identifier_length: 128)
+      @adapter.valid_table_name?(name, max_identifier_length: max_identifier_length)
+    end
+
     it "should be valid with letters and digits" do
-      expect(@adapter.valid_table_name?("abc_123")).to be_truthy
+      expect(valid?("abc_123")).to be_truthy
     end
 
     it "should be valid with schema name" do
-      expect(@adapter.valid_table_name?("abc_123.def_456")).to be_truthy
+      expect(valid?("abc_123.def_456")).to be_truthy
     end
 
     it "should be valid with schema name and object name in different case" do
-      expect(@adapter.valid_table_name?("TEST_DBA.def_456")).to be_truthy
+      expect(valid?("TEST_DBA.def_456")).to be_truthy
     end
 
     it "should be valid with $ in name" do
-      expect(@adapter.valid_table_name?("sys.v$session")).to be_truthy
+      expect(valid?("sys.v$session")).to be_truthy
     end
 
     it "should be valid with upcase schema name" do
-      expect(@adapter.valid_table_name?("ABC_123.DEF_456")).to be_truthy
+      expect(valid?("ABC_123.DEF_456")).to be_truthy
     end
 
     it "should not be valid with two dots in name" do
-      expect(@adapter.valid_table_name?("abc_123.def_456.ghi_789")).to be_falsey
+      expect(valid?("abc_123.def_456.ghi_789")).to be_falsey
     end
 
     it "should not be valid with invalid characters" do
-      expect(@adapter.valid_table_name?("warehouse-things")).to be_falsey
+      expect(valid?("warehouse-things")).to be_falsey
     end
 
     it "should not be valid with for camel-case" do
-      expect(@adapter.valid_table_name?("Abc")).to be_falsey
-      expect(@adapter.valid_table_name?("aBc")).to be_falsey
-      expect(@adapter.valid_table_name?("abC")).to be_falsey
+      expect(valid?("Abc")).to be_falsey
+      expect(valid?("aBc")).to be_falsey
+      expect(valid?("abC")).to be_falsey
     end
 
-    it "should not be valid for names > 30 characters" do
-      expect(@adapter.valid_table_name?("a" * 31)).to be_falsey
+    it "honors the per-call max_identifier_length bound" do
+      expect(valid?("a" * 30, max_identifier_length: 30)).to be_truthy
+      expect(valid?("a" * 31, max_identifier_length: 30)).to be_falsey
+      expect(valid?("a" * 128, max_identifier_length: 128)).to be_truthy
+      expect(valid?("a" * 129, max_identifier_length: 128)).to be_falsey
     end
 
-    it "should not be valid for schema names > 30 characters" do
-      expect(@adapter.valid_table_name?(("a" * 31) + ".validname")).to be_falsey
+    it "applies max_identifier_length per identifier component, not to the full schema.table string" do
+      expect(valid?(("a" * 100) + "." + ("a" * 100))).to be_truthy
+      expect(valid?(("a" * 129) + "." + ("a" * 100))).to be_falsey
+      expect(valid?(("a" * 100) + "." + ("a" * 129))).to be_falsey
+    end
+
+    it "should not be valid for schema names > max_identifier_length" do
+      expect(valid?(("a" * 129) + ".validname")).to be_falsey
     end
 
     it "should not be valid for names that do not begin with alphabetic characters" do
-      expect(@adapter.valid_table_name?("1abc")).to be_falsey
-      expect(@adapter.valid_table_name?("_abc")).to be_falsey
-      expect(@adapter.valid_table_name?("abc.1xyz")).to be_falsey
-      expect(@adapter.valid_table_name?("abc._xyz")).to be_falsey
+      expect(valid?("1abc")).to be_falsey
+      expect(valid?("_abc")).to be_falsey
+      expect(valid?("abc.1xyz")).to be_falsey
+      expect(valid?("abc._xyz")).to be_falsey
     end
 
     it "should not be valid when the object name part is missing" do
-      expect(@adapter.valid_table_name?("")).to be_falsey
-      expect(@adapter.valid_table_name?("schema.")).to be_falsey
-      expect(@adapter.valid_table_name?(".table")).to be_falsey
-      expect(@adapter.valid_table_name?("   ")).to be_falsey
+      expect(valid?("")).to be_falsey
+      expect(valid?("schema.")).to be_falsey
+      expect(valid?(".table")).to be_falsey
+      expect(valid?("   ")).to be_falsey
+    end
+
+    it "warns and falls back to the legacy 30-byte bound when max_identifier_length: is omitted" do
+      expect { @adapter.valid_table_name?("a" * 30) }
+        .to output(/valid_table_name\? called without.*max_identifier_length.*activerecord-oracle_enhanced-adapter/m)
+        .to_stderr
+      ActiveRecord::ConnectionAdapters::OracleEnhanced.deprecator.silence do
+        expect(@adapter.valid_table_name?("a" * 30)).to be_truthy
+        expect(@adapter.valid_table_name?("a" * 31)).to be_falsey
+      end
     end
   end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/quoting_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/quoting_spec.rb
@@ -100,12 +100,17 @@ describe "OracleEnhancedAdapter quoting" do
       expect(@adapter.valid_table_name?("abC")).to be_falsey
     end
 
-    it "should not be valid for names > 30 characters" do
-      expect(@adapter.valid_table_name?("a" * 31)).to be_falsey
+    it "should be valid for names up to 128 characters" do
+      expect(@adapter.valid_table_name?("a" * 31)).to be_truthy
+      expect(@adapter.valid_table_name?("a" * 128)).to be_truthy
     end
 
-    it "should not be valid for schema names > 30 characters" do
-      expect(@adapter.valid_table_name?(("a" * 31) + ".validname")).to be_falsey
+    it "should not be valid for names > 128 characters" do
+      expect(@adapter.valid_table_name?("a" * 129)).to be_falsey
+    end
+
+    it "should not be valid for schema names > 128 characters" do
+      expect(@adapter.valid_table_name?(("a" * 129) + ".validname")).to be_falsey
     end
 
     it "should not be valid for names that do not begin with alphabetic characters" do

--- a/spec/active_record/connection_adapters/oracle_enhanced/quoting_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/quoting_spec.rb
@@ -146,6 +146,26 @@ describe "OracleEnhancedAdapter quoting" do
     end
   end
 
+  describe "deprecated Quoting constants" do
+    let(:quoting) { ActiveRecord::ConnectionAdapters::OracleEnhanced::Quoting }
+
+    it "emits a deprecation warning and returns the legacy 30-byte grammar for NONQUOTED_OBJECT_NAME" do
+      nonquoted = nil
+      expect { nonquoted = quoting::NONQUOTED_OBJECT_NAME }
+        .to output(/NONQUOTED_OBJECT_NAME is deprecated.*activerecord-oracle_enhanced-adapter.*a future version/m)
+        .to_stderr
+      expect(nonquoted).to eq(/[[:alpha:]][\w$#]{0,29}/)
+    end
+
+    it "emits a deprecation warning and returns the legacy 30-byte grammar for VALID_TABLE_NAME" do
+      valid_table_name = nil
+      expect { valid_table_name = quoting::VALID_TABLE_NAME }
+        .to output(/VALID_TABLE_NAME is deprecated.*activerecord-oracle_enhanced-adapter.*a future version/m)
+        .to_stderr
+      expect(valid_table_name).to eq(/\A(?:[[:alpha:]][\w$#]{0,29}\.)?[[:alpha:]][\w$#]{0,29}\Z/)
+    end
+  end
+
   describe "table quoting" do
     def create_warehouse_things_table
       ActiveRecord::Schema.define do

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -451,15 +451,18 @@ describe "OracleEnhancedAdapter schema definition" do
   end
 
   it "should raise error when current index name and new index name are identical" do
+    original_name = @conn.index_name("test_employees", column: "first_name")
     expect do
-      @conn.rename_index("test_employees", "i_test_employees_first_name", "i_test_employees_first_name")
+      @conn.rename_index("test_employees", original_name, original_name)
     end.to raise_error(ActiveRecord::StatementInvalid)
   end
 
   it "should raise error when new index name length is too long" do
-    skip if @oracle12cr2_or_higher
+    original_name = @conn.index_name("test_employees", column: "first_name")
+    too_long = "a" * (@conn.max_identifier_length + 1)
+
     expect do
-      @conn.rename_index("test_employees", "i_test_employees_first_name", "a" * 31)
+      @conn.rename_index("test_employees", original_name, too_long)
     end.to raise_error(ArgumentError)
   end
 
@@ -470,9 +473,9 @@ describe "OracleEnhancedAdapter schema definition" do
   end
 
   it "should rename index name with new one" do
-    skip if @oracle12cr2_or_higher
+    original_name = @conn.index_name("test_employees", column: "first_name")
     expect do
-      @conn.rename_index("test_employees", "i_test_employees_first_name", "new_index_name")
+      @conn.rename_index("test_employees", original_name, "new_index_name")
     end.not_to raise_error
   end
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -330,13 +330,14 @@ describe "OracleEnhancedAdapter schema definition" do
     end
 
     after(:each) do
+      long_name = ("a" * (@conn.max_identifier_length - 3)).to_sym
       schema_define do
         drop_table :test_employees_no_primary_key, if_exists: true
         drop_table :test_employees, if_exists: true
         drop_table :new_test_employees, if_exists: true
         drop_table :test_employees_no_pkey, if_exists: true
         drop_table :new_test_employees_no_pkey, if_exists: true
-        drop_table :aaaaaaaaaaaaaaaaaaaaaaaaaaa, if_exists: true
+        drop_table long_name, if_exists: true
       end
     end
 
@@ -348,14 +349,25 @@ describe "OracleEnhancedAdapter schema definition" do
 
     it "should raise error when new table name length is too long" do
       expect do
-        @conn.rename_table("test_employees", "a" * 31)
+        @conn.rename_table("test_employees", "a" * (@conn.max_identifier_length + 1))
       end.to raise_error(ArgumentError)
     end
 
     it "should not raise error when new sequence name length is too long" do
       expect do
-        @conn.rename_table("test_employees", "a" * 27)
+        @conn.rename_table("test_employees", "a" * (@conn.max_identifier_length - 3))
       end.not_to raise_error
+    end
+
+    it "measures new table name length in bytes, not characters" do
+      # "é" is 2 bytes in UTF-8, so half the max in chars is the full max
+      # in bytes. The check fires on bytesize before any SQL is issued.
+      multibyte_name = "é" * ((@conn.max_identifier_length / 2) + 1)
+      expect(multibyte_name.bytesize).to be > @conn.max_identifier_length
+      expect(multibyte_name.length).to be <= @conn.max_identifier_length
+      expect do
+        @conn.rename_table("test_employees", multibyte_name)
+      end.to raise_error(ArgumentError)
     end
 
     it "should rename table when table has no primary key and sequence" do

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -398,9 +398,15 @@ describe "OracleEnhancedAdapter schema definition" do
   end
 
   it "should raise error when new index name length is too long" do
-    skip if @oracle12cr2_or_higher
+    too_long =
+      if @conn.supports_longer_identifier?
+        "a" * 129   # Oracle 12.2+ rejects identifiers longer than 128 bytes
+      else
+        "a" * 31    # Oracle 12.1 and earlier (or use_legacy_identifier_length) reject identifiers longer than 30 bytes
+      end
+
     expect do
-      @conn.rename_index("test_employees", "i_test_employees_first_name", "a" * 31)
+      @conn.rename_index("test_employees", "i_test_employees_first_name", too_long)
     end.to raise_error(ArgumentError)
   end
 
@@ -411,9 +417,9 @@ describe "OracleEnhancedAdapter schema definition" do
   end
 
   it "should rename index name with new one" do
-    skip if @oracle12cr2_or_higher
+    original_name = @conn.index_name("test_employees", column: "first_name")
     expect do
-      @conn.rename_index("test_employees", "i_test_employees_first_name", "new_index_name")
+      @conn.rename_index("test_employees", original_name, "new_index_name")
     end.not_to raise_error
   end
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -296,6 +296,7 @@ describe "OracleEnhancedAdapter schema definition" do
     end
 
     after(:each) do
+      long_name = ("a" * (@conn.max_identifier_length - 3)).to_sym
       schema_define do
         drop_table :test_employees_no_primary_key, if_exists: true
         drop_table :test_employees, if_exists: true
@@ -303,6 +304,7 @@ describe "OracleEnhancedAdapter schema definition" do
         drop_table :test_employees_no_pkey, if_exists: true
         drop_table :new_test_employees_no_pkey, if_exists: true
         drop_table :aaaaaaaaaaaaaaaaaaaaaaaaaaa, if_exists: true
+        drop_table long_name, if_exists: true
       end
     end
 
@@ -314,13 +316,13 @@ describe "OracleEnhancedAdapter schema definition" do
 
     it "should raise error when new table name length is too long" do
       expect do
-        @conn.rename_table("test_employees", "a" * 31)
+        @conn.rename_table("test_employees", "a" * (@conn.max_identifier_length + 1))
       end.to raise_error(ArgumentError)
     end
 
     it "should not raise error when new sequence name length is too long" do
       expect do
-        @conn.rename_table("test_employees", "a" * 27)
+        @conn.rename_table("test_employees", "a" * (@conn.max_identifier_length - 3))
       end.not_to raise_error
     end
 


### PR DESCRIPTION
## Summary

Oracle Database 12.2+ supports 128 byte identifiers, but several code paths still hardcoded the legacy 30 byte limit. This PR makes longer identifiers the default and leaves `max_identifier_length` as the single source of truth.

### Changes

- `DatabaseLimits::IDENTIFIER_MAX_LENGTH` becomes a deprecated constant (resolved via `const_missing`, still returns `30`); `sequence_name_length` delegates to `max_identifier_length`. A short comment on the shim explains why a deprecated-constant proxy does not fit (the replacement is a method, not another constant).
- `rename_table` uses `max_identifier_length` instead of a hardcoded 30 byte check (fixes rsim/oracle-enhanced#2128). The length check is byte-based (`bytesize`) to match Oracle's own enforcement.
- `OracleEnhanced::Quoting.valid_table_name?` gains an explicit `max_identifier_length:` keyword so the byte bound is supplied by the caller (which already has connection context). The grammar regex is inlined in the method and no longer encodes a length bound — bytesize is checked separately against `max_identifier_length`.
- `OracleEnhanced::Quoting::NONQUOTED_OBJECT_NAME` and `VALID_TABLE_NAME` are removed. External references are resolved via `const_missing` with a deprecation warning, returning the pre-deprecation **30-byte grammar** (same convention as `IDENTIFIER_MAX_LENGTH`'s shim, so deprecation preserves behavior rather than silently widening). Direct reads still work; reflection APIs (`const_defined?`, `defined?`, `.constants`) do not see these names because nothing is actually declared — noted in code comments.
- New `use_legacy_identifier_length` cattr (default `false`) and matching per-connection config key for multi-database setups where different connections need different identifier sizes. The per-connection value is coerced through `ActiveModel::Type::Boolean.new.cast` so YAML strings like `"true"` behave correctly. On pre-12.2 databases, the adapter silently falls back to 30 bytes.
- `use_shorter_identifier` is kept as a deprecated alias (rsim/oracle-enhanced#1707).
- `supports_longer_identifier?` is marked `:nodoc:` — it is effectively an internal predicate used by `max_identifier_length` and one spec.
- Deprecation warnings emitted by the `IDENTIFIER_MAX_LENGTH` / `NONQUOTED_OBJECT_NAME` / `VALID_TABLE_NAME` shims and the `use_shorter_identifier` aliases flow through the shared `ActiveRecord::ConnectionAdapters::OracleEnhanced.deprecator` introduced in rsim/oracle-enhanced#2543, so they carry the gem name and horizon.
- Tests that previously skipped on 12.2+ because they hardcoded 30 byte inputs now run on every supported version. All three `rename_index` specs (identical-name, length-check, happy path) look up the auto-generated index name via `@conn.index_name(...)` instead of hardcoding `i_test_employees_first_name`, which changes under the longer identifier scheme — otherwise the identical-name and length-check specs pass for the wrong reason on 12.2+ (they raise because the hardcoded old name does not exist, not because of the behavior under test). The length-check spec derives `too_long = @conn.max_identifier_length + 1` so every version exercises the one-byte-over boundary; absolute-value coverage for `max_identifier_length` (30 / 128) lives in `identifier_length_spec`.
- A multibyte `rename_table` spec verifies the bytesize check fires on names whose char count fits the max but whose bytesize does not.
- A note on the `valid_table_name?` docstring flags that the grammar regex still has mixed Unicode semantics (`[[:alpha:]]` is Unicode-aware but `\w` is ASCII-only), so non-ASCII characters beyond the first position are rejected — stricter than Oracle's actual rules under AL32UTF8. Out of scope here; flagged for a follow-up.
- Mirrors the Rails precedent of aliasing `index_name_length` / `table_alias_length` to `max_identifier_length` (rails/rails@64e494f748).

### Commits

1. `Use longer identifiers by default on Oracle 12.2+ and per-connection override` — core behavior change (`max_identifier_length`, `use_legacy_identifier_length`, `rename_table` bytesize check + multibyte spec, `valid_table_name?` signature + inlined grammar regex with per-component bytesize check, `IDENTIFIER_MAX_LENGTH` deprecation shim + reflection-gap note).
2. `Drop NONQUOTED_OBJECT_NAME / VALID_TABLE_NAME in favor of valid_table_name?` — delete the two module-level constants and resolve them via `const_missing` returning the legacy 30-byte grammar; docstring note on regex Unicode inconsistency + reflection-gap note.
3. `Unskip rename_index specs on Oracle 12.2+` — unblock all three rename_index specs so every version exercises the real index name and the one-byte-over length boundary.
4. `Annotate valid_table_name? guards and rename use_legacy local` — add inline WHY comments above the grammar and per-component bytesize guards in `valid_table_name?` (flagging the ASCII-only `\w` semantics and per-identifier byte limit), and rename the `use_legacy` local in `supports_longer_identifier?` to `use_legacy_length` so it reads unambiguously alongside the `use_legacy_identifier_length` cattr it derives from. Comments/rename only — no behavior change.

### Related

- Closes rsim/oracle-enhanced#2128
- Supersedes rsim/oracle-enhanced#1707
- Builds on rsim/oracle-enhanced#2543 (shared deprecator), rsim/oracle-enhanced#2544 (removal of long-deprecated `table_name_length` / `column_name_length`), and rsim/oracle-enhanced#2572 (byte-based `default_sequence_name` / `index_name`, which lets `rename_table`'s bytesize check compose with the rest of the name-generation pipeline without a char/byte gap).
- Follow-up to rsim/oracle-enhanced#2567 (independent tightening of `VALID_TABLE_NAME`, already on master).

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/quoting_spec.rb`
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb`
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/identifier_length_spec.rb`
- [x] Full `bundle exec rspec` on Oracle 23ai after rebase onto master (includes #2572) — 503 examples, 0 failures, 4 pending
- [ ] CI green on all matrix rows
