### PR TITLE
Phase 2: Auto-enable identity primary keys in Migration[8.2]+ (depends on Rails per-adapter-migration-compatibility) [DRAFT]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development do
   gem "rspec"
   gem "rdoc"
   gem "rake"
-  gem "activerecord",   github: "rails/rails", branch: "main"
+  gem "activerecord",   github: "yahonda/rails", branch: "per-adapter-migration-compatibility"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do

--- a/lib/active_record/connection_adapters/oracle_enhanced/migration_compatibility.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/migration_compatibility.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module OracleEnhanced
+      module MigrationCompatibility # :nodoc: all
+        extend ActiveRecord::Migration::Compatibility::Versioned
+
+        module V8_2
+          def create_table(table_name, **options)
+            options[:identity] = true if oracle_enhanced_default_to_identity?(options)
+            super
+          end
+
+          private
+            def oracle_enhanced_default_to_identity?(options)
+              return false if options.key?(:identity)
+              return false if options[:sequence_name] || options[:sequence_start_value]
+              return false if options.fetch(:id, :primary_key) != :primary_key
+              return false if options[:primary_key].is_a?(Array)
+              connection.supports_identity_columns?
+            end
+        end
+
+        module V8_1
+          def create_table(table_name, **options)
+            options[:identity] = false unless options.key?(:identity)
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -187,6 +187,8 @@ module ActiveRecord # :nodoc:
                   tbl.print ", primary_key_trigger: true"
                   default_name = @connection.default_trigger_name(table).upcase
                   tbl.print ", trigger_name: #{trigger_name.downcase.inspect}" unless trigger_name == default_name
+                elsif @connection.supports_identity_columns?
+                  tbl.print ", identity: false"
                 end
               when Array
                 tbl.print ", primary_key: #{pk.inspect}"

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -263,8 +263,11 @@ module ActiveRecord
           end
           schema_cache.clear_data_source_cache!(table_name.to_s)
           schema_cache.clear_data_source_cache!(new_name.to_s)
+          identity_pk = identity_pk?(table_name)
           execute "RENAME #{quote_table_name(table_name)} TO #{quote_table_name(new_name)}"
-          execute "RENAME #{default_sequence_name(table_name, nil)} TO #{default_sequence_name(new_name, nil)}" rescue nil
+          unless identity_pk
+            execute "RENAME #{default_sequence_name(table_name, nil)} TO #{default_sequence_name(new_name, nil)}" rescue nil
+          end
           rename_pk_trigger(table_name, new_name)
           clear_table_caches(table_name)
           clear_table_caches(new_name)
@@ -281,10 +284,13 @@ module ActiveRecord
 
           table_names.each do |table_name|
             schema_cache.clear_data_source_cache!(table_name.to_s)
-            seq_name = custom_sequence_name || default_sequence_name(table_name, nil)
+            # Identity-backed tables never carry a default `<table>_seq`, so
+            # skip the sequence drop entirely on those. `identity_pk?` must
+            # run before the table drop, while the table is still present.
+            seq_name = custom_sequence_name || (identity_pk?(table_name) ? nil : default_sequence_name(table_name, nil))
 
             drop_if_exists("TABLE", table_name, cascade_constraints: cascade, if_exists: if_exists)
-            drop_if_exists("SEQUENCE", seq_name, if_exists: true)
+            drop_if_exists("SEQUENCE", seq_name, if_exists: true) if seq_name
           ensure
             clear_table_caches(table_name)
           end
@@ -1229,6 +1235,18 @@ module ActiveRecord
           def missing_object_ora_code?(message, object_type)
             code = MISSING_OBJECT_ORA_CODES[object_type.to_s.upcase]
             code && message.include?(code)
+          end
+
+          # True when +table_name+ exists and its primary key column is an Oracle
+          # identity column. Returns false when the table is not present (e.g.
+          # +drop_table if_exists:+ for a missing table) or when the database does
+          # not support identity columns.
+          def identity_pk?(table_name)
+            return false unless supports_identity_columns?
+            owner, desc_table_name = resolve_data_source_name(table_name)
+            identity_primary_key?(owner, desc_table_name)
+          rescue OracleEnhanced::ConnectionException
+            false
           end
 
           def index_column_names(column_names) # :nodoc:

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -38,6 +38,7 @@ require "active_record/connection_adapters/statement_pool"
 require "active_record/connection_adapters/oracle_enhanced/deprecator"
 require "active_record/connection_adapters/oracle_enhanced/connection"
 require "active_record/connection_adapters/oracle_enhanced/database_statements"
