### PR TITLE
Move Connection#describe to SchemaStatements helpers

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -16,101 +16,18 @@ module ActiveRecord
           end
         end
 
-        attr_reader :raw_connection
+        attr_reader :raw_connection, :owner
 
         private
-          # Used always by JDBC connection as well by OCI connection when describing tables over database link
-          def describe(name)
-            name = name.to_s
-            if name.include?("@")
-              raise ArgumentError "db link is not supported"
-            else
-              default_owner = @owner
-            end
-            real_name = OracleEnhanced::Quoting.valid_table_name?(name) ? name.upcase : name
-            if real_name.include?(".")
-              table_owner, table_name = real_name.split(".")
-            else
-              table_owner, table_name = default_owner, real_name
-            end
-            sql = <<~SQL.squish
-              SELECT owner, table_name, 'TABLE' name_type
-              FROM all_tables
-              WHERE owner = :table_owner
-                AND table_name = :table_name
-              UNION ALL
-              SELECT owner, view_name table_name, 'VIEW' name_type
-              FROM all_views
-              WHERE owner = :table_owner
-                AND view_name = :table_name
-              UNION ALL
-              SELECT table_owner, table_name, 'SYNONYM' name_type
-              FROM all_synonyms
-              WHERE owner = :table_owner
-                AND synonym_name = :table_name
-              UNION ALL
-              SELECT table_owner, table_name, 'SYNONYM' name_type
-              FROM all_synonyms
-              WHERE owner = 'PUBLIC'
-                AND synonym_name = :real_name
-            SQL
-            if result = _select_one(sql, "CONNECTION", [table_owner, table_name, table_owner, table_name, table_owner, table_name, real_name])
-              case result["name_type"]
-              when "SYNONYM"
-                describe("#{result['owner'] && "#{result['owner']}."}#{result['table_name']}")
-              else
-                [result["owner"], result["table_name"]]
-              end
-            else
-              raise OracleEnhanced::ConnectionException, %Q{"DESC #{name}" failed; does it exist?}
-            end
-          end
-
           # Oracle column names by default are case-insensitive, but treated as upcase;
           # for neatness, we'll downcase within Rails. EXCEPT that folks CAN quote
           # their column names when creating Oracle tables, which makes then case-sensitive.
           # I don't know anybody who does this, but we'll handle the theoretical case of a
           # camelCase column name. I imagine other dbs handle this different, since there's a
           # unit test that's currently failing test_oci.
-          #
-          # `_oracle_downcase` is expected to be called only from
-          # `ActiveRecord::ConnectionAdapters::OracleEnhanced::OCIConnection`
-          # or `ActiveRecord::ConnectionAdapters::OracleEnhanced::JDBCConnection`.
-          # Other method should call `ActiveRecord:: ConnectionAdapters::OracleEnhanced::Quoting#oracle_downcase`
-          # since this is kind of quoting, not connection.
-          # To avoid it is called from anywhere else, added _ at the beginning of the method name.
           def _oracle_downcase(column_name)
             return nil if column_name.nil?
             /[a-z]/.match?(column_name) ? column_name : column_name.downcase
-          end
-
-          # _select_one and _select_value methods are expected to be called
-          # only from `ActiveRecord::ConnectionAdapters::OracleEnhanced::Connection#describe`
-          # Other methods should call `ActiveRecord::ConnectionAdapters::DatabaseStatements#select_one`
-          # and  `ActiveRecord::ConnectionAdapters::DatabaseStatements#select_value`
-          # To avoid called from its subclass added a underscore in each method.
-
-          # Returns a record hash with the column names as keys and column values
-          # as values.
-          # binds is a array of native values in contrast to ActiveRecord::Relation::QueryAttribute
-          def _select_one(arel, name = nil, binds = [])
-            cursor = prepare(arel)
-            cursor.bind_params(binds)
-            cursor.exec
-            columns = cursor.get_col_names.map do |col_name|
-              _oracle_downcase(col_name)
-            end
-            row = cursor.fetch
-            columns.each_with_index.to_h { |x, i| [x, row[i]] } if row
-          ensure
-            cursor.close
-          end
-
-          # Returns a single value from a record
-          def _select_value(arel, name = nil, binds = [])
-            if result = _select_one(arel, name, binds)
-              result.values.first
-            end
           end
       end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -526,11 +526,6 @@ module ActiveRecord
           end
         end
 
-        # To allow private method called from `JDBCConnection`
-        def describe(name)
-          super
-        end
-
         # Return java.sql.SQLException error code
         def error_code(exception)
           case exception

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -237,10 +237,6 @@ module ActiveRecord
           lob.write value
         end
 
-        def describe(name)
-          super
-        end
-
         # Return OCIError error code
         def error_code(exception)
           case exception

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -53,7 +53,7 @@ module ActiveRecord
         end
 
         def data_source_exists?(table_name)
-          (_owner, _table_name) = _connection.describe(table_name)
+          (_owner, _table_name) = resolve_data_source_name(table_name)
           true
         rescue
           false
@@ -87,7 +87,7 @@ module ActiveRecord
         end
 
         def indexes(table_name) # :nodoc:
-          (_owner, table_name) = _connection.describe(table_name)
+          (_owner, table_name) = resolve_data_source_name(table_name)
           default_tablespace_name = default_tablespace
 
           result = select_all(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name)])
