### PR TITLE
Remove long-deprecated table_name_length and column_name_length

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_limits.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_limits.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/deprecation"
-
 module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced
@@ -12,18 +10,6 @@ module ActiveRecord
         def table_alias_length # :nodoc:
           IDENTIFIER_MAX_LENGTH
         end
-
-        # the maximum length of a table name
-        def table_name_length
-          IDENTIFIER_MAX_LENGTH
-        end
-        deprecate :table_name_length, deprecator: ActiveSupport::Deprecation.new
-
-        # the maximum length of a column name
-        def column_name_length
-          IDENTIFIER_MAX_LENGTH
-        end
-        deprecate :column_name_length, deprecator: ActiveSupport::Deprecation.new
 
         # the maximum length of an index name
         # supported by this database


### PR DESCRIPTION
## Summary

Removes the long-deprecated `table_name_length` and `column_name_length` methods from `OracleEnhanced::DatabaseLimits`.

Both were deprecated in oracle-enhanced v6.0.0 via commit 5c8a7769 (2018-10-05) — 7+ years and 3 major versions ago. Rails itself removed these from `AbstractAdapter` in Rails 5.0 (2016), so overriding them here has had no effect on upstream behavior for a long time.

Also drops the now-unused `require "active_support/deprecation"` from this file (it only existed to support the `deprecate :..., deprecator: ActiveSupport::Deprecation.new` call sites being removed).

## Test plan

- [x] `bundle exec rubocop`
- [x] CI green on all matrix rows