### PR TITLE
Accept primary_key argument in empty_insert_statement_value

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -191,7 +191,7 @@ module ActiveRecord
         # Oracle Database does not support this feature
         # Refer https://community.oracle.com/ideas/13845 and consider to vote
         # if you need this feature.
-        def empty_insert_statement_value
+        def empty_insert_statement_value(primary_key = nil)
           raise NotImplementedError
         end
 


### PR DESCRIPTION
## Summary

- Rails 6.0 changed `AbstractAdapter#empty_insert_statement_value` to accept an optional `primary_key` argument via [rails/rails#32667](https://github.com/rails/rails/pull/32667), and `ActiveRecord::Persistence#_insert_record` now calls it with the primary key. The oracle-enhanced override was defined with zero arguments, which raised `ArgumentError: wrong number of arguments (given 1, expected 0)` at insert time.
- Match the abstract signature by accepting `primary_key = nil`. Oracle still does not support `DEFAULT VALUES`, so the method keeps raising `NotImplementedError`.

## Test plan

- [x] `bundle exec rspec spec/active_record/oracle_enhanced/type/dirty_spec.rb` — was failing with `ArgumentError`, now passes (11 examples, 0 failures).
- [x] `bundle exec rubocop lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb` — no offenses.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
