### PR TITLE
Backport #2577 and #2588 to release81: fix DISTINCT + ORDER BY with NULLS FIRST/LAST

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -685,8 +685,9 @@ module ActiveRecord
         # It does not construct DISTINCT clause. Just return column names for distinct.
         order_columns = orders.reject(&:blank?).map { |s|
             s = visitor.compile(s) unless s.is_a?(String)
-            # remove any ASC/DESC modifiers
-            s.gsub(/\s+(ASC|DESC)\s*?/i, "")
+            # remove any ASC/DESC and NULLS FIRST/LAST modifiers
+            s.gsub(/\s+(?:ASC|DESC)\b/i, "")
+             .gsub(/\s+NULLS\s+(?:FIRST|LAST)\b/i, "")
           }.reject(&:blank?).map.with_index { |column, i|
             "FIRST_VALUE(#{column}) OVER (PARTITION BY #{columns.join(', ')} ORDER BY #{column}) AS alias_#{i}__"
           }

--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -172,8 +172,12 @@ module Arel # :nodoc: all
           end.flatten
           o.orders = []
           orders.each_with_index do |order, i|
-            o.orders <<
-              Nodes::SqlLiteral.new("alias_#{i}__#{' DESC' if /\bdesc$/i.match?(order)}")
+            parts = ["alias_#{i}__"]
+            parts << "DESC" if /\bdesc\b/i.match?(order)
+            if (nulls_match = order.match(/\bNULLS\s+(FIRST|LAST)\b/i))
+              parts << "NULLS #{nulls_match[1].upcase}"
+            end
+            o.orders << Nodes::SqlLiteral.new(parts.join(" "))
           end
           o
         end

--- a/spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+describe "OracleEnhancedAdapter#columns_for_distinct" do
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @conn = ActiveRecord::Base.connection
+  end
+
+  it "strips ASC modifier" do
+    sql = @conn.columns_for_distinct(["posts.id"], ["posts.created_at ASC"])
+    expect(sql).to include("FIRST_VALUE(posts.created_at)")
+    expect(sql).not_to match(/\bASC\b/i)
+  end
+
+  it "strips DESC modifier" do
+    sql = @conn.columns_for_distinct(["posts.id"], ["posts.created_at DESC"])
+    expect(sql).to include("FIRST_VALUE(posts.created_at)")
+    expect(sql).not_to match(/\bDESC\b/i)
+  end
+
+  it "strips NULLS FIRST modifier" do
+    sql = @conn.columns_for_distinct(["posts.id"], ["posts.created_at NULLS FIRST"])
+    expect(sql).to include("FIRST_VALUE(posts.created_at)")
+    expect(sql).not_to match(/NULLS\s+FIRST/i)
+  end
+
+  it "strips NULLS LAST modifier" do
+    sql = @conn.columns_for_distinct(["posts.id"], ["posts.created_at NULLS LAST"])
+    expect(sql).to include("FIRST_VALUE(posts.created_at)")
+    expect(sql).not_to match(/NULLS\s+LAST/i)
+  end
+
+  it "strips combined DESC NULLS LAST" do
+    sql = @conn.columns_for_distinct(["posts.id"], ["posts.created_at DESC NULLS LAST"])
+    expect(sql).to include("FIRST_VALUE(posts.created_at)")
+    expect(sql).not_to match(/\bDESC\b/i)
+    expect(sql).not_to match(/NULLS/i)
+  end
+
+  it "strips combined ASC NULLS FIRST" do
+    sql = @conn.columns_for_distinct(["posts.id"], ["posts.created_at ASC NULLS FIRST"])
+    expect(sql).to include("FIRST_VALUE(posts.created_at)")
+    expect(sql).not_to match(/\bASC\b/i)
+    expect(sql).not_to match(/NULLS/i)
+  end
+
+  it "strips lowercase desc nulls last" do
+    sql = @conn.columns_for_distinct(["posts.id"], ["posts.created_at desc nulls last"])
+    expect(sql).to include("FIRST_VALUE(posts.created_at)")
+    expect(sql).not_to match(/\bdesc\b/i)
+    expect(sql).not_to match(/nulls/i)
+  end
+
+  it "joins composite primary key columns in PARTITION BY" do
+    sql = @conn.columns_for_distinct(["posts.id", "posts.tenant_id"], ["posts.created_at DESC"])
+    expect(sql).to include("PARTITION BY posts.id, posts.tenant_id")
+  end
+
+  it "strips DESC NULLS LAST from an Arel ordering node" do
+    order_node = Arel::Table.new(:posts)[:created_at].desc.nulls_last
+    sql = @conn.columns_for_distinct(["posts.id"], [order_node])
+    expect(sql).to match(/FIRST_VALUE\("POSTS"\."CREATED_AT"\)/i)
+    expect(sql).not_to match(/\bDESC\b/i)
+    expect(sql).not_to match(/NULLS/i)
+  end
+end

