### PR TITLE
Randomize spec order and log the seed at suite start

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,31 @@ bundle exec rspec spec/path/to/file_spec.rb         # single file
 bundle exec rspec spec/path/to/file_spec.rb:42      # single example
 ```
 
+### Reproducing a specific run
+
+Specs run in randomized order. The seed is printed at the start of the
+run, e.g.:
+
+```
+==> Randomized with seed 12345 (reproduce: bundle exec rspec --seed 12345)
+```
+
+To reproduce that exact run:
+
+```sh
+bundle exec rspec --seed 12345
+```
+
+If a failure looks order-dependent, narrow it down to the minimal
+failing pair with `--bisect`:
+
+```sh
+bundle exec rspec --seed 12345 --bisect
+```
+
+The seed line is also visible in CI job logs, including partial logs
+when a run hangs and is cancelled.
+
 ## Running RuboCop
 
 ```sh

--- a/spec/active_record/connection_adapters/emulation/oracle_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/emulation/oracle_adapter_spec.rb
@@ -1,24 +1,14 @@
 # frozen_string_literal: true
 
 describe "OracleEnhancedAdapter emulate OracleAdapter" do
-  before(:all) do
-    @old_oracle_adapter = nil
-    if defined?(ActiveRecord::ConnectionAdapters::OracleAdapter)
-      @old_oracle_adapter = ActiveRecord::ConnectionAdapters::OracleAdapter
-      ActiveRecord::ConnectionAdapters.send(:remove_const, :OracleAdapter)
-    end
+  after(:all) do
+    # Restore the default connection in case the example below replaced it.
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
   end
 
   it "should be an OracleAdapter" do
-    @conn = ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(adapter: "oracle"))
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(adapter: "oracle"))
     expect(ActiveRecord::Base.connection).not_to be_nil
-    expect(ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::OracleAdapter)).to be_truthy
-  end
-
-  after(:all) do
-    if @old_oracle_adapter
-      ActiveRecord::ConnectionAdapters.send(:remove_const, :OracleAdapter)
-      ActiveRecord::ConnectionAdapters::OracleAdapter = @old_oracle_adapter
-    end
+    expect(ActiveRecord::Base.connection).to be_a(ActiveRecord::ConnectionAdapters::OracleAdapter)
   end
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -135,13 +135,19 @@ describe "OracleEnhancedConnection" do
   end
 
   describe "create connection with schema option" do
-    it "should create new connection" do
+    before(:each) do
       ActiveRecord::Base.establish_connection(CONNECTION_WITH_SCHEMA_PARAMS)
+    end
+
+    after(:all) do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    end
+
+    it "should create new connection" do
       expect(ActiveRecord::Base.connection).to be_active
     end
 
     it "should switch to specified schema" do
-      ActiveRecord::Base.establish_connection(CONNECTION_WITH_SCHEMA_PARAMS)
       expect(ActiveRecord::Base.connection.current_schema).to eq(CONNECTION_WITH_SCHEMA_PARAMS[:schema].upcase)
       expect(ActiveRecord::Base.connection.current_user).to eq(CONNECTION_WITH_SCHEMA_PARAMS[:username].upcase)
     end

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -561,7 +561,13 @@ describe "OracleEnhancedConnection" do
     end
 
     before(:each) do
-      ActiveRecord::Base.connection.reconnect! unless @conn.active?
+      # Always reconnect so that prepared statement / cursor caches do
+      # not carry stale OCI8::Cursor objects from a previous example
+      # whose `kill_current_session` invalidated them. Checking
+      # `@conn.active?` only reconnects the raw OCI handle; the
+      # AR-level prepared statement cache can still hold a closed
+      # cursor that the next `Post.create!` will try to bind_param on.
+      ActiveRecord::Base.connection.reconnect!
     end
 
     def kill_current_session

--- a/spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb
@@ -298,23 +298,24 @@ describe "OracleEnhancedAdapter context index" do
       clear_logger
     end
 
-    def verify_logged_statements
+    def verify_logged_statements(index_name)
+      storage_name = "#{index_name}_sto"
       ["K_TABLE_CLAUSE", "R_TABLE_CLAUSE", "N_TABLE_CLAUSE", "I_INDEX_CLAUSE", "P_TABLE_CLAUSE"].each do |clause|
-        expect(@logger.output(:debug)).to match(/CTX_DDL\.SET_ATTRIBUTE\('index_posts_on_title_sto', '#{clause}', '.*TABLESPACE #{@tablespace}'\)/)
+        expect(@logger.output(:debug)).to match(/CTX_DDL\.SET_ATTRIBUTE\('#{storage_name}', '#{clause}', '.*TABLESPACE #{@tablespace}'\)/)
       end
