### PR TITLE
Align method visibility with Rails + CI drift detector

### DIFF
--- a/.github/workflows/check_method_visibility.yml
+++ b/.github/workflows/check_method_visibility.yml
@@ -1,0 +1,43 @@
+name: check_method_visibility
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  schedule:
+    - cron: "0 0 * * 1" # Mondays at 00:00 UTC
+  workflow_dispatch:
+
+jobs:
+  check:
+    name: "Compare Ruby visibility against Rails"
+    runs-on: ubuntu-latest
+    env:
+      ORACLE_HOME: /opt/oracle/instantclient_23_26
+      LD_LIBRARY_PATH: /opt/oracle/instantclient_23_26
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          rubygems: latest
+      - name: Create symbolic link for libaio library compatibility
+        run: |
+          sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
+      - name: Download Oracle instant client
+        run: |
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-basic-linux.x64-23.26.1.0.0.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-sdk-linux.x64-23.26.1.0.0.zip
+      - name: Install Oracle instant client
+        run: |
+          sudo unzip instantclient-basic-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
+          sudo unzip -o instantclient-sdk-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
+          echo "/opt/oracle/instantclient_23_26" >> $GITHUB_PATH
+      - name: Bundle install
+        run: |
+          bundle install --jobs 4 --retry 3
+      - name: Check method visibility against Rails
+        run: |
+          bundle exec ruby -Ilib ci/check_method_visibility.rb

--- a/ci/check_method_visibility.rb
+++ b/ci/check_method_visibility.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+# Surfaces visibility drift between oracle_enhanced and Rails.
+#
+# For every instance method defined inside an `OracleEnhanced::*` module or the
+# `OracleEnhancedAdapter` class, this script finds the nearest non-OE Rails
+# adapter ancestor that also defines that method and compares the Ruby
+# visibility (public / private / protected). Any mismatch is reported, and the
+# script exits non-zero so CI can catch it.
+#
+# Because it walks `OracleEnhancedAdapter.ancestors`, it intentionally does not
+# care which Rails module the counterpart lives in. A method we define in
+# `OracleEnhanced::SchemaStatements` that Rails defines directly on
+# `AbstractAdapter` (or vice versa) is still detected as a drift as long as
+# both sides name the method the same way.
+#
+# What this does NOT catch (known limitations):
+#
+# - Methods Rails renames / relocates without keeping the old name. If Rails
+#   turns `foo` into `bar`, this script sees two unrelated methods.
+# - Methods that only exist as class methods (`self.foo`) — only instance
+#   methods are compared.
+# - Semantic drift — signature changes and behavioural differences are
+#   invisible to a visibility check.
+# - `# :nodoc:` markers — those are source-level comments, not reflectable at
+#   runtime. A follow-up could parse the AST if this becomes important.
+#
+# Run locally:
+#   bundle exec ruby -Ilib ci/check_method_visibility.rb
+
+require "active_record"
+require "active_record/connection_adapters/oracle_enhanced_adapter"
+
+ADAPTER = ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter
+
+# Drifts listed here are intentionally accepted, with a one-line reason. Keep
+# this set small and give it a good justification — the whole point of the
+# check is to flag *unintentional* drift.
+IGNORED_DRIFTS = [
+  # { method: :some_method, oe_owner: "Some::Module", rails_owner: "Some::Rails" },
+].freeze
+
+OE_NAMESPACE = /(^|::)OracleEnhanced(?:Adapter)?(?:::|$)/
+
+def oe_owned?(owner)
+  owner.name && owner.name.match?(OE_NAMESPACE)
+end
+
+def rails_owned?(owner)
+  name = owner.name
+  return false unless name
+  return false if oe_owned?(owner)
+  # Only consider Rails adapter-contract namespaces. ActiveSupport mixins
+  # (Callbacks, Tryable, ...) and ActiveRecord non-adapter modules
+  # (Migration, QueryCache helpers, ...) are deliberately out of scope for
+  # this adapter-visibility check.
+  name.start_with?("ActiveRecord::ConnectionAdapters::") ||
+    name.start_with?("Arel::")
+end
+
+def visibility_of(owner, method_name)
+  return :public    if owner.public_instance_methods(false).include?(method_name)
+  return :private   if owner.private_instance_methods(false).include?(method_name)
+  return :protected if owner.protected_instance_methods(false).include?(method_name)
+  nil
+end
+
+# Find the nearest Rails (non-OE) ancestor that defines method_name, walking
+# the class's ancestor list in MRO order. Returns [ancestor_owner, visibility]
+# or nil.
+def find_rails_counterpart(ancestors, method_name)
+  ancestors.each do |owner|
+    next unless rails_owned?(owner)
+    vis = visibility_of(owner, method_name)
+    return [owner, vis] if vis
+  end
+  nil
+end
+
+def ignored?(drift)
+  IGNORED_DRIFTS.any? do |pat|
+    pat[:method].to_s == drift[:method].to_s &&
+      pat[:oe_owner] == drift[:oe_owner] &&
+      pat[:rails_owner] == drift[:rails_owner]
+  end
+end
+
+drifts = []
+ancestors = ADAPTER.ancestors
+oe_ancestors = ancestors.select { |owner| oe_owned?(owner) }
+
+oe_ancestors.each do |oe_owner|
+  own_methods = oe_owner.public_instance_methods(false) +
+                oe_owner.private_instance_methods(false) +
+                oe_owner.protected_instance_methods(false)
+
+  own_methods.sort.each do |method_name|
+    rails_pair = find_rails_counterpart(ancestors, method_name)
+    next unless rails_pair
+
+    rails_owner, rails_vis = rails_pair
+    oe_vis = visibility_of(oe_owner, method_name)
+    next if oe_vis == rails_vis
+
+    drift = {
+      method: method_name,
+      oe_owner: oe_owner.name,
+      oe_vis: oe_vis,
+      rails_owner: rails_owner.name,
+      rails_vis: rails_vis,
+    }
+    drifts << drift unless ignored?(drift)
+  end
+end
+
+if drifts.empty?
+  puts "OK: every overridden method matches the Rails counterpart's visibility."
+  exit 0
+end
+
+puts "Visibility drift detected (#{drifts.size} method#{drifts.size == 1 ? '' : 's'}):"
+drifts.sort_by { |d| [d[:oe_owner], d[:method].to_s] }.each do |d|
+  puts "  - #{d[:method]}"
+  puts "      #{d[:oe_owner]}: #{d[:oe_vis]}"
+  puts "      #{d[:rails_owner]}: #{d[:rails_vis]}"
+end
+puts
+puts "If the drift is intentional (Rails changed its contract and we are tracking"
+puts "the old behavior deliberately), add an entry to IGNORED_DRIFTS in this"
+puts "script with a one-line comment explaining why. Otherwise, reconcile"
+puts "oracle_enhanced with Rails by moving the method's visibility to match."
+exit 1

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -24,18 +24,6 @@ module ActiveRecord
           super
         end
 
-        def cast_result(result)
-          if result.nil?
-            ActiveRecord::Result.empty
-          else
-            ActiveRecord::Result.new(result[:columns], result[:rows])
-          end
-        end
-
-        def affected_rows(result)
-          result[:affected_rows_count]
-        end
-
         def supports_explain?
           true
         end
@@ -54,16 +42,6 @@ module ActiveRecord
         def build_explain_clause(options = [])
           # Oracle does not have anything similar to "EXPLAIN ANALYZE"
           # https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/EXPLAIN-PLAN.html#GUID-FD540872-4ED3-4936-96A2-362539931BA0
-        end
-
-        # New method in ActiveRecord 3.1
-        # Will add RETURNING clause in case of trigger generated primary keys
-        def sql_for_insert(sql, pk, binds, _returning)
-          unless pk == false || pk.nil? || pk.is_a?(Array) || pk.is_a?(String)
-            sql = "#{sql} RETURNING #{quote_column_name(pk)} INTO :returning_id"
-            (binds = binds.dup) << ActiveRecord::Relation::QueryAttribute.new("returning_id", nil, Type::OracleEnhanced::Integer.new)
-          end
-          super
         end
 
         def insert(arel, name = nil, pk = nil, id_value = nil, sequence_name = nil, binds = [], returning: nil)
