### PR TITLE
Add deferrable foreign key support

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -73,6 +73,12 @@ module ActiveRecord
             end
           end
 
+          def visit_ForeignKeyDefinition(o)
+            super.dup.tap do |sql|
+              sql << " DEFERRABLE INITIALLY #{o.deferrable.to_s.upcase}" if o.deferrable
+            end
+          end
+
           def action_sql(action, dependency)
             if action == "UPDATE"
               raise ArgumentError, <<~MSG

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -541,6 +541,12 @@ module ActiveRecord
           SQL
         end
 
+        def add_foreign_key(from_table, to_table, **options)
+          assert_valid_deferrable(options[:deferrable])
+
+          super
+        end
+
         # get table foreign keys for schema dump
         def foreign_keys(table_name) # :nodoc:
           (_owner, desc_table_name) = resolve_data_source_name(table_name)
@@ -551,6 +557,8 @@ module ActiveRecord
                   ,cc.column_name
                   ,c.constraint_name name
                   ,c.delete_rule
+                  ,c.deferrable
+                  ,c.deferred
               FROM all_constraints c, all_cons_columns cc,
                    all_constraints r, all_cons_columns rc
              WHERE c.owner = SYS_CONTEXT('userenv', 'current_schema')
@@ -573,6 +581,7 @@ module ActiveRecord
               primary_key: oracle_downcase(row["references_column"])
             }
             options[:on_delete] = extract_foreign_key_action(row["delete_rule"])
+            options[:deferrable] = extract_foreign_key_deferrable(row["deferrable"], row["deferred"])
             ActiveRecord::ConnectionAdapters::ForeignKeyDefinition.new(oracle_downcase(table_name), oracle_downcase(row["to_table"]), options)
           end
         end
@@ -644,6 +653,17 @@ module ActiveRecord
             when "CASCADE"; :cascade
             when "SET NULL"; :nullify
             end
+          end
+
+          def extract_foreign_key_deferrable(deferrable, deferred)
+            return false unless deferrable == "DEFERRABLE"
+            deferred == "DEFERRED" ? :deferred : :immediate
+          end
+
+          def assert_valid_deferrable(deferrable)
+            return if !deferrable || %i(immediate deferred).include?(deferrable)
+
+            raise ArgumentError, "deferrable must be `:immediate` or `:deferred`, got: `#{deferrable.inspect}`"
           end
 
           def create_alter_table(name)

--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -231,6 +231,7 @@ module ActiveRecord # :nodoc:
           when :delete
             sql << " ON DELETE CASCADE"
           end
+          sql << " DEFERRABLE INITIALLY #{options[:deferrable].to_s.upcase}" if options[:deferrable]
           sql
         end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -326,6 +326,12 @@ module ActiveRecord
         true
       end
 
+      # Oracle has supported DEFERRABLE constraints since 8i:
+      # https://docs.oracle.com/cd/A87860_01/doc/appdev.817/a76939/adg05itg.htm
+      def supports_deferrable_constraints?
+        true
+      end
+
       def supports_optimizer_hints?
         true
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -159,6 +159,30 @@ describe "OracleEnhancedAdapter schema dump" do
       expect(output).to match(/add_foreign_key "test_comments", "test_posts", on_delete: :nullify/)
     end
 
+    it "should include deferrable initially deferred foreign key in schema dump" do
+      schema_define do
+        add_foreign_key :test_comments, :test_posts, deferrable: :deferred
+      end
+      output = dump_table_schema "test_comments"
+      expect(output).to match(/add_foreign_key "test_comments", "test_posts", deferrable: :deferred/)
+    end
+
+    it "should include deferrable initially immediate foreign key in schema dump" do
+      schema_define do
+        add_foreign_key :test_comments, :test_posts, deferrable: :immediate
+      end
+      output = dump_table_schema "test_comments"
+      expect(output).to match(/add_foreign_key "test_comments", "test_posts", deferrable: :immediate/)
+    end
+
+    it "should not emit deferrable option when foreign key is not deferrable" do
+      schema_define do
+        add_foreign_key :test_comments, :test_posts
+      end
+      output = dump_table_schema "test_comments"
+      expect(output).to match(/add_foreign_key "test_comments", "test_posts"$/)
+    end
+
     it "should not include foreign keys on ignored table names in schema dump" do
       schema_define do
         add_foreign_key :test_comments, :test_posts

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -735,6 +735,38 @@ end
       expect(@logger.logged(:debug).last).to match(/:desc_table_name/)
       expect(@logger.logged(:debug).last).to match(/\["desc_table_name", "TEST_COMMENTS"\]\]/)
     end
