### PR TITLE
Require column argument in default_sequence_name to match AbstractAdapter

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -145,7 +145,7 @@ module ActiveRecord
         # vs ASCII-only +\w+) plus +$+ and +#+ to match Oracle's unquoted
         # identifier rules (see +Quoting::NONQUOTED_OBJECT_NAME+), with +-+
         # kept for backward compatibility with quoted-identifier callers.
-        def default_sequence_name(table_name, primary_key = nil)
+        def default_sequence_name(table_name, _column)
           table_name.to_s.gsub(/(\A|\.)([[:word:]$#-]+)\z/) do
             prefix = Regexp.last_match(1)
             name = Regexp.last_match(2)

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -259,7 +259,7 @@ module ActiveRecord
           schema_cache.clear_data_source_cache!(table_name.to_s)
           schema_cache.clear_data_source_cache!(new_name.to_s)
           execute "RENAME #{quote_table_name(table_name)} TO #{quote_table_name(new_name)}"
-          execute "RENAME #{quote_table_name("#{table_name}_seq")} TO #{default_sequence_name(new_name)}" rescue nil
+          execute "RENAME #{quote_table_name("#{table_name}_seq")} TO #{default_sequence_name(new_name, nil)}" rescue nil
 
           rename_table_indexes(table_name, new_name, **options)
         end
@@ -271,7 +271,7 @@ module ActiveRecord
           table_names.each do |table_name|
             schema_cache.clear_data_source_cache!(table_name.to_s)
             execute "DROP TABLE #{quote_table_name(table_name)}#{' CASCADE CONSTRAINTS' if options[:force] == :cascade}"
-            seq_name = custom_sequence_name || default_sequence_name(table_name)
+            seq_name = custom_sequence_name || default_sequence_name(table_name, nil)
             execute "DROP SEQUENCE #{quote_table_name(seq_name)}" rescue nil
           rescue ActiveRecord::StatementInvalid => e
             raise e unless options[:if_exists]
@@ -716,7 +716,7 @@ module ActiveRecord
           def create_sequence_and_trigger(table_name, options)
             # TODO: Needs rename since no triggers created
             # This method will be removed since sequence will not be created separately
-            seq_name = options[:sequence_name] || default_sequence_name(table_name)
+            seq_name = options[:sequence_name] || default_sequence_name(table_name, nil)
             seq_start_value = options[:sequence_start_value] || default_sequence_start_value
             execute "CREATE SEQUENCE #{quote_table_name(seq_name)} START WITH #{seq_start_value}"
           end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -557,7 +557,7 @@ module ActiveRecord
           begin
             sequence_name = table_name.classify.constantize.sequence_name
           rescue
-            sequence_name = default_sequence_name(table_name)
+            sequence_name = default_sequence_name(table_name, primary_key)
           end
         end
 
@@ -643,7 +643,7 @@ module ActiveRecord
       def pk_and_sequence_for(table_name, owner = nil, desc_table_name = nil) # :nodoc:
         (owner, desc_table_name) = resolve_data_source_name(table_name)
 
-        seqs = select_values_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("sequence_name", default_sequence_name(desc_table_name))])
+        seqs = select_values_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("sequence_name", default_sequence_name(desc_table_name, nil))])
           select us.sequence_name
           from all_sequences us
           where us.sequence_owner = :owner

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -102,7 +102,7 @@ describe "OracleEnhancedAdapter schema definition" do
     it "should return sequence name without truncating too much" do
       seq_name_length = ActiveRecord::Base.connection.sequence_name_length
       tname = "#{DATABASE_USER}" + "." + "a" * (seq_name_length - DATABASE_USER.length) + "z" * (DATABASE_USER).length
-      expect(ActiveRecord::Base.connection.default_sequence_name(tname)).to match (/z_seq$/)
+      expect(ActiveRecord::Base.connection.default_sequence_name(tname, nil)).to match (/z_seq$/)
     end
 
     it "truncates the trailing identifier by bytes for multibyte names" do
