### PR TITLE
Set NLS_LANG in check_method_visibility workflow

### DIFF
--- a/.github/workflows/check_method_visibility.yml
+++ b/.github/workflows/check_method_visibility.yml
@@ -16,6 +16,7 @@ jobs:
     env:
       ORACLE_HOME: /opt/oracle/instantclient_23_26
       LD_LIBRARY_PATH: /opt/oracle/instantclient_23_26
+      NLS_LANG: American_America.AL32UTF8
     steps:
       - uses: actions/checkout@v6
       - name: Set up Ruby


### PR DESCRIPTION
## Summary

Add `NLS_LANG: American_America.AL32UTF8` to the `check_method_visibility` workflow so the Oracle Instant Client used by ruby-oci8 stops emitting `Warning: NLS_LANG is not set. fallback to US7ASCII.` at the start of every run.

The sibling `check_method_signatures` workflow already sets the same value; this just mirrors it.

## Test plan

- [ ] CI: check_method_visibility job runs without the NLS_LANG fallback warning