### PR TITLE
Backport #2592 to release81: Use default_sequence_name to identify sequence when renaming a table

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -259,7 +259,7 @@ module ActiveRecord
           schema_cache.clear_data_source_cache!(table_name.to_s)
           schema_cache.clear_data_source_cache!(new_name.to_s)
           execute "RENAME #{quote_table_name(table_name)} TO #{quote_table_name(new_name)}"
-          execute "RENAME #{quote_table_name("#{table_name}_seq")} TO #{default_sequence_name(new_name)}" rescue nil
+          execute "RENAME #{default_sequence_name(table_name)} TO #{default_sequence_name(new_name)}" rescue nil
 
           rename_table_indexes(table_name, new_name, **options)
         end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -296,6 +296,7 @@ describe "OracleEnhancedAdapter schema definition" do
     end
 
     after(:each) do
+      long_name = ("a" * (@conn.sequence_name_length - 3)).to_sym
       schema_define do
         drop_table :test_employees_no_primary_key, if_exists: true
         drop_table :test_employees, if_exists: true
@@ -303,6 +304,7 @@ describe "OracleEnhancedAdapter schema definition" do
         drop_table :test_employees_no_pkey, if_exists: true
         drop_table :new_test_employees_no_pkey, if_exists: true
         drop_table :aaaaaaaaaaaaaaaaaaaaaaaaaaa, if_exists: true
+        drop_table long_name, if_exists: true
       end
     end
 
@@ -328,6 +330,26 @@ describe "OracleEnhancedAdapter schema definition" do
       expect do
         @conn.rename_table("test_employees_no_pkey", "new_test_employees_no_pkey")
       end.not_to raise_error
+    end
+
+    it "renames the auto-generated sequence when the source table name is long enough to truncate it" do
+      long_source = "a" * (@conn.sequence_name_length - 3)
+      schema_define do
+        create_table long_source.to_sym, force: true do |t|
+          t.string :first_name
+        end
+      end
+
+      expected_old_seq = @conn.default_sequence_name(long_source).upcase
+      expected_new_seq = @conn.default_sequence_name("new_test_employees").upcase
+
+      @conn.rename_table(long_source, "new_test_employees")
+
+      sequences = @conn.select_values(
+        "SELECT sequence_name FROM user_sequences WHERE sequence_name IN ('#{expected_old_seq}', '#{expected_new_seq}')"
+      )
+      expect(sequences).to include(expected_new_seq)
+      expect(sequences).not_to include(expected_old_seq)
     end
   end
 


### PR DESCRIPTION
## Summary
- Backports #2592 to `release81`.
- Fix `rename_table` so the source sequence is resolved through `default_sequence_name`, matching the target side. Previously the source was built as `"#{table_name}_seq"` without truncation, so for tables whose name exceeds `sequence_name_length - 4` bytes (>124 bytes on Oracle 12.2+, >26 bytes on earlier releases), the auto-generated sequence is truncated and the RENAME silently failed under `rescue nil`.
- Add a regression spec that creates a table long enough to force sequence truncation, renames it, and asserts the new truncated sequence exists while the old one is gone. The spec keys off `@conn.sequence_name_length`, which governs truncation (on release81 this resolves to 30; on Oracle 12.2+ master it resolves to 128).

## Test plan
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb` — 81 examples, 0 failures, 3 unrelated pending
- [x] `bundle exec rubocop` on the touched files — clean
- [x] Sanity check: reverting the one-line fix causes the new spec to fail with `expect(sequences).to include(expected_new_seq)`, confirming the spec actually exercises the bug
