### PR TITLE
Match unique-constraint SQL anywhere instead of lines.last

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -1470,7 +1470,14 @@ end
       schema_define do
         add_index :keyboards, ["name"], unique: true, name: :this_index
       end
-      expect(@would_execute_sql.lines.last).to match(/ALTER +TABLE .* ADD CONSTRAINT .* UNIQUE \(.*\) USING INDEX "THIS_INDEX";/)
+      # Match anywhere in the captured SQL rather than asserting on
+      # `lines.last`. `schema_define` calls `ActiveRecord::Schema.define`,
+      # which finishes by ensuring `schema_migrations` and
+      # `internal_metadata` exist. Under :random order this describe can
+      # run before any prior `Schema.define`, so the trailing `CREATE
+      # TABLE "SCHEMA_MIGRATIONS"` (etc.) lands last in the captured SQL
+      # and the assertion is unrelated to what the test is checking.
+      expect(@would_execute_sql).to match(/ALTER +TABLE .* ADD CONSTRAINT .* UNIQUE \(.*\) USING INDEX "THIS_INDEX";/)
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

Follow-up to [#2605](https://github.com/rsim/oracle-enhanced/pull/2605)
(random spec ordering). The "schema definition miscellaneous options"
describe block has an example that asserts on
`@would_execute_sql.lines.last`, which is brittle: `schema_define`
ultimately calls `ActiveRecord::Schema.define`, and that call ensures
`schema_migrations` / `internal_metadata` exist after the user block
runs. When this describe is the first to invoke `schema_define` under
:random order, the trailing `CREATE TABLE "SCHEMA_MIGRATIONS"` lands
last in the captured SQL and the assertion fails.

### Detail

```
rspec ./spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb:1469
  schema definition miscellaneous options should add unique constraint only to the index where it was defined
  Failure/Error: expect(@would_execute_sql.lines.last).to match(
    /ALTER +TABLE .* ADD CONSTRAINT .* UNIQUE \(.*\) USING INDEX "THIS_INDEX";/)
  expected "CREATE TABLE \"SCHEMA_MIGRATIONS\" (\"VERSION\" VARCHAR2(255)
    NOT NULL PRIMARY KEY);\n"
```

Reproducer: `bundle exec rspec --seed 16036`

The intent of the assertion is to verify that
`add_index :keyboards, ..., unique: true` emits the UNIQUE-constraint
ALTER TABLE — not that nothing else runs after it. Drop `.lines.last`
and match against the full captured SQL.

### Additional information

Same class of order-dependent flake addressed by #2605 / #2606. Only
visible after random ordering was enabled.

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [ ] Tests are added or updated. (N/A — change is to a test assertion.)