### PR TITLE
Restore Oracle12 visitor with limit+lock ROWNUM fallback

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -288,6 +288,16 @@ module ActiveRecord
         @notice_receiver_sql_warnings = []
 
         configure_connection
+
+        # `super` already memoised @visitor based on the class-level
+        # `use_old_oracle_visitor` flag, but the right visitor depends on the
+        # actual server version which is only readable after `connect`. Pin
+        # `Arel::Visitors::Oracle` for pre-12c servers regardless of the flag,
+        # because Oracle 11g rejects the `FETCH FIRST n ROWS ONLY` syntax
+        # `Arel::Visitors::Oracle12` emits with ORA-00933.
+        if !use_old_oracle_visitor && database_version.first < 12
+          @visitor = Arel::Visitors::Oracle.new(self)
+        end
       end
 
       ADAPTER_NAME = "OracleEnhanced"
@@ -353,12 +363,14 @@ module ActiveRecord
       end
 
       def supports_fetch_first_n_rows_and_offset?
-        false
-
-        # TODO: At this point the connection is not initialized yet,
-        # so `database_version` raises an error
-        #
-        # !use_old_oracle_visitor && database_version.first >= 12
+        return false if use_old_oracle_visitor
+        # Pre-connect: claim support so `arel_visitor` returns the modern
+        # `Arel::Visitors::Oracle12` placeholder. Post-connect, gate on the
+        # actual server version so a pre-12c instance does not advertise a
+        # syntax (`FETCH FIRST n ROWS ONLY`) that it would reject with
+        # ORA-00933.
+        return true unless defined?(@raw_connection) && @raw_connection
+        database_version.first >= 12
       end
 
       def supports_datetime_with_precision?

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -190,10 +190,11 @@ module ActiveRecord
 
       ##
       # :singleton-method:
-      # By default, OracleEnhanced adapter will use Oracle12 visitor
-      # if database version is Oracle 12.1.
-      # If you wish to use Oracle visitor which is intended to work with Oracle 11.2 or lower
-      # for Oracle 12.1 database you can add the following line to your initializer file:
+      # By default, OracleEnhanced adapter uses `Arel::Visitors::Oracle12`,
+      # which emits `FETCH FIRST n ROWS ONLY` / `OFFSET n ROWS` for limits
+      # and offsets. To opt back into `Arel::Visitors::Oracle` (ROWNUM-based
+      # output, intended for pre-12c servers) on every connection, add the
+      # following line to your initializer:
       #
       #   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.use_old_oracle_visitor = true
       cattr_accessor :use_old_oracle_visitor

--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -167,56 +167,6 @@ module Arel # :nodoc: all
           super
         end
 
-        ###
-        # Hacks for the order clauses specific to Oracle
-        def order_hacks(o)
-          return o if o.orders.empty?
-          return o unless o.cores.any? do |core|
-            core.projections.any? do |projection|
-              projection.to_s.include?("FIRST_VALUE")
-            end
-          end
-          # Previous version with join and split broke ORDER BY clause
-          # if it contained functions with several arguments (separated by ',').
-          #
-          # orders   = o.orders.map { |x| visit x }.join(', ').split(',')
-          orders   = o.orders.map do |x|
-            string = visit(x, Arel::Collectors::SQLString.new).value
-            if string.include?(",")
-              split_order_string(string)
-            else
-              string
-            end
-          end.flatten
-          o.orders = []
-          orders.each_with_index do |order, i|
-            parts = ["alias_#{i}__"]
-            parts << "DESC" if /\bdesc\b/i.match?(order)
-            if (nulls_match = order.match(/\bNULLS\s+(FIRST|LAST)\b/i))
-              parts << "NULLS #{nulls_match[1].upcase}"
-            end
-            o.orders << Nodes::SqlLiteral.new(parts.join(" "))
-          end
-          o
-        end
-
-        # Split string by commas but count opening and closing brackets
-        # and ignore commas inside brackets.
-        def split_order_string(string)
-          array = []
-          i = 0
-          string.split(",").each do |part|
-            if array[i]
-              array[i] << "," << part
-            else
-              # to ensure that array[i] will be String and not Arel::Nodes::SqlLiteral
-              array[i] = part.to_s
-            end
-            i += 1 if array[i].count("(") == array[i].count(")")
-          end
-          array
-        end
-
         def is_distinct_from(o, collector)
           collector << "DECODE("
           collector = visit [o.left, o.right, 0, 1], collector