@@ -348,7 +348,7 @@ module ActiveRecord
         #
         # Will always query database and not index cache.
         def index_name_exists?(table_name, index_name)
-          (_owner, table_name) = _connection.describe(table_name)
+          (_owner, table_name) = resolve_data_source_name(table_name)
           result = select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name), bind_string("index_name", index_name.to_s.upcase)])
             SELECT 1 FROM all_indexes i
             WHERE i.owner = SYS_CONTEXT('userenv', 'current_schema')
@@ -491,7 +491,7 @@ module ActiveRecord
 
         def table_comment(table_name) # :nodoc:
           # TODO
-          (_owner, table_name) = _connection.describe(table_name)
+          (_owner, table_name) = resolve_data_source_name(table_name)
           select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name)])
             SELECT comments FROM all_tab_comments
             WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
@@ -507,7 +507,7 @@ module ActiveRecord
 
         def column_comment(table_name, column_name) # :nodoc:
           # TODO: it  does not exist in Abstract adapter
-          (_owner, table_name) = _connection.describe(table_name)
+          (_owner, table_name) = resolve_data_source_name(table_name)
           select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name), bind_string("column_name", column_name.upcase)])
             SELECT comments FROM all_col_comments
             WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
@@ -535,7 +535,7 @@ module ActiveRecord
 
         # get table foreign keys for schema dump
         def foreign_keys(table_name) # :nodoc:
-          (_owner, desc_table_name) = _connection.describe(table_name)
+          (_owner, desc_table_name) = resolve_data_source_name(table_name)
 
           fk_info = select_all(<<~SQL.squish, "SCHEMA", [bind_string("desc_table_name", desc_table_name)])
             SELECT r.table_name to_table
@@ -732,6 +732,73 @@ module ActiveRecord
             return unless index_name
 
             execute("ALTER INDEX #{quote_column_name(index_name)} REBUILD TABLESPACE #{tablespace}")
