### PR TITLE
Refactor create_table to delegate to AbstractAdapter#create_table

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -200,11 +200,18 @@ module ActiveRecord
         #   end
 
         def create_table(table_name, id: :primary_key, primary_key: nil, force: nil, **options)
+          # Mirror upstream guard: `super` is called with `force: nil` below, so the same check there is bypassed.
+          if force && options.key?(:if_not_exists)
+            raise ArgumentError, "Options `:force` and `:if_not_exists` cannot be used simultaneously."
+          end
+
           identity = options[:identity]
           validate_identity_options!(identity, id, primary_key)
 
           if force && data_source_exists?(table_name)
             drop_table(table_name, force: force, if_exists: true)
+          elsif options[:if_not_exists] && data_source_exists?(table_name)
+            return
           end
 
           captured_td = nil

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -672,7 +672,7 @@ module ActiveRecord
         end
 
         def valid_primary_key_options # :nodoc:
-          super + [:identity]
+          super + [:identity, :sequence_name, :sequence_start_value]
         end
 
         private

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -638,10 +638,13 @@ module ActiveRecord
 
           def should_create_sequence?(td, id, identity)
             return false if identity
-            return true if id != false
-            td.columns.any? do |column|
-              column.options[:primary_key] &&
-                [:primary_key, :integer, :bigint, :decimal].include?(column.type)
+            numeric_pk_types = [:primary_key, :integer, :bigint, :decimal]
+            if id
+              numeric_pk_types.include?(id)
+            else
+              td.columns.any? do |column|
+                column.options[:primary_key] && numeric_pk_types.include?(column.type)
+              end
             end
           end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -523,18 +523,12 @@ module ActiveRecord
 
         def change_table_comment(table_name, comment_or_changes)
           clear_cache!
-          comment = extract_new_comment_value(comment_or_changes)
-          if comment.nil?
-            execute "COMMENT ON TABLE #{quote_table_name(table_name)} IS ''"
-          else
-            execute "COMMENT ON TABLE #{quote_table_name(table_name)} IS #{quote(comment)}"
-          end
+          execute change_table_comment_sql(table_name, comment_or_changes)
         end
 
         def change_column_comment(table_name, column_name, comment_or_changes)
           clear_cache!
-          comment = extract_new_comment_value(comment_or_changes)
-          execute "COMMENT ON COLUMN #{quote_table_name(table_name)}.#{quote_column_name(column_name)} IS '#{comment}'"
+          execute change_column_comment_sql(table_name, column_name, comment_or_changes)
         end
 
         def table_comment(table_name) # :nodoc:
@@ -676,6 +670,20 @@ module ActiveRecord
         end
 
         private
+          def change_table_comment_sql(table_name, comment_or_changes)
+            comment = extract_new_comment_value(comment_or_changes)
+            if comment.nil?
+              "COMMENT ON TABLE #{quote_table_name(table_name)} IS ''"
+            else
+              "COMMENT ON TABLE #{quote_table_name(table_name)} IS #{quote(comment)}"
+            end
+          end
+
+          def change_column_comment_sql(table_name, column_name, comment_or_changes)
+            comment = extract_new_comment_value(comment_or_changes)
+            "COMMENT ON COLUMN #{quote_table_name(table_name)}.#{quote_column_name(column_name)} IS '#{comment}'"
+          end
+
           def insert_versions_sql(versions)
             sm_table = quote_table_name(ActiveRecord::Tasks::DatabaseTasks.migration_connection_pool.schema_migration.table_name)
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -766,9 +766,10 @@ module ActiveRecord
             column
           end
 
+          # TODO: extend to also create a BEFORE INSERT trigger when issue
+          # https://github.com/rsim/oracle-enhanced/issues/2597 introduces
+          # `primary_key_trigger: true`.
           def create_pk_sequence(table_name, options)
-            # TODO: Needs rename since no triggers created
-            # This method will be removed since sequence will not be created separately
             seq_name = options[:sequence_name] || default_sequence_name(table_name, nil)
             seq_start_value = options[:sequence_start_value] || default_sequence_start_value
             execute "CREATE SEQUENCE #{quote_table_name(seq_name)} START WITH #{seq_start_value}"

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -261,7 +261,7 @@ module ActiveRecord
 
           execute schema_creation.accept td
 