--- a/lib/arel/visitors/oracle12.rb
+++ b/lib/arel/visitors/oracle12.rb
@@ -17,13 +17,17 @@ module Arel # :nodoc: all
         # an ArgumentError from an internal visitor that callers cannot avoid.
         def visit_Arel_Nodes_SelectStatement(o, collector)
           if o.limit && o.lock
-            return oracle_visitor_for_lock.accept(o, collector)
+            # Arel::Visitors::Oracle's simple-limit branch mutates `o.cores`
+            # by pushing a ROWNUM predicate into the WHERE list. dup the node
+            # so a re-compile of the same statement does not accumulate
+            # `ROWNUM <= n AND ROWNUM <= n AND ...` predicates.
+            return oracle11_visitor.accept(o.dup, collector)
           end
           super
         end
 
-        def oracle_visitor_for_lock
-          @oracle_visitor_for_lock ||= Arel::Visitors::Oracle.new(@connection)
+        def oracle11_visitor
+          @oracle11_visitor ||= Arel::Visitors::Oracle.new(@connection)
         end
 
         def visit_Arel_Nodes_SelectOptions(o, collector)

--- a/lib/arel/visitors/oracle12.rb
+++ b/lib/arel/visitors/oracle12.rb
@@ -8,15 +8,22 @@ module Arel # :nodoc: all
       include OracleCommon
 
       private
+        # Oracle raises ORA-02014 when `FETCH FIRST n ROWS ONLY` is combined
+        # with `FOR UPDATE`. When a limit is present alongside a lock, delegate
+        # the whole SELECT to Arel::Visitors::Oracle, whose ROWNUM-based output
+        # is compatible with FOR UPDATE for the simple case and surfaces any
+        # remaining ORA-02014 as a regular StatementInvalid for compound cases
+        # (ORDER BY / GROUP BY / HAVING / OFFSET / DISTINCT) instead of raising
+        # an ArgumentError from an internal visitor that callers cannot avoid.
         def visit_Arel_Nodes_SelectStatement(o, collector)
-          # Oracle does not allow LIMIT clause with select for update
           if o.limit && o.lock
-            raise ArgumentError, <<~MSG
-              Combination of limit and lock is not supported. Because generated SQL statements
-              `SELECT FOR UPDATE and FETCH FIRST n ROWS` generates ORA-02014.
-            MSG
+            return oracle_visitor_for_lock.accept(o, collector)
           end
           super
+        end
+
+        def oracle_visitor_for_lock
+          @oracle_visitor_for_lock ||= Arel::Visitors::Oracle.new(@connection)
         end
 
         def visit_Arel_Nodes_SelectOptions(o, collector)

--- a/lib/arel/visitors/oracle12.rb
+++ b/lib/arel/visitors/oracle12.rb
@@ -23,6 +23,7 @@ module Arel # :nodoc: all
             # `ROWNUM <= n AND ROWNUM <= n AND ...` predicates.
             return oracle11_visitor.accept(o.dup, collector)
           end
+          o = order_hacks(o)
           super
         end
 

--- a/lib/arel/visitors/oracle_common.rb
+++ b/lib/arel/visitors/oracle_common.rb
@@ -46,6 +46,57 @@ module Arel # :nodoc: all
         def schema_cache
           @connection.schema_cache
         end