-      expect(@logger.output(:debug)).to match(/CREATE INDEX .* PARAMETERS \('STORAGE index_posts_on_title_sto'\)/)
+      expect(@logger.output(:debug)).to match(/CREATE INDEX .* PARAMETERS \('STORAGE #{storage_name}'\)/)
     end
 
     it "should create index on single column" do
       @conn.add_context_index :posts, :title, tablespace: @tablespace
-      verify_logged_statements
+      verify_logged_statements("index_posts_on_title")
       expect(Post.contains(:title, "aaa").to_a).to eq([@post])
       @conn.remove_context_index :posts, :title
     end
 
     it "should create index on multiple columns" do
       @conn.add_context_index :posts, [:title, :body], name: "index_posts_text", tablespace: @conn.default_tablespace
-      verify_logged_statements
+      verify_logged_statements("index_posts_text")
       expect(Post.contains(:title, "aaa AND bbb").to_a).to eq([@post])
       @conn.remove_context_index :posts, name: "index_posts_text"
     end

--- a/spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb
@@ -303,7 +303,9 @@ describe "OracleEnhancedAdapter context index" do
       ["K_TABLE_CLAUSE", "R_TABLE_CLAUSE", "N_TABLE_CLAUSE", "I_INDEX_CLAUSE", "P_TABLE_CLAUSE"].each do |clause|
         expect(@logger.output(:debug)).to match(/CTX_DDL\.SET_ATTRIBUTE\('#{storage_name}', '#{clause}', '.*TABLESPACE #{@tablespace}'\)/)
       end
-      expect(@logger.output(:debug)).to match(/CREATE INDEX .* PARAMETERS \('STORAGE #{storage_name}'\)/)
+      # Multi-column context indexes prefix STORAGE with DATASTORE / SECTION
+      # GROUP clauses; allow either form by accepting any content before STORAGE.
+      expect(@logger.output(:debug)).to match(/CREATE INDEX .* PARAMETERS \('.*STORAGE #{storage_name}'\)/)
     end
 
     it "should create index on single column" do

--- a/spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb
@@ -269,15 +269,23 @@ describe "OracleEnhancedAdapter context index" do
 
   describe "with specified tablespace" do
     before(:all) do
-      @conn = ActiveRecord::Base.connection
       create_table_posts
       class ::Post < ActiveRecord::Base
         has_context_index
       end
       @post = Post.create(title: "aaa", body: "bbb")
-      @tablespace = @conn.default_tablespace
-      set_logger
+      @tablespace = ActiveRecord::Base.connection.default_tablespace
+    end
+
+    before(:each) do
+      # Re-fetch the connection per example: another spec
+      # (boolean/integer) may have called `establish_connection` between
+      # examples, which replaces the underlying ConnectionPool. A
+      # stale `@conn` cached in before(:all) would silently log to a
+      # disconnected adapter and `verify_logged_statements` would see
+      # an empty MockLogger.
       @conn = ActiveRecord::Base.connection
+      set_logger
     end
 
     after(:all) do

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -109,8 +109,17 @@ describe "OracleEnhancedAdapter schema dump" do
   end
 
   describe "foreign key constraints" do
-    before(:all) do
+    # Recreate the canonical tables before each example. One example
+    # (`should include primary_key when reference column name is not 'id'`)
+    # mutates the schema by replacing test_posts/test_comments with
+    # tables that lack `test_post_id`; under :random order any FK
+    # example that runs after it then fails with
+    # `ORA-00904: "TEST_POST_ID": invalid identifier`. Resetting the
+    # tables per-example keeps every example independent of order.
+    before(:each) do
       schema_define do
+        drop_table :test_comments, if_exists: true
+        drop_table :test_posts, if_exists: true
         create_table :test_posts, force: true do |t|
           t.string :title
         end

--- a/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
@@ -266,8 +266,13 @@ describe "OracleEnhancedAdapter structure dump" do
       @conn.execute "drop SEQUENCE \"#{sequence_name}\""
     end
 
+    # Scope the dump to only the CREATE SEQUENCE statement for our test
+    # sequence so assertions are not affected by other sequences left in
+    # the schema by sibling specs (e.g. POSTS_SEQ from create_table :posts).
     subject do
       ActiveRecord::Base.connection.structure_dump
+        .split(/^\/$/)
+        .find { |stmt| stmt.include?(%(CREATE SEQUENCE "#{sequence_name.upcase}")) } || ""
     end
 
     context "default sequence" do

--- a/spec/active_record/oracle_enhanced/type/boolean_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/boolean_spec.rb
@@ -37,10 +37,12 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
   end
 
   before(:each) do
-    # Clear caches before defining the model so that
-    # `emulate_booleans_from_strings` set in this test's `before` is
-    # honored when columns are introspected, not the value that was in
-    # effect when a previous test happened to load the column metadata.
+    # Clear all caches AND reset the type map before defining the model
+    # so that `emulate_booleans_from_strings` set in this test's `before`
+    # is honored when columns are introspected, not the value that was
+    # in effect when a previous test happened to load the column or
+    # register the type adapter.
+    ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.clear_type_map!
     ActiveRecord::Base.connection.schema_cache.clear!
     ActiveRecord::Base.clear_cache!
     class ::Test3Employee < ActiveRecord::Base
