### PR TITLE
Accept options as keyword arguments in remove_column

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -459,7 +459,7 @@ module ActiveRecord
           clear_table_columns_cache(table_name)
         end
 
-        def remove_column(table_name, column_name, type = nil, options = {}) # :nodoc:
+        def remove_column(table_name, column_name, type = nil, **options) # :nodoc:
           execute "ALTER TABLE #{quote_table_name(table_name)} DROP COLUMN #{quote_column_name(column_name)} CASCADE CONSTRAINTS"
         ensure
           clear_table_columns_cache(table_name)

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -1066,7 +1066,7 @@ end
 
     it "should ignore type and options parameter and remove column" do
       schema_define do
-        remove_column :test_posts, :title, :string, {}
+        remove_column :test_posts, :title, :string, if_exists: true
       end
       TestPost.reset_column_information
       expect(TestPost.columns_hash["title"]).to be_nil


### PR DESCRIPTION
## Summary

Rails `AbstractAdapter#remove_column` uses `**options`; the OE override was still declared with the pre-Ruby-3 positional `options = {}` form.

```ruby
# before
def remove_column(table_name, column_name, type = nil, options = {})
# after (this PR)
def remove_column(table_name, column_name, type = nil, **options)
```

A caller passing a keyword argument like `remove_column :t, :c, :string, if_exists: true` now routes through `**options` instead of being bound to the positional slot, matching the AbstractAdapter contract. The adapter still ignores `type` and `options`, same as before.

Update the "should ignore type and options parameter" spec to pass an actual keyword argument (`if_exists: true`) so it exercises the new shape rather than the now-incompatible `{}` positional literal.

Surfaced by the method-signature check being added in #2580; the corresponding `IGNORED_DRIFTS` entry is empty in that PR, so merging this one flips the check green for `remove_column`.

## Note on backward compatibility

Callers passing a trailing positional hash like `remove_column(:posts, :title, :string, {})` will now raise `ArgumentError`. In Ruby 3+ that call pattern was already discouraged (implicit hash-to-kwargs conversion was removed), and every sibling adapter (sqlite3, postgresql, mysql2) already uses `**options`, so external usage should already be kwarg-style.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb` — 85 examples, 0 failures (1 pending, unrelated)
- [x] `bundle exec rubocop lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb` — no offenses
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
