### PR TITLE
Quote / validate values in configure_connection ALTER SESSION statements

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -723,32 +723,43 @@ module ActiveRecord
         connect
       end
 
+      CURSOR_SHARING_VALUES = %w[EXACT FORCE SIMILAR].freeze
+      SCHEMA_IDENTIFIER_PATTERN = /\A[[:alpha:]][\w$#]*\z/
+
       private def configure_connection
         super
 
-        cursor_sharing = @config[:cursor_sharing] || "force"
-        execute("alter session set cursor_sharing = #{cursor_sharing}", "SCHEMA") if cursor_sharing
+        cursor_sharing = (@config[:cursor_sharing] || "force").to_s.upcase
+        unless CURSOR_SHARING_VALUES.include?(cursor_sharing)
+          raise ArgumentError, "Invalid :cursor_sharing value #{@config[:cursor_sharing].inspect}; allowed: #{CURSOR_SHARING_VALUES.join(', ')}"
+        end
+        execute("alter session set cursor_sharing = #{cursor_sharing}", "SCHEMA")
 
         if ORACLE_ENHANCED_CONNECTION == :oci
           time_zone = @config[:time_zone] || ENV["TZ"]
           case ActiveRecord.default_timezone
           when :local
-            execute("alter session set time_zone = '#{time_zone}'", "SCHEMA") unless time_zone.blank?
+            execute("alter session set time_zone = #{quote(time_zone)}", "SCHEMA") unless time_zone.blank?
           when :utc
             execute("alter session set time_zone = '+00:00'", "SCHEMA")
           end
         end
 
         schema = @config[:schema].to_s
-        execute("alter session set current_schema = #{schema}", "SCHEMA") unless schema.blank?
+        unless schema.blank?
+          unless schema.match?(SCHEMA_IDENTIFIER_PATTERN)
+            raise ArgumentError, "Invalid :schema value #{schema.inspect}; must be an Oracle unquoted identifier"
+          end
+          execute("alter session set current_schema = #{schema}", "SCHEMA")
+        end
 
         DEFAULT_NLS_PARAMETERS.each do |key, default_value|
           value = @config[key] || ENV[key.to_s.upcase] || default_value
-          execute("alter session set #{key} = '#{value}'", "SCHEMA") if value
+          execute("alter session set #{key} = #{quote(value.to_s)}", "SCHEMA") if value
         end
 
         FIXED_NLS_PARAMETERS.each do |key, value|
-          execute("alter session set #{key} = '#{value}'", "SCHEMA")
+          execute("alter session set #{key} = #{quote(value)}", "SCHEMA")
         end
       end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -47,6 +47,11 @@ describe "OracleEnhancedAdapter establish connection" do
     expect(ActiveRecord::Base.connection.select_value("select value from v$parameter where name = 'cursor_sharing'")).to eq("EXACT")
   end
 
+  it "should raise ArgumentError for an unsupported cursor_sharing value" do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(cursor_sharing: "not_a_valid_mode"))
+    expect { ActiveRecord::Base.connection }.to raise_error(ArgumentError, /Invalid :cursor_sharing value/)
+  end
+
   it "should not use JDBC statement caching" do
     if ORACLE_ENHANCED_CONNECTION == :jdbc
       ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS)
@@ -144,6 +149,11 @@ describe "OracleEnhancedConnection" do
     it "should switch to specified schema after reset" do
       ActiveRecord::Base.connection.reset!
       expect(ActiveRecord::Base.connection.current_schema).to eq(CONNECTION_WITH_SCHEMA_PARAMS[:schema].upcase)
+    end
+
+    it "should raise ArgumentError for a :schema value that is not an Oracle unquoted identifier" do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(schema: "oracle_enhanced;DROP TABLE x;--"))
+      expect { ActiveRecord::Base.connection }.to raise_error(ArgumentError, /Invalid :schema value/)
     end
   end
 


### PR DESCRIPTION
## Summary

Follow-up to #2529. Harden the four user-supplied interpolations in `OracleEnhancedAdapter#configure_connection`:

- `:cursor_sharing` — upcase and require one of `EXACT` / `FORCE` / `SIMILAR`; raise `ArgumentError` for anything else (it's a keyword, not a string literal).
- `:time_zone` and NLS-parameter values — route through the adapter's `quote()` helper so single quotes are escaped (e.g. `O'Reilly`-style inputs can no longer break the statement).
- `:schema` — validate against `/\A[[:alpha:]][\w$#]*\z/`, which matches the Oracle unquoted-identifier grammar without capping length (12.2+ supports 128-byte identifiers); raise `ArgumentError` for anything that isn't a legal identifier.

Addresses the Copilot PR-bot review comments on #2529. The same unsafe interpolation pattern lived in the OCI / JDBC driver factories before #2529 moved session setup into the adapter, so this is pre-existing hardening rather than a regression from the move.

## Behavior

Identical for every value that was valid before. Invalid values that would have produced broken SQL (or enabled injection) now raise `ArgumentError` at connection configuration time with a clear message.

## Test plan

- [x] `bundle exec rubocop` clean
- [x] `bundle exec rspec` full suite passes (441 examples, 0 failures)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
