### PR TITLE
Use ActiveRecord::Base.lease_connection in specs

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/lob.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/lob.rb
@@ -28,11 +28,11 @@ module ActiveRecord # :nodoc:
         private
           def enhanced_write_lobs
             # Skip if using prepared statements - LOB data is already written via temp LOB binding
-            return if self.class.connection.prepared_statements
+            return if self.class.lease_connection.prepared_statements
 
-            if self.class.connection.is_a?(ConnectionAdapters::OracleEnhancedAdapter) &&
+            if self.class.lease_connection.is_a?(ConnectionAdapters::OracleEnhancedAdapter) &&
                 !(self.class.custom_create_method || self.class.custom_update_method)
-              self.class.connection.write_lobs(self.class.table_name, self.class, attributes, @changed_lob_columns)
+              self.class.lease_connection.write_lobs(self.class.table_name, self.class, attributes, @changed_lob_columns)
             end
           end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
@@ -186,7 +186,7 @@ module ActiveRecord # :nodoc:
       end
 
       def log_custom_method(sql, name, &block)
-        connection = self.class.connection
+        connection = self.class.lease_connection
         intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(
           adapter: connection, raw_sql: sql, name: name, binds: []
         )

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -681,12 +681,12 @@ module ActiveRecord
               } << "SELECT * FROM DUAL\n"
             else
               if versions.is_a?(Array)
-                # called from ActiveRecord::Base.connection#dump_schema_versions
+                # called from ActiveRecord::Base.lease_connection#dump_schema_versions
                 versions.map { |version|
                   "INSERT INTO #{sm_table} (version) VALUES (#{quote(version)})"
                 }.join("\n\n/\n\n")
               else
-                # called from ActiveRecord::Base.connection#assume_migrated_upto_version
+                # called from ActiveRecord::Base.lease_connection#assume_migrated_upto_version
                 "INSERT INTO #{sm_table} (version) VALUES (#{quote(versions)})"
               end
             end

--- a/spec/active_record/connection_adapters/emulation/oracle_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/emulation/oracle_adapter_spec.rb
@@ -8,7 +8,7 @@ describe "OracleEnhancedAdapter emulate OracleAdapter" do
 
   it "should be an OracleAdapter" do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(adapter: "oracle"))
-    expect(ActiveRecord::Base.connection).not_to be_nil
-    expect(ActiveRecord::Base.connection).to be_a(ActiveRecord::ConnectionAdapters::OracleAdapter)
+    expect(ActiveRecord::Base.lease_connection).not_to be_nil
+    expect(ActiveRecord::Base.lease_connection).to be_a(ActiveRecord::ConnectionAdapters::OracleAdapter)
   end
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb
@@ -3,7 +3,7 @@
 describe "OracleEnhancedAdapter#columns_for_distinct" do
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    @conn = ActiveRecord::Base.connection
+    @conn = ActiveRecord::Base.lease_connection
   end
 
   it "strips ASC modifier" do

--- a/spec/active_record/connection_adapters/oracle_enhanced/compatibility_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/compatibility_spec.rb
@@ -5,7 +5,7 @@ describe "compatibility migrations" do
 
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    @conn = ActiveRecord::Base.connection
+    @conn = ActiveRecord::Base.lease_connection
     schema_define do
       create_table :test_employees, force: true
     end

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -3,68 +3,68 @@
 describe "OracleEnhancedAdapter establish connection" do
   it "should connect to database" do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    expect(ActiveRecord::Base.connection).not_to be_nil
-    expect(ActiveRecord::Base.connection.class).to eq(ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter)
+    expect(ActiveRecord::Base.lease_connection).not_to be_nil
+    expect(ActiveRecord::Base.lease_connection.class).to eq(ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter)
   end
 
   it "should connect to database as SYSDBA" do
     ActiveRecord::Base.establish_connection(SYS_CONNECTION_PARAMS)
-    expect(ActiveRecord::Base.connection).not_to be_nil
-    expect(ActiveRecord::Base.connection.class).to eq(ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter)
+    expect(ActiveRecord::Base.lease_connection).not_to be_nil
+    expect(ActiveRecord::Base.lease_connection.class).to eq(ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter)
   end
 
   it "should be active after connection to database" do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    expect(ActiveRecord::Base.connection).to be_active
+    expect(ActiveRecord::Base.lease_connection).to be_active
   end
 
   it "should not be active after disconnection to database" do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    ActiveRecord::Base.connection.disconnect!
-    expect(ActiveRecord::Base.connection).not_to be_active
+    ActiveRecord::Base.lease_connection.disconnect!
+    expect(ActiveRecord::Base.lease_connection).not_to be_active
   end
 
   it "should be active after reconnection to database" do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    ActiveRecord::Base.connection.reconnect!
-    expect(ActiveRecord::Base.connection).to be_active
+    ActiveRecord::Base.lease_connection.reconnect!
+    expect(ActiveRecord::Base.lease_connection).to be_active
   end
 
   it "should be active after reconnection to database with restore_transactions: true" do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    ActiveRecord::Base.connection.reconnect!(restore_transactions: true)
-    expect(ActiveRecord::Base.connection).to be_active
+    ActiveRecord::Base.lease_connection.reconnect!(restore_transactions: true)
+    expect(ActiveRecord::Base.lease_connection).to be_active
   end
 
   it "should use database default cursor_sharing parameter value force by default" do
     # Use `SYSTEM_CONNECTION_PARAMS` to query v$parameter
     ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS)
-    expect(ActiveRecord::Base.connection.select_value("select value from v$parameter where name = 'cursor_sharing'")).to eq("FORCE")
+    expect(ActiveRecord::Base.lease_connection.select_value("select value from v$parameter where name = 'cursor_sharing'")).to eq("FORCE")
   end
 
   it "should use modified cursor_sharing value exact" do
     ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS.merge(cursor_sharing: :exact))
-    expect(ActiveRecord::Base.connection.select_value("select value from v$parameter where name = 'cursor_sharing'")).to eq("EXACT")
+    expect(ActiveRecord::Base.lease_connection.select_value("select value from v$parameter where name = 'cursor_sharing'")).to eq("EXACT")
   end
 
   it "should raise ArgumentError for an unsupported cursor_sharing value" do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(cursor_sharing: "not_a_valid_mode"))
-    expect { ActiveRecord::Base.connection }.to raise_error(ArgumentError, /Invalid :cursor_sharing value/)
+    expect { ActiveRecord::Base.lease_connection }.to raise_error(ArgumentError, /Invalid :cursor_sharing value/)
   end
 
   it "should not use JDBC statement caching" do
     if ORACLE_ENHANCED_CONNECTION == :jdbc
       ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS)
-      expect(ActiveRecord::Base.connection.raw_connection.getImplicitCachingEnabled).to be(false)
-      expect(ActiveRecord::Base.connection.raw_connection.getStatementCacheSize).to eq(-1)
+      expect(ActiveRecord::Base.lease_connection.raw_connection.getImplicitCachingEnabled).to be(false)
+      expect(ActiveRecord::Base.lease_connection.raw_connection.getStatementCacheSize).to eq(-1)
     end
   end
 
   it "should use JDBC statement caching" do
     if ORACLE_ENHANCED_CONNECTION == :jdbc
       ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS.merge(jdbc_statement_cache_size: 100))
-      expect(ActiveRecord::Base.connection.raw_connection.getImplicitCachingEnabled).to be(true)
-      expect(ActiveRecord::Base.connection.raw_connection.getStatementCacheSize).to eq(100)
+      expect(ActiveRecord::Base.lease_connection.raw_connection.getImplicitCachingEnabled).to be(true)
+      expect(ActiveRecord::Base.lease_connection.raw_connection.getStatementCacheSize).to eq(100)
       # else: don't raise error if OCI connection has parameter "jdbc_statement_cache_size", still ignore it
     end
   end
@@ -73,7 +73,7 @@ describe "OracleEnhancedAdapter establish connection" do
     skip "Oracle 11g XE does not support native network encryption" if ENV["DATABASE_VERSION"] == "11.2.0.2"
     if ORACLE_ENHANCED_CONNECTION == :jdbc
       ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS.merge(jdbc_connect_properties: { "oracle.net.encryption_client" => "REJECTED" }))
-      conn = ActiveRecord::Base.connection.send(:_connection)
+      conn = ActiveRecord::Base.lease_connection.send(:_connection)
       expect(conn.select("SELECT COUNT(*) Records FROM v$Session_Connect_Info WHERE SID=SYS_CONTEXT('USERENV', 'SID') AND Network_Service_Banner LIKE '%Encryption service adapter%'")).to eq([{ "records" => 0 }])
     end
   end
@@ -82,15 +82,15 @@ describe "OracleEnhancedAdapter establish connection" do
     skip "Oracle 11g XE does not support native network encryption" if ENV["DATABASE_VERSION"] == "11.2.0.2"
     if ORACLE_ENHANCED_CONNECTION == :jdbc
       ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS.merge(jdbc_connect_properties: { "oracle.net.encryption_client" => "REQUESTED" }))
-      conn = ActiveRecord::Base.connection.send(:_connection)
+      conn = ActiveRecord::Base.lease_connection.send(:_connection)
       expect(conn.select("SELECT COUNT(*) Records FROM v$Session_Connect_Info WHERE SID=SYS_CONTEXT('USERENV', 'SID') AND Network_Service_Banner LIKE '%Encryption service adapter%'")).to eq([{ "records" => 1 }])
     end
   end
 
   it "should connect to database using service_name" do
     ActiveRecord::Base.establish_connection(SERVICE_NAME_CONNECTION_PARAMS)
-    expect(ActiveRecord::Base.connection).not_to be_nil
-    expect(ActiveRecord::Base.connection.class).to eq(ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter)
+    expect(ActiveRecord::Base.lease_connection).not_to be_nil
+    expect(ActiveRecord::Base.lease_connection.class).to eq(ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter)
   end
 end
 
@@ -144,22 +144,22 @@ describe "OracleEnhancedConnection" do
     end
 
     it "should create new connection" do
-      expect(ActiveRecord::Base.connection).to be_active
+      expect(ActiveRecord::Base.lease_connection).to be_active
     end
 
     it "should switch to specified schema" do
