### PR TITLE
Align clear_cache! signature with AbstractAdapter

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -497,7 +497,7 @@ module ActiveRecord
         @logger.warn "#{adapter_name} automatic reconnection failed: #{e.message}" if @logger
       end
 
-      def clear_cache!(*args, **kwargs)
+      def clear_cache!(new_connection: false)
         super
         self.class.clear_type_map!
       end


### PR DESCRIPTION
## Summary

Rails `AbstractAdapter#clear_cache!` is declared as `clear_cache!(new_connection: false)`; the Oracle enhanced adapter override was `clear_cache!(*args, **kwargs)`, which accepted and forwarded anything Rails happened to pass.

```ruby
# before
def clear_cache!(*args, **kwargs)
  super
  self.class.clear_type_map!
end

# after (this PR)
def clear_cache!(new_connection: false)
  super
  self.class.clear_type_map!
end
```

Switch to the explicit keyword signature so the adapter states its contract and drifts from a future Rails change are caught by the method-signature check instead of being absorbed silently. `super` continues to forward the captured keyword without an explicit splat.

The `new_connection:` keyword was introduced in Rails 7.1 by rails/rails@4e37a4c552 (rails/rails#44527, "The server discards prepared statements when disconnected"), which also updated `reconnect!` and `disconnect!` to call `clear_cache!(new_connection: true)`.

Surfaced by the method-signature check being added in #2580.

Refs #2267.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb` — 42 examples, 0 failures
- [x] `bundle exec rubocop lib/active_record/connection_adapters/oracle_enhanced_adapter.rb` — no offenses
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
