### PR TITLE
Allow ORACLE_SYSTEM_USER to override hard-coded SYSTEM user

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_tasks.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_tasks.rb
@@ -26,13 +26,21 @@ module ActiveRecord
               raise ArgumentError, "Invalid Oracle privilege in OracleEnhancedAdapter.permissions: #{permission.inspect}"
             end
           end
+          # Oracle Autonomous Database (OCI) ships with ADMIN -- not SYSTEM --
+          # as the predefined administrative user, so the caller needs a way
+          # to override the default. See
+          # https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/doc/autonomous-admin-user-roles.html
+          system_username = ENV["ORACLE_SYSTEM_USER"].presence || "SYSTEM"
+          unless system_username.match?(ORACLE_IDENTIFIER)
+            raise ArgumentError, "Invalid Oracle identifier for ORACLE_SYSTEM_USER: #{system_username.inspect}"
+          end
           quoted_password = %("#{configuration_hash[:password].to_s.gsub('"', '""')}")
 
           system_password = ENV.fetch("ORACLE_SYSTEM_PASSWORD") {
-            print "Please provide the SYSTEM password for your Oracle installation (set ORACLE_SYSTEM_PASSWORD to avoid this prompt)\n>"
+            print "Please provide the #{system_username} password for your Oracle installation (set ORACLE_SYSTEM_PASSWORD to avoid this prompt)\n>"
             $stdin.gets.strip
           }
-          establish_connection(configuration_hash.merge(username: "SYSTEM", password: system_password))
+          establish_connection(configuration_hash.merge(username: system_username, password: system_password))
           begin
             connection.execute "CREATE USER #{username} IDENTIFIED BY #{quoted_password}"
           rescue => e

--- a/spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb
@@ -135,6 +135,94 @@ describe "Oracle Enhanced adapter database tasks" do
     end
   end
 
+  describe "create with ORACLE_SYSTEM_USER" do
+    include ActiveSupport::Testing::Stream
+
+    let(:captured_connect_config) { {} }
+    let(:fake_connection) do
+      double("connection").tap { |c| allow(c).to receive(:execute) }
+    end
+
+    before do
+      allow(ActiveRecord::Base).to receive(:establish_connection) do |cfg|
+        captured_connect_config.replace(cfg)
+      end
+      allow(ActiveRecord::Base).to receive(:lease_connection).and_return(fake_connection)
+      ENV["ORACLE_SYSTEM_PASSWORD"] = "dummy"
+    end
+
+    after do
+      ENV.delete("ORACLE_SYSTEM_PASSWORD")
+      ENV.delete("ORACLE_SYSTEM_USER")
+    end
+
+    it "defaults to SYSTEM when ORACLE_SYSTEM_USER is unset" do
+      quietly do
+        ActiveRecord::Tasks::DatabaseTasks.create(config.merge(username: "oracle_enhanced_test_user"))
+      end
+      expect(captured_connect_config[:username]).to eq("SYSTEM")
+    end
+
+    it "uses the value of ORACLE_SYSTEM_USER when set (e.g. ADMIN on Oracle Cloud Autonomous Database)" do
+      ENV["ORACLE_SYSTEM_USER"] = "ADMIN"
+      quietly do
+        ActiveRecord::Tasks::DatabaseTasks.create(config.merge(username: "oracle_enhanced_test_user"))
+      end
+      expect(captured_connect_config[:username]).to eq("ADMIN")
+    end
+
+    it "falls back to SYSTEM when ORACLE_SYSTEM_USER is set but empty" do
+      ENV["ORACLE_SYSTEM_USER"] = ""
+      quietly do
+        ActiveRecord::Tasks::DatabaseTasks.create(config.merge(username: "oracle_enhanced_test_user"))
+      end
+      expect(captured_connect_config[:username]).to eq("SYSTEM")
+    end
+
+    it "falls back to SYSTEM when ORACLE_SYSTEM_USER is whitespace-only" do
+      ENV["ORACLE_SYSTEM_USER"] = "   "
+      quietly do
+        ActiveRecord::Tasks::DatabaseTasks.create(config.merge(username: "oracle_enhanced_test_user"))
+      end
+      expect(captured_connect_config[:username]).to eq("SYSTEM")
+    end
+
+    it "raises ArgumentError before touching the database when ORACLE_SYSTEM_USER is not an Oracle identifier" do
+      ENV["ORACLE_SYSTEM_USER"] = "oracle;DROP USER system;--"
+      quietly do
+        expect {
+          ActiveRecord::Tasks::DatabaseTasks.create(config.merge(username: "oracle_enhanced_test_user"))
+        }.to raise_error(ArgumentError, /Invalid Oracle identifier for ORACLE_SYSTEM_USER/)
+      end
+      expect(captured_connect_config).to be_empty
+    end
+
+    it "keeps the original 'SYSTEM password' prompt wording when ORACLE_SYSTEM_USER is unset" do
+      ENV.delete("ORACLE_SYSTEM_PASSWORD")
+      original_stdin = $stdin
+      $stdin = StringIO.new("pwd\n")
+      output = capture(:stdout) do
+        ActiveRecord::Tasks::DatabaseTasks.create(config.merge(username: "oracle_enhanced_test_user"))
+      end
+      expect(output).to include("Please provide the SYSTEM password")
+    ensure
+      $stdin = original_stdin
+    end
+
+    it "names the override user in the prompt when ORACLE_SYSTEM_USER is set and ORACLE_SYSTEM_PASSWORD is unset" do
+      ENV.delete("ORACLE_SYSTEM_PASSWORD")
+      ENV["ORACLE_SYSTEM_USER"] = "ADMIN"
+      original_stdin = $stdin
+      $stdin = StringIO.new("pwd\n")
+      output = capture(:stdout) do
+        ActiveRecord::Tasks::DatabaseTasks.create(config.merge(username: "oracle_enhanced_test_user"))
+      end
+      expect(output).to include("Please provide the ADMIN password")
+    ensure
+      $stdin = original_stdin
+    end
+  end
+
   context "with test table" do
     before(:all) do
       $stdout, @original_stdout = StringIO.new, $stdout


### PR DESCRIPTION
## Summary

- Lets `DatabaseTasks#create` read `ENV["ORACLE_SYSTEM_USER"]` and use it in place of the hard-coded `"SYSTEM"` when establishing the bootstrap connection that runs `CREATE USER` / `GRANT`. Motivation: Oracle Autonomous Database (OCI) ships with `ADMIN` — not `SYSTEM` — as the predefined administrative user, so `rake db:create` on ADB is currently unusable. Oracle docs: [ADMIN User on Autonomous AI Database](https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/doc/autonomous-admin-user-roles.html) ("the predefined administrative user is ADMIN and this account has privileges to manage users and to manage the database").
- Uses `.presence` so an exported-but-empty / whitespace-only value falls back to `"SYSTEM"` instead of attempting a blank login. Validates the resolved username against the existing `ORACLE_IDENTIFIER` regex for consistency with the `:username` and `permissions` validation added in #2558 — the value does not currently flow into SQL (only into `establish_connection`), but fail-fast validation prevents a future refactor from silently creating an injection site.
- Prompt text interpolates the effective username, so the default path prints exactly the same string as today (`"Please provide the SYSTEM password ..."`) and the OCI path prints `"Please provide the ADMIN password ..."`.

Revives the intent of #2261 (closed, targeted `release70`); renewed request in https://github.com/rsim/oracle-enhanced/pull/2261#issuecomment-4290991944. Resolves #2257.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb` — 19 examples, 0 failures. New `describe "create with ORACLE_SYSTEM_USER"` block covers: default SYSTEM, ADMIN override, empty-string fallback, whitespace-only fallback, invalid-identifier rejection, default prompt wording preserved, override prompt wording.
- [x] `bundle exec rubocop` — clean.
- [x] End-to-end integration test on local Oracle 23 Free: created an ADMIN-role user as `SYSTEM`, granted DBA, set `ORACLE_SYSTEM_USER=<that user>` + `ORACLE_SYSTEM_PASSWORD`, and ran `DatabaseTasks.create` — verified the target user was created with all expected privileges and could log in.
- [x] Reviewed with GitHub Copilot CLI.

Co-authored with Joey Perry (@ioev), original author of #2261.
