### PR TITLE
Replace use_legacy_identifier_length with identifier_max_length (:auto default)

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -246,41 +246,49 @@ module ActiveRecord
       cattr_accessor :default_sequence_start_value
       self.default_sequence_start_value = 1
 
-      ##
-      # :singleton-method:
-      # Controls the identifier length used by the adapter.
-      #
-      # * +false+ (default) — use 128 byte identifiers on Oracle 12.2+, and
-      #   silently fall back to 30 bytes on older databases.
-      # * +true+ — force the legacy 30 byte limit, even on 12.2+.
-      #
-      # Can be set globally in an initializer:
-      #
-      #   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.use_legacy_identifier_length = true
-      #
-      # or per connection via database.yml:
+      # Per-connection identifier-length policy. Set via database.yml:
       #
       #   production:
       #     adapter: oracle_enhanced
-      #     use_legacy_identifier_length: true
-      cattr_accessor :use_legacy_identifier_length
-      self.use_legacy_identifier_length = false
+      #     identifier_max_length: short  # :auto (default), :short, or :long
+      #
+      # Accepted values:
+      # * +:auto+ (default when the key is absent) — use 128 byte identifiers on
+      #   Oracle 12.2+, silently fall back to 30 bytes on older databases.
+      # * +:short+ — force the 30 byte limit on every database version.
+      # * +:long+ — request 128 byte identifiers. Raises +ArgumentError+ on
+      #   pre-12.2 databases (use +:auto+ if you want the version-aware
+      #   fallback to 30 bytes).
+      #
+      # Unknown values (e.g. +identifier_max_length: :legacy+) and non-Symbol /
+      # non-String inputs (e.g. a stray boolean after a mechanical YAML
+      # migration) raise +ArgumentError+ up front rather than degrading
+      # silently.
+      #
+      # +use_shorter_identifier+ (below) is a deprecated global fallback for
+      # connections that do not set +identifier_max_length+ themselves.
 
-      # Deprecated alias for +use_legacy_identifier_length+.
+      @@use_shorter_identifier = false
+
+      ##
+      # :singleton-method:
+      # Deprecated. Prefer the per-connection +identifier_max_length+ key in
+      # database.yml. When truthy, behaves as +identifier_max_length: short+ for
+      # connections that do not set +identifier_max_length+ themselves.
       def self.use_shorter_identifier
         OracleEnhanced.deprecator.deprecation_warning(
           "ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.use_shorter_identifier",
-          "use `use_legacy_identifier_length` instead"
+          "set `identifier_max_length: short` per connection in database.yml instead"
         )
-        use_legacy_identifier_length
+        @@use_shorter_identifier
       end
 
       def self.use_shorter_identifier=(value)
         OracleEnhanced.deprecator.deprecation_warning(
           "ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.use_shorter_identifier=",
-          "use `use_legacy_identifier_length=` instead"
+          "set `identifier_max_length: short` per connection in database.yml instead"
         )
-        self.use_legacy_identifier_length = value
+        @@use_shorter_identifier = value
       end
 
       def use_shorter_identifier
@@ -457,14 +465,13 @@ module ActiveRecord
         false
       end
 
+      # Pure capability flag: does the connected database support 128-byte
+      # identifiers? Independent of the +identifier_max_length+ config — the
+      # adapter may still emit 30-byte identifiers via +:short+ or
+      # +use_shorter_identifier+ on a 12.2+ server. Use +max_identifier_length+
+      # for the byte count the adapter actually emits.
       def supports_longer_identifier? # :nodoc:
-        per_connection = @config[:use_legacy_identifier_length] if @config.key?(:use_legacy_identifier_length)
-        use_legacy_length = if per_connection.nil?
-          self.class.use_legacy_identifier_length
-        else
-          ActiveModel::Type::Boolean.new.cast(per_connection)
-        end
-        !use_legacy_length && Gem::Version.new(database_version.join(".")) >= Gem::Version.new("12.2")
+        Gem::Version.new(database_version.join(".")) >= Gem::Version.new("12.2")
       end
 
       # :stopdoc:
@@ -866,7 +873,20 @@ module ActiveRecord
       end
 
       def max_identifier_length
-        supports_longer_identifier? ? 128 : 30
+        case resolve_identifier_max_length
+        when :short
+          30
+        when :auto
+          supports_longer_identifier? ? 128 : 30
+        when :long
+          unless supports_longer_identifier?
+            raise ArgumentError,
+              "identifier_max_length: :long requires Oracle 12.2 or later " \
+              "(connected server reports #{database_version.join('.')}). " \
+              "Use :auto for version-aware default, or :short to force 30-byte identifiers."
+          end
+          128
+        end
       end
       alias table_alias_length max_identifier_length
       alias index_name_length max_identifier_length
