### PR TITLE
Make default_sequence_name and index_name byte-based

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -138,9 +138,26 @@ module ActiveRecord
         end
 
         # Returns default sequence name for table.
-        # Will take all or first 26 characters of table name and append _seq suffix
+        # Truncates the trailing identifier component (after the last +.+) by
+        # bytes so the result fits within +sequence_name_length+, leaving room
+        # for the +_seq+ suffix. Byte-based to match Oracle's enforcement.
+        # Character class is +[[:word:]$#-]+: +[[:word:]]+ (Unicode-aware,
+        # vs ASCII-only +\w+) plus +$+ and +#+ to match Oracle's unquoted
+        # identifier rules (see +Quoting::NONQUOTED_OBJECT_NAME+), with +-+
+        # kept for backward compatibility with quoted-identifier callers.
         def default_sequence_name(table_name, primary_key = nil)
-          table_name.to_s.gsub((/(^|\.)([\w$-]{1,#{sequence_name_length - 4}})([\w$-]*)$/), '\1\2_seq')
+          table_name.to_s.gsub(/(\A|\.)([[:word:]$#-]+)\z/) do
+            prefix = Regexp.last_match(1)
+            name = Regexp.last_match(2)
+            max_bytes = sequence_name_length - 4
+            if name.bytesize > max_bytes
+              name = name.byteslice(0, max_bytes)
+              # Back off a byte at a time if the slice fell in the middle of a
+              # multibyte character.
+              name = name.byteslice(0, name.bytesize - 1) until name.bytesize.zero? || name.valid_encoding?
+            end
+            "#{prefix}#{name}_seq"
+          end
         end
 
         # Inserts the given fixture into the table. Overridden to properly handle lobs.

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -324,17 +324,17 @@ module ActiveRecord
           # sometimes options can be String or Array with column names
           options = {} unless options.is_a?(Hash)
           identifier_max_length = options[:identifier_max_length] || index_name_length
-          return default_name if default_name.length <= identifier_max_length
+          return default_name if default_name.bytesize <= identifier_max_length
 
           # remove 'index', 'on' and 'and' keywords
           shortened_name = "i_#{table_name}_#{Array(options[:column]) * '_'}"
 
           # leave just first three letters from each word
-          if shortened_name.length > identifier_max_length
+          if shortened_name.bytesize > identifier_max_length
             shortened_name = shortened_name.split("_").map { |w| w[0, 3] }.join("_")
           end
           # generate unique name using hash function
-          if shortened_name.length > identifier_max_length
+          if shortened_name.bytesize > identifier_max_length
             shortened_name = "i" + OpenSSL::Digest::SHA1.hexdigest(default_name)[0, identifier_max_length - 1]
           end
           @logger.warn "#{adapter_name} shortened default index name #{default_name} to #{shortened_name}" if @logger

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -104,6 +104,40 @@ describe "OracleEnhancedAdapter schema definition" do
       tname = "#{DATABASE_USER}" + "." + "a" * (seq_name_length - DATABASE_USER.length) + "z" * (DATABASE_USER).length
       expect(ActiveRecord::Base.connection.default_sequence_name(tname)).to match (/z_seq$/)
     end
+
+    it "truncates the trailing identifier by bytes for multibyte names" do
+      conn = ActiveRecord::Base.connection
+      max = conn.sequence_name_length
+      # "é" is 2 bytes in UTF-8. Build a name that exceeds the byte budget.
+      name = "é" * max # 2 * max bytes, definitely over
+      seq = conn.default_sequence_name(name)
+      expect(seq).to end_with("_seq")
+      expect(seq.bytesize).to be <= max
+    end
+
+    it "preserves a schema prefix when truncating multibyte names" do
+      conn = ActiveRecord::Base.connection
+      max = conn.sequence_name_length
+      name = "schema." + ("é" * max)
+      seq = conn.default_sequence_name(name)
+      expect(seq).to start_with("schema.")
+      expect(seq).to end_with("_seq")
+      table_part = seq.delete_prefix("schema.")
+      expect(table_part.bytesize).to be <= max
+    end
+
+    it "backs off a byte when the naive byte slice would land mid-character" do
+      conn = ActiveRecord::Base.connection
+      # Craft a name whose `max - 4` byte boundary lands in the middle of
+      # a 2-byte character.
+      max = conn.sequence_name_length
+      ascii_prefix = "a" * (max - 4 - 1) # ends 1 byte short of budget
+      name = ascii_prefix + "é" * 4      # é straddles the budget boundary
+      seq = conn.default_sequence_name(name)
+      expect(seq).to end_with("_seq")
+      expect(seq.bytesize).to be <= max
+      expect(seq).to be_valid_encoding
+    end
   end
 
   describe "sequence creation parameters" do
@@ -365,6 +399,21 @@ describe "OracleEnhancedAdapter schema definition" do
           "i" + OpenSSL::Digest::SHA1.hexdigest("index_test_employees_on_first_name_and_middle_name_and_last_name")[0, 29]
         )
       end
+    end
+
+    it "measures default index name length in bytes, not characters" do
+      max = @conn.index_name_length
+      # "index_t_on_<col>" fits in `max` characters but overflows in bytes
+      # when <col> is multibyte. Without bytesize-awareness this would be
+      # returned unchanged and Oracle would reject it.
+      col = "é" * (max - "index_t_on_".length)
+      default = "index_t_on_#{col}"
+      expect(default.length).to eq(max)
+      expect(default.bytesize).to be > max
+
+      name = @conn.index_name("t", column: col)
+      expect(name.bytesize).to be <= max
+      expect(name).not_to eq(default)
     end
   end
 


### PR DESCRIPTION
## Summary

Oracle enforces its identifier length limit in bytes, but both `default_sequence_name` (`database_statements.rb`) and `index_name` (`schema_statements.rb`) previously truncated and compared by character count. On multibyte table or column names this means a generated sequence or index name can exceed Oracle's byte limit and be rejected (ORA-00972).

### Changes

- **`default_sequence_name`** is rewritten to truncate the trailing identifier component by bytes via `byteslice`, backing off a byte at a time when the naive slice lands inside a multibyte character. Two regex adjustments:
  - `\w` → `[[:word:]]` so Unicode letters match consistently (Ruby's `\w` is ASCII-only in the default encoding; `[[:word:]]` is Unicode-aware under UTF-8).
  - Character class now includes `#` to match Oracle's unquoted-identifier rules (alongside the existing `$` and `-`). This aligns with `Quoting::NONQUOTED_OBJECT_NAME = /[[:alpha:]][\w$#]{0,29}/`; `-` is kept for backward compatibility with quoted-identifier callers (e.g., the existing `warehouse-things` fixture).
- **`index_name`** has its three length checks changed from `.length` to `.bytesize` (default-name short-circuit, per-word shortening decision, and SHA1-fallback decision). The per-word `w[0, 3]` heuristic stays character-based for readable abbreviations; the SHA1 fallback catches any byte overflow that slips past.

### Tests

- `default sequence name` block gains three specs: plain multibyte name, schema-qualified multibyte name, and a crafted mid-byte-boundary case exercising the back-off loop.
- `add index` block gains one spec asserting `bytesize`-based shortening for a multibyte column whose default index name fits in characters but not in bytes.

### Motivation

Surfaced during review of #2542 (longer identifiers by default on 12.2+) — that PR left a code comment noting this char-vs-byte inconsistency. Landing this first lets that comment go away and keeps the byte-based intent consistent across `rename_table`, `valid_table_name?`, and the derived-name paths.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/` on Oracle 23ai (342 examples, 0 failures, 6 pending)
- [x] `bundle exec rubocop lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb`
- [ ] CI green on all matrix rows
