### PR TITLE
Accept multiple tables in drop_table

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -264,15 +264,20 @@ module ActiveRecord
           rename_table_indexes(table_name, new_name, **options)
         end
 
-        def drop_table(table_name, **options) # :nodoc:
-          schema_cache.clear_data_source_cache!(table_name.to_s)
-          execute "DROP TABLE #{quote_table_name(table_name)}#{' CASCADE CONSTRAINTS' if options[:force] == :cascade}"
-          seq_name = options[:sequence_name] || default_sequence_name(table_name)
-          execute "DROP SEQUENCE #{quote_table_name(seq_name)}" rescue nil
-        rescue ActiveRecord::StatementInvalid => e
-          raise e unless options[:if_exists]
-        ensure
-          clear_table_columns_cache(table_name)
+        def drop_table(*table_names, **options) # :nodoc:
+          # :sequence_name names a single sequence, so it cannot unambiguously
+          # apply across multiple tables; honor it only for single-table drops.
+          custom_sequence_name = table_names.size == 1 ? options[:sequence_name] : nil
+          table_names.each do |table_name|
+            schema_cache.clear_data_source_cache!(table_name.to_s)
+            execute "DROP TABLE #{quote_table_name(table_name)}#{' CASCADE CONSTRAINTS' if options[:force] == :cascade}"
+            seq_name = custom_sequence_name || default_sequence_name(table_name)
+            execute "DROP SEQUENCE #{quote_table_name(seq_name)}" rescue nil
+          rescue ActiveRecord::StatementInvalid => e
+            raise e unless options[:if_exists]
+          ensure
+            clear_table_columns_cache(table_name)
+          end
         end
 
         def add_index(table_name, column_name, **options) # :nodoc:

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -306,10 +306,31 @@ describe "OracleEnhancedAdapter schema definition" do
       @conn = ActiveRecord::Base.connection
     end
 
+    after(:each) do
+      schema_define do
+        drop_table :multi_drop_posts, if_exists: true
+        drop_table :multi_drop_comments, if_exists: true
+      end
+    end
+
     it "should drop table with :if_exists option no raise error" do
       expect do
         @conn.drop_table("nonexistent_table", if_exists: true)
       end.not_to raise_error
+    end
+
+    it "drops multiple tables in a single call" do
+      schema_define do
+        create_table :multi_drop_posts, force: true
+        create_table :multi_drop_comments, force: true
+      end
+
+      expect do
+        @conn.drop_table :multi_drop_posts, :multi_drop_comments
+      end.not_to raise_error
+
+      expect(@conn.table_exists?(:multi_drop_posts)).to be_falsey
+      expect(@conn.table_exists?(:multi_drop_comments)).to be_falsey
     end
   end
 


### PR DESCRIPTION
## Summary

Rails `AbstractSchemaStatements#drop_table` became `drop_table(*table_names, **options)` so callers can drop several tables in one call. The Oracle enhanced adapter override still required a single `table_name`, so passing more than one argument raised `ArgumentError` even though Rails documents the splat form.

```ruby
# before
def drop_table(table_name, **options)
# after (this PR)
def drop_table(*table_names, **options)
```

The body iterates over `table_names` and applies the existing per-table logic (sequence drop, `if_exists` rescue, `clear_table_columns_cache` in `ensure`). Single-table calls continue to work unchanged because the splat binds a single argument to a one-element array.

### `sequence_name` option

`:sequence_name` names a single sequence, so it cannot unambiguously apply across multiple tables; it is honored only when exactly one table is being dropped. Passing `sequence_name:` together with multiple tables falls back to `default_sequence_name(table_name)` per table rather than attempting to drop the same custom sequence repeatedly.

### Rails origin

The `*table_names` form was introduced in Rails 8.0 by rails/rails@1666bad840 (rails/rails#52773, "Allow drop_table to accept an array of table names").

### Regression test

Adds a spec that creates two tables and drops them in a single `drop_table(:t1, :t2)` call, asserting both tables are gone afterward. This exercises the new multi-table iteration path end-to-end rather than only the signature.

Surfaced by the method-signature check being added in #2580.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb` — 86 examples, 0 failures (1 pending, unrelated)
- [x] `bundle exec rubocop lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb` — no offenses
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