@@ -1077,6 +1097,41 @@ module ActiveRecord
       private
         AREL_VISITOR_MODES = %i[auto rownum fetch_first].freeze
         private_constant :AREL_VISITOR_MODES
+
+        IDENTIFIER_MAX_LENGTH_MODES = %i[auto short long].freeze
+        private_constant :IDENTIFIER_MAX_LENGTH_MODES
+
+        # Per-connection +identifier_max_length+ is the canonical source. The
+        # deprecated global +use_shorter_identifier+ (read via @@class var to
+        # skip its deprecation warning on every lookup) is honored only when
+        # the connection config does not set +identifier_max_length+ itself;
+        # an explicit per-connection value always wins.
+        #
+        # Type and value are validated up front — unknown values and
+        # non-Symbol / non-String inputs raise +ArgumentError+ here.
+        def resolve_identifier_max_length
+          raw = @config[:identifier_max_length]
+          if raw.nil?
+            return @@use_shorter_identifier ? :short : :auto
+          end
+          unless raw.is_a?(String) || raw.is_a?(Symbol)
+            raise ArgumentError,
+              "identifier_max_length must be a String or Symbol (got #{raw.inspect}). " \
+              "Expected #{identifier_max_length_modes_list}."
+          end
+          mode = raw.to_sym
+          unless IDENTIFIER_MAX_LENGTH_MODES.include?(mode)
+            raise ArgumentError,
+              "Unknown identifier_max_length #{mode.inspect}. " \
+              "Expected #{identifier_max_length_modes_list}."
+          end
+          mode
+        end
+
+        def identifier_max_length_modes_list
+          symbols = IDENTIFIER_MAX_LENGTH_MODES.map { |mode| ":#{mode}" }
+          "#{symbols[0..-2].join(', ')}, or #{symbols.last}"
+        end
 
         def arel_visitor
           case resolved_arel_visitor_mode

--- a/spec/active_record/connection_adapters/oracle_enhanced/identifier_length_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/identifier_length_spec.rb
@@ -8,87 +8,168 @@ describe "OracleEnhancedAdapter identifier length configuration" do
   end
 
   after(:each) do
-    adapter_class.use_legacy_identifier_length = false
     ActiveRecord::Base.remove_connection
+    # Reset the deprecated global fallback that individual tests may have toggled.
+    # Use the class variable directly to avoid emitting a deprecation warning.
+    adapter_class.class_variable_set(:@@use_shorter_identifier, false)
   end
 
-  describe "use_shorter_identifier" do
-    it "is deprecated when assigned and delegates to use_legacy_identifier_length" do
+  def twelve_two_or_later?(conn)
+    Gem::Version.new(conn.database_version.join(".")) >= Gem::Version.new("12.2")
+  end
+
+  describe "use_shorter_identifier (deprecated global fallback)" do
+    setter_warning = /use_shorter_identifier=.* is deprecated and will be removed from activerecord-oracle_enhanced-adapter a future version/m
+    getter_warning = /use_shorter_identifier.* is deprecated and will be removed from activerecord-oracle_enhanced-adapter a future version/m
+
+    it "warns of deprecation and future removal when assigned" do
       expect {
         adapter_class.use_shorter_identifier = true
-      }.to output(/use_shorter_identifier.* is deprecated/).to_stderr
+      }.to output(setter_warning).to_stderr
 
-      expect(adapter_class.use_legacy_identifier_length).to be(true)
+      expect(adapter_class.class_variable_get(:@@use_shorter_identifier)).to be(true)
     end
 
-    it "is deprecated when read and reflects use_legacy_identifier_length" do
-      adapter_class.use_legacy_identifier_length = true
+    it "warns of deprecation and future removal when read" do
+      adapter_class.class_variable_set(:@@use_shorter_identifier, true)
 
       expect {
         expect(adapter_class.use_shorter_identifier).to be(true)
-      }.to output(/use_shorter_identifier.* is deprecated/).to_stderr
+      }.to output(getter_warning).to_stderr
+    end
+
+    it "is honored by connections that do not set identifier_max_length themselves" do
+      adapter_class.class_variable_set(:@@use_shorter_identifier, true)
+      ActiveRecord::Base.remove_connection
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+      conn = ActiveRecord::Base.connection
+
+      expect(conn.max_identifier_length).to eq(30)
+    end
+
+    it "is overridden by an explicit per-connection identifier_max_length" do
+      adapter_class.class_variable_set(:@@use_shorter_identifier, true)
+      ActiveRecord::Base.remove_connection
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(identifier_max_length: :auto))
+      conn = ActiveRecord::Base.connection
+
+      if twelve_two_or_later?(conn)
+        expect(conn.max_identifier_length).to eq(128)
+      else
+        expect(conn.max_identifier_length).to eq(30)
+      end
     end
   end
 