+require "active_record/connection_adapters/oracle_enhanced/migration_compatibility"
 require "active_record/connection_adapters/oracle_enhanced/schema_creation"
 require "active_record/connection_adapters/oracle_enhanced/schema_definitions"
 require "active_record/connection_adapters/oracle_enhanced/schema_dumper"
@@ -621,6 +622,10 @@ module ActiveRecord
       # check; +:data_dictionary+ remains explicitly selectable on 12.1+.
       def use_dbms_metadata_dump? # :nodoc:
         database_version >= "12.1"
+      end
+
+      def migration_compatibility_module_for(migration_class) # :nodoc:
+        OracleEnhanced::MigrationCompatibility.module_for(migration_class)
       end
 
       def supports_json?

--- a/spec/active_record/connection_adapters/oracle_enhanced/identity_primary_key_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/identity_primary_key_spec.rb
@@ -336,6 +336,7 @@ RSpec.describe "identity primary keys" do
       ActiveRecord::SchemaDumper.ignore_tables = []
 
       expect(stream.string).to include('create_table "test_identity_pks"')
+      expect(stream.string).to include("identity: false")
       expect(stream.string).not_to include("identity: true")
     end
   end
@@ -350,6 +351,113 @@ RSpec.describe "identity primary keys" do
       expect {
         @conn.empty_insert_statement_value(nil)
       }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "identity counterparts to sequence-prerequisite behavior" do