-          create_sequence_and_trigger(table_name, options) if create_sequence && !identity
+          create_pk_sequence(table_name, options) if create_sequence && !identity
 
           if supports_comments? && !supports_comments_in_create?
             if table_comment = td.comment.presence
@@ -449,7 +449,7 @@ module ActiveRecord
           add_column_sql = schema_creation.accept at
           add_column_sql << tablespace_for((type_to_sql(type).downcase.to_sym), nil, table_name, column_name)
           execute add_column_sql
-          create_sequence_and_trigger(table_name, options) if type && type.to_sym == :primary_key
+          create_pk_sequence(table_name, options) if type && type.to_sym == :primary_key
           change_column_comment(table_name, column_name, options[:comment]) if options.key?(:comment)
         ensure
           clear_table_columns_cache(table_name)
@@ -791,7 +791,7 @@ module ActiveRecord
             column
           end
 
-          def create_sequence_and_trigger(table_name, options)
+          def create_pk_sequence(table_name, options)
             # TODO: Needs rename since no triggers created
             # This method will be removed since sequence will not be created separately
             seq_name = options[:sequence_name] || default_sequence_name(table_name, nil)

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -399,7 +399,7 @@ module ActiveRecord
           add_column_sql = schema_creation.accept at
           add_column_sql << tablespace_for((type_to_sql(type).downcase.to_sym), nil, table_name, column_name)
           execute add_column_sql
-          create_pk_sequence(table_name, options) if type && type.to_sym == :primary_key
+          create_pk_sequence(table_name, options) if type.to_sym == :primary_key
           change_column_comment(table_name, column_name, options[:comment]) if options.key?(:comment)
         ensure
           clear_table_columns_cache(table_name)

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -201,78 +201,21 @@ module ActiveRecord
 
         def create_table(table_name, id: :primary_key, primary_key: nil, force: nil, **options)
           identity = options[:identity]
-          create_sequence = id != false
-          td = create_table_definition(
-            table_name, **options.extract!(:temporary, :options, :as, :comment, :tablespace, :organization)
-          )
-
-          if identity
-            unless supports_identity_columns?
-              raise ArgumentError,
-                "`identity: true` requires Oracle Database 12.1 or higher (current: #{database_version.join('.')}). Remove `identity: true` or upgrade the database."
-            end
-            unless id == :primary_key
-              raise ArgumentError,
-                "`identity: true` requires `id: :primary_key` (the default); got id: #{id.inspect}."
-            end
-            if primary_key.is_a?(Array)
-              raise ArgumentError,
-                "`identity: true` cannot be combined with a composite primary key."
-            end
-          end
-
-          if id && !td.as
-            pk = primary_key || Base.get_primary_key(table_name.to_s.singularize)
-
-            if pk.is_a?(Array)
-              td.primary_keys pk
-            else
-              td.primary_key pk, id, **options
-            end
-          end
-
-          # store that primary key was defined in create_table block
-          unless create_sequence
-            class << td
-              attr_accessor :create_sequence
-              # Only request a sequence when the primary key column is a
-              # numeric type that a +NUMBER+ sequence can populate. For
-              # example, +t.primary_key :code, :string+ inside +id: false+
-              # creates a VARCHAR2 PK; building a numeric sequence for it
-              # is meaningless and pollutes the schema with an unused
-              # +<table>_seq+.
-              def primary_key(name, type = :primary_key, **options)
-                if [:primary_key, :integer, :bigint, :decimal].include?(type)
-                  self.create_sequence = true
-                end
-                super(name, type, **options)
-              end
-            end
-          end
-
-          yield td if block_given?
-          create_sequence = create_sequence || td.create_sequence
+          validate_identity_options!(identity, id, primary_key)
 
           if force && data_source_exists?(table_name)
             drop_table(table_name, force: force, if_exists: true)
-          else
-            schema_cache.clear_data_source_cache!(table_name.to_s)
           end
 