-  describe "supports_longer_identifier?" do
-    it "honors global use_legacy_identifier_length" do
-      adapter_class.use_legacy_identifier_length = true
+  describe "supports_longer_identifier? (pure DB capability)" do
+    it "reflects the connected database version, ignoring identifier_max_length config" do
       ActiveRecord::Base.remove_connection
-      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-      conn = ActiveRecord::Base.lease_connection
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(identifier_max_length: :short))
+      conn = ActiveRecord::Base.connection
 
-      expect(conn.supports_longer_identifier?).to be(false)
-      expect(conn.max_identifier_length).to eq(30)
+      expect(conn.supports_longer_identifier?).to be(twelve_two_or_later?(conn))
     end
+  end
 
-    it "honors per-connection use_legacy_identifier_length" do
-      ActiveRecord::Base.remove_connection
-      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(use_legacy_identifier_length: true))
-      conn = ActiveRecord::Base.lease_connection
-
-      expect(conn.supports_longer_identifier?).to be(false)
-      expect(conn.max_identifier_length).to eq(30)
-    end
-
-    it "per-connection config overrides global (legacy locally, longer globally)" do
-      adapter_class.use_legacy_identifier_length = false
-      ActiveRecord::Base.remove_connection
-      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(use_legacy_identifier_length: true))
-      conn = ActiveRecord::Base.lease_connection
-
-      expect(conn.supports_longer_identifier?).to be(false)
-    end
-
-    it "per-connection config overrides global (longer locally, legacy globally)" do
-      adapter_class.use_legacy_identifier_length = true
-      ActiveRecord::Base.remove_connection
-      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(use_legacy_identifier_length: false))
-      conn = ActiveRecord::Base.lease_connection
-
-      if Gem::Version.new(conn.database_version.join(".")) >= Gem::Version.new("12.2")
-        expect(conn.supports_longer_identifier?).to be(true)
+  describe "identifier_max_length (per-connection)" do
+    it "defaults to :auto when the key is absent" do
+      conn = ActiveRecord::Base.connection
+      if twelve_two_or_later?(conn)
         expect(conn.max_identifier_length).to eq(128)
       else
-        expect(conn.supports_longer_identifier?).to be(false)
         expect(conn.max_identifier_length).to eq(30)
       end
     end
 
-    it "silently falls back to 30-byte identifiers on a pre-12.2 database" do
-      conn = ActiveRecord::Base.lease_connection
-      allow(conn).to receive(:database_version).and_return([11, 2])
-      expect(conn.supports_longer_identifier?).to be(false)
+    it "honors identifier_max_length: :short" do
+      ActiveRecord::Base.remove_connection
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(identifier_max_length: :short))
+      conn = ActiveRecord::Base.connection
+
+      expect(conn.max_identifier_length).to eq(30)
+    end
+
+    it "honors identifier_max_length: :long on 12.2+, raises ArgumentError on pre-12.2" do
+      ActiveRecord::Base.remove_connection
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(identifier_max_length: :long))
+      conn = ActiveRecord::Base.connection
+
+      if twelve_two_or_later?(conn)
+        expect(conn.max_identifier_length).to eq(128)
+      else
+        expect { conn.max_identifier_length }.to raise_error(
+          ArgumentError,
+          /identifier_max_length: :long requires Oracle 12\.2 or later \(connected server reports #{Regexp.escape(conn.database_version.join("."))}\)/
+        )
+      end
+    end
+
+    it "accepts YAML string values and coerces them via to_sym" do
+      ActiveRecord::Base.remove_connection
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(identifier_max_length: "short"))
+      conn = ActiveRecord::Base.connection
+
+      expect(conn.max_identifier_length).to eq(30)
+    end
+
+    it "silently falls back to 30-byte identifiers on a pre-12.2 database with :auto" do
+      conn = ActiveRecord::Base.connection
+      skip "requires Oracle pre-12.2" if twelve_two_or_later?(conn)
+
       expect(conn.max_identifier_length).to eq(30)
     end
 
     it "falls back to the global setting when the per-connection value is nil" do
-      adapter_class.use_legacy_identifier_length = true
+      adapter_class.class_variable_set(:@@use_shorter_identifier, true)
       ActiveRecord::Base.remove_connection
