### PR TITLE
Backport #2559 to release81: Use explicit UTF-8 encoding for db_stored_code append

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_tasks.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_tasks.rb
@@ -47,7 +47,7 @@ module ActiveRecord
           establish_connection(@config)
           File.open(filename, "w:utf-8") { |f| f << connection.structure_dump }
           if @config[:structure_dump] == "db_stored_code"
-            File.open(filename, "a") { |f| f << connection.structure_dump_db_stored_code }
+            File.open(filename, "a:utf-8") { |f| f << connection.structure_dump_db_stored_code }
           end
         end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb
@@ -113,6 +113,24 @@ describe "Oracle Enhanced adapter database tasks" do
       end
     end
 
+    describe "structure_dump with db_stored_code" do
+      let(:temp_file) { Tempfile.create(["oracle_enhanced", ".sql"]).path }
+      let(:stored_code_config) { config.merge(structure_dump: "db_stored_code") }
+
+      after { File.unlink(temp_file) if File.exist?(temp_file) }
+
+      it "opens both writes with UTF-8 encoding" do
+        target = temp_file
+        opened = []
+        allow(File).to receive(:open).and_wrap_original do |original, path, mode, *args, &block|
+          opened << mode if path == target
+          original.call(path, mode, *args, &block)
+        end
+        ActiveRecord::Tasks::DatabaseTasks.structure_dump(stored_code_config, target)
+        expect(opened).to eq(["w:utf-8", "a:utf-8"])
+      end
+    end
+
     after do
       schema_define do
         drop_table :test_posts, if_exists: true


### PR DESCRIPTION
## Summary

- Backport of #2559 (merge commit 675ecf96f9a4da54404c6a5730af034b316b8bd1) to `release81`.
- `structure_dump` already opens the initial file with `"w:utf-8"`, but the follow-up `File.open(..., "a")` for `db_stored_code` falls back to the default external encoding, which can produce a mixed-encoding file on setups where the default is not UTF-8. Match the encoding across both writes by using `"a:utf-8"`.
- Adds a spec that pins the encoding of both writes via `allow(File).to receive(:open).and_wrap_original`.

## Cherry-pick notes

- `git cherry-pick -m 1 -x 675ecf96f9a4da54404c6a5730af034b316b8bd1` applied cleanly — no conflicts.
- Landing this ahead of the #2556 backport lets the #2556 cherry-pick apply cleanly as well (without it, the `structure_dump` line is the sole conflict point).

## Test plan

- [x] `bundle exec rubocop lib/.../database_tasks.rb spec/.../database_tasks_spec.rb` — 2 files inspected, no offenses.
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb` against Oracle Database Free (FREEPDB1) — 7 examples, 0 failures.
- [x] Copilot CLI review — no issues; added spec runs on this branch's Rails 8.1.3 / RSpec stack as written.