@@ -114,10 +92,6 @@ module ActiveRecord
             cursor.close unless cached
             build_result(columns: returning_id_col || [], rows: rows)
           end
-        end
-
-        def returning_column_values(result)
-          result.rows.first
         end
 
         def begin_db_transaction # :nodoc:
@@ -228,6 +202,32 @@ module ActiveRecord
         end
 
         private
+          def cast_result(result)
+            if result.nil?
+              ActiveRecord::Result.empty
+            else
+              ActiveRecord::Result.new(result[:columns], result[:rows])
+            end
+          end
+
+          def affected_rows(result)
+            result[:affected_rows_count]
+          end
+
+          # New method in ActiveRecord 3.1
+          # Will add RETURNING clause in case of trigger generated primary keys
+          def sql_for_insert(sql, pk, binds, _returning) # :nodoc:
+            unless pk == false || pk.nil? || pk.is_a?(Array) || pk.is_a?(String)
+              sql = "#{sql} RETURNING #{quote_column_name(pk)} INTO :returning_id"
+              (binds = binds.dup) << ActiveRecord::Relation::QueryAttribute.new("returning_id", nil, Type::OracleEnhanced::Integer.new)
+            end
+            super
+          end
+
+          def returning_column_values(result)
+            result.rows.first
+          end
+
           def perform_query(raw_connection, intent)
             sql = intent.processed_sql
             binds = intent.binds

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -28,7 +28,7 @@ module ActiveRecord
           true
         end
 
-        def explain(arel, binds = [], options = [])
+        def explain(arel, binds = [], options = []) # :nodoc:
           sql = "EXPLAIN PLAN FOR #{to_sql(arel, binds)}"
           return if /FROM all_/.match?(sql)
           if ORACLE_ENHANCED_CONNECTION == :jdbc

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -598,11 +598,11 @@ module ActiveRecord
           end
         end
 
-        def update_table_definition(table_name, base)
+        def update_table_definition(table_name, base) # :nodoc:
           OracleEnhanced::Table.new(table_name, base)
         end
 
-        def create_schema_dumper(options)
+        def create_schema_dumper(options) # :nodoc:
           OracleEnhanced::SchemaDumper.create(self, options)
         end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -275,26 +275,6 @@ module ActiveRecord
           clear_table_columns_cache(table_name)
         end
 
-        def insert_versions_sql(versions) # :nodoc:
-          sm_table = quote_table_name(ActiveRecord::Tasks::DatabaseTasks.migration_connection_pool.schema_migration.table_name)
-
-          if supports_multi_insert?
-            versions.inject(+"INSERT ALL\n") { |sql, version|
-              sql << "INTO #{sm_table} (version) VALUES (#{quote(version)})\n"
-            } << "SELECT * FROM DUAL\n"
-          else
-            if versions.is_a?(Array)
-              # called from ActiveRecord::Base.connection#dump_schema_versions
-              versions.map { |version|
-                "INSERT INTO #{sm_table} (version) VALUES (#{quote(version)})"
-              }.join("\n\n/\n\n")
-            else
-              # called from ActiveRecord::Base.connection#assume_migrated_upto_version
-              "INSERT INTO #{sm_table} (version) VALUES (#{quote(versions)})"
-            end
-          end
-        end
-
         def add_index(table_name, column_name, **options) # :nodoc:
           index_name, index_type, quoted_column_names, tablespace, index_options = add_index_options(table_name, column_name, **options)
           execute "CREATE #{index_type} INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} (#{quoted_column_names})#{tablespace} #{index_options}"
@@ -589,13 +569,6 @@ module ActiveRecord
           end
         end
 