-      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(use_legacy_identifier_length: nil))
-      conn = ActiveRecord::Base.lease_connection
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(identifier_max_length: nil))
+      conn = ActiveRecord::Base.connection
 
-      expect(conn.supports_longer_identifier?).to be(false)
       expect(conn.max_identifier_length).to eq(30)
+    end
+
+    it "raises ArgumentError for unknown symbol values" do
+      ActiveRecord::Base.remove_connection
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(identifier_max_length: :bogus))
+      conn = ActiveRecord::Base.connection
+      expect { conn.max_identifier_length }.to raise_error(
+        ArgumentError,
+        /Unknown identifier_max_length :bogus\. Expected :auto, :short, or :long/
+      )
+    end
+
+    it "raises ArgumentError for unknown string values" do
+      ActiveRecord::Base.remove_connection
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(identifier_max_length: "bogus"))
+      conn = ActiveRecord::Base.connection
+      expect { conn.max_identifier_length }.to raise_error(
+        ArgumentError,
+        /Unknown identifier_max_length :bogus\. Expected :auto, :short, or :long/
+      )
+    end
+
+    it "raises ArgumentError for non-symbol/non-string values (e.g. booleans) per-connection" do
+      ActiveRecord::Base.remove_connection
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(identifier_max_length: true))
+      conn = ActiveRecord::Base.connection
+      expect { conn.max_identifier_length }.to raise_error(
+        ArgumentError,
+        /identifier_max_length must be a String or Symbol \(got true\)\. Expected :auto, :short, or :long/
+      )
+    end
+
+    it "lets per-connection identifier_max_length: :long win over use_shorter_identifier=true" do
+      adapter_class.class_variable_set(:@@use_shorter_identifier, true)
+      ActiveRecord::Base.remove_connection
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(identifier_max_length: :long))
+      conn = ActiveRecord::Base.connection
+
+      if twelve_two_or_later?(conn)
+        expect(conn.max_identifier_length).to eq(128)
+      else
+        expect { conn.max_identifier_length }
+          .to raise_error(ArgumentError, /identifier_max_length: :long requires Oracle 12\.2 or later/)
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