+          end
+
+          # Resolves an Oracle data-source name to its underlying [owner, table_name]
+          # by following synonyms through the catalog. Defaults the schema to
+          # `_connection.owner` (the adapter's configured default schema, taken
+          # from `config[:schema]` or `config[:username]`) when the name is not
+          # schema-qualified. This is distinct from
+          # `SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA')`, which can differ after
+          # `ALTER SESSION SET CURRENT_SCHEMA`.
+          # Raises OracleEnhanced::ConnectionException if the object does not
+          # exist or if synonym resolution produces a looping chain.
+          def resolve_data_source_name(name)
+            visited = Set.new
+            loop do
+              schema, identifier = extract_schema_qualified_name(name)
+              real_name = schema ? "#{schema}.#{identifier}" : identifier
+              owner = schema || _connection.owner
+
+              unless visited.add?([owner, identifier])
+                raise OracleEnhanced::ConnectionException,
+                      %Q{"DESC #{name}" failed; looping chain of synonyms}
+              end
+
+              binds = [
+                bind_string("table_owner", owner),
+                bind_string("table_name", identifier),
+                bind_string("table_owner", owner),
+                bind_string("table_name", identifier),
+                bind_string("table_owner", owner),
+                bind_string("table_name", identifier),
+                bind_string("real_name", real_name),
+              ]
+              result = select_one(<<~SQL.squish, "SCHEMA", binds)
+                SELECT owner, table_name, 'TABLE' name_type
+                FROM all_tables WHERE owner = :table_owner AND table_name = :table_name
+                UNION ALL
+                SELECT owner, view_name table_name, 'VIEW' name_type
+                FROM all_views WHERE owner = :table_owner AND view_name = :table_name
+                UNION ALL
+                SELECT table_owner, table_name, 'SYNONYM' name_type
+                FROM all_synonyms WHERE owner = :table_owner AND synonym_name = :table_name
+                UNION ALL
+                SELECT table_owner, table_name, 'SYNONYM' name_type
+                FROM all_synonyms WHERE owner = 'PUBLIC' AND synonym_name = :real_name
+              SQL
+
+              raise OracleEnhanced::ConnectionException, %Q{"DESC #{name}" failed; does it exist?} unless result
+
+              if result["name_type"] == "SYNONYM"
+                name = "#{result['owner'] && "#{result['owner']}."}#{result['table_name']}"
+              else
+                return [result["owner"], result["table_name"]]
+              end
+            end
+          end
+
+          # Splits "schema.identifier" into its parts, returning [schema, identifier].
+          # Mirrors Rails' PostgreSQL/MySQL adapters: a non-qualified name yields
+          # schema = nil. Oracle-specific bits: rejects db links and upcases valid
+          # identifiers so catalog lookups match the stored upper-case names.
+          def extract_schema_qualified_name(string)
+            string = string.to_s
+            raise ArgumentError, "db link is not supported" if string.include?("@")
+
+            string = string.upcase if OracleEnhanced::Quoting.valid_table_name?(string)
+            schema, identifier = string.split(".") if string.include?(".")
+            [schema, identifier || string]
           end
       end
     end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -503,7 +503,7 @@ module ActiveRecord
         table_name = table_name.to_s
         do_not_prefetch = @do_not_prefetch_primary_key[table_name]
         if do_not_prefetch.nil?
-          owner, desc_table_name = _connection.describe(table_name)
+          owner, desc_table_name = resolve_data_source_name(table_name)
           @do_not_prefetch_primary_key[table_name] = do_not_prefetch = !has_primary_key?(table_name, owner, desc_table_name)
         end
         !do_not_prefetch
@@ -572,7 +572,7 @@ module ActiveRecord
       end
 
       def column_definitions(table_name)
-        (owner, desc_table_name) = _connection.describe(table_name)
+        (owner, desc_table_name) = resolve_data_source_name(table_name)
 
         select_all(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("table_name", desc_table_name)])
           SELECT cols.column_name AS name, cols.data_type AS sql_type,
@@ -604,7 +604,7 @@ module ActiveRecord
       # Find a table's primary key and sequence.
       # *Note*: Only primary key is implemented - sequence will be nil.
       def pk_and_sequence_for(table_name, owner = nil, desc_table_name = nil) # :nodoc:
-        (owner, desc_table_name) = _connection.describe(table_name)
+        (owner, desc_table_name) = resolve_data_source_name(table_name)
 
         seqs = select_values_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("sequence_name", default_sequence_name(desc_table_name))])
           select us.sequence_name
@@ -646,7 +646,7 @@ module ActiveRecord
       end
 
       def primary_keys(table_name) # :nodoc:
-        (_owner, desc_table_name) = _connection.describe(table_name)
+        (_owner, desc_table_name) = resolve_data_source_name(table_name)
 
         pks = select_values_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("table_name", desc_table_name)])
           SELECT cc.column_name

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -637,59 +637,150 @@ describe "OracleEnhancedConnection" do
     end
   end
 
-  describe "describe table" do
+  describe "resolve_data_source_name" do
     before(:all) do
-      @conn = ActiveRecord::ConnectionAdapters::OracleEnhanced::Connection.create(CONNECTION_PARAMS)
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+      @conn = ActiveRecord::Base.connection
       @owner = CONNECTION_PARAMS[:username].upcase
     end
 