-      expect(ActiveRecord::Base.connection.current_schema).to eq(CONNECTION_WITH_SCHEMA_PARAMS[:schema].upcase)
-      expect(ActiveRecord::Base.connection.current_user).to eq(CONNECTION_WITH_SCHEMA_PARAMS[:username].upcase)
+      expect(ActiveRecord::Base.lease_connection.current_schema).to eq(CONNECTION_WITH_SCHEMA_PARAMS[:schema].upcase)
+      expect(ActiveRecord::Base.lease_connection.current_user).to eq(CONNECTION_WITH_SCHEMA_PARAMS[:username].upcase)
     end
 
     it "should switch to specified schema after reset" do
-      ActiveRecord::Base.connection.reset!
-      expect(ActiveRecord::Base.connection.current_schema).to eq(CONNECTION_WITH_SCHEMA_PARAMS[:schema].upcase)
+      ActiveRecord::Base.lease_connection.reset!
+      expect(ActiveRecord::Base.lease_connection.current_schema).to eq(CONNECTION_WITH_SCHEMA_PARAMS[:schema].upcase)
     end
 
     it "should raise ArgumentError for a :schema value that is not an Oracle unquoted identifier" do
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(schema: "oracle_enhanced;DROP TABLE x;--"))
-      expect { ActiveRecord::Base.connection }.to raise_error(ArgumentError, /Invalid :schema value/)
+      expect { ActiveRecord::Base.lease_connection }.to raise_error(ArgumentError, /Invalid :schema value/)
     end
   end
 
@@ -187,7 +187,7 @@ describe "OracleEnhancedConnection" do
 
     before(:all) do
       ActiveRecord::Base.establish_connection(schema_owner_params)
-      schema_conn = ActiveRecord::Base.connection
+      schema_conn = ActiveRecord::Base.lease_connection
       schema_conn.drop_table :schema_probe_table, if_exists: true
       schema_conn.create_table :schema_probe_table, id: :integer
       schema_conn.execute "GRANT SELECT ON schema_probe_table TO #{DATABASE_USER}"
@@ -199,20 +199,20 @@ describe "OracleEnhancedConnection" do
     after(:all) do
       ActiveRecord::Base.remove_connection
       ActiveRecord::Base.establish_connection(schema_owner_params)
-      ActiveRecord::Base.connection.drop_table :schema_probe_table, if_exists: true
+      ActiveRecord::Base.lease_connection.drop_table :schema_probe_table, if_exists: true
       ActiveRecord::Base.remove_connection
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
     end
 
     it "sets CURRENT_SCHEMA so unqualified raw SQL resolves in the :schema user" do
-      expect(ActiveRecord::Base.connection.current_schema).to eq(DATABASE_SCHEMA.upcase)
+      expect(ActiveRecord::Base.lease_connection.current_schema).to eq(DATABASE_SCHEMA.upcase)
       expect {
-        ActiveRecord::Base.connection.execute("SELECT COUNT(*) FROM schema_probe_table")
+        ActiveRecord::Base.lease_connection.execute("SELECT COUNT(*) FROM schema_probe_table")
       }.not_to raise_error
     end
 
     it "data_source_exists? resolves an unqualified name in the :schema user" do
-      expect(ActiveRecord::Base.connection.data_source_exists?("schema_probe_table")).to be true
+      expect(ActiveRecord::Base.lease_connection.data_source_exists?("schema_probe_table")).to be true
     end
   end
 
@@ -224,13 +224,13 @@ describe "OracleEnhancedConnection" do
     it "should use NLS_TERRITORY environment variable" do
       ENV["NLS_TERRITORY"] = "JAPAN"
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-      expect(ActiveRecord::Base.connection.select_value("select SYS_CONTEXT('userenv', 'NLS_TERRITORY') from dual")).to eq("JAPAN")
+      expect(ActiveRecord::Base.lease_connection.select_value("select SYS_CONTEXT('userenv', 'NLS_TERRITORY') from dual")).to eq("JAPAN")
     end
 
     it "should use configuration value and ignore NLS_TERRITORY environment variable" do
       ENV["NLS_TERRITORY"] = "AMERICA"
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(nls_territory: "INDONESIA"))
-      expect(ActiveRecord::Base.connection.select_value("select SYS_CONTEXT('userenv', 'NLS_TERRITORY') from dual")).to eq("INDONESIA")
+      expect(ActiveRecord::Base.lease_connection.select_value("select SYS_CONTEXT('userenv', 'NLS_TERRITORY') from dual")).to eq("INDONESIA")
     end
   end
 
@@ -242,19 +242,19 @@ describe "OracleEnhancedConnection" do
     it "should ignore NLS_DATE_FORMAT environment variable" do
       ENV["NLS_DATE_FORMAT"] = "YYYY-MM-DD"
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-      expect(ActiveRecord::Base.connection.select_value("select SYS_CONTEXT('userenv', 'NLS_DATE_FORMAT') from dual")).to eq("YYYY-MM-DD HH24:MI:SS")
+      expect(ActiveRecord::Base.lease_connection.select_value("select SYS_CONTEXT('userenv', 'NLS_DATE_FORMAT') from dual")).to eq("YYYY-MM-DD HH24:MI:SS")
     end
 
     it "should ignore NLS_DATE_FORMAT configuration value" do
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(nls_date_format: "YYYY-MM-DD HH24:MI"))
-      expect(ActiveRecord::Base.connection.select_value("select SYS_CONTEXT('userenv', 'NLS_DATE_FORMAT') from dual")).to eq("YYYY-MM-DD HH24:MI:SS")
+      expect(ActiveRecord::Base.lease_connection.select_value("select SYS_CONTEXT('userenv', 'NLS_DATE_FORMAT') from dual")).to eq("YYYY-MM-DD HH24:MI:SS")
     end
 
     it "should use default value when NLS_DATE_FORMAT environment variable is not set" do
       ENV["NLS_DATE_FORMAT"] = nil
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
       default = ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter::FIXED_NLS_PARAMETERS[:nls_date_format]
-      expect(ActiveRecord::Base.connection.select_value("select SYS_CONTEXT('userenv', 'NLS_DATE_FORMAT') from dual")).to eq(default)
+      expect(ActiveRecord::Base.lease_connection.select_value("select SYS_CONTEXT('userenv', 'NLS_DATE_FORMAT') from dual")).to eq(default)
     end
   end
 
@@ -265,24 +265,24 @@ describe "OracleEnhancedConnection" do
       # Taint NLS_DATE_FORMAT on the current session so the post-reconnect
       # assertion can only pass if configure_connection actively re-applies
       # FIXED_NLS_PARAMETERS on the fresh physical session.
-      ActiveRecord::Base.connection.execute("ALTER SESSION SET NLS_DATE_FORMAT = 'DD-MON-RRRR'")
-      ActiveRecord::Base.connection.reconnect!
-      expect(ActiveRecord::Base.connection.select_value("select SYS_CONTEXT('userenv', 'NLS_DATE_FORMAT') from dual")).to eq(expected)
+      ActiveRecord::Base.lease_connection.execute("ALTER SESSION SET NLS_DATE_FORMAT = 'DD-MON-RRRR'")
+      ActiveRecord::Base.lease_connection.reconnect!
+      expect(ActiveRecord::Base.lease_connection.select_value("select SYS_CONTEXT('userenv', 'NLS_DATE_FORMAT') from dual")).to eq(expected)
     end
 
     it "re-applies current_schema after reconnect!" do
       ActiveRecord::Base.establish_connection(CONNECTION_WITH_SCHEMA_PARAMS)
       expected = CONNECTION_WITH_SCHEMA_PARAMS[:schema].upcase
-      expect(ActiveRecord::Base.connection.current_schema).to eq(expected)
-      ActiveRecord::Base.connection.reconnect!
-      expect(ActiveRecord::Base.connection.current_schema).to eq(expected)
+      expect(ActiveRecord::Base.lease_connection.current_schema).to eq(expected)
+      ActiveRecord::Base.lease_connection.reconnect!
+      expect(ActiveRecord::Base.lease_connection.current_schema).to eq(expected)
     end
 
     it "re-applies cursor_sharing after reconnect!" do
       ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS.merge(cursor_sharing: :exact))
-      expect(ActiveRecord::Base.connection.select_value("select value from v$parameter where name = 'cursor_sharing'")).to eq("EXACT")
-      ActiveRecord::Base.connection.reconnect!
-      expect(ActiveRecord::Base.connection.select_value("select value from v$parameter where name = 'cursor_sharing'")).to eq("EXACT")
+      expect(ActiveRecord::Base.lease_connection.select_value("select value from v$parameter where name = 'cursor_sharing'")).to eq("EXACT")
+      ActiveRecord::Base.lease_connection.reconnect!
+      expect(ActiveRecord::Base.lease_connection.select_value("select value from v$parameter where name = 'cursor_sharing'")).to eq("EXACT")
     end
   end
 
@@ -512,7 +512,7 @@ describe "OracleEnhancedConnection" do
     before(:all) do
       ENV["NLS_NUMERIC_CHARACTERS"] = ", "
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-      @conn_base = ActiveRecord::Base.connection
+      @conn_base = ActiveRecord::Base.lease_connection
       @conn = @conn_base.send(:_connection)
       @conn.exec "CREATE TABLE test_employees (age NUMBER(10,2))"
     end
@@ -546,7 +546,7 @@ describe "OracleEnhancedConnection" do
 
     before(:all) do
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-      @conn = ActiveRecord::Base.connection.send(:_connection)
+      @conn = ActiveRecord::Base.lease_connection.send(:_connection)
       @sys_conn = ActiveRecord::ConnectionAdapters::OracleEnhanced::Connection.create(SYS_CONNECTION_PARAMS)
       schema_define do
         create_table :posts, force: true
@@ -567,7 +567,7 @@ describe "OracleEnhancedConnection" do
       # `@conn.active?` only reconnects the raw OCI handle; the
       # AR-level prepared statement cache can still hold a closed
       # cursor that the next `Post.create!` will try to bind_param on.
-      ActiveRecord::Base.connection.reconnect!
+      ActiveRecord::Base.lease_connection.reconnect!
     end
 
     def kill_current_session