Replace the master-only `use_legacy_identifier_length` config (added in #2542, never shipped in a released gem) with `identifier_max_length`, a **per-connection-only** `database.yml` key that accepts `:auto`, `:short`, or `:long`. Aligns with the recent master-branch direction of favoring per-connection configs over global cattrs, and deprecating existing globals.

### Accepted values

- `:auto` (default when the key is absent) — use 128 byte identifiers on Oracle 12.2+, silently fall back to 30 bytes on older databases.
- `:short` — force the 30 byte limit on every database version.
- `:long` — request 128 byte identifiers. Raises `ArgumentError` on pre-12.2 databases naming both the requirement and the connected version. Use `:auto` if you want the version-aware silent fallback.

Unknown values (`:bogus`, `"bogus"`) and non-Symbol / non-String inputs (`true`, integers, etc.) raise `ArgumentError` up front rather than degrading silently.

### Usage

```yaml
production:
  adapter: oracle_enhanced
  identifier_max_length: short   # :auto (default), :short, or :long
```

There is intentionally **no** `OracleEnhancedAdapter.identifier_max_length =` class accessor — the value lives on the connection.

### `supports_longer_identifier?` vs `max_identifier_length`

Two distinct concerns, two methods:

- `supports_longer_identifier?` — **pure DB capability flag**. Returns `true` on Oracle 12.2+ regardless of `identifier_max_length` config. Restored to its pre-#2542 (v6.0.0–v8.1.x released) semantics; the conflated config-resolved form was master-only and never shipped.
- `max_identifier_length` — **adapter's expressed limit**, what the adapter will accept and emit, as resolved from `identifier_max_length` and the deprecated `use_shorter_identifier` global. This is the contract Rails uses to validate identifiers in migrations and schema operations.

Example: on a 12.2+ DB with `identifier_max_length: :short`, `supports_longer_identifier?` is `true` (capability) but `max_identifier_length` is `30` (adapter's choice).

### Precedence matrix: `use_shorter_identifier` (global, deprecated) × `identifier_max_length:` (per-connection)

| `use_shorter_identifier` | `identifier_max_length:` | DB | `supports_longer_identifier?` | `max_identifier_length` |
|---|---|---|---|---|
| `false` (default) | absent / `nil` | 12.2+ | `true` | 128 |
| `false` (default) | absent / `nil` | pre-12.2 | `false` | 30 |
| `true` (deprecated) | absent / `nil` | 12.2+ | `true` | 30 (global short) |
| `true` (deprecated) | absent / `nil` | pre-12.2 | `false` | 30 |
| any | `:auto` | 12.2+ | `true` | 128 (per-conn wins, FC) |
| any | `:auto` | pre-12.2 | `false` | 30 (silent, FC) |
| any | `:short` | 12.2+ | `true` | 30 |
| any | `:short` | pre-12.2 | `false` | 30 |
| any | `:long` | 12.2+ | `true` | 128 (per-conn wins) |
| any | `:long` | pre-12.2 | `false` | **ArgumentError** |
| any | unknown Symbol / String | any | (DB version) | **ArgumentError** |
| any | non-Symbol / non-String | any | (DB version) | **ArgumentError** |

Per-connection always wins silently over the deprecated global, matching #2575's `use_old_oracle_visitor` × `arel_visitor:` precedence. FC = forward-compatible: same resolved value before and after `use_shorter_identifier` is removed.

### Migration path for `use_shorter_identifier = true` users

| Phase | What the user sees | What the user does |
|---|---|---|
| **This PR (deprecation)** | The existing initializer line still works; `OracleEnhanced.deprecator` emits "set `identifier_max_length: short` per connection in database.yml instead" on every assignment / read | Add `identifier_max_length: short` to each affected connection in `database.yml`; remove the initializer line |
| **Migrated** | No deprecation warning; behavior unchanged | — |
| **Next major (removal)** | `OracleEnhancedAdapter.use_shorter_identifier = true` raises `NoMethodError` because the setter, getter, and storage are gone | Migrated users keep working via `identifier_max_length: short`; un-migrated users get a fail-fast error pointing at the missing method |

The `NoMethodError` at the next major is intentional. A silent semantic change (the same code suddenly resolving to `:auto` because the initializer line no longer affects anything) would be far worse than an explicit error that names the missing method.

Users who write `identifier_max_length: :auto` instead of `:short` get the version-aware default (128 bytes on 12.2+), which is the same `max_identifier_length` they will get after `use_shorter_identifier` is removed. Both `:short` and `:auto` are forward-compatible migration choices.

### Changes

- New per-connection `identifier_max_length` key, read from `@config[:identifier_max_length]`. YAML string values (`"short"`, `"long"`, `"auto"`) are coerced via `to_sym`. Unknown values and non-Symbol / non-String inputs raise `ArgumentError` up front (`IDENTIFIER_MAX_LENGTH_MODES` private constant, validation pattern mirroring #2575's `configured_arel_visitor_mode`).
- `:long` on pre-12.2 raises `ArgumentError` rather than warning + silent fallback. Mirrors the convention from #2575 where `arel_visitor: :fetch_first` on a pre-12.1 server raises rather than warning + falling back.
- `supports_longer_identifier?` restored to its pre-#2542 (v6.0.0–v8.1.x) meaning as a pure DB capability flag. Config resolution moved to `max_identifier_length`.
- `use_shorter_identifier` stays as a **deprecated global fallback**. It keeps its own `@@use_shorter_identifier` storage (separate from the new config), and its setter/getter emit deprecation warnings pointing users to the per-connection key. Resolution consults the deprecated global only when the per-connection key is absent, and reads it via the bare class variable to avoid tripping the warning on every lookup. An explicit per-connection value always wins (matching #2575).
- No shim for `use_legacy_identifier_length` — it never shipped (latest release `v8.1.2` on `release81` still uses `use_shorter_identifier`; master diverged on 2026-04-22 with #2542).

### Naming

`identifier_max_length` follows the existing `default_sequence_start_value` noun-chain shape. Values (`:auto`, `:short`, `:long`) are descriptive rather than judgment-laden (no `:legacy` / `:modern`).

### Related

- Builds on #2542 (introduced `use_legacy_identifier_length` and the per-connection override hook)
- Builds on #2543 (shared `OracleEnhanced.deprecator` with gem name + "a future version" horizon)
- Mirrors #2575 (per-connection `arel_visitor` config; same `:auto` / fail-fast-on-forced-mode-vs-unsupported-version convention; same per-connection-wins precedence over deprecated global)

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/identifier_length_spec.rb` — 16 examples, 0 failures, 1 pending (the `:auto` silent-fallback example skips on the 23ai test row and runs only on pre-12.2 CI matrix rows)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb spec/active_record/connection_adapters/oracle_enhanced/quoting_spec.rb` — 106 examples, 0 failures, 1 pending
- [x] Full `bundle exec rspec` on Oracle 23ai — 693 examples, 0 failures, 10 pending
- [x] `bundle exec rubocop` — no offenses
- [ ] CI green on all matrix rows
