### PR TITLE
Set JRUBY_OPTS=--dev for JRuby CI jobs

### DIFF
--- a/.github/workflows/jruby_head.yml
+++ b/.github/workflows/jruby_head.yml
@@ -19,6 +19,7 @@ jobs:
       DATABASE_SYS_PASSWORD: Oracle18
       DATABASE_HOST: localhost
       DATABASE_PORT: 1521
+      JRUBY_OPTS: "--dev"
 
     services:
       oracle:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,11 @@ jobs:
           '3.3',
           'jruby-10.1.0.0',
         ]
+        include:
+          - ruby: 'jruby-10.1.0.0'
+            jruby_opts: '--dev'
     env:
+      JRUBY_OPTS: ${{ matrix.jruby_opts }}
       ORACLE_HOME: /opt/oracle/instantclient_23_26
       LD_LIBRARY_PATH: /opt/oracle/instantclient_23_26
       NLS_LANG: AMERICAN_AMERICA.AL32UTF8

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -23,7 +23,11 @@ jobs:
           '3.3',
           'jruby-10.1.0.0',
         ]
+        include:
+          - ruby: 'jruby-10.1.0.0'
+            jruby_opts: '--dev'
     env:
+      JRUBY_OPTS: ${{ matrix.jruby_opts }}
       ORACLE_HOME: /opt/oracle/instantclient_21_15
       LD_LIBRARY_PATH: /opt/oracle/instantclient_21_15
       NLS_LANG: AMERICAN_AMERICA.AL32UTF8

--- a/.github/workflows/test_11g_ojdbc11.yml
+++ b/.github/workflows/test_11g_ojdbc11.yml
@@ -25,6 +25,7 @@ jobs:
       DATABASE_HOST: localhost
       DATABASE_PORT: 1521
       DATABASE_VERSION: 11.2.0.2
+      JRUBY_OPTS: "--dev"
 
     services:
       oracle:


### PR DESCRIPTION
## Summary

Retry of #2536. Sets `JRUBY_OPTS=--dev` for every JRuby CI job so the JVM uses `-XX:TieredStopAtLevel=1` and the other flags JRuby's [Improving startup time](https://github.com/jruby/jruby/wiki/Improving-startup-time) wiki recommends for dev/test workloads. On these workflows total time is dominated by bundle install, RSpec, and the bug report templates, not long-running compiled code, so trading peak JIT for faster startup is the right call.

Since #2536 was closed, #2521 replaced a slow `UNION ALL` query with an optimized `all_objects` query in `resolve_data_source_name`, which reduced total CI time. JRuby jobs are still noticeably slower than CRuby jobs on each workflow on top of that faster baseline, so re-landing `--dev` is worth another look.

## Scope

- Mixed CRuby + JRuby matrices — `test.yml`, `test_11g.yml`: `matrix.include` adds `jruby_opts: '--dev'` for the `jruby-10.1.0.0` row, and the top-level `env:` maps it via `JRUBY_OPTS: ${{ matrix.jruby_opts }}` so CRuby rows receive an empty value.
- JRuby-only workflows — `test_11g_ojdbc11.yml`, `jruby_head.yml`: `JRUBY_OPTS: "--dev"` is set directly on the workflow's `env:` block.

The `.rspec` `--profile 10` line from #2536 (added only to produce benchmark tables) is intentionally omitted.

## Test plan

- [ ] CI runs green on `test.yml` for CRuby 4.0 / 3.4 / 3.3 and the `jruby-10.1.0.0` row
- [ ] CI runs green on `test_11g.yml` for the same matrix
- [ ] Compare JRuby execution-step totals (Bundle install + Run RSpec + bug report templates) against a recent `master` run on the same workflow
- [ ] `test_11g_ojdbc11.yml` and `jruby_head.yml` scheduled runs remain green
