### PR TITLE
Drop oracle-enhanced fetch_type_metadata override, inline TypeMetadata wrap

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -670,7 +670,7 @@ module ActiveRecord
               field["data_default"] = false if field["data_default"] == "N" && OracleEnhancedAdapter.emulate_booleans_from_strings
             end
 
-            type_metadata = fetch_type_metadata(field["sql_type"], is_virtual)
+            type_metadata = OracleEnhanced::TypeMetadata.new(fetch_type_metadata(field["sql_type"]), virtual: is_virtual)
             default_value = extract_value_from_default(field["data_default"])
             default_value = nil if is_virtual
             OracleEnhanced::Column.new(oracle_downcase(field["name"]),
@@ -680,10 +680,6 @@ module ActiveRecord
                              field["nullable"] == "Y",
                              comment: field["column_comment"]
             )
-          end
-
-          def fetch_type_metadata(sql_type, virtual = nil)
-            OracleEnhanced::TypeMetadata.new(super(sql_type), virtual: virtual)
           end
 
           def tablespace_for(obj_type, tablespace_option, table_name = nil, column_name = nil)


### PR DESCRIPTION
## Summary

Rails's private `fetch_type_metadata(sql_type)` has a single positional argument; the OE override added a second `virtual = nil` positional so `new_column_from_field` could pass the Oracle virtual-column flag in one call. That extra argument is not part of the Rails contract, and `new_column_from_field` is the only caller inside the adapter, so the override was not pulling its weight.

```ruby
# before
def fetch_type_metadata(sql_type, virtual = nil)
  OracleEnhanced::TypeMetadata.new(super(sql_type), virtual: virtual)
end

# after (this PR)
# (override removed)
```

Delete the override and inline the `OracleEnhanced::TypeMetadata` wrap at the single call site. `fetch_type_metadata(field["sql_type"])` now returns Rails' `SqlTypeMetadata` unchanged, and the caller constructs `OracleEnhanced::TypeMetadata.new(..., virtual: is_virtual)` directly where `is_virtual` is already in scope.

No caller outside `new_column_from_field` relied on the override, so behavior is identical for virtual and non-virtual columns.

Surfaced by the method-signature check being added in #2580.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb` — 122 examples, 0 failures (3 pending, unrelated)
- [x] `bundle exec rspec ... -e "virtual"` — 6 examples, 0 failures (virtual column specs pass)
- [x] `bundle exec rubocop lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb` — no offenses
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