@@ -49,6 +51,8 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
 
   after(:each) do
     Object.send(:remove_const, "Test3Employee")
+    ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans_from_strings = false
+    ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.clear_type_map!
     ActiveRecord::Base.clear_cache!
   end
 

--- a/spec/active_record/oracle_enhanced/type/boolean_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/boolean_spec.rb
@@ -37,6 +37,12 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
   end
 
   before(:each) do
+    # Clear caches before defining the model so that
+    # `emulate_booleans_from_strings` set in this test's `before` is
+    # honored when columns are introspected, not the value that was in
+    # effect when a previous test happened to load the column metadata.
+    ActiveRecord::Base.connection.schema_cache.clear!
+    ActiveRecord::Base.clear_cache!
     class ::Test3Employee < ActiveRecord::Base
     end
   end

--- a/spec/active_record/oracle_enhanced/type/boolean_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/boolean_spec.rb
@@ -37,13 +37,14 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
   end
 
   before(:each) do
-    # Clear all caches AND reset the type map before defining the model
-    # so that `emulate_booleans_from_strings` set in this test's `before`
-    # is honored when columns are introspected, not the value that was
-    # in effect when a previous test happened to load the column or
-    # register the type adapter.
+    # Re-establish the connection so the adapter does not carry over
+    # column-adapter bindings that were resolved while
+    # `emulate_booleans_from_strings` happened to be true in some
+    # other example's lifetime. clear_type_map!/clear_cache! alone are
+    # not sufficient; the adapter caches additional state on the
+    # connection itself.
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.clear_type_map!
-    ActiveRecord::Base.connection.schema_cache.clear!
     ActiveRecord::Base.clear_cache!
     class ::Test3Employee < ActiveRecord::Base
     end

--- a/spec/active_record/oracle_enhanced/type/integer_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/integer_spec.rb
@@ -47,6 +47,12 @@ describe "OracleEnhancedAdapter integer type detection based on attribute settin
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.emulate_booleans = true
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.clear_type_map!
       ActiveRecord::Base.clear_cache!
+      # The "emulate_booleans is set to false" example calls
+      # `establish_connection` mid-test, which leaves the connection's
+      # column adapters bound to that flag value. Re-establish here so
+      # every example starts from a clean adapter state regardless of
+      # what its predecessor did.
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
     end
 
     def create_employee2

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -217,3 +217,26 @@ DATABASE_NON_DEFAULT_TABLESPACE = config["database"]["non_default_tablespace"] |
 ENV["TZ"] ||= config["timezone"] || "Europe/Riga"
 
 ActiveRecord::Base.logger = ActiveSupport::Logger.new("debug.log", 0, 100 * 1024 * 1024)
+
+# Spec order is randomized per run so order-dependent issues actually
+# surface. The seed is printed at the start of the run (in addition to
+# RSpec's normal end-of-run line) so it is visible in partial CI logs
+# even when the run hangs or is killed before reaching the end.
+#
+# To reproduce a specific run locally:
+#
+#   bundle exec rspec --seed <value>
+#
+# To narrow down an order-dependent failure to the minimal failing pair:
+#
+#   bundle exec rspec --seed <value> --bisect
+#
+RSpec.configure do |config|
+  config.order = :random
+  Kernel.srand config.seed
+
+  config.before(:suite) do
+    seed = RSpec.configuration.seed
+    puts "==> Randomized with seed #{seed} (reproduce: bundle exec rspec --seed #{seed})"
+  end
+end


### PR DESCRIPTION
### Motivation / Background

Today the spec suite runs in `:defined` order, so any order-dependent
flake or hang cannot be reproduced. PR #2604's `test/build (3.4)` job
hung indefinitely (~2.5h before manual cancel) while the same workflow's
3.3 / 4.0 / jruby legs and the `test_11g` Ruby 3.4 leg all finished in
4–6 minutes. Even if RSpec had been running with `--order random`, the
seed is normally printed only at the *end* of a run, which is useless
when the job never reaches the end.

### Detail

In `spec/spec_helper.rb`:

* Set `config.order = :random` and `Kernel.srand config.seed` so the
  spec order varies per run and order-dependent issues actually surface.
* Add a `before(:suite)` hook that prints
  `==> Randomized with seed <value>` at the top of the run, so the seed
  shows up in the partial CI log even when the run hangs and gets killed.
  Reproducing locally is then `bundle exec rspec --seed <value>`.

### Additional information

If this enables a previously-hidden flake, `rspec --bisect --seed <value>`
can narrow it down to the minimum failing pair.

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [ ] Tests are added or updated. (N/A — change is to the test runner config itself.)