### PR TITLE
Sync .rubocop.yml with rails/rails

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -152,6 +152,7 @@ Layout/SpaceBeforeBlockBraces:
 # Use `foo { bar }` not `foo {bar}`.
 Layout/SpaceInsideBlockBraces:
   Enabled: true
+  EnforcedStyleForEmptyBraces: space
 
 # Use `{ a: 1 }` not `{a:1}`.
 Layout/SpaceInsideHashLiteralBraces:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -224,6 +224,9 @@ Lint/RedundantCopDisableDirective:
 Lint/RedundantCopEnableDirective:
   Enabled: true
 
+Lint/RedundantRequireStatement:
+  Enabled: true
+
 Lint/RedundantStringCoercion:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -289,6 +289,9 @@ Style/RedundantCondition:
 Style/RedundantDoubleSplatHashBraces:
   Enabled: true
 
+Style/OpenStructUse:
+  Enabled: true
+
 Performance/BindCall:
   Enabled: true
 
@@ -327,9 +330,6 @@ Performance/DeletePrefix:
   Enabled: true
 
 Performance/DeleteSuffix:
-  Enabled: true
-
-Performance/OpenStruct:
   Enabled: true
 
 # RuboCop RSpec cops

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -286,6 +286,9 @@ Style/TrivialAccessors:
 Style/RedundantCondition:
   Enabled: true
 
+Style/RedundantDoubleSplatHashBraces:
+  Enabled: true
+
 Performance/BindCall:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -230,6 +230,9 @@ Lint/RedundantRequireStatement:
 Lint/RedundantStringCoercion:
   Enabled: true
 
+Lint/RedundantSafeNavigation:
+  Enabled: true
+
 Lint/UriEscapeUnescape:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -79,6 +79,7 @@ Lint/SafeNavigationChain:
 # Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }.
 Style/HashSyntax:
   Enabled: true
+  EnforcedShorthandSyntax: either
 
 # Method definitions after `private` or `protected` isolated calls need one
 # extra level of indentation.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -247,6 +247,11 @@ Lint/InterpolationCheck:
   Exclude:
     - '**/spec/**/*'
 
+Style/EvalWithLocation:
+  Enabled: true
+  Exclude:
+    - '**/spec/**/*'
+
 Style/ParenthesesAroundCondition:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -295,6 +295,9 @@ Style/OpenStructUse:
 Style/ArrayIntersect:
   Enabled: true
 
+Style/KeywordArgumentsMerging:
+  Enabled: true
+
 Performance/BindCall:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -292,6 +292,9 @@ Style/RedundantDoubleSplatHashBraces:
 Style/OpenStructUse:
   Enabled: true
 
+Style/ArrayIntersect:
+  Enabled: true
+
 Performance/BindCall:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -221,6 +221,9 @@ Lint/RequireParentheses:
 Lint/RedundantCopDisableDirective:
   Enabled: true
 
+Lint/RedundantCopEnableDirective:
+  Enabled: true
+
 Lint/RedundantStringCoercion:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -338,6 +338,18 @@ Performance/DeletePrefix:
 Performance/DeleteSuffix:
   Enabled: true
 
+Performance/InefficientHashSearch:
+  Enabled: true
+
+Performance/ConstantRegexp:
+  Enabled: true
+
+Performance/RedundantStringChars:
+  Enabled: true
+
+Performance/StringInclude:
+  Enabled: true
+
 # RuboCop RSpec cops
 RSpec/BeEq:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -182,6 +182,9 @@ Layout/TrailingWhitespace:
 Style/RedundantPercentQ:
   Enabled: true
 
+Lint/NestedMethodDefinition:
+  Enabled: true
+
 Lint/AmbiguousOperator:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -211,6 +211,9 @@ Lint/ErbNewArguments:
 Lint/EnsureReturn:
   Enabled: true
 
+Lint/MissingCopEnableDirective:
+  Enabled: true
+
 # Use my_method(my_arg) not my_method( my_arg ) or my_method my_arg.
 Lint/RequireParentheses:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -242,6 +242,11 @@ Lint/UselessAssignment:
 Lint/DeprecatedClassMethods:
   Enabled: true
 