-        def extract_foreign_key_action(specifier) # :nodoc:
-          case specifier
-          when "CASCADE"; :cascade
-          when "SET NULL"; :nullify
-          end
-        end
-
         # REFERENTIAL INTEGRITY ====================================
 
         def disable_referential_integrity(&block) # :nodoc:
@@ -618,10 +591,6 @@ module ActiveRecord
           end
         end
 
-        def create_alter_table(name)
-          OracleEnhanced::AlterTable.new create_table_definition(name)
-        end
-
         def add_timestamps(table_name, **options)
           fragments = add_timestamps_for_alter(table_name, **options)
           fragments.each do |fragment|
@@ -638,6 +607,37 @@ module ActiveRecord
         end
 
         private
+          def insert_versions_sql(versions)
+            sm_table = quote_table_name(ActiveRecord::Tasks::DatabaseTasks.migration_connection_pool.schema_migration.table_name)
+
+            if supports_multi_insert?
+              versions.inject(+"INSERT ALL\n") { |sql, version|
+                sql << "INTO #{sm_table} (version) VALUES (#{quote(version)})\n"
+              } << "SELECT * FROM DUAL\n"
+            else
+              if versions.is_a?(Array)
+                # called from ActiveRecord::Base.connection#dump_schema_versions
+                versions.map { |version|
+                  "INSERT INTO #{sm_table} (version) VALUES (#{quote(version)})"
+                }.join("\n\n/\n\n")
+              else
+                # called from ActiveRecord::Base.connection#assume_migrated_upto_version
+                "INSERT INTO #{sm_table} (version) VALUES (#{quote(versions)})"
+              end
+            end
+          end
+
+          def extract_foreign_key_action(specifier)
+            case specifier
+            when "CASCADE"; :cascade
+            when "SET NULL"; :nullify
+            end
+          end
+
+          def create_alter_table(name)
+            OracleEnhanced::AlterTable.new create_table_definition(name)
+          end
+
           def schema_creation
             OracleEnhanced::SchemaCreation.new self
           end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -606,6 +606,10 @@ module ActiveRecord
           OracleEnhanced::SchemaDumper.create(self, options)
         end
 
+        def schema_creation # :nodoc:
+          OracleEnhanced::SchemaCreation.new self
+        end
+
         private
           def insert_versions_sql(versions)
             sm_table = quote_table_name(ActiveRecord::Tasks::DatabaseTasks.migration_connection_pool.schema_migration.table_name)
@@ -636,10 +640,6 @@ module ActiveRecord
 
           def create_alter_table(name)
             OracleEnhanced::AlterTable.new create_table_definition(name)
-          end
-
-          def schema_creation
-            OracleEnhanced::SchemaCreation.new self
           end
 
           def create_table_definition(name, **options)

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -255,14 +255,6 @@ module ActiveRecord
         raise NotImplementedError
       end
 
-      def arel_visitor # :nodoc:
-        if supports_fetch_first_n_rows_and_offset?
-          Arel::Visitors::Oracle12.new(self)
-        else
-          Arel::Visitors::Oracle.new(self)
-        end
-      end
-
       def return_value_after_insert?(column) # :nodoc:
         # TODO: Return true if there this column will be populated (e.g by a sequence)
         super
@@ -284,10 +276,6 @@ module ActiveRecord
         end
 
         find_cmd_and_exec(ActiveRecord.database_cli[:oracle] || "sqlplus", logon)
-      end
-
-      def build_statement_pool
-        StatementPool.new(self.class.type_cast_config_to_integer(@config[:statement_limit]))
       end
 
       def supports_savepoints? # :nodoc:
@@ -462,12 +450,6 @@ module ActiveRecord
         _connection.ping
       rescue OracleEnhanced::ConnectionException
         false
-      end
-
-      def reconnect
-        _connection.reset # tentative
-      rescue OracleEnhanced::ConnectionException
-        connect
       end
 
       # Reconnects to the database.
@@ -777,10 +759,6 @@ module ActiveRecord
           end
       end
 
