### PR TITLE
Create .bundle before booting the dev container in CI

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Ensure .bundle mount source exists
+        run: mkdir -p .bundle
+
       - name: Boot dev container and run tests
         uses: devcontainers/ci@v0.3
         with:


### PR DESCRIPTION
## Summary

- Fix the `devcontainer` workflow ([failed run](https://github.com/rsim/oracle-enhanced/actions/runs/24630639416/job/72017287422)) that was aborting in `postCreateCommand` with `Errno::EACCES: Permission denied @ dir_s_mkdir - /home/vscode/.bundle/cache`.

## Why it failed

`.devcontainer/devcontainer.json` bind-mounts `${localWorkspaceFolder}/.bundle` onto `/home/vscode/.bundle` to persist Bundler's cache across container rebuilds. `.bundle` is in `.gitignore`, so a fresh CI checkout has no such directory. Docker Compose (with `create_host_path: true`) then lets the Docker daemon — running as root — create the missing source path. `devcontainers/ci@v0.3` remaps the container's `vscode` user to the runner's non-root UID, which cannot write to the root-owned mount, so `bundle install` fails when it tries to create its cache directory.

Local developers never see this because their workspaces already contain a user-owned `.bundle/` from prior bundler runs.

## Fix

Pre-create `.bundle` as the runner user before `devcontainers/ci@v0.3` boots the container, so the bind-mount source exists with the correct ownership. No change is needed for local developers.

## Test plan

- [ ] `gh workflow run devcontainer.yml --ref devcontainer-ci-bundle-mount-source` completes successfully (reaches `bundle exec rake spec` and `bundle exec rubocop`).
- [ ] Opening the devcontainer locally still works (`.bundle/` remains user-owned, `bundle install` succeeds).
