### PR TITLE
Run jruby-head CI only on the scheduled workflow

### DIFF
--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -22,7 +22,6 @@ jobs:
           '3.4',
           '3.3',
           'jruby-10.0.5.0',
-          'jruby-head',
         ]
     env:
       ORACLE_HOME: /opt/oracle/instantclient_21_15

--- a/.github/workflows/test_11g_ojdbc11.yml
+++ b/.github/workflows/test_11g_ojdbc11.yml
@@ -19,7 +19,6 @@ jobs:
       matrix:
         ruby: [
           'jruby-10.0.5.0',
-          'jruby-head',
         ]
     env:
       ORACLE_HOME: /opt/oracle/instantclient_21_15


### PR DESCRIPTION
## Summary

- Match jruby-head's CI trigger pattern to ruby-head: run only on the scheduled workflow, not on every pull request.
- Drop `jruby-head` from the `test_11g.yml` and `test_11g_ojdbc11.yml` matrices; both workflows trigger on `push` / `pull_request` / `schedule` and the other members of the matrix stay.
- Nightly jruby-head coverage is unchanged — `.github/workflows/jruby_head.yml` already runs on `schedule` (and `workflow_dispatch`) only and gives jruby-head signal against Oracle Free, mirroring `ruby_head.yml`.

## Why

ruby-head and jruby-head are moving targets; PR authors shouldn't be blocked on a head-Ruby regression that's unrelated to their change. ruby-head already lives on a scheduled workflow; this brings jruby-head into line.

## Test plan

- [x] `yq` / Ruby YAML.load_file round-trip on both edited files (still valid YAML, matrices non-empty).
- [x] Grep confirms the only remaining `jruby-head` reference in `.github/workflows/` is `jruby_head.yml`, which is `schedule` + `workflow_dispatch` only.
- [ ] Wait for the push-triggered CI run on this branch to confirm the PR no longer spawns any `jruby-head` jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