-      def type_map
-        self.class.type_map
-      end
-
       def extract_value_from_default(default)
         case default
         when String
@@ -796,27 +774,6 @@ module ActiveRecord
           19
         when /\((.*)\)/
           $1.to_i
-        end
-      end
-
-      def translate_exception(exception, message:, sql:, binds:) # :nodoc:
-        return ActiveRecord::ConnectionFailed.new(message, sql: sql, binds: binds, connection_pool: @pool) if _connection.lost_connection?(exception)
-
-        case _connection.error_code(exception)
-        when 1
-          RecordNotUnique.new(message, sql: sql, binds: binds)
-        when 60
-          Deadlocked.new(message)
-        when 900, 904, 942, 955, 1418, 2289, 2449, 17008
-          ActiveRecord::StatementInvalid.new(message, sql: sql, binds: binds)
-        when 1400
-          ActiveRecord::NotNullViolation.new(message, sql: sql, binds: binds)
-        when 2291, 2292
-          InvalidForeignKey.new(message, sql: sql, binds: binds)
-        when 12899
-          ValueTooLong.new(message, sql: sql, binds: binds)
-        else
-          super
         end
       end
 
@@ -843,6 +800,50 @@ module ActiveRecord
 
       ActiveRecord::Type.register(:boolean, Type::OracleEnhanced::Boolean, adapter: :oracle_enhanced)
       ActiveRecord::Type.register(:json, Type::OracleEnhanced::Json, adapter: :oracle_enhanced)
+
+      private
+        def arel_visitor
+          if supports_fetch_first_n_rows_and_offset?
+            Arel::Visitors::Oracle12.new(self)
+          else
+            Arel::Visitors::Oracle.new(self)
+          end
+        end
+
+        def build_statement_pool
+          StatementPool.new(self.class.type_cast_config_to_integer(@config[:statement_limit]))
+        end
+
+        def reconnect
+          _connection.reset # tentative
+        rescue OracleEnhanced::ConnectionException
+          connect
+        end
+
+        def type_map
+          self.class.type_map
+        end
+
+        def translate_exception(exception, message:, sql:, binds:)
+          return ActiveRecord::ConnectionFailed.new(message, sql: sql, binds: binds, connection_pool: @pool) if _connection.lost_connection?(exception)
+
+          case _connection.error_code(exception)
+          when 1
+            RecordNotUnique.new(message, sql: sql, binds: binds)
+          when 60
+            Deadlocked.new(message)
+          when 900, 904, 942, 955, 1418, 2289, 2449, 17008
+            ActiveRecord::StatementInvalid.new(message, sql: sql, binds: binds)
+          when 1400
+            ActiveRecord::NotNullViolation.new(message, sql: sql, binds: binds)
+          when 2291, 2292
+            InvalidForeignKey.new(message, sql: sql, binds: binds)
+          when 12899
+            ValueTooLong.new(message, sql: sql, binds: binds)
+          else
+            super
+          end
+        end
     end
   end
 end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -696,11 +696,11 @@ module ActiveRecord
         128
       end
 
-      def get_database_version
+      def get_database_version # :nodoc:
         _connection.database_version
       end
 
-      def check_version
+      def check_version # :nodoc:
         version = get_database_version.join(".").to_f
 
         if version < 10

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -1292,7 +1292,7 @@ end
         skip "Not supported in this database version" unless ActiveRecord::Base.connection.supports_multi_insert?
 
         expect {
-          @conn.execute @conn.insert_versions_sql(versions)
+          @conn.execute @conn.send(:insert_versions_sql, versions)
         }.not_to raise_error
 
         expect(@conn.select_value("SELECT COUNT(version) FROM schema_migrations")).to eq versions.count
@@ -1304,7 +1304,7 @@ end
         skip "Not supported in this database version" if ActiveRecord::Base.connection.supports_multi_insert?
 
         expect {
-          versions.each { |version| @conn.execute @conn.insert_versions_sql(version) }
+          versions.each { |version| @conn.execute @conn.send(:insert_versions_sql, version) }
         }.not_to raise_error
 
         expect(@conn.select_value("SELECT COUNT(version) FROM schema_migrations")).to eq versions.count


