### PR TITLE
[experiment, do not merge] Measure 11g rspec time with OPTIMIZER_FEATURES_ENABLE=10.2.0.5

### DIFF
--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -19,8 +19,6 @@ jobs:
       matrix:
         ruby: [
           '4.0',
-          '3.4',
-          '3.3',
           'jruby-10.0.5.0',
         ]
     env:
@@ -89,6 +87,14 @@ jobs:
       - name: Create database user
         run: |
           ./ci/setup_accounts.sh
+      - name: Lower OPTIMIZER_FEATURES_ENABLE for timing experiment
+        run: |
+          sqlplus -s sys/${DATABASE_SYS_PASSWORD}@${DATABASE_NAME} as sysdba <<'SQL'
+          WHENEVER SQLERROR EXIT SQL.SQLCODE;
+          ALTER SYSTEM SET OPTIMIZER_FEATURES_ENABLE = '10.2.0.5' SCOPE=MEMORY;
+          SHOW PARAMETER OPTIMIZER_FEATURES_ENABLE;
+          EXIT;
+          SQL
       - name: Update RubyGems
         run: |
           gem update --system || gem update --system 3.4.22

--- a/.github/workflows/test_11g_ojdbc11.yml
+++ b/.github/workflows/test_11g_ojdbc11.yml
@@ -85,6 +85,14 @@ jobs:
       - name: Create database user
         run: |
           ./ci/setup_accounts.sh
+      - name: Lower OPTIMIZER_FEATURES_ENABLE for timing experiment
+        run: |
+          sqlplus -s sys/${DATABASE_SYS_PASSWORD}@${DATABASE_NAME} as sysdba <<'SQL'
+          WHENEVER SQLERROR EXIT SQL.SQLCODE;
+          ALTER SYSTEM SET OPTIMIZER_FEATURES_ENABLE = '10.2.0.5' SCOPE=MEMORY;
+          SHOW PARAMETER OPTIMIZER_FEATURES_ENABLE;
+          EXIT;
+          SQL
       - name: Update RubyGems
         run: |
           gem update --system || gem update --system 3.4.22


### PR DESCRIPTION
## Summary

Experiment-only branch to measure how much `bundle exec rspec` wall-clock time on the Oracle 11g XE CI jobs changes when the optimizer is forced to an older plan-generation mode.

**Not intended for merge.** I'll close this PR after comparing timings against master's nightly 11g run.

## What it does

1. In both 11g workflows (`test_11g.yml` and `test_11g_ojdbc11.yml`), adds a step after the account-creation step that runs

   ```sql
   ALTER SYSTEM SET OPTIMIZER_FEATURES_ENABLE = '10.2.0.5' SCOPE=MEMORY;
   ```

   via `sqlplus` as `SYS`. `SCOPE=MEMORY` is sufficient — the container is ephemeral, there is no spfile to keep in sync. `WHENEVER SQLERROR EXIT SQL.SQLCODE` + a `SHOW PARAMETER` readback make the step fail loudly (rather than silently) if the ALTER SYSTEM itself is rejected.

2. Trims `test_11g.yml`'s matrix from `[4.0, 3.4, 3.3, jruby-10.0.5.0]` down to `[4.0, jruby-10.0.5.0]`. 3.3 / 3.4 would add CI minutes without telling us anything the 4.0 cell doesn't. `test_11g_ojdbc11.yml` was already jruby-only so its matrix is unchanged.

## How to read the results

- **Baseline** = `test_11g` and `test_11g_ojdbc11` on master's most recent nightly (or push) run — specifically the `4.0` and `jruby-10.0.5.0` cells.
- **Experiment** = this PR's run of the same two cells with OFE forced to `10.2.0.5`.
- Compare the `Run RSpec` step duration in each matrix cell side-by-side.

## Why `10.2.0.5` and not lower

`10.2.0.5` is the last 10g release and a commonly-used "stable plan" compat value — a meaningful step down from 11.2.0.2 without going so far back (e.g. 9.2.0 / 8.1.7) that we risk plan-related spec failures muddying the signal. Easy to drop further if the first run looks promising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
