### PR TITLE
Preserve DESC / NULLS FIRST|LAST modifiers in Oracle order_hacks

### DIFF
--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -172,8 +172,12 @@ module Arel # :nodoc: all
           end.flatten
           o.orders = []
           orders.each_with_index do |order, i|
-            o.orders <<
-              Nodes::SqlLiteral.new("alias_#{i}__#{' DESC' if /\bdesc$/i.match?(order)}")
+            parts = ["alias_#{i}__"]
+            parts << "DESC" if /\bdesc\b/i.match?(order)
+            if (nulls_match = order.match(/\bNULLS\s+(FIRST|LAST)\b/i))
+              parts << "NULLS #{nulls_match[1].upcase}"
+            end
+            o.orders << Nodes::SqlLiteral.new(parts.join(" "))
           end
           o
         end

--- a/spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb
@@ -63,4 +63,32 @@ describe "OracleEnhancedAdapter#columns_for_distinct" do
     expect(sql).not_to match(/\bDESC\b/i)
     expect(sql).not_to match(/NULLS/i)
   end
+
+  describe "integration with Arel::Visitors::Oracle#order_hacks" do
+    def compile_distinct_order(distinct_columns, order)
+      projection = "DISTINCT #{distinct_columns.join(', ')}, " \
+                   "#{@conn.columns_for_distinct(distinct_columns, [order])}"
+      stmt = Arel::Nodes::SelectStatement.new
+      stmt.cores.first.projections << Arel::Nodes::SqlLiteral.new(projection)
+      stmt.orders << (order.is_a?(String) ? Arel::Nodes::SqlLiteral.new(order) : order)
+      @conn.visitor.accept(stmt, Arel::Collectors::SQLString.new).value
+    end
+
+    it "preserves DESC NULLS LAST in the outer ORDER BY for a raw SQL order" do
+      sql = compile_distinct_order(["posts.id"], "posts.created_at DESC NULLS LAST")
+      expect(sql).to include("ORDER BY alias_0__ DESC NULLS LAST")
+    end
+
+    it "preserves DESC NULLS LAST in the outer ORDER BY for an Arel ordering node" do
+      order_node = Arel::Table.new(:posts)[:created_at].desc.nulls_last
+      sql = compile_distinct_order(["posts.id"], order_node)
+      expect(sql).to include("ORDER BY alias_0__ DESC NULLS LAST")
+    end
+
+    it "preserves NULLS FIRST without emitting DESC for an ASC-with-nulls order" do
+      sql = compile_distinct_order(["posts.id"], "posts.created_at ASC NULLS FIRST")
+      expect(sql).to match(/ORDER BY alias_0__ NULLS FIRST\b/)
+      expect(sql).not_to match(/alias_0__ DESC/)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`Arel::Visitors::Oracle#order_hacks` rewrites the outer `ORDER BY` of a DISTINCT + `FIRST_VALUE` query into `ORDER BY alias_N__[ DESC]`. The existing DESC detection uses `/\bdesc$/i` — an end-of-string anchor — so orders that carry a `NULLS FIRST` / `NULLS LAST` modifier after the direction (e.g. `col DESC NULLS LAST`) miss the match, and the outer clause is emitted as just `ORDER BY alias_0__` with no direction.

With #2577 now merged, `columns_for_distinct` strips the `NULLS` modifier so the `FIRST_VALUE(...)` analytic SQL is parseable, but a `.distinct.order(col: { nulls: :last })` query still silently returns rows in **ascending** order because the outer rewrite drops DESC along with the NULLS fragment. The end-to-end result for the very case #2577 targets is wrong direction rather than a syntax error.

This change:

- Switches the DESC detection to `/\bdesc\b/i` so `DESC NULLS LAST` (and any other trailing modifier) still triggers the match.
- Additionally captures any `NULLS FIRST` / `NULLS LAST` modifier via `/\bNULLS\s+(FIRST|LAST)\b/i` and preserves it on the rewritten alias, emitted in canonical uppercase form.
- Remains idempotent — repeated calls to `order_hacks` over the same statement produce the same output, since the rewritten `alias_N__ DESC NULLS LAST` still matches both regexes.

Refs #2482.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb` — 12 examples, 0 failures (Oracle 23c Free / FREEPDB1). Three new integration tests assert that the final visitor output preserves `DESC NULLS LAST` (raw SQL + Arel node) and `NULLS FIRST` (without spurious DESC).
- [x] Verified the three new tests **fail** on this branch with `lib/arel/visitors/oracle.rb` reverted (the 9 pre-existing `columns_for_distinct` tests still pass, confirming they're genuine regression guards, not covered by the existing suite).
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/composite_spec.rb spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb` — 88 examples, 0 failures, 2 pre-existing pending.
- [x] `bundle exec rubocop lib/arel/visitors/oracle.rb spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb` — clean.

## Notes

- Plain `col DESC` (no NULLS) still round-trips as `alias_N__ DESC` — the new regex is strictly broader than the old end-anchored form.
- Identifiers that happen to contain the tokens (`nulls_count`, `descending_order`, `ascending`) are unaffected because both regexes use `\b` word boundaries.
- Lowercase input (`desc nulls last`) is normalized to canonical uppercase on the alias.
- The new integration tests piggyback on the `columns_for_distinct_spec.rb` file added by #2577 so they exercise the full `columns_for_distinct` → `order_hacks` path end-to-end.