### PR DESCRIPTION
## Summary

Align the Ruby visibility (public / private / protected) of instance methods in oracle_enhanced with Rails' bundled adapter conventions, and add a CI guard so future drift is surfaced automatically. Presented as 4 focused commits in one PR.

## Why

A reflection audit against the Rails checkout found 10 methods that oracle_enhanced exposes as `public` but Rails keeps `private` (accidentally leaking implementation details as public API), 1 method that OE keeps `private` while Rails has `public :nodoc:` (hiding what Rails intends to expose to adapter hooks), and 5 methods that both sides keep public but only Rails marks with `:nodoc:` (cluttering oracle_enhanced's rdoc with internals). Without a recurring guard, this kind of drift silently accumulates whenever Rails refactors the adapter contract.

## Commits

1. **Align private-leaning internals with Rails adapter visibility** — move 10 methods from public to private to match Rails' abstract / concrete adapters. All call sites use implicit self so no runtime behavior changes; one spec that used `@conn.insert_versions_sql(...)` is updated to `@conn.send(:insert_versions_sql, ...)`, matching how Rails tests its own private adapter helpers.
   - `OracleEnhancedAdapter`: `arel_visitor`, `build_statement_pool`, `reconnect`, `type_map`, `translate_exception`
   - `OracleEnhanced::DatabaseStatements`: `cast_result`, `affected_rows`, `sql_for_insert`, `returning_column_values`
   - `OracleEnhanced::SchemaStatements`: `insert_versions_sql`, `extract_foreign_key_action`, `create_alter_table`

2. **Expose `schema_creation` publicly with `:nodoc:`, matching Rails** — move out of `private` and add `:nodoc:` so the Rails adapter contract (where concrete / abstract adapters keep `schema_creation` public `:nodoc:` so hooks and extensions can call it via explicit receiver) holds.

3. **Add `:nodoc:` to public adapter hooks Rails marks `:nodoc:`** — same visibility as Rails, but harmonise rdoc output so oracle_enhanced's generated docs don't show lifecycle / schema-builder internals users shouldn't depend on:
   - `get_database_version`, `check_version` (`OracleEnhancedAdapter`)
   - `create_schema_dumper`, `update_table_definition` (`OracleEnhanced::SchemaStatements`)
   - `explain` (`OracleEnhanced::DatabaseStatements`)

4. **Add CI check that compares method visibility against Rails** — add `ci/check_method_visibility.rb` plus a new `check_method_visibility` GitHub Actions workflow that runs on every push / PR plus a weekly cron (Mondays at 00:00 UTC). The script walks `OracleEnhancedAdapter.ancestors`, finds the nearest Rails adapter ancestor that defines each OE-owned instance method, and exits non-zero on any visibility mismatch. Because it searches the whole ancestor chain rather than pairing modules by name, it also catches cross-module drift. Narrowed `rails_owned?` to `ActiveRecord::ConnectionAdapters::*` and `Arel::*` only, and added an `IGNORED_DRIFTS` allowlist for future deliberate divergences.

## Test plan

- [x] `bundle exec rspec` — 428 examples, 0 failures, 6 pending (same as master)
- [x] `bundle exec rubocop <changed files>` — no offenses
- [x] `bundle exec ruby -Ilib ci/check_method_visibility.rb` — `OK: every overridden method matches the Rails counterpart's visibility.`
- [x] Copilot CLI review — no blockers; the two nits (narrow `rails_owned?` scope; run on PR, not cron-only) are addressed in the committed version
- [ ] Confirm CI green on push (the new workflow will run itself on this PR)

## Known limitations of the drift detector

Documented at the top of `ci/check_method_visibility.rb`:

- No `# :nodoc:` drift detection (comments are not reflectable at runtime; would require AST parsing)
- Instance methods only (class methods like `self.foo` are out of scope)
- Signature / semantic drift is not detected — this is a visibility check only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
