### PR TITLE
Bump actions/download-artifact from 6 to 8 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,11 +53,11 @@ jobs:
       actions: read
     steps:
       - name: Download CRuby gem
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: gem-cruby
       - name: Download JRuby gem
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: gem-jruby
       - name: Set up Ruby


### PR DESCRIPTION
## Summary

- Silences the Node.js 20 deprecation annotation that appeared on the `Push gems to RubyGems` job of the v8.1.3 release run ([runs/24871451585](https://github.com/rsim/oracle-enhanced/actions/runs/24871451585)).
- `actions/download-artifact@v6` is pinned to Node.js 20; `@v8` (latest) ships on Node.js 24.
- `actions/upload-artifact@v6` already runs on Node.js 24 upstream, so no change is needed there on `release81`.
- `rubygems/configure-rubygems-credentials@main` is still `using: node20` and has no newer tag; the upstream fix is tracked in [rubygems/configure-rubygems-credentials#372](https://github.com/rubygems/configure-rubygems-credentials/issues/372). That annotation will remain until upstream publishes a Node.js 24 build.

Node.js 20 becomes unsupported as the default runner on 2026-06-02 and is removed entirely on 2026-09-16 per the [GitHub blog post](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

## Test plan

- [ ] Workflow only runs on `v*` tag pushes, so end-to-end exercise happens on the next release. YAML parses cleanly and the only change is the two `@v6` → `@v8` bumps on the two `Download ... gem` steps.