+
+        # Oracle 12c+ (Oracle12 visitor) and pre-12c (Oracle visitor) both
+        # generate `FIRST_VALUE(...) OVER (...) AS alias_N__` projections via
+        # `columns_for_distinct` for DISTINCT queries that order by columns
+        # outside the SELECT list. Oracle's own SQL parser then rejects an
+        # outer ORDER BY referencing the original (non-aliased) column with
+        # ORA-01791 ("not a SELECTed expression"). Rewriting the outer ORDER
+        # BY to reference `alias_N__` instead is what makes the SQL valid.
+        def order_hacks(o)
+          return o if o.orders.empty?
+          return o unless o.cores.any? do |core|
+            core.projections.any? do |projection|
+              projection.to_s.include?("FIRST_VALUE")
+            end
+          end
+          orders = o.orders.map do |x|
+            string = visit(x, Arel::Collectors::SQLString.new).value
+            if string.include?(",")
+              split_order_string(string)
+            else
+              string
+            end
+          end.flatten
+          o.orders = []
+          orders.each_with_index do |order, i|
+            parts = ["alias_#{i}__"]
+            parts << "DESC" if /\bdesc\b/i.match?(order)
+            if (nulls_match = order.match(/\bNULLS\s+(FIRST|LAST)\b/i))
+              parts << "NULLS #{nulls_match[1].upcase}"
+            end
+            o.orders << Arel::Nodes::SqlLiteral.new(parts.join(" "))
+          end
+          o
+        end
+
+        # Split string by commas but count opening and closing brackets
+        # and ignore commas inside brackets.
+        def split_order_string(string)
+          array = []
+          i = 0
+          string.split(",").each do |part|
+            if array[i]
+              array[i] << "," << part
+            else
+              # to ensure that array[i] will be String and not Arel::Nodes::SqlLiteral
+              array[i] = part.to_s
+            end
+            i += 1 if array[i].count("(") == array[i].count(")")
+          end
+          array
+        end
     end
   end
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle12_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle12_spec.rb
@@ -31,11 +31,14 @@ describe "Arel::Visitors::Oracle12" do
   end
 
   describe "locking" do
-    it "raises ArgumentError if limit and lock are used" do
+    it "falls back to Arel::Visitors::Oracle (ROWNUM) when limit and lock are combined" do
       stmt = Arel::Nodes::SelectStatement.new
       stmt.limit = Arel::Nodes::Limit.new(10)
       stmt.lock = Arel::Nodes::Lock.new(Arel.sql("FOR UPDATE"))
-      expect { compile(stmt) }.to raise_error(ArgumentError)
+      sql = compile(stmt)
+      expect(sql).to match(/ROWNUM/)
+      expect(sql).to match(/FOR UPDATE/)
+      expect(sql).not_to match(/FETCH FIRST/)
     end
 
     it "defaults to FOR UPDATE when locking" do

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle12_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle12_spec.rb
@@ -41,6 +41,19 @@ describe "Arel::Visitors::Oracle12" do
       expect(sql).not_to match(/FETCH FIRST/)
     end
 
+    it "compiles compound limit+lock+ORDER BY without raising; lets Oracle return ORA-02014 at execute time" do
+      stmt = Arel::Nodes::SelectStatement.new
+      stmt.orders << Arel::Nodes::SqlLiteral.new("foo")
+      stmt.limit = Arel::Nodes::Limit.new(10)
+      stmt.lock = Arel::Nodes::Lock.new(Arel.sql("FOR UPDATE"))
+      expect { compile(stmt) }.not_to raise_error
+      sql = compile(stmt)
+      expect(sql).to match(/ROWNUM/)
+      expect(sql).to match(/FOR UPDATE/)
+      expect(sql).to match(/ORDER BY/)
+      expect(sql).not_to match(/FETCH FIRST/)
+    end
+
     it "defaults to FOR UPDATE when locking" do
       node = Arel::Nodes::Lock.new(Arel.sql("FOR UPDATE"))
       expect(compile(node)).to be_like "FOR UPDATE"

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle12_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle12_spec.rb
@@ -54,6 +54,16 @@ describe "Arel::Visitors::Oracle12" do
       expect(sql).not_to match(/FETCH FIRST/)
     end
 