+Lint/InterpolationCheck:
+  Enabled: true
+  Exclude:
+    - '**/spec/**/*'
+
 Style/ParenthesesAroundCondition:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -199,6 +199,9 @@ Lint/Debugger:
 Lint/DuplicateRequire:
   Enabled: true
 
+Lint/DuplicateMagicComment:
+  Enabled: true
+
 Lint/DuplicateMethods:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -218,6 +218,9 @@ Lint/MissingCopEnableDirective:
 Lint/RequireParentheses:
   Enabled: true
 
+Lint/RedundantCopDisableDirective:
+  Enabled: true
+
 Lint/RedundantStringCoercion:
   Enabled: true
 

--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -27,7 +27,7 @@ This adapter is superset of original ActiveRecord Oracle adapter.
 
   s.add_runtime_dependency("activerecord", ["~> 8.2.0.alpha"])
   s.add_runtime_dependency("ruby-plsql", [">= 0.6.0"])
-  if /java/.match?(RUBY_PLATFORM)
+  if RUBY_PLATFORM.include?("java")
     s.platform = Gem::Platform.new("java")
   else
     s.add_runtime_dependency("ruby-oci8")

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -30,7 +30,7 @@ module ActiveRecord
 
         def explain(arel, binds = [], options = []) # :nodoc:
           sql = "EXPLAIN PLAN FOR #{to_sql(arel, binds)}"
-          return if /FROM all_/.match?(sql)
+          return if sql.include?("FROM all_")
           if ORACLE_ENHANCED_CONNECTION == :jdbc
             exec_query(sql, "EXPLAIN", binds)
           else
@@ -72,7 +72,7 @@ module ActiveRecord
 
                 cursor.bind_params(type_casted_binds)
 
-                if /:returning_id/.match?(sql)
+                if sql.include?(":returning_id")
                   # it currently expects that returning_id comes last part of binds
                   returning_id_index = binds.size
                   cursor.bind_returning_param(returning_id_index, Integer)

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_tasks.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_tasks.rb
@@ -36,7 +36,7 @@ module ActiveRecord
           begin
             connection.execute "CREATE USER #{username} IDENTIFIED BY #{quoted_password}"
           rescue => e
-            if /ORA-01920/.match?(e.message) # user name conflicts with another user or role name
+            if e.message.include?("ORA-01920") # user name conflicts with another user or role name
               connection.execute "ALTER USER #{username} IDENTIFIED BY #{quoted_password}"
             else
               raise e

--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -13,7 +13,7 @@ module Arel # :nodoc: all
 
           # if need to select first records without ORDER BY and GROUP BY and without DISTINCT
           # then can use simple ROWNUM in WHERE clause
-          if o.limit && o.orders.empty? && o.cores.first.groups.empty? && !o.offset && !o.cores.first.set_quantifier.class.to_s.match?(/Distinct/)
+          if o.limit && o.orders.empty? && o.cores.first.groups.empty? && !o.offset && !o.cores.first.set_quantifier.class.to_s.include?("Distinct")
             o.cores.last.wheres.push Nodes::LessThanOrEqual.new(
               Nodes::SqlLiteral.new("ROWNUM"), o.limit.expr
             )
@@ -155,7 +155,7 @@ module Arel # :nodoc: all
           return o if o.orders.empty?
           return o unless o.cores.any? do |core|
             core.projections.any? do |projection|
-              /FIRST_VALUE/ === projection
+              projection.to_s.include?("FIRST_VALUE")
             end
           end
           # Previous version with join and split broke ORDER BY clause

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -1221,7 +1221,7 @@ end
         @conn.create_table :tablespace_tests do |t|
           t.string :foo
         end