@@ -587,7 +587,7 @@ describe "OracleEnhancedConnection" do
 
     it "should reconnect and execute SQL statement if connection is lost and auto retry is enabled" do
       # @conn.auto_retry = true
-      ActiveRecord::Base.connection.auto_retry = true
+      ActiveRecord::Base.lease_connection.auto_retry = true
       kill_current_session
       expect(@conn.exec("SELECT * FROM dual")).not_to be_nil
     end
@@ -600,21 +600,21 @@ describe "OracleEnhancedConnection" do
     # Regression test ported from rails/rails#46273, which only covers
     # Mysql2 and PostgreSQL in the Rails repository.
     it "adapter #execute is retryable when allow_retry: true is passed" do
-      previous_auto_retry = ActiveRecord::Base.connection.auto_retry
-      ActiveRecord::Base.connection.auto_retry = false
+      previous_auto_retry = ActiveRecord::Base.lease_connection.auto_retry
+      ActiveRecord::Base.lease_connection.auto_retry = false
       begin
         initial_connection_id = connection_id_from_server(@conn)
         kill_current_session
-        expect { ActiveRecord::Base.connection.execute("SELECT 1 FROM dual", allow_retry: true) }.not_to raise_error
+        expect { ActiveRecord::Base.lease_connection.execute("SELECT 1 FROM dual", allow_retry: true) }.not_to raise_error
         expect(connection_id_from_server(@conn)).not_to eq(initial_connection_id)
       ensure
-        ActiveRecord::Base.connection.auto_retry = previous_auto_retry
+        ActiveRecord::Base.lease_connection.auto_retry = previous_auto_retry
       end
     end
 
     it "should not reconnect and execute SQL statement if connection is lost and auto retry is disabled" do
       # @conn.auto_retry = false
-      ActiveRecord::Base.connection.auto_retry = false
+      ActiveRecord::Base.lease_connection.auto_retry = false
       kill_current_session
       if defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
         expect { @conn.exec("SELECT * FROM dual") }.to raise_error(Java::JavaSql::SQLRecoverableException)
@@ -625,14 +625,14 @@ describe "OracleEnhancedConnection" do
 
     it "should reconnect and execute SQL select if connection is lost and auto retry is enabled" do
       # @conn.auto_retry = true
-      ActiveRecord::Base.connection.auto_retry = true
+      ActiveRecord::Base.lease_connection.auto_retry = true
       kill_current_session
       expect(@conn.select("SELECT * FROM dual")).to eq([{ "dummy" => "X" }])
     end
 
     it "should not reconnect and execute SQL select if connection is lost and auto retry is disabled" do
       # @conn.auto_retry = false
-      ActiveRecord::Base.connection.auto_retry = false
+      ActiveRecord::Base.lease_connection.auto_retry = false
       kill_current_session
       if defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
         expect { @conn.select("SELECT * FROM dual") }.to raise_error(Java::JavaSql::SQLRecoverableException)
@@ -643,14 +643,14 @@ describe "OracleEnhancedConnection" do
 
     it "should reconnect and execute query if connection is lost and auto retry is enabled" do
       Post.create!
-      ActiveRecord::Base.connection.auto_retry = true
+      ActiveRecord::Base.lease_connection.auto_retry = true
       kill_current_session
       expect(Post.take).not_to be_nil
     end
 
     it "should not reconnect and execute query if connection is lost and auto retry is disabled" do
       Post.create!
-      ActiveRecord::Base.connection.auto_retry = false
+      ActiveRecord::Base.lease_connection.auto_retry = false
       kill_current_session
       expect { Post.take }.to raise_error(ActiveRecord::StatementInvalid)
     end
@@ -690,7 +690,7 @@ describe "OracleEnhancedConnection" do
   describe "resolve_data_source_name" do
     before(:all) do
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
       @owner = CONNECTION_PARAMS[:username].upcase
     end
 
@@ -825,7 +825,7 @@ describe "OracleEnhancedConnection" do
   describe "extract_schema_qualified_name" do
     before(:all) do
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
     end
 
     def extract(string)

--- a/spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb
@@ -61,7 +61,7 @@ describe "OracleEnhancedAdapter context index" do
 
   describe "on single table" do
     before(:all) do
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
       @title_words = %w{aaa bbb ccc}
       @body_words = %w{foo bar baz}
       create_table_posts
@@ -185,7 +185,7 @@ describe "OracleEnhancedAdapter context index" do
 
   describe "on multiple tables" do
     before(:all) do
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
       create_tables
       class ::Post < ActiveRecord::Base
         has_many :comments, dependent: :destroy
@@ -274,7 +274,7 @@ describe "OracleEnhancedAdapter context index" do
         has_context_index
       end
       @post = Post.create(title: "aaa", body: "bbb")
-      @tablespace = ActiveRecord::Base.connection.default_tablespace
+      @tablespace = ActiveRecord::Base.lease_connection.default_tablespace
     end
 
     before(:each) do
@@ -284,7 +284,7 @@ describe "OracleEnhancedAdapter context index" do
       # stale `@conn` cached in before(:all) would silently log to a
       # disconnected adapter and `verify_logged_statements` would see
       # an empty MockLogger.
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
       set_logger
     end
 
@@ -326,7 +326,7 @@ describe "OracleEnhancedAdapter context index" do
   describe "schema dump" do
     describe "without table prefixe and suffix" do
       before(:all) do
-        @conn = ActiveRecord::Base.connection
+        @conn = ActiveRecord::Base.lease_connection
         create_tables
       end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb
@@ -43,15 +43,15 @@ describe "Oracle Enhanced adapter database tasks" do
 
     it "creates user" do
       query = "SELECT COUNT(*) FROM dba_users WHERE UPPER(username) = '#{new_user_config[:username].upcase}'"
-      expect(ActiveRecord::Base.connection.select_value(query)).to eq(1)
+      expect(ActiveRecord::Base.lease_connection.select_value(query)).to eq(1)
     end
     it "grants permissions defined by OracleEnhancedAdapter.persmissions" do
       query = "SELECT COUNT(*) FROM DBA_SYS_PRIVS WHERE GRANTEE = '#{new_user_config[:username].upcase}'"
       permissions_count = ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.permissions.size
-      expect(ActiveRecord::Base.connection.select_value(query)).to eq(permissions_count)
+      expect(ActiveRecord::Base.lease_connection.select_value(query)).to eq(permissions_count)
     end
     after do
-      ActiveRecord::Base.connection.execute("DROP USER #{new_user_config[:username]}")
+      ActiveRecord::Base.lease_connection.execute("DROP USER #{new_user_config[:username]}")
     end
 
     def fake_terminal(input)
@@ -246,7 +246,7 @@ describe "Oracle Enhanced adapter database tasks" do
       before { ActiveRecord::Tasks::DatabaseTasks.drop(config) }
 
       it "drops all tables" do
-        expect(ActiveRecord::Base.connection.table_exists?(:test_posts)).to be_falsey
+        expect(ActiveRecord::Base.lease_connection.table_exists?(:test_posts)).to be_falsey
       end
     end
 
@@ -254,8 +254,8 @@ describe "Oracle Enhanced adapter database tasks" do
       before { ActiveRecord::Tasks::DatabaseTasks.purge(config) }
 
       it "drops all tables" do
-        expect(ActiveRecord::Base.connection.table_exists?(:test_posts)).to be_falsey
-        expect(ActiveRecord::Base.connection.select_value("SELECT COUNT(*) FROM RECYCLEBIN")).to eq(0)
+        expect(ActiveRecord::Base.lease_connection.table_exists?(:test_posts)).to be_falsey
+        expect(ActiveRecord::Base.lease_connection.select_value("SELECT COUNT(*) FROM RECYCLEBIN")).to eq(0)
       end
     end
 
@@ -263,7 +263,7 @@ describe "Oracle Enhanced adapter database tasks" do
       let(:temp_file) { Tempfile.create(["oracle_enhanced", ".sql"]).path }
       before do
         ActiveRecord::Base.connection_pool.schema_migration.create_table
-        ActiveRecord::Base.connection.execute "INSERT INTO schema_migrations (version) VALUES ('20150101010000')"
+        ActiveRecord::Base.lease_connection.execute "INSERT INTO schema_migrations (version) VALUES ('20150101010000')"
       end
 
       describe "structure_dump" do
@@ -284,7 +284,7 @@ describe "Oracle Enhanced adapter database tasks" do
         end
 
         it "loads the database structure from a file" do
-          expect(ActiveRecord::Base.connection.table_exists?(:test_posts)).to be_truthy
+          expect(ActiveRecord::Base.lease_connection.table_exists?(:test_posts)).to be_truthy
         end
       end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/dbms_output_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/dbms_output_spec.rb
@@ -5,7 +5,7 @@ describe "OracleEnhancedAdapter logging dbms_output from plsql" do
 
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    ActiveRecord::Base.connection.execute <<~SQL
+    ActiveRecord::Base.lease_connection.execute <<~SQL
       CREATE or REPLACE
       FUNCTION MORE_THAN_FIVE_CHARACTERS_LONG (some_text VARCHAR2) RETURN INTEGER
       AS
@@ -26,13 +26,13 @@ describe "OracleEnhancedAdapter logging dbms_output from plsql" do
   end
 
   after(:all) do
-    ActiveRecord::Base.connection.execute "DROP FUNCTION MORE_THAN_FIVE_CHARACTERS_LONG"
+    ActiveRecord::Base.lease_connection.execute "DROP FUNCTION MORE_THAN_FIVE_CHARACTERS_LONG"
   end
 
   before(:each) do
     set_logger
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    @conn = ActiveRecord::Base.connection
+    @conn = ActiveRecord::Base.lease_connection
   end
 
   after(:each) do

--- a/spec/active_record/connection_adapters/oracle_enhanced/identifier_length_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/identifier_length_spec.rb
@@ -35,7 +35,7 @@ describe "OracleEnhancedAdapter identifier length configuration" do
       adapter_class.use_legacy_identifier_length = true
       ActiveRecord::Base.remove_connection
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-      conn = ActiveRecord::Base.connection
+      conn = ActiveRecord::Base.lease_connection
 
       expect(conn.supports_longer_identifier?).to be(false)
       expect(conn.max_identifier_length).to eq(30)