-    it "should describe existing table" do
-      @conn.exec "CREATE TABLE test_employees (first_name VARCHAR2(20))" rescue nil
-      expect(@conn.describe("test_employees")).to eq([@owner, "TEST_EMPLOYEES"])
-      @conn.exec "DROP TABLE test_employees" rescue nil
+    def resolve(name)
+      @conn.send(:resolve_data_source_name, name)
     end
 
-    it "should not describe non-existing table" do
-      expect { @conn.describe("test_xxx") }.to raise_error(ActiveRecord::ConnectionAdapters::OracleEnhanced::ConnectionException)
+    it "should resolve existing table" do
+      @conn.execute "CREATE TABLE test_employees (first_name VARCHAR2(20))" rescue nil
+      expect(resolve("test_employees")).to eq([@owner, "TEST_EMPLOYEES"])
+      @conn.execute "DROP TABLE test_employees" rescue nil
     end
 
-    it "should describe table in other schema" do
-      expect(@conn.describe("sys.dual")).to eq(["SYS", "DUAL"])
+    it "should not resolve non-existing table" do
+      expect { resolve("test_xxx") }.to raise_error(ActiveRecord::ConnectionAdapters::OracleEnhanced::ConnectionException)
     end
 
-    it "should describe table in other schema if the schema and table are in different cases" do
-      expect(@conn.describe("SYS.dual")).to eq(["SYS", "DUAL"])
+    it "should resolve table in other schema" do
+      expect(resolve("sys.dual")).to eq(["SYS", "DUAL"])
     end
 
-    it "should describe existing view" do
-      @conn.exec "CREATE TABLE test_employees (first_name VARCHAR2(20))" rescue nil
-      @conn.exec "CREATE VIEW test_employees_v AS SELECT * FROM test_employees" rescue nil
-      expect(@conn.describe("test_employees_v")).to eq([@owner, "TEST_EMPLOYEES_V"])
-      @conn.exec "DROP VIEW test_employees_v" rescue nil
-      @conn.exec "DROP TABLE test_employees" rescue nil
+    it "should resolve table in other schema if the schema and table are in different cases" do
+      expect(resolve("SYS.dual")).to eq(["SYS", "DUAL"])
     end
 
-    it "should describe view in other schema" do
-      expect(@conn.describe("sys.v_$version")).to eq(["SYS", "V_$VERSION"])
+    it "should resolve existing view" do
+      @conn.execute "CREATE TABLE test_employees (first_name VARCHAR2(20))" rescue nil
+      @conn.execute "CREATE VIEW test_employees_v AS SELECT * FROM test_employees" rescue nil
+      expect(resolve("test_employees_v")).to eq([@owner, "TEST_EMPLOYEES_V"])
+      @conn.execute "DROP VIEW test_employees_v" rescue nil
+      @conn.execute "DROP TABLE test_employees" rescue nil
     end
 
-    it "should describe existing private synonym" do
-      @conn.exec "CREATE SYNONYM test_dual FOR sys.dual" rescue nil
-      expect(@conn.describe("test_dual")).to eq(["SYS", "DUAL"])
-      @conn.exec "DROP SYNONYM test_dual" rescue nil
+    it "should resolve view in other schema" do
+      expect(resolve("sys.v_$version")).to eq(["SYS", "V_$VERSION"])
     end
 
-    it "should describe existing public synonym" do
-      expect(@conn.describe("all_tables")).to eq(["SYS", "ALL_TABLES"])
+    it "should resolve existing materialized view" do
+      @conn.execute "CREATE TABLE test_employees (first_name VARCHAR2(20))" rescue nil
+      @conn.execute "CREATE MATERIALIZED VIEW test_employees_mv AS SELECT * FROM test_employees" rescue nil
+      expect(resolve("test_employees_mv")).to eq([@owner, "TEST_EMPLOYEES_MV"])
+      @conn.execute "DROP MATERIALIZED VIEW test_employees_mv" rescue nil
+      @conn.execute "DROP TABLE test_employees" rescue nil
     end
 
