### PR TITLE
Use explicit UTF-8 encoding for the db_stored_code append in structure_dump

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_tasks.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_tasks.rb
@@ -47,7 +47,7 @@ module ActiveRecord
           establish_connection(@config)
           File.open(filename, "w:utf-8") { |f| f << connection.structure_dump }
           if @config[:structure_dump] == "db_stored_code"
-            File.open(filename, "a") { |f| f << connection.structure_dump_db_stored_code }
+            File.open(filename, "a:utf-8") { |f| f << connection.structure_dump_db_stored_code }
           end
         end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb
@@ -113,6 +113,24 @@ describe "Oracle Enhanced adapter database tasks" do
       end
     end
 
+    describe "structure_dump with db_stored_code" do
+      let(:temp_file) { Tempfile.create(["oracle_enhanced", ".sql"]).path }
+      let(:stored_code_config) { config.merge(structure_dump: "db_stored_code") }
+
+      after { File.unlink(temp_file) if File.exist?(temp_file) }
+
+      it "opens both writes with UTF-8 encoding" do
+        target = temp_file
+        opened = []
+        allow(File).to receive(:open).and_wrap_original do |original, path, mode, *args, &block|
+          opened << mode if path == target
+          original.call(path, mode, *args, &block)
+        end
+        ActiveRecord::Tasks::DatabaseTasks.structure_dump(stored_code_config, target)
+        expect(opened).to eq(["w:utf-8", "a:utf-8"])
+      end
+    end
+
     after do
       schema_define do
         drop_table :test_posts, if_exists: true


### PR DESCRIPTION
## Summary

The initial `structure_dump` write opens the dump file with `"w:utf-8"`, but the follow-up append for `db_stored_code` used `"a"` — which falls back to the Ruby default external encoding. On setups where that default isn't UTF-8, the resulting file can end up with mixed encodings and fail to load cleanly.

Use `"a:utf-8"` so both writes pin the same external encoding.

## Test

Added a regression spec that stubs `File.open` (via `and_wrap_original`, with the tempfile path materialized to a local before the stub to avoid recursion into the `let(:temp_file)` block) and asserts both mode strings on the target file are `w:utf-8` and `a:utf-8`. Verified the spec fails when the fix is reverted.

## Context

Originally landed as a drive-by commit on #2529, then extracted here so #2529 stays focused on `configure_connection`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