@@ -44,7 +44,7 @@ describe "OracleEnhancedAdapter identifier length configuration" do
     it "honors per-connection use_legacy_identifier_length" do
       ActiveRecord::Base.remove_connection
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(use_legacy_identifier_length: true))
-      conn = ActiveRecord::Base.connection
+      conn = ActiveRecord::Base.lease_connection
 
       expect(conn.supports_longer_identifier?).to be(false)
       expect(conn.max_identifier_length).to eq(30)
@@ -54,7 +54,7 @@ describe "OracleEnhancedAdapter identifier length configuration" do
       adapter_class.use_legacy_identifier_length = false
       ActiveRecord::Base.remove_connection
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(use_legacy_identifier_length: true))
-      conn = ActiveRecord::Base.connection
+      conn = ActiveRecord::Base.lease_connection
 
       expect(conn.supports_longer_identifier?).to be(false)
     end
@@ -63,7 +63,7 @@ describe "OracleEnhancedAdapter identifier length configuration" do
       adapter_class.use_legacy_identifier_length = true
       ActiveRecord::Base.remove_connection
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(use_legacy_identifier_length: false))
-      conn = ActiveRecord::Base.connection
+      conn = ActiveRecord::Base.lease_connection
 
       if Gem::Version.new(conn.database_version.join(".")) >= Gem::Version.new("12.2")
         expect(conn.supports_longer_identifier?).to be(true)
@@ -75,7 +75,7 @@ describe "OracleEnhancedAdapter identifier length configuration" do
     end
 
     it "silently falls back to 30-byte identifiers on a pre-12.2 database" do
-      conn = ActiveRecord::Base.connection
+      conn = ActiveRecord::Base.lease_connection
       allow(conn).to receive(:database_version).and_return([11, 2])
       expect(conn.supports_longer_identifier?).to be(false)
       expect(conn.max_identifier_length).to eq(30)
@@ -85,7 +85,7 @@ describe "OracleEnhancedAdapter identifier length configuration" do
       adapter_class.use_legacy_identifier_length = true
       ActiveRecord::Base.remove_connection
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(use_legacy_identifier_length: nil))
-      conn = ActiveRecord::Base.connection
+      conn = ActiveRecord::Base.lease_connection
 
       expect(conn.supports_longer_identifier?).to be(false)
       expect(conn.max_identifier_length).to eq(30)

--- a/spec/active_record/connection_adapters/oracle_enhanced/identity_primary_key_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/identity_primary_key_spec.rb
@@ -5,7 +5,7 @@ describe "identity primary keys" do
 
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    @conn = ActiveRecord::Base.connection
+    @conn = ActiveRecord::Base.lease_connection
     @oracle12c_or_higher = @conn.database_version.first >= 12
   end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/multiple_databases_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/multiple_databases_spec.rb
@@ -19,12 +19,12 @@ describe "OracleEnhancedAdapter multiple database support" do
       establish_connection REMOTE_CONNECTION_PARAMS
     end
 
-    ActiveRecord::Base.connection.create_table :multi_db_primary_employees, force: true do |t|
+    ActiveRecord::Base.lease_connection.create_table :multi_db_primary_employees, force: true do |t|
       t.string :name, limit: 50
       t.integer :multi_db_remote_employee_id
     end
 
-    MultiDbRemoteBase.connection.create_table :multi_db_remote_employees, force: true do |t|
+    MultiDbRemoteBase.lease_connection.create_table :multi_db_remote_employees, force: true do |t|
       t.string :name, limit: 50
     end
 
@@ -52,14 +52,14 @@ describe "OracleEnhancedAdapter multiple database support" do
   after(:all) do
     if Object.const_defined?(:MultiDbRemoteBase)
       begin
-        MultiDbRemoteBase.connection.drop_table :multi_db_remote_employees, if_exists: true
+        MultiDbRemoteBase.lease_connection.drop_table :multi_db_remote_employees, if_exists: true
       ensure
         MultiDbRemoteBase.remove_connection
       end
     end
   ensure
     begin
-      ActiveRecord::Base.connection.drop_table :multi_db_primary_employees, if_exists: true
+      ActiveRecord::Base.lease_connection.drop_table :multi_db_primary_employees, if_exists: true
     ensure
       %w[MultiDbPrimaryEmployee MultiDbRemoteEmployee MultiDbRemoteEmployee2 MultiDbRemoteBase].each do |name|
         Object.send(:remove_const, name) if Object.const_defined?(name)

--- a/spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb
@@ -8,7 +8,7 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
 
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    @conn = ActiveRecord::Base.connection
+    @conn = ActiveRecord::Base.lease_connection
     plsql.activerecord_class = ActiveRecord::Base
     schema_define do
       create_table :test_employees, force: true do |t|
@@ -90,7 +90,7 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
   end
 
   after(:all) do
-    @conn = ActiveRecord::Base.connection
+    @conn = ActiveRecord::Base.lease_connection
     @conn.drop_table :test_employees, if_exists: true
     @conn.execute "DROP PACKAGE test_employees_pkg"
   end

--- a/spec/active_record/connection_adapters/oracle_enhanced/quoting_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/quoting_spec.rb
@@ -57,7 +57,7 @@ describe "OracleEnhancedAdapter quoting" do
     end
 
     it "should remove double quotes in column quoting" do
-      expect(ActiveRecord::Base.connection.quote_column_name('aaa "bbb" ccc')).to eq('"aaa bbb ccc"')
+      expect(ActiveRecord::Base.lease_connection.quote_column_name('aaa "bbb" ccc')).to eq('"aaa bbb ccc"')
     end
   end
 
@@ -190,7 +190,7 @@ describe "OracleEnhancedAdapter quoting" do
     end
 
     before(:all) do
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
     end
 
     after(:each) do

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -6,7 +6,7 @@ describe "OracleEnhancedAdapter schema dump" do
 
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    @conn = ActiveRecord::Base.connection
+    @conn = ActiveRecord::Base.lease_connection
     @oracle11g_or_higher = !! @conn.select_value(
       "select * from product_component_version where product like 'Oracle%' and to_number(substr(version,1,2)) >= 11")
   end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_isolation_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_isolation_spec.rb
@@ -21,11 +21,11 @@ describe "Oracle schema isolation between primary and remote connections" do
       establish_connection REMOTE_CONNECTION_PARAMS
     end
 
-    ActiveRecord::Base.connection.create_table :schema_isolation_primary, force: true do |t|
+    ActiveRecord::Base.lease_connection.create_table :schema_isolation_primary, force: true do |t|
       t.string :name, limit: 50
     end
 
-    SchemaIsolationRemoteBase.connection.create_table :schema_isolation_remote, force: true do |t|
+    SchemaIsolationRemoteBase.lease_connection.create_table :schema_isolation_remote, force: true do |t|
       t.string :name, limit: 50
     end
   end
@@ -33,7 +33,7 @@ describe "Oracle schema isolation between primary and remote connections" do
   after(:all) do
     if Object.const_defined?(:SchemaIsolationRemoteBase)
       begin
-        SchemaIsolationRemoteBase.connection.drop_table :schema_isolation_remote, if_exists: true
+        SchemaIsolationRemoteBase.lease_connection.drop_table :schema_isolation_remote, if_exists: true
       ensure
         begin
           SchemaIsolationRemoteBase.remove_connection
@@ -44,7 +44,7 @@ describe "Oracle schema isolation between primary and remote connections" do
     end
   ensure
     begin
-      ActiveRecord::Base.connection.drop_table :schema_isolation_primary, if_exists: true
+      ActiveRecord::Base.lease_connection.drop_table :schema_isolation_primary, if_exists: true
     ensure
       ActiveRecord::Base.clear_cache!
     end
