### PR TITLE
De-duplicate _oracle_downcase via Quoting.oracle_downcase

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -17,18 +17,6 @@ module ActiveRecord
         end
 
         attr_reader :raw_connection, :owner
-
-        private
-          # Oracle column names by default are case-insensitive, but treated as upcase;
-          # for neatness, we'll downcase within Rails. EXCEPT that folks CAN quote
-          # their column names when creating Oracle tables, which makes then case-sensitive.
-          # I don't know anybody who does this, but we'll handle the theoretical case of a
-          # camelCase column name. I imagine other dbs handle this different, since there's a
-          # unit test that's currently failing test_oci.
-          def _oracle_downcase(column_name)
-            return nil if column_name.nil?
-            /[a-z]/.match?(column_name) ? column_name : column_name.downcase
-          end
       end
 
       # Returns array with major and minor version of database (e.g. [12, 1])

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -494,7 +494,7 @@ module ActiveRecord
           column_count = metadata.getColumnCount
 
           cols_types_index = (1..column_count).map do |i|
-            col_name = _oracle_downcase(metadata.getColumnName(i))
+            col_name = OracleEnhanced::Quoting.oracle_downcase(metadata.getColumnName(i))
             next if col_name == "raw_rnum_"
             column_hash[col_name] = nil
             [col_name, metadata.getColumnTypeName(i).to_sym, i]

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -200,7 +200,7 @@ module ActiveRecord
           cols = []
           # Ignore raw_rnum_ which is used to simulate LIMIT and OFFSET
           cursor.get_col_names.each do |col_name|
-            col_name = _oracle_downcase(col_name)
+            col_name = OracleEnhanced::Quoting.oracle_downcase(col_name)
             cols << col_name unless col_name == "raw_rnum_"
           end
           # Reuse the same hash for all rows

--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -170,6 +170,12 @@ module ActiveRecord
             return nil if column_name.nil?
             /[a-z]/.match?(column_name) ? column_name : column_name.downcase
           end
+
+          # Also expose `oracle_downcase` as `Quoting.oracle_downcase(...)` so the raw-driver
+          # `select` paths in OCIConnection / JDBCConnection can reuse it without mixing in
+          # the whole Quoting module. It stays a private instance method when Quoting is
+          # included into the adapter.
+          module_function :oracle_downcase
       end
     end
   end


### PR DESCRIPTION
## Summary

`OracleEnhanced::Connection#_oracle_downcase` and `OracleEnhanced::Quoting#oracle_downcase` had identical implementations:

```ruby
return nil if column_name.nil?
/[a-z]/.match?(column_name) ? column_name : column_name.downcase
```

The duplicate existed because the raw-driver `select` paths in `OCIConnection` and `JDBCConnection` needed the helper but did not include the `Quoting` module. This PR exposes `Quoting#oracle_downcase` as a module function so those call sites can reuse it directly, and removes the duplicate copy from `Connection`.

Rebased onto `master` after #2545 was merged — that PR moved `describe` / `_select_one` / `_select_value` out of `Connection` into `SchemaStatements#resolve_data_source_name`, so `Connection`'s `private` section is now empty and has been dropped entirely.

## Changes

- `Quoting#oracle_downcase` — add `module_function :oracle_downcase` with a short comment explaining intent. The method stays a private instance method when `Quoting` is included into `OracleEnhancedAdapter` (no behavior change for adapter-side callers); it also becomes callable as `OracleEnhanced::Quoting.oracle_downcase(...)`.
- `OCIConnection#select` — call `OracleEnhanced::Quoting.oracle_downcase(col_name)` instead of the local `_oracle_downcase`.
- `JDBCConnection#select_no_retry` — same.
- `Connection#_oracle_downcase` — removed, along with the now-empty `private` section.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb`
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb`
- [x] `bundle exec rubocop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