--- a/spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb
@@ -63,4 +63,32 @@ describe "OracleEnhancedAdapter#columns_for_distinct" do
     expect(sql).not_to match(/\bDESC\b/i)
     expect(sql).not_to match(/NULLS/i)
   end
+
+  describe "integration with Arel::Visitors::Oracle#order_hacks" do
+    def compile_distinct_order(distinct_columns, order)
+      projection = "DISTINCT #{distinct_columns.join(', ')}, " \
+                   "#{@conn.columns_for_distinct(distinct_columns, [order])}"
+      stmt = Arel::Nodes::SelectStatement.new
+      stmt.cores.first.projections << Arel::Nodes::SqlLiteral.new(projection)
+      stmt.orders << (order.is_a?(String) ? Arel::Nodes::SqlLiteral.new(order) : order)
+      @conn.visitor.accept(stmt, Arel::Collectors::SQLString.new).value
+    end
+
+    it "preserves DESC NULLS LAST in the outer ORDER BY for a raw SQL order" do
+      sql = compile_distinct_order(["posts.id"], "posts.created_at DESC NULLS LAST")
+      expect(sql).to include("ORDER BY alias_0__ DESC NULLS LAST")
+    end
+
+    it "preserves DESC NULLS LAST in the outer ORDER BY for an Arel ordering node" do
+      order_node = Arel::Table.new(:posts)[:created_at].desc.nulls_last
+      sql = compile_distinct_order(["posts.id"], order_node)
+      expect(sql).to include("ORDER BY alias_0__ DESC NULLS LAST")
+    end
+
+    it "preserves NULLS FIRST without emitting DESC for an ASC-with-nulls order" do
+      sql = compile_distinct_order(["posts.id"], "posts.created_at ASC NULLS FIRST")
+      expect(sql).to match(/ORDER BY alias_0__ NULLS FIRST\b/)
+      expect(sql).not_to match(/alias_0__ DESC/)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Backports two related fixes so that `.distinct.order(col: { nulls: :last })` works correctly on release81:

- **#2577** — `OracleEnhancedAdapter#columns_for_distinct`: strip `NULLS FIRST` / `NULLS LAST` from the injected `FIRST_VALUE(...)` analytic expression so the generated SQL parses on Oracle. Also tightens the adjacent `ASC`/`DESC` regex to use `\b` word boundaries, mirroring Rails' PostgreSQL adapter.
- **#2588** — `Arel::Visitors::Oracle#order_hacks`: switch `/\bdesc$/i` to `/\bdesc\b/i` and preserve any `NULLS FIRST` / `NULLS LAST` modifier on the rewritten `alias_N__` output. Without this, even after #2577 lets the query parse, the outer `ORDER BY` silently drops `DESC` (returns rows in ascending order) when a NULLS modifier follows.

Fixes #2482 on release81.

## Cherry-pick details

- `git cherry-pick -m 1 b5e040ae` — PR #2577 merge commit from master.
- `git cherry-pick -m 1 aea10394` — PR #2588 merge commit from master.

Both picks applied cleanly with no conflicts.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb` — 12 examples, 0 failures (Oracle 23c Free / FREEPDB1). Covers raw SQL orders, lowercase, combined `DESC NULLS LAST` / `ASC NULLS FIRST`, composite PK, Arel ordering nodes, and three integration tests exercising the full `columns_for_distinct` → `order_hacks` path.
- [x] `bundle exec rubocop lib/active_record/connection_adapters/oracle_enhanced_adapter.rb lib/arel/visitors/oracle.rb spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb` — clean.
