### PR TITLE
Sort table columns by name when dumping schema

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -202,7 +202,7 @@ module ActiveRecord # :nodoc:
               tbl.puts ", force: :cascade do |t|"
 
               # then dump all non-primary key columns
-              columns.each do |column|
+              columns.sort_by(&:name).each do |column|
                 raise StandardError, "Unknown type '#{column.sql_type}' for column '#{column.name}'" unless @connection.valid_type?(column.type)
                 next if column.name == pk
                 type, colspec = column_spec(column)

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -49,6 +49,13 @@ RSpec.describe "OracleEnhancedAdapter schema dump" do
       create_test_posts_table
       expect(standard_dump(ignore_tables: [ /test_posts/i ])).not_to match(/create_table "test_posts"/)
     end
+
+    it "should dump non-primary key columns in alphabetical order" do
+      create_test_posts_table
+      output = dump_table_schema "test_posts"
+      column_names = output.scan(/^\s+t\.\w+\s+"(\w+)"/).flatten
+      expect(column_names).to eq(column_names.sort)
+    end
   end
 
   describe "dumping default values" do


### PR DESCRIPTION
### Motivation / Background

Port [rails/rails#53281](https://github.com/rails/rails/pull/53281) ("Sort
table columns by name when dumping schema") to the Oracle enhanced adapter.

`OracleEnhanced::SchemaDumper` overrides the entire `#table` method instead of
calling `super`, so it does not inherit the alphabetical column-ordering
behavior introduced upstream. Without this change, schema dumps generated
against Oracle remain in column-creation order, producing noisy
`db/schema.rb` diffs when developers add columns out of order across branches.

### Detail

* `lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb`:
  change `columns.each` to `columns.sort_by(&:name).each` inside `#table`,
  mirroring the upstream one-line fix.
* `spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb`:
  add an example asserting non-primary-key columns are dumped in alphabetical
  order.

### Additional information

Brings Oracle in line with the other adapters once Rails 8.2 is released.

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated.