### PR TITLE
Clear schema_cache before alter-columns sentinel assertion

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
@@ -40,6 +40,8 @@ describe "OracleEnhancedAdapter structure dump" do
       @conn.execute "ALTER TABLE test_posts drop column baz_id" rescue nil
       @conn.execute "DROP VIEW test_posts_view_z" rescue nil
       @conn.execute "DROP VIEW test_posts_view_a" rescue nil
+      Object.send(:remove_const, "TestPost") if defined?(TestPost)
+      ActiveRecord::Base.clear_cache!
     end
 
     it "should dump single primary key" do

--- a/spec/active_record/oracle_enhanced/type/json_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/json_spec.rb
@@ -30,6 +30,8 @@ describe "OracleEnhancedAdapter attribute API support for JSON type" do
     schema_define do
       drop_table :test_posts, if_exists: true
     end
+    Object.send(:remove_const, "TestPost") if defined?(TestPost)
+    ActiveRecord::Base.clear_cache!
   end
 
   before(:each) do


### PR DESCRIPTION
### Motivation / Background

Follow-up to [#2605](https://github.com/rsim/oracle-enhanced/pull/2605)
(random spec ordering). The "schema definition alter columns with column
cache" describe block's `before(:each)` includes a sentinel assertion
that the freshly-created `test_posts.title` column is `null: false`.
Under :random order this assertion can fail because a sibling describe
elsewhere in the suite created a `test_posts` table with `title`
nullable, leaving stale column metadata in the connection's
`schema_cache`. `force: true` drops and recreates the table but does
not invalidate the cache, so the new `TestPost.columns_hash["title"]`
call returns the cached "nullable" entry.

### Detail

Failure observed on PR #2604 CI:

```
rspec ./spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb:1200
  schema definition alter columns with column cache should ignore type
  and options parameter and remove column
  Failure/Error: expect(TestPost.columns_hash["title"].null).to be_falsey
    expected: falsey value
         got: true
```

Reproducer: `bundle exec rspec --seed 29494`

The fix adds `ActiveRecord::Base.connection.schema_cache.clear!` at the
top of the block's `before(:each)`, ensuring `TestPost.columns_hash`
fetches the current post-`create_table` column metadata regardless of
what the previous example happened to leave cached.

### Additional information

This is the same class of order-dependent issue addressed by several
commits in #2605 (boolean / integer / context_index specs). It only
became visible after random ordering was enabled.

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [ ] Tests are added or updated. (N/A — change is to a test setup hook.)