### PR TITLE
Run test_11g_ojdbc11 CI only on the scheduled workflow

### DIFF
--- a/.github/workflows/test_11g_ojdbc11.yml
+++ b/.github/workflows/test_11g_ojdbc11.yml
@@ -1,18 +1,12 @@
 name: test_11g_ojdbc11
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   build:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- `test_11g_ojdbc11` exercises a single JRuby 10.0.5.0 build against Oracle 11g XE with `ojdbc11.jar` — a legacy compatibility check that rarely changes.
- Running it on every push to `master` and every PR is unnecessary CI cost; mirror the `ruby_head` / `jruby_head` pattern and trigger only on the daily cron plus `workflow_dispatch`.
- Drop the job-level `if:` draft-PR guard since `pull_request` is no longer a trigger.

## Test plan
- [ ] Confirm `test_11g_ojdbc11` is absent from this PR's checks (only the daily schedule and manual dispatch should trigger it).
- [ ] After merge, manually run the workflow from the Actions tab via `workflow_dispatch` to confirm it still executes end-to-end.
- [ ] Verify the next scheduled run (00:00 UTC) fires automatically via Actions history.

Generated with [Claude Code](https://claude.com/claude-code)