-          execute schema_creation.accept td
-
-          create_pk_sequence(table_name, options) if create_sequence && !identity
-
-          if supports_comments? && !supports_comments_in_create?
-            if table_comment = td.comment.presence
-              change_table_comment(table_name, table_comment)
-            end
-            td.columns.each do |column|
-              change_column_comment(table_name, column.name, column.comment) if column.comment.present?
-            end
+          captured_td = nil
+          super(table_name, id: id, primary_key: primary_key, force: nil, **options) do |td|
+            captured_td = td
+            yield td if block_given?
           end
-          td.indexes.each { |c, o| add_index table_name, c, **o }
 
+          captured_td.indexes.each { |c, o| add_index table_name, c, **o }
+
+          create_pk_sequence(table_name, options) if should_create_sequence?(captured_td, id, identity)
           rebuild_primary_key_index_to_default_tablespace(table_name, options)
         end
 
@@ -670,6 +613,31 @@ module ActiveRecord
         end
 
         private
+          def validate_identity_options!(identity, id, primary_key)
+            return unless identity
+            unless supports_identity_columns?
+              raise ArgumentError,
+                "`identity: true` requires Oracle Database 12.1 or higher (current: #{database_version.join('.')}). Remove `identity: true` or upgrade the database."
+            end
+            unless id == :primary_key
+              raise ArgumentError,
+                "`identity: true` requires `id: :primary_key` (the default); got id: #{id.inspect}."
+            end
+            if primary_key.is_a?(Array)
+              raise ArgumentError,
+                "`identity: true` cannot be combined with a composite primary key."
+            end
+          end
+
+          def should_create_sequence?(td, id, identity)
+            return false if identity
+            return true if id != false
+            td.columns.any? do |column|
+              column.options[:primary_key] &&
+                [:primary_key, :integer, :bigint, :decimal].include?(column.type)
+            end
+          end
+
           def change_table_comment_sql(table_name, comment_or_changes)
             comment = extract_new_comment_value(comment_or_changes)
             if comment.nil?

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -211,6 +211,9 @@ module ActiveRecord
           if force && data_source_exists?(table_name)
             drop_table(table_name, force: force, if_exists: true)
           elsif options[:if_not_exists] && data_source_exists?(table_name)
+            # Oracle 21c and earlier do not support `CREATE TABLE IF NOT EXISTS` DDL;
+            # pre-check existence in Ruby so the emitted SQL stays identical across
+            # all supported Oracle releases.
             return
           end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -659,7 +659,11 @@ module ActiveRecord
 
           def change_column_comment_sql(table_name, column_name, comment_or_changes)
             comment = extract_new_comment_value(comment_or_changes)
-            "COMMENT ON COLUMN #{quote_table_name(table_name)}.#{quote_column_name(column_name)} IS '#{comment}'"
+            if comment.nil?
+              "COMMENT ON COLUMN #{quote_table_name(table_name)}.#{quote_column_name(column_name)} IS ''"
+            else
+              "COMMENT ON COLUMN #{quote_table_name(table_name)}.#{quote_column_name(column_name)} IS #{quote(comment)}"
+            end
           end
 
           def insert_versions_sql(versions)

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -667,6 +667,10 @@ module ActiveRecord
           OracleEnhanced::SchemaCreation.new self
         end
 
+        def valid_table_definition_options # :nodoc:
+          super + [:tablespace, :organization]
+        end
+
         def valid_primary_key_options # :nodoc:
           super + [:identity]
         end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -361,6 +361,15 @@ module ActiveRecord
         true
       end
 
+      # Oracle has no inline non-constraint index syntax (true through 23ai); this
+      # override only returns true to make Rails' base `create_table` skip its index
+      # branch, which is incompatible with oracle-enhanced's `add_index_options`
+      # return shape. Removed once https://github.com/rsim/oracle-enhanced/issues/2611
+      # lands.
+      def supports_indexes_in_create?
+        true
+      end
+
       def supports_multi_insert?
         database_version.to_s >= [11, 2].to_s
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -616,6 +616,51 @@ end
     end
   end
 