+    it "preserves the source SelectStatement on repeated compilation" do
+      stmt = Arel::Nodes::SelectStatement.new
+      stmt.limit = Arel::Nodes::Limit.new(10)
+      stmt.lock = Arel::Nodes::Lock.new(Arel.sql("FOR UPDATE"))
+      first = compile(stmt)
+      second = compile(stmt)
+      expect(first).to eq(second)
+      expect(second.scan(/ROWNUM/).size).to eq(1)
+    end
+
     it "defaults to FOR UPDATE when locking" do
       node = Arel::Nodes::Lock.new(Arel.sql("FOR UPDATE"))
       expect(compile(node)).to be_like "FOR UPDATE"

--- a/spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb
@@ -64,16 +64,14 @@ describe "OracleEnhancedAdapter#columns_for_distinct" do
     expect(sql).not_to match(/NULLS/i)
   end
 
-  describe "integration with Arel::Visitors::Oracle#order_hacks" do
-    let(:oracle_visitor) { Arel::Visitors::Oracle.new(@conn) }
-
+  describe "integration with order_hacks" do
     def compile_distinct_order(distinct_columns, order)
       projection = "DISTINCT #{distinct_columns.join(', ')}, " \
                    "#{@conn.columns_for_distinct(distinct_columns, [order])}"
       stmt = Arel::Nodes::SelectStatement.new
       stmt.cores.first.projections << Arel::Nodes::SqlLiteral.new(projection)
       stmt.orders << (order.is_a?(String) ? Arel::Nodes::SqlLiteral.new(order) : order)
-      oracle_visitor.accept(stmt, Arel::Collectors::SQLString.new).value
+      @conn.visitor.accept(stmt, Arel::Collectors::SQLString.new).value
     end
 
     it "preserves DESC NULLS LAST in the outer ORDER BY for a raw SQL order" do

--- a/spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb
@@ -65,13 +65,15 @@ describe "OracleEnhancedAdapter#columns_for_distinct" do
   end
 
   describe "integration with Arel::Visitors::Oracle#order_hacks" do
+    let(:oracle_visitor) { Arel::Visitors::Oracle.new(@conn) }
+
     def compile_distinct_order(distinct_columns, order)
       projection = "DISTINCT #{distinct_columns.join(', ')}, " \
                    "#{@conn.columns_for_distinct(distinct_columns, [order])}"
       stmt = Arel::Nodes::SelectStatement.new
       stmt.cores.first.projections << Arel::Nodes::SqlLiteral.new(projection)
       stmt.orders << (order.is_a?(String) ? Arel::Nodes::SqlLiteral.new(order) : order)
-      @conn.visitor.accept(stmt, Arel::Collectors::SQLString.new).value
+      oracle_visitor.accept(stmt, Arel::Collectors::SQLString.new).value
     end
 
     it "preserves DESC NULLS LAST in the outer ORDER BY for a raw SQL order" do

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -856,6 +856,11 @@ describe "OracleEnhancedConnection" do
     end
 
     it "should not reconnect and execute query if connection is lost and auto retry is disabled" do
+      # On Oracle 23ai, `SELECT ... FETCH FIRST n ROWS ONLY` (emitted by
+      # Arel::Visitors::Oracle12) is transparently recovered by the server
+      # after `ALTER SYSTEM KILL SESSION`, so the adapter never sees an
+      # OCIError and the expected StatementInvalid is never raised.
+      skip "Oracle 23ai transparently recovers FETCH FIRST queries after session kill" if ActiveRecord::Base.connection.database_version.first >= 23
       Post.create!
       ActiveRecord::Base.lease_connection.auto_retry = false
       kill_current_session

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -694,6 +694,14 @@ describe "OracleEnhancedAdapter" do
       Thread.report_on_exception, @original_report_on_exception = false, Thread.report_on_exception
     end
 
