### PR TITLE
Backport #2556 to release81: implement check_current_protected_environment!

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_tasks.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_tasks.rb
@@ -1,40 +1,35 @@
 # frozen_string_literal: true
 
 require "active_record/base"
+require "active_record/tasks/abstract_tasks"
 
 module ActiveRecord
   module ConnectionAdapters
     class OracleEnhancedAdapter
-      class DatabaseTasks
-        delegate :connection, :establish_connection, to: ActiveRecord::Base
-
-        def initialize(config)
-          @config = config
-        end
-
+      class DatabaseTasks < ActiveRecord::Tasks::AbstractTasks
         def create
           system_password = ENV.fetch("ORACLE_SYSTEM_PASSWORD") {
             print "Please provide the SYSTEM password for your Oracle installation (set ORACLE_SYSTEM_PASSWORD to avoid this prompt)\n>"
             $stdin.gets.strip
           }
-          establish_connection(@config.merge(username: "SYSTEM", password: system_password))
+          establish_connection(configuration_hash.merge(username: "SYSTEM", password: system_password))
           begin
-            connection.execute "CREATE USER #{@config[:username]} IDENTIFIED BY #{@config[:password]}"
+            connection.execute "CREATE USER #{configuration_hash[:username]} IDENTIFIED BY #{configuration_hash[:password]}"
           rescue => e
             if /ORA-01920/.match?(e.message) # user name conflicts with another user or role name
-              connection.execute "ALTER USER #{@config[:username]} IDENTIFIED BY #{@config[:password]}"
+              connection.execute "ALTER USER #{configuration_hash[:username]} IDENTIFIED BY #{configuration_hash[:password]}"
             else
               raise e
             end
           end
 
           OracleEnhancedAdapter.permissions.each do |permission|
-            connection.execute "GRANT #{permission} TO #{@config[:username]}"
+            connection.execute "GRANT #{permission} TO #{configuration_hash[:username]}"
           end
         end
 
         def drop
-          establish_connection(@config)
+          establish_connection
           connection.execute_structure_dump(connection.full_drop)
         end
 
@@ -44,15 +39,15 @@ module ActiveRecord
         end
 
         def structure_dump(filename, extra_flags)
-          establish_connection(@config)
+          establish_connection
           File.open(filename, "w:utf-8") { |f| f << connection.structure_dump }
-          if @config[:structure_dump] == "db_stored_code"
+          if configuration_hash[:structure_dump] == "db_stored_code"
             File.open(filename, "a:utf-8") { |f| f << connection.structure_dump_db_stored_code }
           end
         end
 
         def structure_load(filename, extra_flags)
-          establish_connection(@config)
+          establish_connection
           connection.execute_structure_dump(File.read(filename))
         end
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb
@@ -9,6 +9,29 @@ describe "Oracle Enhanced adapter database tasks" do
 
   let(:config) { CONNECTION_PARAMS.with_indifferent_access }
 
+  describe "check_current_protected_environment!" do
+    before do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+      ActiveRecord::Base.connection_pool.schema_migration.create_table
+    end
+
+    after do
+      ActiveRecord::Base.connection_pool.schema_migration.drop_table
+    end
+
+    it "is dispatched from ActiveRecord::Tasks::DatabaseTasks#check_protected_environments!" do
+      original_configurations = ActiveRecord::Base.configurations
+      ActiveRecord::Base.configurations = {
+        "test" => CONNECTION_PARAMS.transform_keys(&:to_s)
+      }
+      expect {
+        ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!("test")
+      }.not_to raise_error
+    ensure
+      ActiveRecord::Base.configurations = original_configurations
+    end
+  end
+
   describe "create" do
     let(:new_user_config) { config.merge(username: "oracle_enhanced_test_user") }
     before do


### PR DESCRIPTION
Backport of #2556 (fixes #2540) to the `release81` line.

## Summary

Rails 8.1 (rails/rails#54879) added `check_current_protected_environment!` to `ActiveRecord::Tasks::AbstractTasks` and made `ActiveRecord::Tasks::DatabaseTasks#check_protected_environments!` dispatch through the adapter-registered task object. `OracleEnhancedAdapter::DatabaseTasks` did not define the method, so `rails db:test:load_schema` aborted with `NoMethodError`.

Refactor `DatabaseTasks` to inherit from `AbstractTasks` following the pattern used by `MySQLDatabaseTasks` / `PostgreSQLDatabaseTasks` / `SQLiteDatabaseTasks` in rails/rails#54879. `create` / `drop` / `purge` / `structure_dump` / `structure_load` now use `configuration_hash` and `db_config` consistently with the other adapters.

## Cherry-pick

`git cherry-pick -m 1 -x 81f5226981d82b8e942f9bd368c37e2fb50d74ca` — applied cleanly with no conflicts on top of #2563 (the `release81` backport of #2559, which is the prerequisite for the `structure_dump` UTF-8 line).

## Dependencies

- #2563 (merged) — backport of #2559. Required so the cherry-pick of #2556 lands without conflict on the `structure_dump` line.

Does not depend on #2557 or #2558 (those are additional hardening on master that aren't required to close #2540).

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb` — 8 examples, 0 failures against activerecord 8.1.3.
- [x] `bundle exec rubocop lib/.../database_tasks.rb spec/.../database_tasks_spec.rb` clean.
- [x] Sample Rails 8.1.3 app validation from #2556 reproduces the pre-fix `NoMethodError` against this branch when reverted and passes `rails db:test:load_schema` cleanly after the fix.
- [x] Copilot CLI review — no issues; AbstractTasks APIs and the new spec are all compatible with ActiveRecord 8.1.3.
- [ ] CI green.
