### PR TITLE
Reject empty VALID_TABLE_NAME matches

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -90,7 +90,7 @@ module ActiveRecord
         # and pound sign (#).
         # Oracle strongly discourages you from using $ and # in nonquoted identifiers.
         NONQUOTED_OBJECT_NAME = /[[:alpha:]][\w$#]{0,29}/
-        VALID_TABLE_NAME = /\A(?:#{NONQUOTED_OBJECT_NAME}\.)?#{NONQUOTED_OBJECT_NAME}?\Z/
+        VALID_TABLE_NAME = /\A(?:#{NONQUOTED_OBJECT_NAME}\.)?#{NONQUOTED_OBJECT_NAME}\Z/
 
         # unescaped table name should start with letter and
         # contain letters, digits, _, $ or #

--- a/spec/active_record/connection_adapters/oracle_enhanced/quoting_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/quoting_spec.rb
@@ -114,6 +114,13 @@ describe "OracleEnhancedAdapter quoting" do
       expect(@adapter.valid_table_name?("abc.1xyz")).to be_falsey
       expect(@adapter.valid_table_name?("abc._xyz")).to be_falsey
     end
+
+    it "should not be valid when the object name part is missing" do
+      expect(@adapter.valid_table_name?("")).to be_falsey
+      expect(@adapter.valid_table_name?("schema.")).to be_falsey
+      expect(@adapter.valid_table_name?(".table")).to be_falsey
+      expect(@adapter.valid_table_name?("   ")).to be_falsey
+    end
   end
 
   describe "table quoting" do


### PR DESCRIPTION
## Summary

`VALID_TABLE_NAME` in `OracleEnhanced::Quoting` ended with `#{NONQUOTED_OBJECT_NAME}?`, which made the optional trailing group match the empty string. That in turn let `valid_table_name?` return `true` for inputs like `""`, `"SCHEMA."`, `".table"`, or whitespace-only strings, which are not valid Oracle identifiers. Callers (`Connection#describe` / `resolve_data_source_name`) would then treat those values as safe to upcase before further handling.

Making the object-name part mandatory keeps the optional schema prefix but requires at least one identifier to be present. The schema-qualified form (`schema.table`) and bare identifiers continue to match exactly as before.

### Change

- `lib/active_record/connection_adapters/oracle_enhanced/quoting.rb` — drop the trailing `?` from the last `NONQUOTED_OBJECT_NAME` in `VALID_TABLE_NAME`.
- `spec/active_record/connection_adapters/oracle_enhanced/quoting_spec.rb` — add coverage for `valid_table_name?("")`, `"schema."`, `".table"`, and whitespace-only (`"   "`) returning `false`.

### Related

- Flagged by Copilot during review of rsim/oracle-enhanced#2542 (comment r3101565600). The fix is independent of #2542 — the looseness is already present on master — so it is being shipped separately.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/quoting_spec.rb` — 17 examples, 0 failures
- [x] `bundle exec rubocop` on the changed files — clean
- [ ] CI green on all matrix rows