@@ -110,7 +110,7 @@ describe "OracleEnhancedAdapter schema definition" do
       max = conn.sequence_name_length
       # "é" is 2 bytes in UTF-8. Build a name that exceeds the byte budget.
       name = "é" * max # 2 * max bytes, definitely over
-      seq = conn.default_sequence_name(name)
+      seq = conn.default_sequence_name(name, nil)
       expect(seq).to end_with("_seq")
       expect(seq.bytesize).to be <= max
     end
@@ -119,7 +119,7 @@ describe "OracleEnhancedAdapter schema definition" do
       conn = ActiveRecord::Base.connection
       max = conn.sequence_name_length
       name = "schema." + ("é" * max)
-      seq = conn.default_sequence_name(name)
+      seq = conn.default_sequence_name(name, nil)
       expect(seq).to start_with("schema.")
       expect(seq).to end_with("_seq")
       table_part = seq.delete_prefix("schema.")
@@ -133,7 +133,7 @@ describe "OracleEnhancedAdapter schema definition" do
       max = conn.sequence_name_length
       ascii_prefix = "a" * (max - 4 - 1) # ends 1 byte short of budget
       name = ascii_prefix + "é" * 4      # é straddles the budget boundary
-      seq = conn.default_sequence_name(name)
+      seq = conn.default_sequence_name(name, nil)
       expect(seq).to end_with("_seq")
       expect(seq.bytesize).to be <= max
       expect(seq).to be_valid_encoding


### PR DESCRIPTION
## Summary

`AbstractAdapter#default_sequence_name` is declared as `default_sequence_name(table, column)` with both arguments required, returning `nil`. The oracle-enhanced override made the second argument optional (`primary_key = nil`) because the body computes the sequence name from the table alone and never reads the second argument.

```ruby
# before
def default_sequence_name(table_name, primary_key = nil)
# after (this PR)
def default_sequence_name(table_name, _column)
```

- Drop the default value to match the Rails positional contract.
- Rename the second parameter to `_column` to match Rails' order and mark it unused.
- Update the in-tree callers that used the single-argument form to pass the primary key when available (`reset_pk_sequence!`) or `nil` otherwise (`rename_table`, `drop_table`, `create_sequence_and_trigger`, `pk_and_sequence_for`, and the four specs that construct sequence names directly).

Signature-only alignment; behavior is identical.

## Rails origin of the (table, column) signature

The `default_sequence_name(table, column)` signature with both arguments required has been the AbstractAdapter contract since sequence support was first introduced in Rails, in rails/rails@[7117fdb8ce](https://github.com/rails/rails/commit/7117fdb8ce) on 2005-10-16 (old Trac ticket #2292, "Sequences, schemas, and fixtures", by Jeremy Kemper). The change predates Rails' move to GitHub, so there is no associated pull request. The line is unchanged to this day — see [`abstract/database_statements.rb#L538`](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb#L538).

In this repo, the divergence was introduced later: the `primary_key = nil` default was added in [4698fa14](https://github.com/rsim/oracle-enhanced/commit/4698fa14) (2009-08-12, "creation of primary key triggers and support for autogenerated primary key values"), renaming `column` to `primary_key` so an internal caller could pass one argument. The body has never read the second argument.

## Alternative: allowlist this one

This drift is genuinely an oracle-enhanced API relaxation rather than a bug — Rails' base is a no-op, and Oracle tooling commonly calls `conn.default_sequence_name(:users)` with a single argument. If the ergonomics of the one-argument form are worth keeping, closing this PR and adding the entry to `IGNORED_DRIFTS` in #2580 with a one-line justification is a reasonable call. Happy to go either way.

Surfaced by the method-signature check being added in #2580.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb` — 127 examples, 0 failures (1 pending, unrelated)
- [x] `bundle exec rubocop` on all touched files — no offenses
- [ ] CI

Rebased onto `upstream/master` to pick up the `drop_table` multi-table change from #2583.

Generated with [Claude Code](https://claude.com/claude-code)
