### PR TITLE
Rename @do_not_prefetch_primary_key to @prefetch_primary_key_cache

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -270,7 +270,7 @@ module ActiveRecord
 
         connect
         @enable_dbms_output = false
-        @do_not_prefetch_primary_key = {}
+        @prefetch_primary_key_cache = {}
         @columns_cache = {}
         @notice_receiver_sql_warnings = []
 
@@ -544,12 +544,11 @@ module ActiveRecord
       def prefetch_primary_key?(table_name = nil)
         return true if table_name.nil?
         table_name = table_name.to_s
-        do_not_prefetch = @do_not_prefetch_primary_key[table_name]
-        if do_not_prefetch.nil?
+        if @prefetch_primary_key_cache[table_name].nil?
           owner, desc_table_name = resolve_data_source_name(table_name)
-          @do_not_prefetch_primary_key[table_name] = do_not_prefetch = !has_primary_key?(table_name, owner, desc_table_name)
+          @prefetch_primary_key_cache[table_name] = has_primary_key?(table_name, owner, desc_table_name)
         end
-        !do_not_prefetch
+        @prefetch_primary_key_cache[table_name]
       end
 
       def reset_pk_sequence!(table_name, primary_key = nil, sequence_name = nil) # :nodoc:


### PR DESCRIPTION
## Summary

Rename the `prefetch_primary_key?` memoization cache and invert its polarity so the cached value matches the question being asked.

The instance variable `@do_not_prefetch_primary_key` (introduced in #1496 when promoting from a class variable) is awkward in two ways:

1. **Imperative-as-noun.** `do_not_prefetch_primary_key` reads as a command ("do not prefetch the primary key") used as a variable name. Variable names should describe state (nouns), not give instructions.
2. **Negative polarity.** The cache stored `true` for "do NOT prefetch this table", which `prefetch_primary_key?` then had to flip on the way out (`!do_not_prefetch`). Combined with the imperative naming, readers had to invert the meaning twice in their head.

After this change:

```ruby
def prefetch_primary_key?(table_name = nil)
  return true if table_name.nil?
  table_name = table_name.to_s
  if @prefetch_primary_key_cache[table_name].nil?
    owner, desc_table_name = resolve_data_source_name(table_name)
    @prefetch_primary_key_cache[table_name] = has_primary_key?(table_name, owner, desc_table_name)
  end
  @prefetch_primary_key_cache[table_name]
end
```

`true` means "prefetch this table", `false` means "skip prefetch". The function body is a straight cache lookup with no double-negation.

No behavior change.

## Test plan

- [x] `bundle exec rubocop` — clean
- [ ] CI: full test suite passes on Oracle 23ai and 11g
