### PR TITLE
Remove unreachable primary_key NULL guard in add_column_options!

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -66,7 +66,7 @@ module ActiveRecord
             if options[:null] == false
               sql << " NOT NULL"
             elsif options[:null] == true
-              sql << " NULL" unless type == :primary_key
+              sql << " NULL"
             end
             # add AS expression for virtual columns
             if options[:as].present?

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -128,6 +128,41 @@ describe "OracleEnhancedAdapter schema definition" do
     end
   end
 
+  describe "primary key with null: true" do
+    # Regression coverage for the contract introduced in
+    # rails/rails#57204: `add_column` must reject `null: true` on a
+    # primary key. The actual ArgumentError is raised by the abstract
+    # `new_column_definition` upstream; this spec guards against
+    # oracle-enhanced's `new_column_definition` override (in
+    # schema_definitions.rb) ever short-circuiting before the upstream
+    # `super` call and silently letting the invalid combination
+    # through.
+    before(:all) do
+      @conn = ActiveRecord::Base.lease_connection
+      schema_define do
+        create_table :test_pk_null_check, force: true do |t|
+          t.string :name
+        end
+      end
+    end
+
+    after(:all) do
+      schema_define { drop_table :test_pk_null_check, if_exists: true }
+    end
+
+    it "raises ArgumentError when adding a :primary_key column with null: true" do
+      expect {
+        @conn.add_column :test_pk_null_check, :other_id, :primary_key, null: true
+      }.to raise_error(ArgumentError, /primary keys cannot be NULL/)
+    end
+
+    it "raises ArgumentError when adding a column with primary_key: true and null: true" do
+      expect {
+        @conn.add_column :test_pk_null_check, :another_id, :integer, primary_key: true, null: true
+      }.to raise_error(ArgumentError, /primary keys cannot be NULL/)
+    end
+  end
+
   describe "default sequence name" do
     it "should return sequence name without truncating too much" do
       seq_name_length = ActiveRecord::Base.lease_connection.sequence_name_length


### PR DESCRIPTION
### Motivation / Background

Follow-up to upstream [rails/rails#57204](https://github.com/rails/rails/pull/57204)
("Let `add_column` raise if `:null` is true for PKs"). That patch puts
an `ArgumentError` raise in the abstract `new_column_definition`
whenever a primary key is given `null: true`, so the case can no longer
reach the SQL generator.

### Detail

`OracleEnhanced::SchemaCreation#add_column_options!` carried a guard
in the column-emission path:

```ruby
elsif options[:null] == true
  sql << " NULL" unless type == :primary_key
end
```

After #57204, `new_column_definition` raises before `add_column_options!`
ever sees a primary key with `null: true`, so the `unless type ==
:primary_key` clause is unreachable. oracle-enhanced's
`new_column_definition` override (`schema_definitions.rb`) just does
some virtual-column preprocessing and then `super`, so the upstream
guard is already in effect for this adapter.

Drop the now-dead clause. The branch unconditionally emits ` NULL`.

### Additional information

For any caller that bypasses `new_column_definition` and calls
`add_column_options!` directly with `options[:null] == true && type ==
:primary_key`, the previous code silently dropped the `NULL`, hiding
the mistake. Without the guard the same call would emit `NULL` for a
PK, which Oracle would reject — surfacing the bug instead. This is
the desired behavior since the public path raises.

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [ ] Tests are added or updated. (N/A — removing dead code already covered by upstream's invalid_options_test.)