### PR TITLE
Implement check_current_protected_environment! for Rails 8.1+

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_tasks.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_tasks.rb
@@ -1,40 +1,35 @@
 # frozen_string_literal: true
 
 require "active_record/base"
+require "active_record/tasks/abstract_tasks"
 
 module ActiveRecord
   module ConnectionAdapters
     class OracleEnhancedAdapter
-      class DatabaseTasks
-        delegate :connection, :establish_connection, to: ActiveRecord::Base
-
-        def initialize(config)
-          @config = config
-        end
-
+      class DatabaseTasks < ActiveRecord::Tasks::AbstractTasks
         def create
           system_password = ENV.fetch("ORACLE_SYSTEM_PASSWORD") {
             print "Please provide the SYSTEM password for your Oracle installation (set ORACLE_SYSTEM_PASSWORD to avoid this prompt)\n>"
             $stdin.gets.strip
           }
-          establish_connection(@config.merge(username: "SYSTEM", password: system_password))
+          establish_connection(configuration_hash.merge(username: "SYSTEM", password: system_password))
           begin
-            connection.execute "CREATE USER #{@config[:username]} IDENTIFIED BY #{@config[:password]}"
+            connection.execute "CREATE USER #{configuration_hash[:username]} IDENTIFIED BY #{configuration_hash[:password]}"
           rescue => e
             if /ORA-01920/.match?(e.message) # user name conflicts with another user or role name
-              connection.execute "ALTER USER #{@config[:username]} IDENTIFIED BY #{@config[:password]}"
+              connection.execute "ALTER USER #{configuration_hash[:username]} IDENTIFIED BY #{configuration_hash[:password]}"
             else
               raise e
             end
           end
 
           OracleEnhancedAdapter.permissions.each do |permission|
-            connection.execute "GRANT #{permission} TO #{@config[:username]}"
+            connection.execute "GRANT #{permission} TO #{configuration_hash[:username]}"
           end
         end
 
         def drop
-          establish_connection(@config)
+          establish_connection
           connection.execute_structure_dump(connection.full_drop)
         end
 
@@ -44,15 +39,15 @@ module ActiveRecord
         end
 
         def structure_dump(filename, extra_flags)
-          establish_connection(@config)
+          establish_connection
           File.open(filename, "w:utf-8") { |f| f << connection.structure_dump }
-          if @config[:structure_dump] == "db_stored_code"
+          if configuration_hash[:structure_dump] == "db_stored_code"
             File.open(filename, "a:utf-8") { |f| f << connection.structure_dump_db_stored_code }
           end
         end
 
         def structure_load(filename, extra_flags)
-          establish_connection(@config)
+          establish_connection
           connection.execute_structure_dump(File.read(filename))
         end
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb
@@ -9,6 +9,29 @@ describe "Oracle Enhanced adapter database tasks" do
 
   let(:config) { CONNECTION_PARAMS.with_indifferent_access }
 
+  describe "check_current_protected_environment!" do
+    before do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+      ActiveRecord::Base.connection_pool.schema_migration.create_table
+    end
+
+    after do
+      ActiveRecord::Base.connection_pool.schema_migration.drop_table
+    end
+
+    it "is dispatched from ActiveRecord::Tasks::DatabaseTasks#check_protected_environments!" do
+      original_configurations = ActiveRecord::Base.configurations
+      ActiveRecord::Base.configurations = {
+        "test" => CONNECTION_PARAMS.transform_keys(&:to_s)
+      }
+      expect {
+        ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!("test")
+      }.not_to raise_error
+    ensure
+      ActiveRecord::Base.configurations = original_configurations
+    end
+  end
+
   describe "create" do
     let(:new_user_config) { config.merge(username: "oracle_enhanced_test_user") }
     before do


### PR DESCRIPTION
## Summary

- `rails/rails#54879` (Rails 8.1) added `check_current_protected_environment!` to `ActiveRecord::Tasks::AbstractTasks` and made `ActiveRecord::Tasks::DatabaseTasks#check_protected_environments!` dispatch through the adapter-registered task object. `OracleEnhancedAdapter::DatabaseTasks` did not define the method, so `rails db:test:load_schema` aborted with `NoMethodError`.
- Refactor `DatabaseTasks` to inherit from `ActiveRecord::Tasks::AbstractTasks` following the pattern that `rails/rails#54879` established for `MySQLDatabaseTasks` / `PostgreSQLDatabaseTasks` / `SQLiteDatabaseTasks`. Drop the custom `initialize(config)` and the `delegate :connection, :establish_connection, to: ActiveRecord::Base`, and let the parent store the `DatabaseConfig`. `create` / `drop` / `purge` / `structure_dump` / `structure_load` now use the parent-provided `configuration_hash` and `db_config` consistently with the other adapters.
- Adds a regression spec that drives `ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!("test")` end-to-end; reverting the fix reproduces the original `NoMethodError`.

Fixes #2540.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb` — 7 examples, 0 failures against activerecord 8.2.0.alpha (rails/main).
- [x] `bundle exec rubocop lib/.../database_tasks.rb spec/.../database_tasks_spec.rb` clean.
- [x] Standalone reproduction via `bundler/inline` against `rails/main` — raised `NoMethodError` before the fix, no longer raises after.
- [ ] Backport to `release81` tracked separately.
