### PR TITLE
Strip NULLS FIRST / NULLS LAST in columns_for_distinct

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -706,8 +706,9 @@ module ActiveRecord
         # It does not construct DISTINCT clause. Just return column names for distinct.
         order_columns = orders.reject(&:blank?).map { |s|
             s = visitor.compile(s) unless s.is_a?(String)
-            # remove any ASC/DESC modifiers
-            s.gsub(/\s+(ASC|DESC)\s*?/i, "")
+            # remove any ASC/DESC and NULLS FIRST/LAST modifiers
+            s.gsub(/\s+(?:ASC|DESC)\b/i, "")
+             .gsub(/\s+NULLS\s+(?:FIRST|LAST)\b/i, "")
           }.reject(&:blank?).map.with_index { |column, i|
             "FIRST_VALUE(#{column}) OVER (PARTITION BY #{columns.join(', ')} ORDER BY #{column}) AS alias_#{i}__"
           }

--- a/spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+describe "OracleEnhancedAdapter#columns_for_distinct" do
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @conn = ActiveRecord::Base.connection
+  end
+
+  it "strips ASC modifier" do
+    sql = @conn.columns_for_distinct(["posts.id"], ["posts.created_at ASC"])
+    expect(sql).to include("FIRST_VALUE(posts.created_at)")
+    expect(sql).not_to match(/\bASC\b/i)
+  end
+
+  it "strips DESC modifier" do
+    sql = @conn.columns_for_distinct(["posts.id"], ["posts.created_at DESC"])
+    expect(sql).to include("FIRST_VALUE(posts.created_at)")
+    expect(sql).not_to match(/\bDESC\b/i)
+  end
+
+  it "strips NULLS FIRST modifier" do
+    sql = @conn.columns_for_distinct(["posts.id"], ["posts.created_at NULLS FIRST"])
+    expect(sql).to include("FIRST_VALUE(posts.created_at)")
+    expect(sql).not_to match(/NULLS\s+FIRST/i)
+  end
+
+  it "strips NULLS LAST modifier" do
+    sql = @conn.columns_for_distinct(["posts.id"], ["posts.created_at NULLS LAST"])
+    expect(sql).to include("FIRST_VALUE(posts.created_at)")
+    expect(sql).not_to match(/NULLS\s+LAST/i)
+  end
+
+  it "strips combined DESC NULLS LAST" do
+    sql = @conn.columns_for_distinct(["posts.id"], ["posts.created_at DESC NULLS LAST"])
+    expect(sql).to include("FIRST_VALUE(posts.created_at)")
+    expect(sql).not_to match(/\bDESC\b/i)
+    expect(sql).not_to match(/NULLS/i)
+  end
+
+  it "strips combined ASC NULLS FIRST" do
+    sql = @conn.columns_for_distinct(["posts.id"], ["posts.created_at ASC NULLS FIRST"])
+    expect(sql).to include("FIRST_VALUE(posts.created_at)")
+    expect(sql).not_to match(/\bASC\b/i)
+    expect(sql).not_to match(/NULLS/i)
+  end
+
+  it "strips lowercase desc nulls last" do
+    sql = @conn.columns_for_distinct(["posts.id"], ["posts.created_at desc nulls last"])
+    expect(sql).to include("FIRST_VALUE(posts.created_at)")
+    expect(sql).not_to match(/\bdesc\b/i)
+    expect(sql).not_to match(/nulls/i)
+  end
+
+  it "joins composite primary key columns in PARTITION BY" do
+    sql = @conn.columns_for_distinct(["posts.id", "posts.tenant_id"], ["posts.created_at DESC"])
+    expect(sql).to include("PARTITION BY posts.id, posts.tenant_id")
+  end
+
+  it "strips DESC NULLS LAST from an Arel ordering node" do
+    order_node = Arel::Table.new(:posts)[:created_at].desc.nulls_last
+    sql = @conn.columns_for_distinct(["posts.id"], [order_node])
+    expect(sql).to match(/FIRST_VALUE\("POSTS"\."CREATED_AT"\)/i)
+    expect(sql).not_to match(/\bDESC\b/i)
+    expect(sql).not_to match(/NULLS/i)
+  end
+end


### PR DESCRIPTION
## Summary
- Strips `NULLS FIRST` / `NULLS LAST` from ORDER BY fragments in `OracleEnhancedAdapter#columns_for_distinct`, mirroring the Rails PostgreSQL adapter (`activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb`).
- Aligns the adjacent `ASC`/`DESC` regex with the same Rails PostgreSQL form — non-capturing group and `\b` word boundary.

`FIRST_VALUE(col NULLS LAST) OVER (... ORDER BY col NULLS LAST)` is invalid Oracle SQL, so callers that end up in `distinct_relation_for_primary_key` with a `nulls: :last` order currently fail. After this change the `NULLS` modifier is stripped alongside `ASC`/`DESC` before the `FIRST_VALUE(...)` wrapper is built.

Fixes #2482.

## Test plan
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb` — 9 examples, 0 failures (Oracle 23c Free / FREEPDB1). Covers raw SQL strings, lowercase, combined `DESC NULLS LAST` / `ASC NULLS FIRST`, composite PK, and an Arel ordering node (`posts[:created_at].desc.nulls_last`) to exercise the `visitor.compile` branch that `distinct_relation_for_primary_key` actually uses.
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/composite_spec.rb` — 3 examples, 0 failures, 1 pre-existing pending (unrelated; rails/rails#55401).
- [x] `bundle exec rubocop lib/active_record/connection_adapters/oracle_enhanced_adapter.rb spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb` — clean.

## Notes
- Autosquash done — branch is a single commit.
- Follow-up PR #2588 is stacked on this branch to preserve `DESC` / `NULLS FIRST|LAST` in the outer ORDER BY rewrite inside `Arel::Visitors::Oracle#order_hacks` (the downstream path that this PR's stripping alone does not fully fix).