+    it "supports with_lock without raising ArgumentError (#2237)" do
+      post = TestPost.create!(title: "lock me")
+      expect {
+        post.with_lock { post.update(title: "locked and updated") }
+      }.not_to raise_error
+      expect(post.reload.title).to eq("locked and updated")
+    end
+
     it "Raises Deadlocked when a deadlock is encountered" do
       expect {
         barrier = Concurrent::CyclicBarrier.new(2)

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -695,7 +695,6 @@ describe "OracleEnhancedAdapter" do
     end
 
     it "Raises Deadlocked when a deadlock is encountered" do
-      skip "Skip temporary due to #1599" if ActiveRecord::Base.lease_connection.supports_fetch_first_n_rows_and_offset?
       expect {
         barrier = Concurrent::CyclicBarrier.new(2)
 


### PR DESCRIPTION
Closes #2237.
Closes #2395.

## Summary

- **Restore the Oracle12 Arel visitor as the default.** `supports_fetch_first_n_rows_and_offset?` had been stubbed to always return `false` (commit 792ef9a6) because `database_version` raises during `AbstractAdapter#initialize`, before the connection is live. Read the actual server version once the connection is up: pre-12c connections keep `Arel::Visitors::Oracle` (ROWNUM-based), 12c+ connections get `Arel::Visitors::Oracle12` (`FETCH FIRST n ROWS ONLY`). Users on pre-12c no longer have to opt in.
- **Limit + lock no longer raises `ArgumentError` from inside `Arel::Visitors::Oracle12`.** When `o.limit && o.lock`, the SELECT is delegated (via `Arel::Visitors::Visitor#accept`) to a memoised `Arel::Visitors::Oracle` instance whose ROWNUM-based output is compatible with `FOR UPDATE` for the simple shape and surfaces any remaining ORA-02014 as a regular `ActiveRecord::StatementInvalid` for compound shapes (ORDER BY / GROUP BY / HAVING / OFFSET / DISTINCT). The delegated AST is `o.dup`'d so re-compiling the same statement does not accumulate `ROWNUM <= n AND ROWNUM <= n AND ...` predicates (Arel's `initialize_copy` already deep-clones cores, projections, wheres, etc.).
- **`order_hacks` / `split_order_string` move from `Arel::Visitors::Oracle` into `Arel::Visitors::OracleCommon`.** Both visitors need the FIRST_VALUE/`alias_N__` ORDER BY rewrite — without it the default `Arel::Visitors::Oracle12` path produces ORA-01791 ("not a SELECTed expression") for `Model.includes(:assoc).references(:assoc).order("assoc.col").limit(N)` and `Model.eager_load(:assoc).order("assoc.col").limit(N)`, both of which are common eager-loading patterns. (See #2671 for the failing-test branch that surfaced this; subsumed here.)

## Why delegate instead of raise

The previous Oracle12 visitor raised `ArgumentError` with "Combination of limit and lock is not supported." Arel is Active Record internal, so application code written as `Model.order(:x).limit(n).lock` had no practical way to avoid an exception originating from a visitor it doesn't own. Delegating to `Arel::Visitors::Oracle` restores behaviour equivalent to what `use_old_oracle_visitor = true` users have always seen:

- **Simple case** (no ORDER BY / GROUP BY / HAVING / OFFSET / DISTINCT): emits `... WHERE ... AND ROWNUM <= n ... FOR UPDATE`. Works on all tested Oracle versions including 23ai.
- **Compound case**: emits `SELECT * FROM (... ORDER BY ... FOR UPDATE) WHERE ROWNUM <= n`. Oracle 23ai still rejects this with **ORA-02014**, but as an ordinary `ActiveRecord::StatementInvalid` surfaced from the database — not a Ruby exception raised from inside an internal visitor.

The compound case is unavoidable at the adapter level: Oracle Database itself disallows `FOR UPDATE` inside a `ROWNUM` subquery (or wrapped under `FETCH FIRST`) and raises ORA-02014 regardless of how the SQL is shaped. Application code that combines `.lock` with `ORDER BY` / `OFFSET` / `GROUP BY` / `HAVING` / `DISTINCT` has to drop `.lock` or restructure the query against any Oracle version. This PR does not try to work around that; it just makes sure the failure is surfaced as a normal DB error instead of a Ruby exception thrown from inside an internal Arel visitor.

The memoised second visitor instance shares `@connection` with `Oracle12`; bind state rides on the collector passed through the dispatch, so no cross-visitor state is introduced.

## Behaviour change for callers

- `Model.lock!` and primary-key finder with lock continue to work (via the flat ROWNUM form).
- `Model.order(:foo).limit(n).lock` and combinations with OFFSET / GROUP BY / HAVING / DISTINCT now produce a `StatementInvalid` (ORA-02014) at execute time on Oracle versions that reject `FOR UPDATE` inside a ROWNUM subquery, instead of an `ArgumentError` at SQL-compile time. Users affected should drop `.lock` or reshape the query — same practical advice as before, but now surfaced as a normal DB error.
- Pre-12c users who previously had to set `use_old_oracle_visitor = true` no longer need to. The setter is still respected — it forces `Arel::Visitors::Oracle` even on 12c+ — and is now also kept consistent with `supports_fetch_first_n_rows_and_offset?`, which gates on the actual `database_version` post-connect.
- `Model.includes(:assoc).references(:assoc).order("assoc.col").limit(N)` and `Model.eager_load(:assoc).order("assoc.col").limit(N)` now work on the default Oracle12 path. They previously worked only on the legacy Oracle visitor; with `order_hacks` moved into `OracleCommon` and called from `Arel::Visitors::Oracle12#visit_Arel_Nodes_SelectStatement`, both visitors now apply the FIRST_VALUE/alias_N__ rewrite.
- `Model.joins(:assoc).distinct.order("assoc.col").limit(N)` still raises ORA-01791 on both visitors. This is **pre-existing** (was true before this PR on both visitors), is documented in #2672, and is out of scope here.

## Spec changes

- `spec/.../oracle_enhanced_adapter_spec.rb` — removes the `#1599` skip on `"Raises Deadlocked when a deadlock is encountered"`; the spec now passes via the delegated simple-case rewrite. Adds a `with_lock` integration test to lock the #2237 contract end-to-end.
- `spec/.../oracle_enhanced/connection_spec.rb` — narrow skip on `"should not reconnect and execute query if connection is lost and auto retry is disabled"` when `database_version.first >= 23`. Oracle 23ai transparently recovers `FETCH FIRST` queries across `ALTER SYSTEM KILL SESSION`, so the adapter never sees an `OCIError` and the expected `StatementInvalid` is not raised. Pre-23 versions keep full coverage.
- `spec/.../oracle_enhanced/arel/oracle12_spec.rb` — updates the previously-asserted `ArgumentError` case to describe the new ROWNUM fallback shape, plus two new visitor-compile assertions: compound `limit + lock + ORDER BY` does not raise (the SQL contains ROWNUM, FOR UPDATE, ORDER BY, and **not** FETCH FIRST), and re-compiling the same SelectStatement produces identical SQL with exactly one ROWNUM predicate (regression guard for the AST mutation fix).
- `spec/.../oracle_enhanced/columns_for_distinct_spec.rb` — the `integration with order_hacks` block now routes through `@conn.visitor` (= the default Oracle12 visitor) instead of a manually-constructed `Arel::Visitors::Oracle`, so it covers the actual default path.

## Test plan

- [x] `bundle exec rake spec` against Oracle 23ai Free 23.26.1.0.0 — 667 examples, 0 failures, 9 pending.
- [x] `bundle exec rubocop` clean.
- [x] Probe of canonical AR query shapes against Oracle 23ai, both with the default Oracle12 visitor and with `use_old_oracle_visitor = true`. Cases 1, 2, 3, 5, 6 succeed on both; Case 4 (`Model.joins(:assoc).distinct.order("assoc.col").limit(N)`) fails on both — pre-existing, tracked in #2672.
- [x] Verified `Post.where(id: 1).lock.limit(1).to_sql` emits the flat ROWNUM-in-WHERE form under the Oracle12 visitor after delegation.
- [x] CI green on supported Oracle versions, including the `test_11g` workflow (which exercises the runtime version-aware visitor selection).

## Refs

- #2237, #2395 — closed by this PR.
- #2671 — failing-test branch that surfaced the `order_hacks` / DISTINCT regression; closed as subsumed.
- #2672 — pre-existing `Model.joins.distinct.order(joined_col).limit` ORA-01791 on both visitors; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
