### PR TITLE
Bump JRuby from 10.0.5.0 to 10.1.0.0 in CI workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 'jruby-10.0.5.0'
+          ruby-version: 'jruby-10.1.0.0'
           rubygems: latest
       - name: Build gem
         run: gem build activerecord-oracle_enhanced-adapter.gemspec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           '4.0',
           '3.4',
           '3.3',
-          'jruby-10.0.5.0',
+          'jruby-10.1.0.0',
         ]
     env:
       ORACLE_HOME: /opt/oracle/instantclient_23_26

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -21,7 +21,7 @@ jobs:
           '4.0',
           '3.4',
           '3.3',
-          'jruby-10.0.5.0',
+          'jruby-10.1.0.0',
         ]
     env:
       ORACLE_HOME: /opt/oracle/instantclient_21_15

--- a/.github/workflows/test_11g_ojdbc11.yml
+++ b/.github/workflows/test_11g_ojdbc11.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [
-          'jruby-10.0.5.0',
+          'jruby-10.1.0.0',
         ]
     env:
       ORACLE_HOME: /opt/oracle/instantclient_21_15


### PR DESCRIPTION
## Summary

Bump the JRuby version pinned in GitHub Actions workflows from `jruby-10.0.5.0` to `jruby-10.1.0.0`.

JRuby 10.1.0.0 was released on 2026-04-21 and is now installable via `ruby/setup-ruby`.

* https://github.com/ruby/setup-ruby/pull/906
* https://www.jruby.org/2026/04/21/jruby-10-1-0-0.html

Files updated:

* `.github/workflows/test.yml`
* `.github/workflows/test_11g.yml`
* `.github/workflows/test_11g_ojdbc11.yml`
* `.github/workflows/release.yml`

`.github/workflows/jruby_head.yml` already uses `jruby-head` and is left unchanged.

## Test plan

- [ ] CI `test` workflow passes on the `jruby-10.1.0.0` matrix entry
- [ ] CI `test_11g` workflow passes on the `jruby-10.1.0.0` matrix entry
- [ ] CI `test_11g_ojdbc11` workflow passes on `jruby-10.1.0.0`