-    if defined?(OCI8)
-      context "OCI8 adapter" do
-        it "should not fallback to SELECT-based logic when querying non-existent table information" do
-          expect(@conn).not_to receive(:select_one)
-          @conn.describe("non_existent") rescue ActiveRecord::ConnectionAdapters::OracleEnhanced::ConnectionException
-        end
+    it "should resolve existing private synonym" do
+      @conn.execute "CREATE SYNONYM test_dual FOR sys.dual" rescue nil
+      expect(resolve("test_dual")).to eq(["SYS", "DUAL"])
+      @conn.execute "DROP SYNONYM test_dual" rescue nil
+    end
+
+    it "should resolve existing public synonym" do
+      expect(resolve("all_tables")).to eq(["SYS", "ALL_TABLES"])
+    end
+
+    it "raises when synonym resolution produces a looping chain" do
+      @conn.execute "CREATE SYNONYM test_cycle_a FOR test_cycle_b" rescue nil
+      @conn.execute "CREATE SYNONYM test_cycle_b FOR test_cycle_a" rescue nil
+      expect { resolve("test_cycle_a") }.to raise_error(
+        ActiveRecord::ConnectionAdapters::OracleEnhanced::ConnectionException,
+        /looping chain of synonyms/
+      )
+    ensure
+      @conn.execute "DROP SYNONYM test_cycle_a" rescue nil
+      @conn.execute "DROP SYNONYM test_cycle_b" rescue nil
+    end
+
+    it "raises when a multi-hop synonym chain eventually revisits an earlier link" do
+      @conn.execute "CREATE SYNONYM test_cycle_a FOR test_cycle_b" rescue nil
+      @conn.execute "CREATE SYNONYM test_cycle_b FOR test_cycle_c" rescue nil
+      @conn.execute "CREATE SYNONYM test_cycle_c FOR test_cycle_a" rescue nil
+      expect { resolve("test_cycle_a") }.to raise_error(
+        ActiveRecord::ConnectionAdapters::OracleEnhanced::ConnectionException,
+        /looping chain of synonyms/
+      )
+    ensure
+      @conn.execute "DROP SYNONYM test_cycle_a" rescue nil
+      @conn.execute "DROP SYNONYM test_cycle_b" rescue nil
+      @conn.execute "DROP SYNONYM test_cycle_c" rescue nil
+    end
+
+    it "raises ArgumentError when the name contains a db link" do
+      expect { resolve("test@db_link") }.to raise_error(ArgumentError, /db link is not supported/)
+    end
+
+    # The previous Connection#describe path bypassed the adapter's query machinery
+    # by driving a raw cursor, so its catalog lookup produced no sql.active_record
+    # event. Routing through select_one(..., "SCHEMA", ...) makes the lookup
+    # participate in logging, instrumentation, and the query cache. Lock that in
+    # so a future refactor can't silently regress to the raw-cursor path.
+    it "emits a SCHEMA sql.active_record event for the catalog lookup" do
+      @conn.execute "CREATE TABLE test_employees (first_name VARCHAR2(20))" rescue nil
+      events = []
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        events << payload
       end
+      resolve("test_employees")
+      expect(events.map { |p| p[:name] }).to include("SCHEMA")
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+      @conn.execute "DROP TABLE test_employees" rescue nil
+    end
+  end
+
+  describe "extract_schema_qualified_name" do
+    before(:all) do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+      @conn = ActiveRecord::Base.connection
+    end
+
+    def extract(string)
+      @conn.send(:extract_schema_qualified_name, string)
+    end
+
+    it "returns [nil, identifier] for an unqualified name and upcases it" do
+      expect(extract("table_name")).to eq([nil, "TABLE_NAME"])
+    end
+
+    it "leaves an already upcased unqualified name as-is" do
+      expect(extract("TABLE_NAME")).to eq([nil, "TABLE_NAME"])
+    end
+
+    it "splits a schema-qualified name and upcases it" do
+      expect(extract("hr.dept")).to eq(["HR", "DEPT"])
+    end
+
+    it "upcases a qualified name whose parts are in different cases" do
+      expect(extract("SYS.dual")).to eq(["SYS", "DUAL"])
+    end
+
+    it "accepts a Symbol and coerces it to a string" do
+      expect(extract(:dept)).to eq([nil, "DEPT"])
+    end
+
+    it "raises ArgumentError when the name contains a db link" do
+      expect { extract("test@db_link") }.to raise_error(ArgumentError, /db link is not supported/)
+    end
+
+    it "does not upcase a name that is not a valid identifier" do
+      expect(extract('"Weird Name"')).to eq([nil, '"Weird Name"'])
     end
   end
 end


