### PR TITLE
Avoid ORA-01722 on Model.create! for tables with a String primary key

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -219,8 +219,16 @@ module ActiveRecord
           unless create_sequence
             class << td
               attr_accessor :create_sequence
+              # Only request a sequence when the primary key column is a
+              # numeric type that a +NUMBER+ sequence can populate. For
+              # example, +t.primary_key :code, :string+ inside +id: false+
+              # creates a VARCHAR2 PK; building a numeric sequence for it
+              # is meaningless and pollutes the schema with an unused
+              # +<table>_seq+.
               def primary_key(name, type = :primary_key, **options)
-                self.create_sequence = true
+                if [:primary_key, :integer, :bigint, :decimal].include?(type)
+                  self.create_sequence = true
+                end
                 super(name, type, **options)
               end
             end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -96,6 +96,36 @@ describe "OracleEnhancedAdapter schema definition" do
       expect(pk.sql_type).to match(/VARCHAR2\(1\)/i)
       expect(pk.null).to be(false)
     end
+
+    it "does not create a sequence for a non-numeric primary key" do
+      schema_define do
+        create_table :test_lookups, force: true, id: false do |t|
+          t.primary_key :code, :string, limit: 10, null: false
+          t.string :name
+        end
+      end
+
+      seq = @conn.select_value(<<~SQL.squish, "SCHEMA")
+        SELECT 1 FROM user_sequences WHERE sequence_name = 'TEST_LOOKUPS_SEQ'
+      SQL
+      expect(seq).to be_nil
+    end
+
+    it "inserts via the Rails insert path on a String primary key" do
+      schema_define do
+        create_table :test_lookups, force: true, id: false do |t|
+          t.primary_key :code, :string, limit: 10, null: false
+          t.string :name
+        end
+      end
+      klass = Class.new(ActiveRecord::Base) do
+        self.table_name = "test_lookups"
+        self.primary_key = "code"
+      end
+
+      expect { klass.create!(code: "ABC", name: "alpha") }.not_to raise_error
+      expect(klass.find("ABC").name).to eq("alpha")
+    end
   end
 
   describe "default sequence name" do


### PR DESCRIPTION
## Summary

`create_table ..., id: false do |t| t.primary_key :code, :string ... end`
silently created a `<table>_seq` NUMBER sequence for the VARCHAR2 PK,
because the block-level `td.primary_key` override flipped
`create_sequence = true` without consulting the column type. The
useless sequence then made `prefetch_primary_key?` (which only checks
"does the table have a PK?") look like a real hint, opening a
fragile path where Rails 8.x could try to populate a non-numeric PK
from a NUMBER sequence.

### Fix

Limit the block-level `t.primary_key` override to numeric PK types
that a NUMBER sequence can actually populate:
`[:primary_key, :integer, :bigint, :decimal]`. Non-numeric PKs no
longer get a `<table>_seq` they can't use.

### What this isn't

A previous draft of this PR also added a defensive shield in
`DatabaseStatements#insert` to clear `pk` when binds already supplied
its value, on the theory that `sql_for_insert` would otherwise append
an Integer-typed `RETURNING` out-bind. In Rails 8.x's actual
`_insert_record` flow `pk` always reaches the adapter as a String
(`primary_key=` coerces Symbol to String), so `sql_for_insert`'s
existing `pk.is_a?(String)` guard already handles it. The shield was
effectively dead code on the realistic path and has been dropped.

## Test plan

- [x] `bundle exec rubocop` — clean
- [x] New regression specs in `spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb`:
    - `does not create a sequence for a non-numeric primary key`
    - `inserts via the Rails insert path on a String primary key`
- [x] CI: integration test job on Oracle 23ai
- [x] CI: Oracle 11.2 path

## Notes

This was discovered while reviewing PR #2579. A regression spec was
originally added on that branch and reverted (the commit message
there assumed the existing shield covered this case; it did not).
This PR carries the spec forward and adds the fix off `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