+    before do
+      skip "requires Oracle 12.1+" unless @oracle12c_or_higher
+    end
+
+    it "renames a long-named identity table without touching a non-existent sequence" do
+      long_source = "a" * (@conn.max_identifier_length - 3)
+      schema_define do
+        create_table long_source.to_sym, force: true, identity: true do |t|
+          t.string :name
+        end
+      end
+
+      expected_old_seq = @conn.default_sequence_name(long_source, nil).upcase
+      expected_new_seq = @conn.default_sequence_name("renamed_identity_long", nil).upcase
+
+      expect {
+        @conn.rename_table(long_source, "renamed_identity_long")
+      }.not_to raise_error
+
+      sequences = @conn.select_values(
+        "SELECT sequence_name FROM user_sequences WHERE sequence_name IN ('#{expected_old_seq}', '#{expected_new_seq}')"
+      )
+      expect(sequences).to be_empty
+    ensure
+      schema_define do
+        drop_table :renamed_identity_long, if_exists: true
+        drop_table long_source.to_sym, if_exists: true
+      end
+    end
+
+    it "returns a nil sequence_name from pk_and_sequence_for for identity tables" do
+      schema_define do
+        create_table :test_identity_pks, identity: true do |t|
+          t.string :name
+        end
+      end
+
+      expect(@conn.pk_and_sequence_for(:test_identity_pks)).to eq(["id", nil])
+    end
+
+    it "does not query NEXTVAL when inserting into an identity table" do
+      schema_define do
+        create_table :test_identity_pks, identity: true do |t|
+          t.string :name
+        end
+      end
+      klass = Class.new(ActiveRecord::Base) { self.table_name = "test_identity_pks" }
+
+      set_logger
+      begin
+        klass.create!(name: "alpha")
+        klass.create!(name: "bravo")
+        expect(@logger.output(:debug)).not_to match(/NEXTVAL/i)
+      ensure
+        clear_logger
+      end
+    end
+
+    it "omits DROP SEQUENCE from full_drop output for identity-backed tables" do
+      schema_define do
+        create_table :test_identity_pks, identity: true do |t|
+          t.string :name
+        end
+      end
+
+      drop = @conn.full_drop
+
+      expect(drop).to match(/DROP TABLE "TEST_IDENTITY_PKS" CASCADE CONSTRAINTS/)
+      expect(drop).not_to match(/DROP SEQUENCE "TEST_IDENTITY_PKS_SEQ"/)
+    end
+
+    it "rename_table leaves an unrelated <table>_seq sequence alone for identity tables" do
+      schema_define do
+        create_table :test_identity_pks, identity: true do |t|
+          t.string :name
+        end
+      end
+      @conn.execute "CREATE SEQUENCE test_identity_pks_seq"
+
+      @conn.rename_table(:test_identity_pks, :test_identity_pks_renamed)
+
+      expect(sequence_exists?(:test_identity_pks_seq)).to be true
+      expect(sequence_exists?(:test_identity_pks_renamed_seq)).to be false
+    ensure
+      @conn.execute("DROP SEQUENCE test_identity_pks_seq") rescue nil
+      schema_define do
+        drop_table :test_identity_pks_renamed, if_exists: true
+      end
+    end
+
+    it "drop_table leaves an unrelated <table>_seq sequence alone for identity tables" do
+      schema_define do
+        create_table :test_identity_pks, identity: true do |t|
+          t.string :name
+        end
+      end
+      @conn.execute "CREATE SEQUENCE test_identity_pks_seq"
+
+      @conn.drop_table(:test_identity_pks)
+
+      expect(sequence_exists?(:test_identity_pks_seq)).to be true
+    ensure
+      @conn.execute("DROP SEQUENCE test_identity_pks_seq") rescue nil
     end
   end
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced/migration_compatibility_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/migration_compatibility_spec.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+RSpec.describe "migration compatibility for identity primary keys" do
+  include SchemaSpecHelper
+
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @conn = ActiveRecord::Base.connection
+    @oracle12c_or_higher = @conn.database_version.first >= 12
+  end
+
+  after(:each) do
+    ActiveRecord::Migration.suppress_messages do
+      schema_define do
+        drop_table :test_identity_pks, if_exists: true
+        drop_table :test_identity_pks_uuid, if_exists: true
+        drop_table :test_identity_pks_composite, if_exists: true
+        drop_table :test_identity_pks_no_id, if_exists: true
+      end
+    end
+    @conn.schema_cache.clear!
+  end
+
+  def run_migration(version, &block)
+    migration = Class.new(ActiveRecord::Migration[version]) do
+      define_method(:change, &block)
+    end.new
+
+    ActiveRecord::Migration.suppress_messages { migration.migrate(:up) }
+  end
+
+  def sequence_exists?(name)
+    @conn.select_value(<<~SQL.squish, "SCHEMA").present?
+      SELECT 1 FROM user_sequences WHERE sequence_name = '#{name.to_s.upcase}' AND ROWNUM = 1
+    SQL
+  end
+
+  def identity_column_exists?(table_name, column_name)
+    @conn.select_value(<<~SQL.squish, "SCHEMA").present?
+      SELECT 1 FROM user_tab_identity_cols
+       WHERE table_name = '#{table_name.to_s.upcase}'
+         AND column_name = '#{column_name.to_s.upcase}'
+         AND ROWNUM = 1
+    SQL
+  end
+
+  context "on Oracle 12.1 or higher" do
+    before do
+      skip "requires Oracle 12.1+" unless @oracle12c_or_higher
+    end
+
+    describe "Migration[8.2]+ default behavior" do
+      it "creates an identity primary key by default" do
+        run_migration(8.2) { create_table :test_identity_pks }
+
+        expect(identity_column_exists?(:test_identity_pks, :id)).to be true
+        expect(sequence_exists?(:test_identity_pks_seq)).to be false
+      end
+
+      it "honors per-table opt-out via identity: false" do
+        run_migration(8.2) { create_table :test_identity_pks, identity: false }
+
+        expect(identity_column_exists?(:test_identity_pks, :id)).to be false
+        expect(sequence_exists?(:test_identity_pks_seq)).to be true
+      end
+
+      it "skips prefetch_primary_key? for the identity table" do
+        run_migration(8.2) { create_table :test_identity_pks }
+
+        expect(@conn.prefetch_primary_key?(:test_identity_pks)).to be false
+      end
+
+      it "skips auto-injection when id: false is passed" do
+        run_migration(8.2) do
+          create_table :test_identity_pks_no_id, id: false do |t|
+            t.string :name
+          end
+        end
+
+        expect(identity_column_exists?(:test_identity_pks_no_id, :id)).to be false
+      end
+
+      it "skips auto-injection when id: :integer is passed" do
+        run_migration(8.2) do
+          create_table :test_identity_pks, id: :integer do |t|
+            t.string :name
+          end
+        end
+
+        expect(identity_column_exists?(:test_identity_pks, :id)).to be false
+        expect(sequence_exists?(:test_identity_pks_seq)).to be true
+      end
+
+      it "skips auto-injection when a composite primary key is passed" do
+        run_migration(8.2) do
+          create_table :test_identity_pks_composite, primary_key: [:a, :b] do |t|
+            t.integer :a
+            t.integer :b
+          end
+        end
+
+        expect(identity_column_exists?(:test_identity_pks_composite, :a)).to be false
+        expect(identity_column_exists?(:test_identity_pks_composite, :b)).to be false
+      end
+    end
+
+    describe "Migration[8.1] (per-migration opt-out)" do
+      it "creates a sequence-backed primary key by default" do
+        run_migration(8.1) { create_table :test_identity_pks }
+
+        expect(identity_column_exists?(:test_identity_pks, :id)).to be false
+        expect(sequence_exists?(:test_identity_pks_seq)).to be true
+      end
+
+      it "still honors explicit identity: true (DB-supported)" do
+        run_migration(8.1) { create_table :test_identity_pks, identity: true }
+
+        expect(identity_column_exists?(:test_identity_pks, :id)).to be true
+        expect(sequence_exists?(:test_identity_pks_seq)).to be false
+      end
+    end
+
+    describe "Migration[7.0] (older versions)" do
+      it "creates a sequence-backed primary key by default" do
+        run_migration(7.0) { create_table :test_identity_pks }
+
+        expect(identity_column_exists?(:test_identity_pks, :id)).to be false
+        expect(sequence_exists?(:test_identity_pks_seq)).to be true
+      end
+    end
+
+    describe "Schema.define / direct connection.create_table" do
+      it "creates a sequence-backed primary key by default (no migration version context)" do
+        schema_define do
+          create_table :test_identity_pks do |t|
+            t.string :name
+          end
+        end
+
+        expect(identity_column_exists?(:test_identity_pks, :id)).to be false
+        expect(sequence_exists?(:test_identity_pks_seq)).to be true
+      end
+
+      it "still honors explicit identity: true" do
+        schema_define do
+          create_table :test_identity_pks, identity: true do |t|
+            t.string :name
+          end
+        end
+
+        expect(identity_column_exists?(:test_identity_pks, :id)).to be true
+        expect(sequence_exists?(:test_identity_pks_seq)).to be false
+      end
+    end
+
+    describe "Migration[8.2]+ with explicit Oracle sequence options" do
+      it "treats sequence_name: as opt-out of the identity default" do
+        run_migration(8.2) do
+          create_table :test_identity_pks, sequence_name: "explicit_seq" do |t|
+            t.string :name
+          end
+        end
+
+        expect(identity_column_exists?(:test_identity_pks, :id)).to be false
+        expect(sequence_exists?("explicit_seq")).to be true
+      ensure
+        @conn.execute("DROP SEQUENCE explicit_seq") rescue nil
+      end
+
+      it "treats sequence_start_value: as opt-out of the identity default" do
+        run_migration(8.2) do
+          create_table :test_identity_pks, sequence_start_value: 10000 do |t|
+            t.string :name
+          end
+        end
+
+        expect(identity_column_exists?(:test_identity_pks, :id)).to be false
+        expect(sequence_exists?(:test_identity_pks_seq)).to be true
+      end
+    end
+  end
+
+  context "on Oracle below 12.1" do
+    before do
+      skip "applies only to Oracle versions before 12.1" if @oracle12c_or_higher
+    end
+
+    it "Migration[8.2]+ falls back to sequence (auto-inject is gated by supports_identity_columns?)" do
+      run_migration(8.2) { create_table :test_identity_pks }
+
+      expect(sequence_exists?(:test_identity_pks_seq)).to be true
+    end
+
+    it "Migration[8.2]+ with explicit identity: true raises ArgumentError" do
+      expect {
+        run_migration(8.2) { create_table :test_identity_pks, identity: true }
+      }.to raise_error(ArgumentError, /Oracle Database 12\.1 or higher/)
+    end
+  end
+end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -953,7 +953,7 @@ RSpec.describe "OracleEnhancedAdapter schema dump" do
 
     it "should dump table comments" do
       output = dump_table_schema "test_table_comments"