+
+    it "should add deferrable initially deferred foreign key" do
+      schema_define do
+        add_foreign_key :test_comments, :test_posts, deferrable: :deferred
+      end
+      fk = ActiveRecord::Base.connection.foreign_keys(:test_comments).first
+      expect(fk.options[:deferrable]).to eq(:deferred)
+    end
+
+    it "should add deferrable initially immediate foreign key" do
+      schema_define do
+        add_foreign_key :test_comments, :test_posts, deferrable: :immediate
+      end
+      fk = ActiveRecord::Base.connection.foreign_keys(:test_comments).first
+      expect(fk.options[:deferrable]).to eq(:immediate)
+    end
+
+    it "should add non-deferrable foreign key when deferrable option is omitted" do
+      schema_define do
+        add_foreign_key :test_comments, :test_posts
+      end
+      fk = ActiveRecord::Base.connection.foreign_keys(:test_comments).first
+      expect(fk.options[:deferrable]).to be(false)
+    end
+
+    it "should raise ArgumentError when deferrable option is invalid" do
+      expect {
+        schema_define do
+          add_foreign_key :test_comments, :test_posts, deferrable: true
+        end
+      }.to raise_error(ArgumentError, /deferrable must be `:immediate` or `:deferred`/)
+    end
   end
 
   describe "lob in table definition" do


### PR DESCRIPTION
## Summary

Brings `deferrable: :immediate | :deferred` to Oracle, following [rails/rails#41487](https://github.com/rails/rails/pull/41487) and the stricter validation enforced after [rails/rails@c09956a3add9](https://github.com/rails/rails/commit/c09956a3add9) removed support for `deferrable: true` in Rails 7.2.

Migrations can now declare deferrable FKs against Oracle:

```ruby
add_foreign_key :aliases, :people, deferrable: :deferred
```

and `foreign_keys(table_name)` / schema dumps round-trip the option.

Oracle accepts [`SET CONSTRAINTS [ALL | name] { IMMEDIATE | DEFERRED }`](https://docs.oracle.com/en/database/oracle/oracle-database/26/sqlrf/SET-CONSTRAINTS.html) within a transaction to flip the check mode of deferrable constraints at runtime.

## Changes

- `supports_deferrable_constraints?` returns `true`.
- `OracleEnhanced::SchemaCreation#visit_ForeignKeyDefinition` appends ``DEFERRABLE INITIALLY { IMMEDIATE | DEFERRED }``; this covers both `ALTER TABLE … ADD CONSTRAINT` and inline FKs in `create_table`.
- `foreign_keys(table_name)` also selects `ALL_CONSTRAINTS.DEFERRABLE` / `DEFERRED` and exposes `options[:deferrable]` as `:immediate` / `:deferred` / `nil`.
- `add_foreign_key` validates the option via `assert_valid_deferrable`, raising `ArgumentError` on anything other than `nil` / `false` / `:immediate` / `:deferred` — matching the PostgreSQL adapter after [rails/rails@c09956a3add9](https://github.com/rails/rails/commit/c09956a3add9).
- `structure_dump.foreign_key_definition` emits the same clause in structure dumps.
- Specs cover both DDL + introspection and schema-dump round-trip.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb -e "deferrable"` (4 examples)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb -e "deferrable"` (3 examples)
- [x] `bundle exec rspec … -e "foreign"` — full FK suites green (30 examples total, no regressions)
- [x] `bundle exec rubocop` — clean
- [ ] CI against supported Oracle versions
