### PR TITLE
Align add_index_options keyword signature with AbstractSchemaStatements

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -276,7 +276,9 @@ module ActiveRecord
         end
 
         def add_index(table_name, column_name, **options) # :nodoc:
-          index_name, index_type, quoted_column_names, tablespace, index_options = add_index_options(table_name, column_name, **options)
+          result = add_index_options(table_name, column_name, **options)
+          return if result.nil?
+          index_name, index_type, quoted_column_names, tablespace, index_options = result
           execute "CREATE #{index_type} INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} (#{quoted_column_names})#{tablespace} #{index_options}"
           if index_type == "UNIQUE"
             unless /\(.*\)/.match?(quoted_column_names)
@@ -285,21 +287,22 @@ module ActiveRecord
           end
         end
 
-        def add_index_options(table_name, column_name, comment: nil, **options) # :nodoc:
+        def add_index_options(table_name, column_name, name: nil, if_not_exists: false, internal: false, **options) # :nodoc:
           column_names = Array(column_name)
           index_name   = index_name(table_name, column: column_names)
 
-          options.assert_valid_keys(:unique, :order, :name, :where, :length, :internal, :tablespace, :options, :using)
+          options.assert_valid_keys(:unique, :order, :where, :length, :tablespace, :options, :using, :comment)
 
           index_type = options[:unique] ? "UNIQUE" : ""
-          index_name = options[:name].to_s if options.key?(:name)
+          index_name = name.to_s if name
           tablespace = tablespace_for(:index, options[:tablespace])
           # TODO: This option is used for NOLOGGING, needs better argument name
           index_options = options[:options]
 
-          validate_index_length!(table_name, index_name, options.fetch(:internal, false))
+          validate_index_length!(table_name, index_name, internal)
 
           if table_exists?(table_name) && index_name_exists?(table_name, index_name)
+            return nil if if_not_exists
             raise ArgumentError, "Index name '#{index_name}' on table '#{table_name}' already exists"
           end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -480,6 +480,36 @@ describe "OracleEnhancedAdapter schema definition" do
   end
 end
 
+  describe "add_index with if_not_exists" do
+    before(:each) do
+      @conn = ActiveRecord::Base.connection
+      schema_define do
+        create_table :test_posts, force: true do |t|
+          t.string :title
+        end
+        add_index :test_posts, :title
+      end
+    end
+
+    after(:each) do
+      schema_define do
+        drop_table :test_posts, if_exists: true
+      end
+    end
+
+    it "is a no-op when the index already exists" do
+      expect do
+        @conn.add_index :test_posts, :title, if_not_exists: true
+      end.not_to raise_error
+    end
+
+    it "raises ArgumentError when the index already exists and if_not_exists is unset" do
+      expect do
+        @conn.add_index :test_posts, :title
+      end.to raise_error(ArgumentError, /already exists/)
+    end
+  end
+
   describe "add timestamps" do
     before(:each) do
       @conn = ActiveRecord::Base.connection


### PR DESCRIPTION
## Summary

Rails `AbstractSchemaStatements#add_index_options` declares `name:`, `if_not_exists:`, and `internal:` as explicit keyword arguments; the Oracle enhanced adapter override accepted `name` and `internal` only inside `**options`, and raised from `assert_valid_keys` on `if_not_exists:` — so a caller passing `if_not_exists: true` (as Rails callers do) got `ArgumentError`.

```ruby
# before
def add_index_options(table_name, column_name, comment: nil, **options)
# after (this PR)
def add_index_options(table_name, column_name, name: nil, if_not_exists: false, internal: false, **options)
```

- Move the body's `options[:name]` / `options.fetch(:internal)` references to the new local variables.
- Honor `if_not_exists:` by returning `nil` when the index already exists rather than raising, mirroring the Rails no-op semantics. `add_index` now checks the nil return and skips emitting DDL, so `add_index :posts, :title, if_not_exists: true` on a table that already has the index is a no-op.
- Drop the previously-declared `comment:` keyword argument — it was declared but never read in the body. Callers passing `comment:` still work because `:comment` is now listed in `options.assert_valid_keys`; it is silently ignored, same as before.

### Rails origin

The explicit-kwarg signature `(table_name, column_name, name: nil, if_not_exists: false, internal: false, **options)` was introduced in Rails 6.1 by rails/rails@2c1b012ad7 (rails/rails#39203, "Refactor index creation to use index definition visitor"). `if_not_exists:` support on `add_index` itself predates that by a few months (rails/rails@7ba08037f8, rails/rails#38555, also Rails 6.1).

### Regression test

Adds specs that pre-create an index on `test_posts(title)` and then invoke `add_index` again — once with `if_not_exists: true` asserting no raise, and once without asserting `ArgumentError` — exercising the new no-op path end-to-end rather than only the signature.

Surfaced by the method-signature check being added in #2580.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb` — 110 examples, 0 failures (1 pending, unrelated)
- [x] `bundle exec rubocop lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb` — no offenses
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
