### PR TITLE
[experiment, do not merge] Measure 11g rspec time with OPTIMIZER_FEATURES_ENABLE=11.1.0.7

### DIFF
--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -19,8 +19,6 @@ jobs:
       matrix:
         ruby: [
           '4.0',
-          '3.4',
-          '3.3',
           'jruby-10.0.5.0',
         ]
     env:
@@ -89,6 +87,14 @@ jobs:
       - name: Create database user
         run: |
           ./ci/setup_accounts.sh
+      - name: Lower OPTIMIZER_FEATURES_ENABLE for timing experiment
+        run: |
+          sqlplus -s sys/${DATABASE_SYS_PASSWORD}@${DATABASE_NAME} as sysdba <<'SQL'
+          WHENEVER SQLERROR EXIT SQL.SQLCODE;
+          ALTER SYSTEM SET OPTIMIZER_FEATURES_ENABLE = '11.1.0.7' SCOPE=MEMORY;
+          SHOW PARAMETER OPTIMIZER_FEATURES_ENABLE;
+          EXIT;
+          SQL
       - name: Update RubyGems
         run: |
           gem update --system || gem update --system 3.4.22

--- a/.github/workflows/test_11g_ojdbc11.yml
+++ b/.github/workflows/test_11g_ojdbc11.yml
@@ -85,6 +85,14 @@ jobs:
       - name: Create database user
         run: |
           ./ci/setup_accounts.sh
+      - name: Lower OPTIMIZER_FEATURES_ENABLE for timing experiment
+        run: |
+          sqlplus -s sys/${DATABASE_SYS_PASSWORD}@${DATABASE_NAME} as sysdba <<'SQL'
+          WHENEVER SQLERROR EXIT SQL.SQLCODE;
+          ALTER SYSTEM SET OPTIMIZER_FEATURES_ENABLE = '11.1.0.7' SCOPE=MEMORY;
+          SHOW PARAMETER OPTIMIZER_FEATURES_ENABLE;
+          EXIT;
+          SQL
       - name: Update RubyGems
         run: |
           gem update --system || gem update --system 3.4.22


### PR DESCRIPTION
## Summary

Second data point in the `OPTIMIZER_FEATURES_ENABLE` timing experiment started in #2552.

**Not intended for merge.** I'll close this PR after the CI timings are captured.

## Why this value

#2552 measured OFE=`10.2.0.5` (one major version below the server's native 11.2.0.2) and saw a **5.6–8.3% slowdown** on all three 11g cells. This branch uses OFE=`11.1.0.7` — only one 11g minor version below the server — to separate two hypotheses:

- **H1**: the slowdown is driven by optimizer features introduced specifically in 11.2 (e.g. cardinality feedback, adaptive cursor sharing enhancements). → 11.1.0.7 should be close to master's baseline.
- **H2**: any OFE below the server's native level costs a flat fixed overhead regardless of how far back. → 11.1.0.7 should still be ~5–8% slower.

## Mechanics

Identical to #2552 apart from the value itself: `ALTER SYSTEM SET OPTIMIZER_FEATURES_ENABLE = '11.1.0.7' SCOPE=MEMORY` via `sqlplus` as `SYS`, with `WHENEVER SQLERROR EXIT SQL.SQLCODE` and a `SHOW PARAMETER` readback so the step fails loudly if ALTER SYSTEM is rejected. Matrix on `test_11g.yml` pruned to `[4.0, jruby-10.0.5.0]`; `test_11g_ojdbc11.yml` matrix unchanged (already jruby-only).

## How to read the results

Compare `Run RSpec` step duration per matrix cell against:
- master's nightly `test_11g` / `test_11g_ojdbc11` (baseline, native 11.2.0.2 optimizer)
- PR #2552's experiment run (OFE=10.2.0.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