-        expect(@would_execute_sql).to match(/CREATE +TABLE .* \(.*\) TABLESPACE #{DATABASE_NON_DEFAULT_TABLESPACE}/)
+        expect(@would_execute_sql).to match(/CREATE +TABLE .* \(.*\) TABLESPACE #{DATABASE_NON_DEFAULT_TABLESPACE}/o)
       end
     end
 
@@ -1259,7 +1259,7 @@ end
         add_index :keyboards, :name
       end
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces.delete(:index)
-      expect(@would_execute_sql).to match(/CREATE +INDEX .* ON .* \(.*\) TABLESPACE #{DATABASE_NON_DEFAULT_TABLESPACE}/)
+      expect(@would_execute_sql).to match(/CREATE +INDEX .* ON .* \(.*\) TABLESPACE #{DATABASE_NON_DEFAULT_TABLESPACE}/o)
     end
 
     it "should create unique function index but not create unique constraints" do


### PR DESCRIPTION
## Summary

Syncs `.rubocop.yml` with `rails/rails/.rubocop.yml` (excluding Minitest-, Markdown-, and Packaging-specific items since this repo is RSpec-based).

Each cop is enabled in its own commit so the git history stays easy to audit. Commit messages reference the Rails PR (or direct commit) that originally enabled the cop upstream. The four `Performance/*` cops from rails/rails#45865 are bundled in one commit per the PR's original grouping.

### Cop changes

Option tweaks:

- `Style/HashSyntax` — `EnforcedShorthandSyntax: either` (rails@8b4e92f4be)
- `Layout/SpaceInsideBlockBraces` — `EnforcedStyleForEmptyBraces: space` (rails@f679933daa)

New cops:

- `Lint/NestedMethodDefinition` (rails/rails#53923)
- `Lint/DuplicateMagicComment` (rails/rails#46497)
- `Lint/MissingCopEnableDirective` (rails@8b4e92f4be)
- `Lint/RedundantCopDisableDirective` (rails@8b4e92f4be)
- `Lint/RedundantCopEnableDirective` (rails@8b4e92f4be)
- `Lint/RedundantRequireStatement` (rails/rails#52689)
- `Lint/RedundantSafeNavigation` (rails/rails#49404)
- `Lint/InterpolationCheck` (rails/rails#49794) — `Exclude` translated from `test/` to `spec/`
- `Style/EvalWithLocation` (rails/rails#46969) — `Exclude` translated from `test/` to `spec/`
- `Style/RedundantDoubleSplatHashBraces` (rails/rails#49582)
- `Style/OpenStructUse` replacing the deprecated `Performance/OpenStruct` (rails/rails#51510)
- `Style/ArrayIntersect` (rails/rails#50639)
- `Style/KeywordArgumentsMerging` (rails/rails#53523)
- `Performance/InefficientHashSearch`, `Performance/ConstantRegexp`, `Performance/RedundantStringChars`, `Performance/StringInclude` (all from rails/rails#45865)

### Source fixes from rubocop autocorrect

`Performance/StringInclude` and `Performance/ConstantRegexp` flagged 8 sites auto-corrected in the same commit as the cop enablement:

- `activerecord-oracle_enhanced-adapter.gemspec`, `lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb` (2 sites), `lib/active_record/connection_adapters/oracle_enhanced/database_tasks.rb`, `lib/arel/visitors/oracle.rb` (2 sites) — regex-with-literal `match?` rewritten as `String#include?`.
- `spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb` — two interpolated regexps got the `/o` option so they are compiled once.
- `lib/arel/visitors/oracle.rb:158` autocorrect was hand-hardened to `projection.to_s.include?("FIRST_VALUE")` because the original `Regexp#===` silently returned false for non-String Arel projections (e.g. `Arel::Attributes::Attribute`), whereas plain `projection.include?(...)` would raise `NoMethodError` on those.

## Test plan

- [x] `bundle exec rubocop` clean at HEAD
- [x] Copilot CLI review completed
- [x] CI green: rubocop, yamllint, method-visibility, build Ruby 3.3 / 3.4 / 4.0 (both Oracle 23ai free and 11g matrices), and JRuby 10.0.5.0
