### PR TITLE
Regression spec for the :schema connection option + JDBC @owner casing fix

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -196,7 +196,7 @@ module ActiveRecord
             @owner = username.upcase unless username.nil?
           else
             exec "alter session set current_schema = #{schema}"
-            @owner = schema
+            @owner = schema.upcase
           end
 
           @raw_connection

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -147,6 +147,59 @@ describe "OracleEnhancedConnection" do
     end
   end
 
+  describe "resolving unqualified names with :schema set to a different user" do
+    # Pins down the end-to-end contract of the `:schema` connection option:
+    #
+    # When `:schema` is present in the connection config, two independent
+    # mechanisms must line up so that unqualified references to tables owned
+    # by the `:schema` user resolve correctly end-to-end:
+    #
+    #   1. At connect time, the adapter runs
+    #      `ALTER SESSION SET CURRENT_SCHEMA = <schema>`, so Oracle's own name
+    #      resolution treats unqualified identifiers in SQL as belonging to
+    #      the `:schema` user.
+    #   2. The connection wrapper sets `@owner = config[:schema]` (falling
+    #      back to `config[:username]`), so the adapter's catalog-lookup path
+    #      (`data_source_exists?`, `column_definitions`, `indexes`, etc.)
+    #      defaults its owner filter to the `:schema` user.
+    #
+    # If either mechanism drifts — e.g. someone changes `@owner` to track the
+    # login user instead of `:schema`, or drops the ALTER SESSION at connect
+    # time — the matching assertion below will fail, forcing the change to be
+    # a conscious decision rather than a silent behavior drift.
+    schema_owner_params = CONNECTION_PARAMS.merge(username: DATABASE_SCHEMA, password: DATABASE_SCHEMA)
+
+    before(:all) do
+      ActiveRecord::Base.establish_connection(schema_owner_params)
+      schema_conn = ActiveRecord::Base.connection
+      schema_conn.drop_table :schema_probe_table, if_exists: true
+      schema_conn.create_table :schema_probe_table, id: :integer
+      schema_conn.execute "GRANT SELECT ON schema_probe_table TO #{DATABASE_USER}"
+      ActiveRecord::Base.remove_connection
+
+      ActiveRecord::Base.establish_connection(CONNECTION_WITH_SCHEMA_PARAMS)
+    end
+
+    after(:all) do
+      ActiveRecord::Base.remove_connection
+      ActiveRecord::Base.establish_connection(schema_owner_params)
+      ActiveRecord::Base.connection.drop_table :schema_probe_table, if_exists: true
+      ActiveRecord::Base.remove_connection
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    end
+
+    it "sets CURRENT_SCHEMA so unqualified raw SQL resolves in the :schema user" do
+      expect(ActiveRecord::Base.connection.current_schema).to eq(DATABASE_SCHEMA.upcase)
+      expect {
+        ActiveRecord::Base.connection.execute("SELECT COUNT(*) FROM schema_probe_table")
+      }.not_to raise_error
+    end
+
+    it "data_source_exists? resolves an unqualified name in the :schema user" do
+      expect(ActiveRecord::Base.connection.data_source_exists?("schema_probe_table")).to be true
+    end
+  end
+
   describe "create connection with NLS parameters" do
     after do
       ENV["NLS_TERRITORY"] = nil


### PR DESCRIPTION
## Summary

Adds an end-to-end regression spec for the `:schema` connection option, and fixes a latent JDBC casing bug that the spec surfaces.

## Why

The existing `"create connection with schema option"` specs only assert that `current_schema` reads back as expected after `ALTER SESSION SET CURRENT_SCHEMA`. They do not exercise any downstream behavior that actually depends on the schema switch — a future refactor that changes how `@owner` tracks `:schema`, or drops the `ALTER SESSION` step, would pass them all and still silently break the feature.

The `:schema` option relies on **two** independent mechanisms lining up:

1. **`ALTER SESSION SET CURRENT_SCHEMA = <schema>`** at connect time (`oci_connection.rb:363`, `jdbc_connection.rb:198`), so Oracle's own name resolution treats unqualified identifiers in SQL as belonging to the `:schema` user.
2. **`@owner = config[:schema]`** on the connection wrapper (`oci_connection.rb:33-35`, `jdbc_connection.rb:196-199`), so the adapter's catalog-lookup path (`data_source_exists?`, `column_definitions`, `indexes`, etc.) defaults its owner filter to the `:schema` user.

Both together make unqualified references to tables in the `:schema` user resolve end-to-end. The new spec covers both — raw-SQL resolution via `CURRENT_SCHEMA`, and catalog resolution via `data_source_exists?`.

## Latent JDBC casing bug fixed here

Writing the spec surfaced a real bug in `jdbc_connection.rb:199`:

```diff
-            @owner = schema
+            @owner = schema.upcase
```

OCI always upcases `@owner` (`oci_connection.rb:35`), but JDBC's `:schema` branch assigned it without upcasing. With the documented lowercase `schema:` config, JDBC ended up querying

```sql
WHERE owner = 'oracle_enhanced_schema'
```

against an Oracle data dictionary that stores unquoted owners uppercase, so `data_source_exists?` of an unqualified name returned `false` under JDBC even though it worked under OCI. Normalising to `schema.upcase` matches the OCI path and makes `:schema` behave identically across adapters.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb -e "create connection with schema option" -e "resolving unqualified names with :schema set to a different user"` — 5 examples, 0 failures (MRI / OCI)
- [x] `bundle exec rubocop lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb` — no offenses
- [ ] CI: confirm the new spec passes on `build (jruby-10.0.5.0)` as well (the JDBC fix is the point — without it, the new spec fails on JDBC)
- [x] Copilot CLI review: two real findings acted on (JDBC casing bug, qualified-name assertion dropped as it doesn't actually test `:schema`), nice-to-haves (SQL-injection in `ALTER SESSION`, quoted identifiers, public-synonym × `:schema` combo) deliberately left out of scope

## Fixture assumptions

The spec uses the test-fixture convention from `spec/support/create_oracle_enhanced_users.sql` that the `DATABASE_SCHEMA` user is identified by the same password as its username (`oracle_enhanced_schema` / `oracle_enhanced_schema`). That matches how the `ci/setup_accounts.sh` provisioning works for CI and for the standard local setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
