### PR TITLE
Recognise JDBC driver ORA-17NNN codes as lost connections

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -465,10 +465,14 @@ module ActiveRecord
             # has reset the connection). Re-raise anything else so genuine
             # driver/resource bugs surface.
             #
-            #   ORA-17002 "Io exception"        - network/socket failure
-            #   ORA-17008 "Closed Connection"   - connection already closed
-            #   ORA-17009 "Closed Statement"    - statement already closed
-            raise unless [17_002, 17_008, 17_009].include?(e.getErrorCode)
+            #   ORA-17002 / ORA-17008 — connection already gone
+            #     (see JDBC_LOST_CONNECTION_ERROR_CODES).
+            #   ORA-17009 "Closed Statement" — the Statement handle is
+            #     gone but the connection may still be alive. It is a
+            #     cursor-local concern, not a lost-connection signal,
+            #     which is why it is allowed here but excluded from
+            #     JDBC_LOST_CONNECTION_ERROR_CODES / lost_connection?.
+            raise unless JDBC_LOST_CONNECTION_ERROR_CODES.include?(e.getErrorCode) || e.getErrorCode == 17009
             nil
           end
         end
@@ -537,14 +541,34 @@ module ActiveRecord
           end
         end
 
-        # JDBC SQLException messages that signal a dropped connection
-        # without a meaningful Oracle error code attached. ORA-17008
-        # (Closed Connection) surfaces as the "Closed Connection" message.
+        # Oracle JDBC driver (ojdbc) client-side error codes that indicate
+        # the underlying connection is gone. Distinct from the shared
+        # LOST_CONNECTION_ERROR_CODES, which lists Oracle Database server-
+        # side ORA-NNNN codes — those can arrive via OCI as well, these
+        # cannot: the 17NNN range is reserved for the JDBC driver itself
+        # (the server never sends ORA-17NNN back).
+        #   ORA-17002 Io exception       — network / socket failure
+        #   ORA-17008 Closed Connection  — connection already closed
+        #
+        # ORA-17009 "Closed Statement" is deliberately NOT listed here:
+        # it signals that only a stale Statement handle is gone while the
+        # connection itself may still be alive, so lost_connection? must
+        # not return true for it (doing so would discard a live session).
+        # Cursor#close tolerates 17009 separately as a cursor-local
+        # concern.
+        JDBC_LOST_CONNECTION_ERROR_CODES = [17002, 17008]
+
+        # Fallback for older ojdbc that surfaces disconnects with
+        # SQLException#getErrorCode == 0 and no ORA-NNNNN prefix in the
+        # message. ojdbc17+ produces proper error codes handled via the
+        # *_ERROR_CODES lists above.
         LOST_CONNECTION_MESSAGE = /\A(Closed Connection|Io exception:|No more data to read from socket|IO Error:)/
 
         def lost_connection?(exception)
           return false unless exception.is_a?(Java::JavaSql::SQLException)
-          LOST_CONNECTION_ERROR_CODES.include?(exception.getErrorCode) ||
+          code = exception.getErrorCode
+          LOST_CONNECTION_ERROR_CODES.include?(code) ||
+            JDBC_LOST_CONNECTION_ERROR_CODES.include?(code) ||
             LOST_CONNECTION_MESSAGE.match?(exception.message)
         end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -551,6 +551,37 @@ describe "OracleEnhancedConnection" do
       kill_current_session
       expect { Post.take }.to raise_error(ActiveRecord::StatementInvalid)
     end
+
+    if RUBY_ENGINE == "jruby"
+      # ojdbc17 surfaces dropped-connection errors with both a proper
+      # SQLException#getErrorCode and an "ORA-17NNN:" prefix in the message.
+      # Regression test for the case where the prefixed message no longer
+      # matches LOST_CONNECTION_MESSAGE and the code must be recognised via
+      # JDBC_LOST_CONNECTION_ERROR_CODES instead.
+      it "recognises ORA-17008 via the JDBC driver error code" do
+        exception = Java::JavaSql::SQLException.new("ORA-17008: Closed connection", nil, 17008)
+        expect(@conn.lost_connection?(exception)).to be true
+      end
+
+      it "recognises ORA-17002 via the JDBC driver error code" do
+        exception = Java::JavaSql::SQLException.new("ORA-17002: Io exception", nil, 17002)
+        expect(@conn.lost_connection?(exception)).to be true
+      end
+
+      it "recognises older ojdbc 'Closed Connection' messages with no error code attached" do
+        exception = Java::JavaSql::SQLException.new("Closed Connection", nil, 0)
+        expect(@conn.lost_connection?(exception)).to be true
+      end
+
+      # ORA-17009 "Closed Statement" means only the Statement handle is
+      # gone; the connection may still be alive. Treating it as a lost
+      # connection would discard a live session, so lost_connection?
+      # must return false. Cursor#close tolerates 17009 separately.
+      it "does not treat ORA-17009 (Closed Statement) as a lost connection" do
+        exception = Java::JavaSql::SQLException.new("ORA-17009: Closed Statement", nil, 17009)
+        expect(@conn.lost_connection?(exception)).to be false
+      end
+    end
   end
 
   describe "describe table" do


### PR DESCRIPTION
Follow-up to #2523, which introduced `LOST_CONNECTION_ERROR_CODES` and the `lost_connection?` predicate.

## Summary

- `JDBCConnection#lost_connection?` missed `ORA-17008` / `ORA-17002` on ojdbc17+, so `translate_exception` raised `StatementInvalid` instead of `ConnectionFailed` — defeating `allow_retry: true` (rails/rails#46273).
- Added `JDBC_LOST_CONNECTION_ERROR_CODES = [17002, 17008]` in `JDBCConnection` and OR'd it into the predicate. The shared `LOST_CONNECTION_ERROR_CODES` stays Oracle Database server-only (not JDBC driver codes).
- Reused the new constant in `Cursor#close` (previously hard-coded `[17_002, 17_008, 17_009]`); the cursor-specific `ORA-17009 Closed Statement` stays inline as a single-code check.
- Kept `LOST_CONNECTION_MESSAGE` as a fallback for pre-ojdbc17 releases (`SQLException#getErrorCode == 0`) and clarified the comment.

## Why

`LOST_CONNECTION_ERROR_CODES = [28, 1012, 3113, 3114, 3135]` (added in #2523) lists Oracle Database server-side `ORA-NNNN` codes. `ORA-17NNN` is the ojdbc driver-side range — OCI will never see those values, so they do not belong in the shared list. Splitting them keeps the domain boundary explicit: Oracle Database server errors on the base module, ojdbc driver errors on `JDBCConnection`.

Before ojdbc17 these driver errors surfaced with `getErrorCode == 0` and a bare `"Closed Connection"` / `"Io exception:"` message; `LOST_CONNECTION_MESSAGE` was added as a fallback for that case. On ojdbc17 they carry the proper error code *and* an `ORA-17NNN:` prefix, which the bare-message regex no longer matches — hence the regression this PR fixes.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb -e "auto reconnection"` (MRI, Docker FREEPDB1) — existing kill-session cases still pass; new JRuby-guarded cases skipped as expected.
- [x] `bundle exec rubocop lib/.../jdbc_connection.rb spec/.../connection_spec.rb` clean.
- [ ] CI (JRuby job) exercises the new `lost_connection?` unit tests for ORA-17008 / ORA-17002 / bare `"Closed Connection"` via fabricated `Java::JavaSql::SQLException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)