-      expect(output).to match(/create_table "test_table_comments", comment: "this is a \\"table comment\\"!", force: :cascade do \|t\|$/)
+      expect(output).to match(/create_table "test_table_comments",(?: identity: (?:true|false),)? comment: "this is a \\"table comment\\"!", force: :cascade do \|t\|$/)
     end
   end
 


### PR DESCRIPTION
## Summary

**Phase 2** of splitting #2579: build on Phase 1's explicit `identity:`
option (now merged) and flip the **default** for `create_table` to
`identity: true` on Oracle 12.1+, scoped to migrations declared at
`Migration[8.2]` or later. `Migration[8.1]` and earlier, `Schema.define`,
and direct `connection.create_table` keep the existing sequence + trigger
behavior, so applications see no change unless they explicitly adopt
`Migration[8.2]`.

**This PR is a draft because it depends on the unmerged Rails extension
point** `AbstractAdapter#migration_compatibility_module_for(migration_class)`
plus the `Migration::Compatibility::Versioned` convention from
[yahonda/rails `per-adapter-migration-compatibility`](https://github.com/yahonda/rails/tree/per-adapter-migration-compatibility).
Once that lands on `rails/rails#main`:
1. Switch `Gemfile` back to `rails/rails#main`
2. Mark this PR ready for review

### Behavior matrix

| Caller | `identity:` arg | Oracle server | Result |
|---|---|---|---|
| `Migration[8.2]+` | omitted | ≥ 12.1 | Identity (V8_2 default) |
| `Migration[8.2]+` | omitted | < 12.1 | Sequence (V8_2 auto-inject gated by `supports_identity_columns?`) |
| `Migration[8.2]+` | omitted, with `sequence_name:` / `sequence_start_value:` | any | Sequence (V8_2 treats sequence options as opt-out) |
| `Migration[8.2]+` | `true` | ≥ 12.1 | Identity (explicit) |
| `Migration[8.2]+` | `true` | < 12.1 | `ArgumentError` (Phase 1) |
| `Migration[8.2]+` | `false` | any | Sequence (per-table opt-out) |
| `Migration[8.1]` or older | omitted | any | Sequence (forced by V8_1 module) |
| `Migration[8.1]` or older | `true` | ≥ 12.1 | Identity (explicit still honored) |
| `Migration[8.1]` or older | `true` | < 12.1 | `ArgumentError` |
| `Migration[8.1]` or older | `false` | any | Sequence |
| `Schema.define` / direct `connection.create_table` | omitted | any | Sequence (no migration version context, default unchanged) |
| `Schema.define` / direct `connection.create_table` | `true` | ≥ 12.1 | Identity (explicit) |
| `Schema.define` / direct `connection.create_table` | `false` | any | Sequence |

### Implementation notes

- `OracleEnhanced::MigrationCompatibility` registers two compat modules
  via Rails' `Migration::Compatibility::Versioned`:
  - `V8_2` forces `options[:identity] = true` when the option is omitted,
    no `sequence_name:` / `sequence_start_value:` is given,
    `id: :primary_key` is in effect (default), the PK is not composite,
    and the server supports identity columns. This is the new flip,
    scoped to migrations at `Migration[8.2]+`.
  - `V8_1` forces `options[:identity] = false` for migrations at
    `Migration[8.1]` or earlier. Because Rails' versioned dispatch
    includes both modules for older migrations and V8_1 sets the
    explicit option first, V8_2 sees `options.key?(:identity)` and
    leaves it alone — older migrations keep sequence-backed behavior.
- `OracleEnhancedSchemaStatements#create_table` honors
  `options[:identity]` exactly as given and does **no** auto-injection
  of its own. Callers that bypass migration compat (`Schema.define`,
  direct `connection.create_table`) therefore keep the existing
  sequence-backed default unless they pass `identity: true` explicitly.
- `OracleEnhancedSchemaStatements#rename_table` and `#drop_table` are
  now identity-aware: they no longer rename or drop `<table>_seq` for
  tables whose primary key is an Oracle identity column. Previously,
  an unrelated application-owned sequence sharing that name would be
  silently mutated or removed. `full_drop` already had this protection
  via its `ISEQ$$_` filter; this brings the table-level DDL paths in
  line.
- `OracleEnhancedSchemaDumper` emits `identity: true` / `identity: false`
  explicitly for every primary-key table when the connected server
  supports identity columns, so `db/schema.rb` roundtrips remain
  unambiguous regardless of which loader runs them.
- `OracleEnhancedDatabaseStatements#empty_insert_statement_value` is
  already in master from #2609 — this PR depends on that change so
  identity tables can satisfy `Model.create!` with no attributes.

### Tests

- New `migration_compatibility_spec.rb` cases exercise the V8_2 / V8_1
  layering, the sequence-option opt-out, and the `Schema.define` /
  direct-call path that preserves sequence-backed PKs by default.
- New `identity_primary_key_spec.rb` cases cover identity-aware
  `rename_table` and `drop_table` against an unrelated app-owned
  `<table>_seq`, plus the identity counterparts to the existing
  sequence-prerequisite tests (`pk_and_sequence_for`, `NEXTVAL`-free
  insert, `full_drop` filter, long-name rename).

## Test plan

- [x] `bundle exec rubocop` — clean
- [x] Full spec suite on Oracle 23ai (FREEPDB1) — 573 examples, 0 failures, 7 pending
- [ ] CI on full matrix (3.3 / 3.4 / 4.0 / jruby)
- [ ] Switch Gemfile back to `rails/rails#main` once `per-adapter-migration-compatibility` lands

## Related

- Phase 1: #2579 (explicit `identity:` option) — merged
- Phase 2 prerequisite: #2609 (`empty_insert_statement_value`) — merged
- Rails dependency: yahonda/rails `per-adapter-migration-compatibility`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

