### PR TITLE
Enable bug report templates CI step for remaining workflows

### DIFF
--- a/.github/workflows/ruby_head.yml
+++ b/.github/workflows/ruby_head.yml
@@ -78,7 +78,6 @@ jobs:
         run: |
           bundle exec rspec
       - name: Run bug report templates
-        if: false
         run: |
           cd guides/bug_report_templates
           ruby active_record_gem.rb

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -106,7 +106,6 @@ jobs:
         run: |
           bundle exec rspec
       - name: Run bug report templates
-        if: "false"
         run: |
           cd guides/bug_report_templates
           ruby active_record_gem.rb

--- a/.github/workflows/test_11g_ojdbc11.yml
+++ b/.github/workflows/test_11g_ojdbc11.yml
@@ -93,7 +93,6 @@ jobs:
         run: |
           bundle exec rspec
       - name: Run bug report templates
-        if: "false"
         run: |
           cd guides/bug_report_templates
           ruby active_record_gem.rb


### PR DESCRIPTION
## Summary

Remove `if: "false"` from `test_11g.yml`, `test_11g_ojdbc11.yml` and `ruby_head.yml` so the bug report templates actually run on these matrices.

#2517 did this for `test.yml`; the other three workflows were missed at the time and the disabled `if: "false"` is leftover. Bug report templates should work everywhere.

## Test plan

- [ ] CI: bug report template step runs (and passes) on the 11g matrices and `ruby-head`