### PR DESCRIPTION
## Summary

Alternative to #2498.

Instead of splitting `OracleEnhanced::Connection` into a dispatcher plus a `DatabaseDescription` module, this PR aligns with how Rails' bundled adapters (mysql2, trilogy, postgresql) handle schema introspection: the logic lives as **private helpers on `SchemaStatements`**, not on the connection wrapper.

- Introduce two private helpers on `OracleEnhanced::SchemaStatements`:
  - `extract_schema_qualified_name(string)` — pure string parsing. Mirrors the helpers of the same name in Rails' PostgreSQL and MySQL adapters. Returns `[schema, identifier]`; a non-qualified name returns `[nil, identifier]`. Oracle-specific bits (rejecting db links, upcasing valid identifiers so catalog lookups match the stored upper-case names) live here and nowhere else.
  - `resolve_data_source_name(name)` — calls the extract helper, defaults the schema to `_connection.owner` when unqualified, runs the catalog query, and iteratively follows synonyms. A `Set` of visited `[owner, identifier]` pairs guards against looping synonym chains. Raises `OracleEnhanced::ConnectionException` when the object does not exist, or with "looping chain of synonyms" (Oracle's own ORA-01775 phrasing) if a cycle is detected. The inline doc comment explicitly contrasts `_connection.owner` (the adapter's configured default schema, from `config[:schema]` or `config[:username]`) against `SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA')`, which can diverge after `ALTER SESSION SET CURRENT_SCHEMA`.
- The catalog query runs through the adapter's `select_one` path, so it participates in logging, instrumentation, and the query cache. The previous `describe` bypassed all of that by driving a raw cursor through `_select_one` / `prepare` / `fetch`.
- Replace all 10 `_connection.describe(name)` call sites in `schema_statements.rb` and `oracle_enhanced_adapter.rb` with `resolve_data_source_name(name)`.
- Remove `describe`, `_select_one`, and `_select_value` from `OracleEnhanced::Connection`. Expose `attr_reader :owner` so the helper can read the default schema.
- Drop the `def describe(name); super; end` shims from `OCIConnection` and `JDBCConnection`.
- Incidentally fix a latent bug: the original `if name.include?("@")` branch on master has had `raise ArgumentError "db link is not supported"` (missing comma) since 2018, so it silently never raised. The new helper uses the correct `raise ArgumentError, "..."` form, and a regression spec locks it in.

## Why this shape

`describe` was effectively internal plumbing that every caller immediately destructured into `[owner, table_name]`. It did not need to be a public method on the connection wrapper, and putting it there made it awkward to route through the adapter's normal query path. Moving it to `SchemaStatements` matches the convention used by `extract_schema_qualified_name` / `quoted_scope` in other Rails adapters.

Splitting `extract_schema_qualified_name` out of `resolve_data_source_name` keeps the parse step pure: no database access, no session state. Whichever follow-up path we take on synonym resolution — `all_objects` (#2521) or `DBMS_UTILITY.NAME_RESOLVE` (#2531) — the catalog-lookup body is the only thing that needs to change.

## Related

#2546 is a separate, independent cleanup that de-duplicates `_oracle_downcase` against `Quoting#oracle_downcase`. It can be merged before or after this PR.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb` (MRI / OCI)
- [x] Full suite: `bundle exec rspec`
- [x] `resolve_data_source_name` specs cover: existing table, non-existing table (raises `ConnectionException`), cross-schema table, cross-schema with mixed case, view, cross-schema view, **materialized view**, private synonym, public synonym, **two-hop looping synonym chain (A↔B)**, **three-hop looping synonym chain (A→B→C→A)**, and db-link rejection
- [x] New `extract_schema_qualified_name` specs cover unqualified / already upcase / lowercase qualified / mixed-case qualified / Symbol input / db-link rejection / non-valid-identifier passthrough
- [x] `bundle exec rubocop`
- [x] Spec-locked: `resolve_data_source_name` emits a `SCHEMA` `sql.active_record` event via AR's `select_one`, proving the refactor exercises the adapter's query machinery (the previous raw-cursor path did not)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