+  describe "create_table with if_not_exists" do
+    before(:each) do
+      @conn = ActiveRecord::Base.lease_connection
+    end
+
+    after(:each) do
+      schema_define { drop_table :test_posts, if_exists: true }
+    end
+
+    it "creates the table when it does not yet exist" do
+      schema_define do
+        create_table :test_posts, if_not_exists: true do |t|
+          t.string :title
+        end
+      end
+      expect(@conn.data_source_exists?(:test_posts)).to be true
+    end
+
+    it "is a no-op when the table already exists" do
+      schema_define do
+        create_table :test_posts, force: true do |t|
+          t.string :title
+        end
+      end
+
+      expect do
+        schema_define do
+          create_table :test_posts, if_not_exists: true do |t|
+            t.string :title
+          end
+        end
+      end.not_to raise_error
+    end
+
+    it "raises ArgumentError when force and if_not_exists are combined" do
+      expect do
+        schema_define do
+          create_table :test_posts, force: true, if_not_exists: true do |t|
+            t.string :title
+          end
+        end
+      end.to raise_error(ArgumentError, /cannot be used simultaneously/)
+    end
+  end
+
   describe "add timestamps" do
     before(:each) do
       @conn = ActiveRecord::Base.lease_connection

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -111,6 +111,34 @@ describe "OracleEnhancedAdapter schema definition" do
       expect(seq).to be_nil
     end
 
+    it "creates a sequence for an integer primary key" do
+      schema_define do
+        create_table :test_lookups, force: true, id: false do |t|
+          t.primary_key :code, :integer
+          t.string :name
+        end
+      end
+
+      seq = @conn.select_value(<<~SQL.squish, "SCHEMA")
+        SELECT 1 FROM user_sequences WHERE sequence_name = 'TEST_LOOKUPS_SEQ'
+      SQL
+      expect(seq).not_to be_nil
+    end
+
+    it "creates a sequence for a bigint primary key" do
+      schema_define do
+        create_table :test_lookups, force: true, id: false do |t|
+          t.primary_key :code, :bigint
+          t.string :name
+        end
+      end
+
+      seq = @conn.select_value(<<~SQL.squish, "SCHEMA")
+        SELECT 1 FROM user_sequences WHERE sequence_name = 'TEST_LOOKUPS_SEQ'
+      SQL
+      expect(seq).not_to be_nil
+    end
+
     it "inserts via the Rails insert path on a String primary key" do
       schema_define do
         create_table :test_lookups, force: true, id: false do |t|

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -1414,12 +1414,16 @@ end
       @conn.instance_variable_set :@would_execute_sql, @would_execute_sql = +""
       class << @conn
         def execute(sql, name = nil); @would_execute_sql << sql << ";\n"; end
+        def execute_batch(statements, name = nil, **kwargs)
+          statements.each { |s| execute(s, name) }
+        end
       end
     end
 
     after(:each) do
       class << @conn
         remove_method :execute
+        remove_method :execute_batch
       end
       @conn.instance_eval { remove_instance_variable :@would_execute_sql }
     end


### PR DESCRIPTION
### Motivation / Background

Closes #2598.

`OracleEnhanced::SchemaStatements#create_table` was a self-contained
implementation that pre-dated Rails' extraction of the abstract-adapter
machinery used by `super`. The abstract `create_table` flow has evolved
in three Rails releases that all matter for this refactor:

* **Rails 7.1 (rails/rails#45625)** — extracted
  `build_create_table_definition` on the abstract adapter, plus
  `TableDefinition#set_primary_key`. This is the public seam that lets
  oracle-enhanced delegate primary-key setup to upstream rather than
  reimplementing it via `td.primary_key` / `td.primary_keys`.
* **Rails 7.1 (rails/rails#46178)** — added `validate_create_table_options!`
  and the `valid_table_definition_options` / `valid_primary_key_options`
  allowlists. To delegate to `super` without tripping the validator, an
  adapter has to declare its non-standard options (here: `:tablespace`,
  `:organization`, `:identity`, `:sequence_name`, `:sequence_start_value`)
  via these `valid_*_options` overrides — commits 1 and 2 in this PR.
* **Rails 8.2 (rails/rails#57000, currently on `main`, no tag yet)** —
  rewrote the abstract `create_table` to accumulate SQL into
  `execute_batch` and introduced `change_table_comment_sql` /
  `change_column_comment_sql` as the SQL-returning seams that the batched
  flow consumes. oracle-enhanced previously only had the `execute`-based
  `change_*_comment` methods, so this PR extracts the SQL-building
  logic into the matching `*_sql` helpers (commit 3) so `super` can
  drive comment emission through `execute_batch`. The same `execute_batch`
  change is also why the existing `execute`-spy in the schema-statements
  spec needs a sibling `execute_batch` override (folded into commit 6).

oracle-enhanced 8.2 targets Rails 8.2, so all three layers are in range.
Delegating to `super` and keeping only Oracle-specific work as overrides
is the cleaner shape.

### Detail

Thirteen commits, grouped by phase:

#### Option-routing allowlists

1. **Add `:tablespace, :organization` to `valid_table_definition_options`** — Oracle-specific table-level options that the upstream `validate_create_table_options!` and `build_create_table_definition` need to recognize once we delegate to `super`.
2. **Add `:sequence_name, :sequence_start_value` to `valid_primary_key_options`** — oracle-enhanced has no standalone sequence DSL, so these options control the primary key's value-generation strategy and slot in alongside the existing `:identity`. The outer override's `options` hash retains them after `super` (Ruby `**options` splatting copies, doesn't mutate) so `create_pk_sequence` keeps working.

#### Compatibility seams for `super`

3. **Implement `change_table_comment_sql` / `change_column_comment_sql`** — Rails base's `create_table` calls these (which return SQL strings) when `supports_comments? && !supports_comments_in_create?`, and accumulates results into `execute_batch`. oracle-enhanced previously only had `change_table_comment` / `change_column_comment` (which `execute` directly). Extract the SQL-building logic into private `*_sql` helpers; the existing public methods now delegate to them.
4. **Return `true` from `supports_indexes_in_create?`** — workaround that tells Rails base to skip its inline-index branch, which is incompatible with oracle-enhanced's `add_index_options` return shape (5-tuple of strings) and missing `visit_CreateIndexDefinition`. The override emits indexes itself via `add_index` after `super` returns. **Tracked as release-blocker in #2611**: migrating to a Rails-standard `CreateIndexDefinition` / visitor flow will let this override be removed before the next gem release. The override now carries an in-source comment pointing at the workaround status.

#### Main refactor

5. **Rename `create_sequence_and_trigger` → `create_pk_sequence`** — the trigger-based PK path was removed in 61f8a305 (2018); the method has been a misnomer since. Leaves room for a future `create_pk_sequence_and_trigger` once issue #2597 lands.
6. **Refactor `create_table` to delegate to `AbstractAdapter#create_table`** — 75 lines collapse to ~15. Helpers extracted:
   - `validate_identity_options!(identity, id, primary_key)` — identity preconditions, with internal early-return so the helper's contract matches its error messages.
   - `should_create_sequence?(td, id, identity)` — post-hoc inspection of `td.columns` to decide whether to create a sequence (folds the `identity` short-circuit in, since identity and sequence are mutually-exclusive PK strategies).
   The `id: false` + `t.primary_key` detection moves from a singleton-class augmentation to a `td.columns` post-hoc check, matching the way Rails core itself decides post-creation work in `create_table`. The `TableDefinition` is captured via the `super` block's yield (`captured_td = td` inside the block) so post-creation Oracle work can read `captured_td.indexes` / `captured_td.columns` after `super` returns.

#### `if_not_exists` symmetry

7. **Honor `:if_not_exists` by pre-checking with `data_source_exists?`** — symmetric to the existing `force && data_source_exists?` drop pattern. Until this commit `:if_not_exists` was silently swallowed by `OracleEnhanced::TableDefinition#initialize`'s anonymous `**`, so passing `if_not_exists: true` on an existing table failed with ORA-00955. Now it is a no-op, matching PostgreSQL / MySQL. `IF NOT EXISTS` DDL is not emitted because Oracle 11g/12c/19c/21c do not support it; the existence check is done in Ruby instead so the emitted SQL stays version-independent. Also raises the same upstream `ArgumentError` when `force: true` and `if_not_exists: true` are combined. Three regression specs cover the contract.

#### Cleanups

8. **Drop redundant `type &&` guard in `add_column`** — `add_column(table_name, column_name, type, ...)` takes `type` as a required positional argument, and `aliased_types(type.to_s, type)` runs earlier and would raise if `type` were nil.
9. **Replace stale TODOs in `create_pk_sequence`** — drop the "Needs rename" TODO (addressed by commit 5) and the "method will be removed" TODO (incorrect — issue #2597 keeps sequence-backed PKs as a first-class strategy). Replace with a forward-looking note pointing at #2597.

#### Review-driven follow-ups

10. **Stop creating a sequence for non-numeric `id:` types** — `should_create_sequence?` previously returned `true` for any non-`false` `id:` value, so `create_table :foo, id: :string` (or `:uuid`, etc.) would silently create a numeric sequence backing a non-numeric primary key — pointless DDL noise that also leaks a `<table>_seq` into the schema. Pre-existing bug, not introduced by the refactor; surfaced during review and fixed while the predicate is already in flux. Incidentally fixes `id: nil` as well: the old `id != false` predicate created a sequence with no PK column to back.
11. **Quote column comment values in `change_column_comment_sql`** — the helper was emitting comments via raw string interpolation (`IS '#{comment}'`), which would produce malformed SQL on values containing single quotes. Mirror the table version's `quote(...)` flow and explicit `nil` branch.
12. **Document why `if_not_exists` short-circuits in Ruby** — three-line code comment at the short-circuit explaining the Oracle ≤21c constraint that drives the workaround.
13. **Add regression specs for `id: false + numeric t.primary_key` sequence creation** — pin the post-hoc branch in `should_create_sequence?` against future regressions, with positive cases for `:integer` and `:bigint`.

### Why split this way

* Commits 1–4 are mechanically necessary for commit 6's `super` call (option routing + comment SQL helpers + index-branch skip).
* Commits 1 and 2 cover separate concerns (table-level vs PK-level options) and slot into different `valid_*_options` lists.
* Commit 5 is a name-only refactor that gates commit 6's call site rename.
* Commit 7 (`if_not_exists`) is technically separable from the main refactor but the pre-check shape only makes sense after the `force` pattern lands.
* Commits 10–13 are review-driven follow-ups; each is small enough to land on its own and reverse independently if needed.

### Notes

* `:identity` was already routed through the existing `valid_primary_key_options` override, so the Phase 1 (#2579) `identity:` API is unchanged.
* `add_column` keeps its existing `ArgumentError` for `identity: true` — out of scope here, intentionally restrictive.
* Post-creation work (`create_pk_sequence`, `rebuild_primary_key_index_to_default_tablespace`) moves from inline to after `super`, with `td` captured via the `super` block's yield.
* Dropped from the override and now provided by `super`: manual `options.extract!(...)`, manual `td.primary_key` / `td.primary_keys`, `schema_cache.clear_data_source_cache!`, `execute schema_creation.accept td`, and the comment-emit loop for adapters lacking `supports_comments_in_create?`.
* Test infrastructure: the "miscellaneous options" describe block in `schema_statements_spec.rb` adds an `execute_batch` singleton override alongside the existing `execute` spy, because Rails 8's `execute_batch` runs each statement through `QueryIntent#execute!` rather than the adapter's `execute`.

### Release-blocker

* `supports_indexes_in_create? = true` is a workaround override, not a true capability claim — Oracle has never supported inline non-constraint indexes (true through 23ai). Issue #2611 tracks migrating to the Rails-standard `CreateIndexDefinition` / visitor flow and **must land before the next gem release**, so the override can be removed and the predicate can inherit the abstract `false` default.

### Forward compatibility

* PR #2596 (Phase 2: auto-enable identity in `Migration[8.2]+`) hooks at the migration class level and sets `options[:identity]` before delegating; this refactor does not interfere with that path.
* Issue #2597 (Phase 3: `primary_key_trigger:` opt-in) can be slotted into the same shape — new option in `valid_primary_key_options`, new `validate_primary_key_trigger_options!` helper paralleling `validate_identity_options!`, and a new branch in the post-creation work selector.

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added (regression specs for `if_not_exists` no-op behavior, `id: false + numeric t.primary_key` sequence creation).