@@ -55,13 +55,13 @@ describe "Oracle schema isolation between primary and remote connections" do
   # intentionally not distinguishing between the two.
   it "primary schema cannot directly access a table owned by the remote schema" do
     expect {
-      ActiveRecord::Base.connection.execute("SELECT * FROM #{DATABASE_REMOTE_USER}.schema_isolation_remote")
+      ActiveRecord::Base.lease_connection.execute("SELECT * FROM #{DATABASE_REMOTE_USER}.schema_isolation_remote")
     }.to raise_error(ActiveRecord::StatementInvalid, /ORA-00942/)
   end
 
   it "remote schema cannot directly access a table owned by the primary schema" do
     expect {
-      SchemaIsolationRemoteBase.connection.execute("SELECT * FROM #{DATABASE_USER}.schema_isolation_primary")
+      SchemaIsolationRemoteBase.lease_connection.execute("SELECT * FROM #{DATABASE_USER}.schema_isolation_primary")
     }.to raise_error(ActiveRecord::StatementInvalid, /ORA-00942/)
   end
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -6,15 +6,15 @@ describe "OracleEnhancedAdapter schema definition" do
 
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    @oracle11g_or_higher = !! !! ActiveRecord::Base.connection.select_value(
+    @oracle11g_or_higher = !! !! ActiveRecord::Base.lease_connection.select_value(
       "select * from product_component_version where product like 'Oracle%' and to_number(substr(version,1,2)) >= 11")
-    @oracle12cr2_or_higher = !! !! ActiveRecord::Base.connection.select_value(
+    @oracle12cr2_or_higher = !! !! ActiveRecord::Base.lease_connection.select_value(
       "select * from product_component_version where product like 'Oracle%' and to_number(substr(version,1,4)) >= 12.2")
   end
 
   describe "option to create sequence when adding a column" do
     before do
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
       schema_define do
         create_table :keyboards, force: true, id: false do |t|
           t.string      :name
@@ -25,7 +25,7 @@ describe "OracleEnhancedAdapter schema definition" do
     end
 
     it "creates a sequence when adding a column with create_sequence = true" do
-      _, sequence_name = ActiveRecord::Base.connection.pk_and_sequence_for(:keyboards)
+      _, sequence_name = ActiveRecord::Base.lease_connection.pk_and_sequence_for(:keyboards)
 
       expect(sequence_name).to eq(Keyboard.sequence_name)
     end
@@ -33,7 +33,7 @@ describe "OracleEnhancedAdapter schema definition" do
 
   describe "table and sequence creation with non-default primary key" do
     before(:all) do
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
       schema_define do
         create_table :keyboards, force: true, id: false do |t|
           t.primary_key :key_number
@@ -61,17 +61,17 @@ describe "OracleEnhancedAdapter schema definition" do
     end
 
     it "should create sequence for non-default primary key" do
-      expect(ActiveRecord::Base.connection.next_sequence_value(Keyboard.sequence_name)).not_to be_nil
+      expect(ActiveRecord::Base.lease_connection.next_sequence_value(Keyboard.sequence_name)).not_to be_nil
     end
 
     it "should create sequence for default primary key" do
-      expect(ActiveRecord::Base.connection.next_sequence_value(IdKeyboard.sequence_name)).not_to be_nil
+      expect(ActiveRecord::Base.lease_connection.next_sequence_value(IdKeyboard.sequence_name)).not_to be_nil
     end
   end
 
   describe "primary_key inside create_table block with type and keyword options" do
     before(:all) do
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
     end
 
     after(:each) do
@@ -130,13 +130,13 @@ describe "OracleEnhancedAdapter schema definition" do
 
   describe "default sequence name" do
     it "should return sequence name without truncating too much" do
-      seq_name_length = ActiveRecord::Base.connection.sequence_name_length
+      seq_name_length = ActiveRecord::Base.lease_connection.sequence_name_length
       tname = "#{DATABASE_USER}" + "." + "a" * (seq_name_length - DATABASE_USER.length) + "z" * (DATABASE_USER).length
-      expect(ActiveRecord::Base.connection.default_sequence_name(tname, nil)).to match (/z_seq$/)
+      expect(ActiveRecord::Base.lease_connection.default_sequence_name(tname, nil)).to match (/z_seq$/)
     end
 
     it "truncates the trailing identifier by bytes for multibyte names" do
-      conn = ActiveRecord::Base.connection
+      conn = ActiveRecord::Base.lease_connection
       max = conn.sequence_name_length
       # "é" is 2 bytes in UTF-8. Build a name that exceeds the byte budget.
       name = "é" * max # 2 * max bytes, definitely over
@@ -146,7 +146,7 @@ describe "OracleEnhancedAdapter schema definition" do
     end
 
     it "preserves a schema prefix when truncating multibyte names" do
-      conn = ActiveRecord::Base.connection
+      conn = ActiveRecord::Base.lease_connection
       max = conn.sequence_name_length
       name = "schema." + ("é" * max)
       seq = conn.default_sequence_name(name, nil)
@@ -157,7 +157,7 @@ describe "OracleEnhancedAdapter schema definition" do
     end
 
     it "backs off a byte when the naive byte slice would land mid-character" do
-      conn = ActiveRecord::Base.connection
+      conn = ActiveRecord::Base.lease_connection
       # Craft a name whose `max - 4` byte boundary lands in the middle of
       # a 2-byte character.
       max = conn.sequence_name_length
@@ -190,7 +190,7 @@ describe "OracleEnhancedAdapter schema definition" do
     end
 
     before(:all) do
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
     end
 
     before(:each) do
@@ -256,7 +256,7 @@ describe "OracleEnhancedAdapter schema definition" do
     end
 
     before(:all) do
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
     end
 
     before(:each) do
@@ -333,7 +333,7 @@ describe "OracleEnhancedAdapter schema definition" do
 
   describe "drop tables" do
     before(:each) do
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
     end
 
     after(:each) do
@@ -366,7 +366,7 @@ describe "OracleEnhancedAdapter schema definition" do
 
   describe "rename tables and sequences" do
     before(:each) do
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
       schema_define do
         create_table  :test_employees, force: true do |t|
           t.string    :first_name
@@ -450,7 +450,7 @@ describe "OracleEnhancedAdapter schema definition" do
 
   describe "add index" do
     before(:all) do
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
     end
 
     it "should return default index name if it is not larger than 30 characters" do
@@ -502,7 +502,7 @@ describe "OracleEnhancedAdapter schema definition" do
 
   describe "rename index" do
   before(:each) do
-    @conn = ActiveRecord::Base.connection
+    @conn = ActiveRecord::Base.lease_connection
     schema_define do
       create_table  :test_employees do |t|
         t.string    :first_name
@@ -553,7 +553,7 @@ end
 
   describe "add_index with if_not_exists" do
     before(:each) do
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
       schema_define do
         create_table :test_posts, force: true do |t|
           t.string :title
@@ -583,7 +583,7 @@ end
 
   describe "add timestamps" do
     before(:each) do
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
       schema_define do
         create_table :test_employees, force: true
       end
@@ -761,7 +761,7 @@ end
       schema_define do
         add_foreign_key :test_comments, :test_posts
       end
-      ActiveRecord::Base.connection.foreign_keys(:test_comments)
+      ActiveRecord::Base.lease_connection.foreign_keys(:test_comments)
       expect(@logger.logged(:debug).last).to match(/:desc_table_name/)
       expect(@logger.logged(:debug).last).to match(/\["desc_table_name", "TEST_COMMENTS"\]\]/)
     end
@@ -770,7 +770,7 @@ end
       schema_define do
         add_foreign_key :test_comments, :test_posts, deferrable: :deferred
       end
-      fk = ActiveRecord::Base.connection.foreign_keys(:test_comments).first
+      fk = ActiveRecord::Base.lease_connection.foreign_keys(:test_comments).first
       expect(fk.options[:deferrable]).to eq(:deferred)
     end
 
@@ -778,7 +778,7 @@ end
       schema_define do
         add_foreign_key :test_comments, :test_posts, deferrable: :immediate
       end
-      fk = ActiveRecord::Base.connection.foreign_keys(:test_comments).first
+      fk = ActiveRecord::Base.lease_connection.foreign_keys(:test_comments).first
       expect(fk.options[:deferrable]).to eq(:immediate)
     end
 
@@ -786,7 +786,7 @@ end
       schema_define do
         add_foreign_key :test_comments, :test_posts
       end
-      fk = ActiveRecord::Base.connection.foreign_keys(:test_comments).first
+      fk = ActiveRecord::Base.lease_connection.foreign_keys(:test_comments).first
       expect(fk.options[:deferrable]).to be(false)
     end
 
@@ -816,9 +816,9 @@ end
           t.binary :test_blob
         end
       end
-      expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_CLOB'")).to eq(DATABASE_NON_DEFAULT_TABLESPACE)
-      expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_NCLOB'")).not_to eq(DATABASE_NON_DEFAULT_TABLESPACE)
-      expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_BLOB'")).not_to eq(DATABASE_NON_DEFAULT_TABLESPACE)
+      expect(TestPost.lease_connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_CLOB'")).to eq(DATABASE_NON_DEFAULT_TABLESPACE)
+      expect(TestPost.lease_connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_NCLOB'")).not_to eq(DATABASE_NON_DEFAULT_TABLESPACE)
+      expect(TestPost.lease_connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_BLOB'")).not_to eq(DATABASE_NON_DEFAULT_TABLESPACE)
     end
 
     it "should use default tablespace for nclobs" do
@@ -832,9 +832,9 @@ end
           t.binary :test_blob
         end
       end
-      expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_NCLOB'")).to eq(DATABASE_NON_DEFAULT_TABLESPACE)
-      expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_CLOB'")).not_to eq(DATABASE_NON_DEFAULT_TABLESPACE)
-      expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_BLOB'")).not_to eq(DATABASE_NON_DEFAULT_TABLESPACE)
+      expect(TestPost.lease_connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_NCLOB'")).to eq(DATABASE_NON_DEFAULT_TABLESPACE)
+      expect(TestPost.lease_connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_CLOB'")).not_to eq(DATABASE_NON_DEFAULT_TABLESPACE)
+      expect(TestPost.lease_connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_BLOB'")).not_to eq(DATABASE_NON_DEFAULT_TABLESPACE)
     end
 
     it "should use default tablespace for blobs" do
@@ -848,9 +848,9 @@ end
           t.binary :test_blob
         end
       end
-      expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_BLOB'")).to eq(DATABASE_NON_DEFAULT_TABLESPACE)
-      expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_CLOB'")).not_to eq(DATABASE_NON_DEFAULT_TABLESPACE)
-      expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_NCLOB'")).not_to eq(DATABASE_NON_DEFAULT_TABLESPACE)
+      expect(TestPost.lease_connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_BLOB'")).to eq(DATABASE_NON_DEFAULT_TABLESPACE)
+      expect(TestPost.lease_connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_CLOB'")).not_to eq(DATABASE_NON_DEFAULT_TABLESPACE)
+      expect(TestPost.lease_connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'TEST_NCLOB'")).not_to eq(DATABASE_NON_DEFAULT_TABLESPACE)
     end
 
     after do
@@ -863,7 +863,7 @@ end
 
   describe "primary key in table definition" do
     before do
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
 
       class ::TestPost < ActiveRecord::Base
       end
@@ -881,7 +881,7 @@ end
             AND constraint_type = 'P'
             AND owner = SYS_CONTEXT('userenv', 'current_schema')")
 
-      expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_indexes WHERE index_name = '#{index_name}'")).to eq("USERS")
+      expect(TestPost.lease_connection.select_value("SELECT tablespace_name FROM user_indexes WHERE index_name = '#{index_name}'")).to eq("USERS")
     end
 
     it "should use non default tablespace for primary key" do
@@ -896,7 +896,7 @@ end
             AND constraint_type = 'P'
             AND owner = SYS_CONTEXT('userenv', 'current_schema')")
 
-      expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_indexes WHERE index_name = '#{index_name}'")).to eq(DATABASE_NON_DEFAULT_TABLESPACE)
+      expect(TestPost.lease_connection.select_value("SELECT tablespace_name FROM user_indexes WHERE index_name = '#{index_name}'")).to eq(DATABASE_NON_DEFAULT_TABLESPACE)
     end
 
     after do
@@ -990,7 +990,7 @@ end
 
   describe "disable referential integrity" do
     before(:all) do
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
     end
 
     before(:each) do
@@ -1036,7 +1036,7 @@ end
 
   describe "synonyms" do
     before(:all) do
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
       @username = CONNECTION_PARAMS[:username]
       schema_define do
         create_table :test_posts, force: true do |t|
@@ -1140,7 +1140,7 @@ end
       schema_define do
         add_column :test_posts, :body, :text
       end
-      expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'BODY'")).to eq(DATABASE_NON_DEFAULT_TABLESPACE)
+      expect(TestPost.lease_connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'BODY'")).to eq(DATABASE_NON_DEFAULT_TABLESPACE)
     end
 
     it "should add ntext type lob column with non_default tablespace" do
@@ -1148,7 +1148,7 @@ end
       schema_define do
         add_column :test_posts, :body, :ntext
       end
-      expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'BODY'")).to eq(DATABASE_NON_DEFAULT_TABLESPACE)
+      expect(TestPost.lease_connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'BODY'")).to eq(DATABASE_NON_DEFAULT_TABLESPACE)
     end
 
     it "should add blob column with non_default tablespace" do
@@ -1156,7 +1156,7 @@ end
       schema_define do
         add_column :test_posts, :attachment, :binary
       end
-      expect(TestPost.connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'ATTACHMENT'")).to eq(DATABASE_NON_DEFAULT_TABLESPACE)
+      expect(TestPost.lease_connection.select_value("SELECT tablespace_name FROM user_lobs WHERE table_name='TEST_POSTS' and column_name = 'ATTACHMENT'")).to eq(DATABASE_NON_DEFAULT_TABLESPACE)
     end
 
     it "should rename column" do
@@ -1342,7 +1342,7 @@ end
 
   describe "materialized views" do
     before(:all) do
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
       schema_define do
         create_table  :test_employees, force: true do |t|
           t.string    :first_name
@@ -1372,7 +1372,7 @@ end
 
   describe "miscellaneous options" do
     before(:all) do
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
     end
 
     before(:each) do
@@ -1487,13 +1487,13 @@ end
     }
 
     before do
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
       ActiveRecord::Base.connection_pool.schema_migration.create_table
     end
 
     context "multi insert is supported" do
       it "should loads the migration schema table from insert versions sql" do
-        skip "Not supported in this database version" unless ActiveRecord::Base.connection.supports_multi_insert?
+        skip "Not supported in this database version" unless ActiveRecord::Base.lease_connection.supports_multi_insert?
 
         expect {
           @conn.execute @conn.send(:insert_versions_sql, versions)
@@ -1505,7 +1505,7 @@ end
 
     context "multi insert is NOT supported" do
       it "should loads the migration schema table from insert versions sql" do
-        skip "Not supported in this database version" if ActiveRecord::Base.connection.supports_multi_insert?
+        skip "Not supported in this database version" if ActiveRecord::Base.lease_connection.supports_multi_insert?
 
         expect {
           versions.each { |version| @conn.execute @conn.send(:insert_versions_sql, version) }

--- a/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
@@ -5,7 +5,7 @@ describe "OracleEnhancedAdapter structure dump" do
 
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    @conn = ActiveRecord::Base.connection
+    @conn = ActiveRecord::Base.lease_connection
     @oracle11g_or_higher = !! @conn.select_value(
       "select * from product_component_version where product like 'Oracle%' and to_number(substr(version,1,2)) >= 11")
   end
@@ -45,7 +45,7 @@ describe "OracleEnhancedAdapter structure dump" do
     end
 
     it "should dump single primary key" do
-      dump = ActiveRecord::Base.connection.structure_dump
+      dump = ActiveRecord::Base.lease_connection.structure_dump
       expect(dump).to match(/CONSTRAINT (.+) PRIMARY KEY \(ID\)\n/)
     end
 
@@ -60,7 +60,7 @@ describe "OracleEnhancedAdapter structure dump" do
         ALTER TABLE TEST_POSTS
         add CONSTRAINT pk_id_title PRIMARY KEY (id, title)
       SQL
-      dump = ActiveRecord::Base.connection.structure_dump
+      dump = ActiveRecord::Base.lease_connection.structure_dump
       expect(dump).to match(/CONSTRAINT (.+) PRIMARY KEY \(ID,TITLE\)\n/)
     end
 
@@ -69,7 +69,7 @@ describe "OracleEnhancedAdapter structure dump" do
         ALTER TABLE TEST_POSTS
         ADD CONSTRAINT fk_test_post_foo FOREIGN KEY (foo_id) REFERENCES foos(id)
       SQL
-      dump = ActiveRecord::Base.connection.structure_dump
+      dump = ActiveRecord::Base.lease_connection.structure_dump
       expect(dump.split('\n').length).to eq(1)
       expect(dump).to match(/ALTER TABLE "?TEST_POSTS"? ADD CONSTRAINT "?FK_TEST_POST_FOO"? FOREIGN KEY \("?FOO_ID"?\) REFERENCES "?FOOS"?\("?ID"?\)/i)
     end
@@ -89,13 +89,13 @@ describe "OracleEnhancedAdapter structure dump" do
         ADD CONSTRAINT fk_test_post_baz FOREIGN KEY (baz_id) REFERENCES foos(baz_id)
       SQL
 
-      dump = ActiveRecord::Base.connection.structure_dump
+      dump = ActiveRecord::Base.lease_connection.structure_dump
       expect(dump.split('\n').length).to eq(1)
       expect(dump).to match(/ALTER TABLE "?TEST_POSTS"? ADD CONSTRAINT "?FK_TEST_POST_BAZ"? FOREIGN KEY \("?BAZ_ID"?\) REFERENCES "?FOOS"?\("?BAZ_ID"?\)/i)
     end
 
     it "should not error when no foreign keys are present" do
-      dump = ActiveRecord::Base.connection.structure_dump_fk_constraints
+      dump = ActiveRecord::Base.lease_connection.structure_dump_fk_constraints
       expect(dump.split('\n').length).to eq(0)
       expect(dump).to eq("")
     end
@@ -110,7 +110,7 @@ describe "OracleEnhancedAdapter structure dump" do
           SELECT 'bar' INTO :new.FOO FROM DUAL;
         END;
       SQL
-      dump = ActiveRecord::Base.connection.structure_dump_db_stored_code.gsub(/\n|\s+/, " ")
+      dump = ActiveRecord::Base.lease_connection.structure_dump_db_stored_code.gsub(/\n|\s+/, " ")
       expect(dump).to match(/CREATE OR REPLACE TRIGGER TEST_POST_TRIGGER/)
     end
 
@@ -118,14 +118,14 @@ describe "OracleEnhancedAdapter structure dump" do
       @conn.execute <<~SQL
         create or replace TYPE TEST_TYPE AS TABLE OF VARCHAR2(10);
       SQL
-      dump = ActiveRecord::Base.connection.structure_dump_db_stored_code.gsub(/\n|\s+/, " ")
+      dump = ActiveRecord::Base.lease_connection.structure_dump_db_stored_code.gsub(/\n|\s+/, " ")
       expect(dump).to match(/CREATE OR REPLACE TYPE TEST_TYPE/)
     end
 
     it "should dump views" do
       @conn.execute "create or replace VIEW test_posts_view_z as select * from test_posts"
       @conn.execute "create or replace VIEW test_posts_view_a as select * from test_posts_view_z"
-      dump = ActiveRecord::Base.connection.structure_dump.gsub(/\n|\s+/, " ")
+      dump = ActiveRecord::Base.lease_connection.structure_dump.gsub(/\n|\s+/, " ")
       expect(dump).to match(/CREATE OR REPLACE FORCE VIEW TEST_POSTS_VIEW_A.*CREATE OR REPLACE FORCE VIEW TEST_POSTS_VIEW_Z/)
     end
 
@@ -138,7 +138,7 @@ describe "OracleEnhancedAdapter structure dump" do
           PRIMARY KEY (ID)
         )
       SQL
-      dump = ActiveRecord::Base.connection.structure_dump
+      dump = ActiveRecord::Base.lease_connection.structure_dump
       expect(dump).to match(/"?ID_PLUS"? NUMBER GENERATED ALWAYS AS \(ID\+2\) VIRTUAL/)
     end
 
@@ -151,7 +151,7 @@ describe "OracleEnhancedAdapter structure dump" do
           PRIMARY KEY (ID)
         )
       SQL
-      dump = ActiveRecord::Base.connection.structure_dump
+      dump = ActiveRecord::Base.lease_connection.structure_dump
       expect(dump).to match(/CREATE TABLE "BARS" \(\n "ID" NUMBER\(38,0\) NOT NULL,\n "SUPER" RAW\(255\) GENERATED ALWAYS AS \(HEXTORAW\(TO_CHAR\(ID\)\)\) VIRTUAL/)
     end
 
@@ -163,7 +163,7 @@ describe "OracleEnhancedAdapter structure dump" do
           PRIMARY KEY (ID)
         )
       SQL
-      dump = ActiveRecord::Base.connection.structure_dump
+      dump = ActiveRecord::Base.lease_connection.structure_dump
       expect(dump).to match(/CREATE TABLE "BARS" \(\n "ID" NUMBER\(38,0\) NOT NULL,\n "NCLOB_TEXT" NCLOB/)
     end
 
@@ -172,36 +172,36 @@ describe "OracleEnhancedAdapter structure dump" do
         ALTER TABLE test_posts
           add CONSTRAINT uk_foo_foo_id UNIQUE (foo, foo_id)
       SQL
-      dump = ActiveRecord::Base.connection.structure_dump_unique_keys("test_posts")
+      dump = ActiveRecord::Base.lease_connection.structure_dump_unique_keys("test_posts")
       expect(dump).to eq(["ALTER TABLE TEST_POSTS ADD CONSTRAINT UK_FOO_FOO_ID UNIQUE (FOO,FOO_ID)"])
 
-      dump = ActiveRecord::Base.connection.structure_dump
+      dump = ActiveRecord::Base.lease_connection.structure_dump
       expect(dump).to match(/CONSTRAINT UK_FOO_FOO_ID UNIQUE \(FOO,FOO_ID\)/)
     end
 
     it "should dump indexes" do
-      ActiveRecord::Base.connection.add_index(:test_posts, :foo, name: :ix_test_posts_foo)
-      ActiveRecord::Base.connection.add_index(:test_posts, :foo_id, name: :ix_test_posts_foo_id, unique: true)
+      ActiveRecord::Base.lease_connection.add_index(:test_posts, :foo, name: :ix_test_posts_foo)
+      ActiveRecord::Base.lease_connection.add_index(:test_posts, :foo_id, name: :ix_test_posts_foo_id, unique: true)
 
       @conn.execute <<~SQL
         ALTER TABLE test_posts
           add CONSTRAINT uk_foo_foo_id UNIQUE (foo, foo_id)
       SQL
 
-      dump = ActiveRecord::Base.connection.structure_dump
+      dump = ActiveRecord::Base.lease_connection.structure_dump
       expect(dump).to match(/CREATE UNIQUE INDEX "?IX_TEST_POSTS_FOO_ID"? ON "?TEST_POSTS"? \("?FOO_ID"?\)/i)
       expect(dump).to match(/CREATE  INDEX "?IX_TEST_POSTS_FOO"? ON "?TEST_POSTS"? \("?FOO"?\)/i)
       expect(dump).not_to match(/CREATE UNIQUE INDEX "?UK_TEST_POSTS_/i)
     end
 
     it "should dump multi-value and function value indexes" do
-      ActiveRecord::Base.connection.add_index(:test_posts, [:foo, :foo_id], name: :ix_test_posts_foo_foo_id)
+      ActiveRecord::Base.lease_connection.add_index(:test_posts, [:foo, :foo_id], name: :ix_test_posts_foo_foo_id)
 
       @conn.execute <<~SQL
         CREATE INDEX "IX_TEST_POSTS_FUNCTION" ON "TEST_POSTS" (TO_CHAR(LENGTH("FOO"))||"FOO")
       SQL
 
-      dump = ActiveRecord::Base.connection.structure_dump
+      dump = ActiveRecord::Base.lease_connection.structure_dump
       expect(dump).to match(/CREATE  INDEX "?IX_TEST_POSTS_FOO_FOO_ID"? ON "?TEST_POSTS"? \("?FOO"?, "?FOO_ID"?\)/i)
       expect(dump).to match(/CREATE  INDEX "?IX_TEST_POSTS_FUNCTION"? ON "?TEST_POSTS"? \(TO_CHAR\(LENGTH\("?FOO"?\)\)\|\|"?FOO"?\)/i)
     end
@@ -214,7 +214,7 @@ describe "OracleEnhancedAdapter structure dump" do
           PRIMARY KEY (ID)
         )
       SQL
-      dump = ActiveRecord::Base.connection.structure_dump
+      dump = ActiveRecord::Base.lease_connection.structure_dump
       expect(dump).to match(/CREATE TABLE "BARS" \(\n "ID" NUMBER\(38,0\) NOT NULL,\n "SUPER" RAW\(255\)/)
     end
 
@@ -222,24 +222,24 @@ describe "OracleEnhancedAdapter structure dump" do
       @conn.execute <<~SQL
         ALTER TABLE test_posts ADD CONSTRAINT test_posts_title_check CHECK (LENGTH(title) > 0)
       SQL
-      dump = ActiveRecord::Base.connection.structure_dump_check_constraints("test_posts")
+      dump = ActiveRecord::Base.lease_connection.structure_dump_check_constraints("test_posts")
       expect(dump.first).to match(/ALTER TABLE "TEST_POSTS" ADD CONSTRAINT "TEST_POSTS_TITLE_CHECK" CHECK/)
 
-      dump = ActiveRecord::Base.connection.structure_dump
+      dump = ActiveRecord::Base.lease_connection.structure_dump
       expect(dump).to match(/ALTER TABLE "TEST_POSTS" ADD CONSTRAINT "TEST_POSTS_TITLE_CHECK" CHECK/)
     end
 
     it "should dump table comments" do
       comment_sql = %Q(COMMENT ON TABLE "TEST_POSTS" IS 'Test posts with ''some'' "quotes"')
       @conn.execute comment_sql
-      dump = ActiveRecord::Base.connection.structure_dump
+      dump = ActiveRecord::Base.lease_connection.structure_dump
       expect(dump).to match(/#{comment_sql}/)
     end
 
     it "should dump column comments" do
       comment_sql = %Q(COMMENT ON COLUMN "TEST_POSTS"."TITLE" IS 'The title of the post with ''some'' "quotes"')
       @conn.execute comment_sql
-      dump = ActiveRecord::Base.connection.structure_dump
+      dump = ActiveRecord::Base.lease_connection.structure_dump
       expect(dump).to match(/#{comment_sql}/)
     end
   end
@@ -253,7 +253,7 @@ describe "OracleEnhancedAdapter structure dump" do
       @conn.create_table :test_comments, temporary: true, id: false do |t|
         t.integer :post_id
       end
-      dump = ActiveRecord::Base.connection.structure_dump
+      dump = ActiveRecord::Base.lease_connection.structure_dump
       expect(dump).to match(/CREATE GLOBAL TEMPORARY TABLE "?TEST_COMMENTS"?/i)
     end
   end
@@ -272,7 +272,7 @@ describe "OracleEnhancedAdapter structure dump" do
     # sequence so assertions are not affected by other sequences left in
     # the schema by sibling specs (e.g. POSTS_SEQ from create_table :posts).
     subject do
-      ActiveRecord::Base.connection.structure_dump
+      ActiveRecord::Base.lease_connection.structure_dump
         .split(/^\/$/)
         .find { |stmt| stmt.include?(%(CREATE SEQUENCE "#{sequence_name.upcase}")) } || ""
     end
@@ -349,7 +349,7 @@ describe "OracleEnhancedAdapter structure dump" do
       end
     end
 
-    let(:dump) { ActiveRecord::Base.connection.dump_schema_versions }
+    let(:dump) { ActiveRecord::Base.lease_connection.dump_schema_versions }
 
     before do
       ActiveRecord::Base.connection_pool.schema_migration.create_table
@@ -360,7 +360,7 @@ describe "OracleEnhancedAdapter structure dump" do
 
     context "multi insert is supported" do
       it "should dump schema migrations using multi inserts" do
-        skip "Not supported in this database version" unless ActiveRecord::Base.connection.supports_multi_insert?
+        skip "Not supported in this database version" unless ActiveRecord::Base.lease_connection.supports_multi_insert?
 
         expect(dump).to eq <<~SQL
           INSERT ALL
@@ -387,7 +387,7 @@ describe "OracleEnhancedAdapter structure dump" do
       }
 
       it "should dump schema migrations one version per insert" do
-        skip "Not supported in this database version" if ActiveRecord::Base.connection.supports_multi_insert?
+        skip "Not supported in this database version" if ActiveRecord::Base.lease_connection.supports_multi_insert?
 
         expect(dump).to eq insert_statement_per_migration
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -10,12 +10,12 @@ describe "OracleEnhancedAdapter" do
 
   describe "cache table columns" do
     before(:all) do
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
       schema_define do
         create_table :test_employees, force: true do |t|
           t.string  :first_name, limit: 20
           t.string  :last_name, limit: 25
-          if ActiveRecord::Base.connection.supports_virtual_columns?
+          if ActiveRecord::Base.lease_connection.supports_virtual_columns?
             t.virtual :full_name, as: "(first_name || ' ' || last_name)"
           else
             t.string  :full_name, limit: 46
@@ -41,7 +41,7 @@ describe "OracleEnhancedAdapter" do
     end
 
     after(:all) do
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
       Object.send(:remove_const, "TestEmployee")
       Object.send(:remove_const, "TestEmployee2")
       @conn.drop_table :test_employees, if_exists: true
@@ -51,7 +51,7 @@ describe "OracleEnhancedAdapter" do
 
     before(:each) do
       set_logger
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
     end
 
     after(:each) do
@@ -61,32 +61,32 @@ describe "OracleEnhancedAdapter" do
     describe "without column caching" do
       it "should identify virtual columns as such" do
         skip "Not supported in this database version" unless @conn.supports_virtual_columns?
-        te = TestEmployee.connection.columns("test_employees").detect(&:virtual?)
+        te = TestEmployee.lease_connection.columns("test_employees").detect(&:virtual?)
         expect(te.name).to eq("full_name")
       end
 
       it "should get columns from database at first time" do
         @conn.clear_table_columns_cache(:test_employees)
-        expect(TestEmployee.connection.columns("test_employees").map(&:name)).to eq(@column_names)
+        expect(TestEmployee.lease_connection.columns("test_employees").map(&:name)).to eq(@column_names)
         expect(@logger.logged(:debug).last).to match(/select .* from all_tab_cols/im)
       end
 
       it "should not get columns from database at second time" do
-        TestEmployee.connection.columns("test_employees")
+        TestEmployee.lease_connection.columns("test_employees")
         @logger.clear(:debug)
-        expect(TestEmployee.connection.columns("test_employees").map(&:name)).to eq(@column_names)
+        expect(TestEmployee.lease_connection.columns("test_employees").map(&:name)).to eq(@column_names)
         expect(@logger.logged(:debug).last).not_to match(/select .* from all_tab_cols/im)
       end
 
       it "should get primary key from database at first time" do
-        expect(TestEmployee.connection.pk_and_sequence_for("test_employees")).to eq(["id", "test_employees_seq"])
+        expect(TestEmployee.lease_connection.pk_and_sequence_for("test_employees")).to eq(["id", "test_employees_seq"])
         expect(@logger.logged(:debug).last).to match(/select .* from all_constraints/im)
       end
 
       it "should get primary key from database at second time without query" do
-        expect(TestEmployee.connection.pk_and_sequence_for("test_employees")).to eq(["id", "test_employees_seq"])
+        expect(TestEmployee.lease_connection.pk_and_sequence_for("test_employees")).to eq(["id", "test_employees_seq"])
         @logger.clear(:debug)
-        expect(TestEmployee.connection.pk_and_sequence_for("test_employees")).to eq(["id", "test_employees_seq"])
+        expect(TestEmployee.lease_connection.pk_and_sequence_for("test_employees")).to eq(["id", "test_employees_seq"])
         expect(@logger.logged(:debug).last).to match(/select .* from all_constraints/im)
       end
 
@@ -109,7 +109,7 @@ describe "OracleEnhancedAdapter" do
 
   describe "session information" do
     before(:all) do
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
     end
 
     it "should get current database name" do
@@ -127,7 +127,7 @@ describe "OracleEnhancedAdapter" do
     before(:all) do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[:table] = "UNUSED"
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_tablespaces[:clob] = "UNUSED"
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
     end
 
     after(:all) do
@@ -277,7 +277,7 @@ describe "OracleEnhancedAdapter" do
   describe "with statement pool" do
     before(:all) do
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(statement_limit: 3))
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
       schema_define do
         drop_table :test_posts, if_exists: true
         create_table :test_posts
@@ -334,7 +334,7 @@ describe "OracleEnhancedAdapter" do
 
   describe "explain" do
     before(:all) do
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
       schema_define do
         drop_table :test_posts, if_exists: true
         create_table :test_posts
@@ -367,7 +367,7 @@ describe "OracleEnhancedAdapter" do
 
   describe "using offset and limit" do
     before(:all) do
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
       schema_define do
         create_table :test_employees, force: true do |t|
           t.integer   :sort_order
@@ -412,7 +412,7 @@ describe "OracleEnhancedAdapter" do
 
   describe "valid_type?" do
     before(:all) do
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
       schema_define do
         create_table :test_employees, force: true do |t|
           t.string :first_name, limit: 20
@@ -565,7 +565,7 @@ describe "OracleEnhancedAdapter" do
     end
 
     it "includes synonyms in data_source" do
-      conn = ActiveRecord::Base.connection
+      conn = ActiveRecord::Base.lease_connection
       expect(conn).to be_data_source_exist("synonym_comments")
       expect(conn.data_sources).to include("synonym_comments")
     end
@@ -574,7 +574,7 @@ describe "OracleEnhancedAdapter" do
   describe "dictionary selects with bind variables" do
     before(:all) do
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
       schema_define do
         drop_table :test_posts, if_exists: true
         create_table :test_posts
@@ -674,7 +674,7 @@ describe "OracleEnhancedAdapter" do
     end
 
     it "Raises Deadlocked when a deadlock is encountered" do
-      skip "Skip temporary due to #1599" if ActiveRecord::Base.connection.supports_fetch_first_n_rows_and_offset?
+      skip "Skip temporary due to #1599" if ActiveRecord::Base.lease_connection.supports_fetch_first_n_rows_and_offset?
       expect {
         barrier = Concurrent::CyclicBarrier.new(2)
 
@@ -714,7 +714,7 @@ describe "OracleEnhancedAdapter" do
   describe "Sequence" do
     before(:all) do
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
       schema_define do
         create_table :table_with_name_thats_just_ok,
           sequence_name: "suitably_short_seq", force: true do |t|
@@ -738,7 +738,7 @@ describe "OracleEnhancedAdapter" do
   describe "Hints" do
     before(:all) do
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
       schema_define do
         drop_table :test_posts, if_exists: true
         create_table :test_posts
@@ -780,7 +780,7 @@ describe "OracleEnhancedAdapter" do
   describe "homogeneous in" do
     before(:all) do
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-      @conn = ActiveRecord::Base.connection
+      @conn = ActiveRecord::Base.lease_connection
       schema_define do
         create_table :test_posts, force: true
         create_table :test_comments, force: true do |t|

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -3,7 +3,7 @@
 describe "OracleEnhancedAdapter date and datetime type detection based on attribute settings" do
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    @conn = ActiveRecord::Base.connection
+    @conn = ActiveRecord::Base.lease_connection
     @conn.execute "DROP TABLE test_employees" rescue nil
     @conn.execute "DROP SEQUENCE test_employees_seq" rescue nil
     @conn.execute <<~SQL
@@ -89,7 +89,7 @@ describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
 
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    @conn = ActiveRecord::Base.connection
+    @conn = ActiveRecord::Base.lease_connection
     schema_define do
       create_table :test_employees, force: true do |t|
         t.string    :first_name,  limit: 20

--- a/spec/active_record/oracle_enhanced/type/binary_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/binary_spec.rb
@@ -5,7 +5,7 @@ describe "OracleEnhancedAdapter handling of BLOB columns" do
 
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    @conn = ActiveRecord::Base.connection
+    @conn = ActiveRecord::Base.lease_connection
     schema_define do
       create_table :test_employees, force: true do |t|
         t.string  :first_name, limit: 20

--- a/spec/active_record/oracle_enhanced/type/boolean_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/boolean_spec.rb
@@ -3,7 +3,7 @@
 describe "OracleEnhancedAdapter boolean type detection based on string column types and names" do
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    @conn = ActiveRecord::Base.connection
+    @conn = ActiveRecord::Base.lease_connection
     @conn.execute <<~SQL
       CREATE TABLE test3_employees (
         id            NUMBER PRIMARY KEY,
@@ -89,7 +89,7 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
 
   it "should translate boolean type to NUMBER(1) if emulate_booleans_from_strings is false" do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = false
-    sql_type = ActiveRecord::Base.connection.type_to_sql(:boolean)
+    sql_type = ActiveRecord::Base.lease_connection.type_to_sql(:boolean)
     expect(sql_type).to eq("NUMBER(1)")
   end
 

--- a/spec/active_record/oracle_enhanced/type/character_string_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/character_string_spec.rb
@@ -3,7 +3,7 @@
 describe "OracleEnhancedAdapter processing CHAR column" do
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    @conn = ActiveRecord::Base.connection
+    @conn = ActiveRecord::Base.lease_connection
     @conn.execute <<~SQL
       CREATE TABLE test_items (
         id       NUMBER(6,0) PRIMARY KEY,

--- a/spec/active_record/oracle_enhanced/type/decimal_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/decimal_spec.rb
@@ -5,7 +5,7 @@ describe "OracleEnhancedAdapter handling of DECIMAL columns" do
 
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    @conn = ActiveRecord::Base.connection
+    @conn = ActiveRecord::Base.lease_connection
     schema_define do
       create_table :test2_employees, force: true do |t|
         t.string  :first_name, limit: 20

--- a/spec/active_record/oracle_enhanced/type/float_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/float_spec.rb
@@ -5,7 +5,7 @@ describe "OracleEnhancedAdapter handling of BINARY_FLOAT columns" do
 
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    @conn = ActiveRecord::Base.connection
+    @conn = ActiveRecord::Base.lease_connection
     schema_define do
       create_table :test2_employees, force: true do |t|
         t.string  :first_name, limit: 20

--- a/spec/active_record/oracle_enhanced/type/json_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/json_spec.rb
@@ -5,7 +5,7 @@ describe "OracleEnhancedAdapter attribute API support for JSON type" do
 
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    @conn = ActiveRecord::Base.connection
+    @conn = ActiveRecord::Base.lease_connection
     @oracle12c_or_higher = !! @conn.select_value(
       "select * from product_component_version where product like 'Oracle%' and to_number(substr(version,1,2)) >= 12")
     skip "Not supported in this database version" unless @oracle12c_or_higher

--- a/spec/active_record/oracle_enhanced/type/national_character_string_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/national_character_string_spec.rb
@@ -3,7 +3,7 @@
 describe "OracleEnhancedAdapter quoting of NCHAR and NVARCHAR2 columns" do
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    @conn = ActiveRecord::Base.connection
+    @conn = ActiveRecord::Base.lease_connection
     @conn.execute <<~SQL
       CREATE TABLE test_items (
         id                  NUMBER(6,0) PRIMARY KEY,

--- a/spec/active_record/oracle_enhanced/type/national_character_text_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/national_character_text_spec.rb
@@ -5,7 +5,7 @@ describe "OracleEnhancedAdapter handling of NCLOB columns" do
 
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    @conn = ActiveRecord::Base.connection
+    @conn = ActiveRecord::Base.lease_connection
     schema_define do
       create_table :test_employees, force: true do |t|
         t.string  :first_name, limit: 20

--- a/spec/active_record/oracle_enhanced/type/text_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/text_spec.rb
@@ -5,7 +5,7 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
 
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
-    @conn = ActiveRecord::Base.connection
+    @conn = ActiveRecord::Base.lease_connection
     schema_define do
       create_table :test_employees, force: true do |t|
         t.string  :first_name, limit: 20

--- a/spec/active_record/oracle_enhanced/type/timestamp_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/timestamp_spec.rb
@@ -6,7 +6,7 @@ describe "OracleEnhancedAdapter timestamp with timezone support" do
   before(:all) do
     ActiveRecord.default_timezone = :local
     ActiveRecord::Base.establish_connection(CONNECTION_WITH_TIMEZONE_PARAMS)
-    @conn = ActiveRecord::Base.connection
+    @conn = ActiveRecord::Base.lease_connection
     schema_define do
       create_table :test_employees, force: true do |t|
         t.string        :first_name,  limit: 20

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -122,7 +122,7 @@ module SchemaSpecHelper
 end
 
 module SchemaDumpingHelper
-  def dump_table_schema(table, connection = ActiveRecord::Base.connection)
+  def dump_table_schema(table, connection = ActiveRecord::Base.lease_connection)
     old_ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
     ActiveRecord::SchemaDumper.ignore_tables = connection.data_sources - [table]
     stream = StringIO.new


### PR DESCRIPTION
### Motivation / Background

Port [rails/rails#51192](https://github.com/rails/rails/pull/51192)
("Make `.connection` always return a permanently leased connection") to the
Oracle enhanced adapter.

In current Rails main, `ActiveRecord::Base.connection` is soft-deprecated in
favor of `#lease_connection` (or `#with_connection`); calling it emits a
deprecation warning when `ActiveRecord.permanent_connection_checkout` is
`:deprecated`. Several specs in this repo were already migrated piecemeal
(`multiple_databases_spec.rb`, `database_tasks_spec.rb`, `integer_spec.rb`,
etc.), but ~200 callsites under `spec/` still used the deprecated API.

### Detail

* Replace every `ActiveRecord::Base.connection` callsite under `spec/` with
  `ActiveRecord::Base.lease_connection` (29 files, 203 sites).
* `spec/spec_helper.rb#dump_table_schema` default param updated.
* The two remaining references in
  `lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb`
  are documentation comments naming upstream entry points and are
  intentionally left untouched.

### Additional information

This is a mechanical rename; behavior of the suite is unchanged. CI will
exercise the migrated callsites against a live Oracle database.

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated.