### PR TITLE
Migrate index emission in create_table to Rails-standard CreateIndexDefinition flow

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -62,18 +62,11 @@ module ActiveRecord
         # This method is used in add_index to identify either column name (which is quoted)
         # or function based index (in which case function expression is not quoted)
         def quote_column_name_or_expression(name) # :nodoc:
-          name = name.to_s
-          case name
-          # if only valid lowercase column characters in name
-          when /^[a-z][a-z_0-9$#]*$/
-            "\"#{name.upcase}\""
-          when /^[a-z][a-z_0-9$#-]*$/i
-            "\"#{name}\""
-          # if other characters present then assume that it is expression
-          # which should not be quoted
-          else
-            name
-          end
+          column_name_expression?(name) ? name.to_s : quote_column_name(name)
+        end
+
+        def column_name_expression?(name) # :nodoc:
+          !/\A[a-z][a-z_0-9$#-]*\z/i.match?(name.to_s)
         end
 
         # Nonquoted Oracle identifiers must begin with an alphabetic

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -83,6 +83,22 @@ module ActiveRecord
             end
           end
 
+          def visit_CreateIndexDefinition(o)
+            index = o.index
+
+            sql = ["CREATE"]
+            sql << "UNIQUE" if index.unique
+            sql << "INDEX"
+            sql << quote_column_name(index.name)
+            sql << "ON"
+            sql << quote_table_name(index.table)
+            sql << "(#{quoted_columns(index)})"
+            sql << "TABLESPACE #{index.tablespace}" if index.tablespace.present?
+            sql << index.statement_parameters if index.statement_parameters.present?
+
+            sql.join(" ")
+          end
+
           def action_sql(action, dependency)
             if action == "UPDATE"
               raise ArgumentError, <<~MSG

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -223,7 +223,7 @@ module ActiveRecord
             yield td if block_given?
           end
 
-          captured_td.indexes.each { |c, o| add_index table_name, c, **o }
+          add_inline_unique_constraints(table_name, captured_td)
 
           create_pk_sequence(table_name, options) if should_create_sequence?(captured_td, id, identity)
           rebuild_primary_key_index_to_default_tablespace(table_name, options)
@@ -653,6 +653,14 @@ module ActiveRecord
           def add_unique_constraint_sql(table_name, columns, index_name)
             quoted_cols = Array(columns).map { |column| quote_column_name_or_expression(column) }.join(", ")
             "ALTER TABLE #{quote_table_name(table_name)} ADD CONSTRAINT #{quote_column_name(index_name)} UNIQUE (#{quoted_cols}) USING INDEX #{quote_column_name(index_name)}"
+          end
+
+          def add_inline_unique_constraints(table_name, td)
+            td.indexes.each do |column_name, index_options|
+              next unless needs_unique_constraint?(index_options[:unique], column_name)
+              inline_index_name = index_options[:name]&.to_s || index_name(table_name, column: index_column_names(column_name))
+              execute add_unique_constraint_sql(table_name, column_name, inline_index_name)
+            end
           end
 
           def validate_identity_options!(identity, id, primary_key)

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -260,38 +260,49 @@ module ActiveRecord
         end
 
         def add_index(table_name, column_name, **options) # :nodoc:
-          result = add_index_options(table_name, column_name, **options)
-          return if result.nil?
-          index_name, index_type, quoted_column_names, tablespace, index_options = result
-          execute "CREATE #{index_type} INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} (#{quoted_column_names})#{tablespace} #{index_options}"
-          if index_type == "UNIQUE"
-            unless /\(.*\)/.match?(quoted_column_names)
-              execute "ALTER TABLE #{quote_table_name(table_name)} ADD CONSTRAINT #{quote_column_name(index_name)} #{index_type} (#{quoted_column_names}) USING INDEX #{quote_column_name(index_name)}"
-            end
+          create_index = build_create_index_definition(table_name, column_name, **options)
+          return unless create_index
+
+          execute schema_creation.accept(create_index)
+
+          index = create_index.index
+          if needs_unique_constraint?(index.unique, index.columns)
+            execute add_unique_constraint_sql(index.table, index.columns, index.name)
           end
         end
 
-        def add_index_options(table_name, column_name, name: nil, if_not_exists: false, internal: false, **options) # :nodoc:
-          column_names = Array(column_name)
-          index_name   = index_name(table_name, column: column_names)
+        def build_create_index_definition(table_name, column_name, **options) # :nodoc:
+          index, algorithm, if_not_exists = add_index_options(table_name, column_name, **options)
 
+          if table_exists?(table_name) && index_name_exists?(table_name, index.name)
+            return if if_not_exists
+            raise ArgumentError, "Index name '#{index.name}' on table '#{table_name}' already exists"
+          end
+
+          CreateIndexDefinition.new(index, algorithm, if_not_exists)
+        end
+
+        def add_index_options(table_name, column_name, name: nil, if_not_exists: false, internal: false, **options) # :nodoc:
           options.assert_valid_keys(:unique, :order, :where, :length, :tablespace, :options, :using, :comment)
 
-          index_type = options[:unique] ? "UNIQUE" : ""
-          index_name = name.to_s if name
-          tablespace = tablespace_for(:index, options[:tablespace])
-          # TODO: This option is used for NOLOGGING, needs better argument name
-          index_options = options[:options]
+          column_names = index_column_names(column_name)
+          index_name = name&.to_s || index_name(table_name, column: column_names)
 
           validate_index_length!(table_name, index_name, internal)
 
-          if table_exists?(table_name) && index_name_exists?(table_name, index_name)
-            return nil if if_not_exists
-            raise ArgumentError, "Index name '#{index_name}' on table '#{table_name}' already exists"
-          end
+          index = OracleEnhanced::IndexDefinition.new(
+            table_name,
+            index_name,
+            options[:unique] || false,
+            column_names,
+            {},
+            nil,
+            nil,
+            options[:options],
+            options[:tablespace] || default_tablespace_for(:index)
+          )
 
-          quoted_column_names = column_names.map { |e| quote_column_name_or_expression(e) }.join(", ")
-          [index_name, index_type, quoted_column_names, tablespace, index_options]
+          [index, nil, if_not_exists]
         end
 
         # Remove the given index from the table.
@@ -632,6 +643,16 @@ module ActiveRecord
         private
           def index_column_names(column_names) # :nodoc:
             column_names.is_a?(Array) ? column_names : Array(column_names)
+          end
+
+          def needs_unique_constraint?(unique, columns)
+            return false unless unique
+            Array(columns).none? { |column| column.to_s.include?("(") }
+          end
+
+          def add_unique_constraint_sql(table_name, columns, index_name)
+            quoted_cols = Array(columns).map { |column| quote_column_name_or_expression(column) }.join(", ")
+            "ALTER TABLE #{quote_table_name(table_name)} ADD CONSTRAINT #{quote_column_name(index_name)} UNIQUE (#{quoted_cols}) USING INDEX #{quote_column_name(index_name)}"
           end
 
           def validate_identity_options!(identity, id, primary_key)

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -622,7 +622,18 @@ module ActiveRecord
           super + [:identity, :sequence_name, :sequence_start_value]
         end
 
+        def quoted_columns_for_index(column_names, options) # :nodoc:
+          quoted_columns = column_names.each_with_object({}) do |name, result|
+            result[name.to_sym] = quote_column_name_or_expression(name).dup
+          end
+          add_options_for_index_columns(quoted_columns, **options).values.join(", ")
+        end
+
         private
+          def index_column_names(column_names) # :nodoc:
+            column_names.is_a?(Array) ? column_names : Array(column_names)
+          end
+
           def validate_identity_options!(identity, id, primary_key)
             return unless identity
             unless supports_identity_columns?

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -361,15 +361,6 @@ module ActiveRecord
         true
       end
 
-      # Oracle has no inline non-constraint index syntax (true through 23ai); this
-      # override only returns true to make Rails' base `create_table` skip its index
-      # branch, which is incompatible with oracle-enhanced's `add_index_options`
-      # return shape. Removed once https://github.com/rsim/oracle-enhanced/issues/2611
-      # lands.
-      def supports_indexes_in_create?
-        true
-      end
-
       def supports_multi_insert?
         database_version.to_s >= [11, 2].to_s
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -1591,6 +1591,74 @@ end
       # and the assertion is unrelated to what the test is checking.
       expect(@would_execute_sql).to match(/ALTER +TABLE .* ADD CONSTRAINT .* UNIQUE \(.*\) USING INDEX "THIS_INDEX";/)
     end
+
+    it "should emit CREATE UNIQUE INDEX and ADD CONSTRAINT for inline t.index unique: true" do
+      schema_define do
+        create_table :test_inline_index_posts, force: true do |t|
+          t.string :title
+          t.index :title, unique: true, name: :uniq_inline_title
+        end
+      end
+      expect(@would_execute_sql).to match(/CREATE UNIQUE INDEX "UNIQ_INLINE_TITLE" ON "TEST_INLINE_INDEX_POSTS" \("TITLE"\)/)
+      expect(@would_execute_sql).to match(/ALTER +TABLE "TEST_INLINE_INDEX_POSTS" ADD CONSTRAINT "UNIQ_INLINE_TITLE" UNIQUE \("TITLE"\) USING INDEX "UNIQ_INLINE_TITLE"/)
+    end
+
+    it "should emit CREATE UNIQUE INDEX without ADD CONSTRAINT for inline functional t.index unique: true" do
+      schema_define do
+        create_table :test_inline_index_posts, force: true do |t|
+          t.string :title
+          t.index "lower(title)", unique: true, name: :uniq_inline_lower_title
+        end
+      end
+      expect(@would_execute_sql).to match(/CREATE UNIQUE INDEX "UNIQ_INLINE_LOWER_TITLE" ON "TEST_INLINE_INDEX_POSTS" \(lower\(title\)\)/)
+      expect(@would_execute_sql).not_to include("ADD CONSTRAINT")
+    end
+
+    it "should emit CREATE INDEX without ADD CONSTRAINT for inline non-unique t.index" do
+      schema_define do
+        create_table :test_inline_index_posts, force: true do |t|
+          t.string :title
+          t.index :title, name: :idx_inline_title
+        end
+      end
+      expect(@would_execute_sql).to match(/CREATE INDEX "IDX_INLINE_TITLE" ON "TEST_INLINE_INDEX_POSTS" \("TITLE"\)/)
+      expect(@would_execute_sql).not_to include("ADD CONSTRAINT")
+    end
+
+    it "should emit TABLESPACE for inline t.index with :tablespace option" do
+      schema_define do
+        create_table :test_inline_index_posts, force: true do |t|
+          t.string :title
+          t.index :title, name: :idx_inline_title_ts, tablespace: "bogus"
+        end
+      end
+      expect(@would_execute_sql).to match(/CREATE INDEX "IDX_INLINE_TITLE_TS" ON "TEST_INLINE_INDEX_POSTS" \("TITLE"\) TABLESPACE bogus/)
+    end
+
+    it "produces the same SQL whether unique index is defined inline or via explicit add_index" do
+      schema_define do
+        create_table :test_explicit_idx_posts, force: true do |t|
+          t.string :title
+        end
+        add_index :test_explicit_idx_posts, :title, unique: true, name: :uniq_title
+      end
+      explicit_sql = @would_execute_sql.dup
+
+      @would_execute_sql.replace("")
+      schema_define do
+        drop_table :test_explicit_idx_posts, if_exists: true
+        create_table :test_explicit_idx_posts, force: true do |t|
+          t.string :title
+          t.index :title, unique: true, name: :uniq_title
+        end
+      end
+      inline_sql = @would_execute_sql
+
+      [/CREATE TABLE "TEST_EXPLICIT_IDX_POSTS"/, /CREATE UNIQUE INDEX "UNIQ_TITLE"/, /ALTER +TABLE "TEST_EXPLICIT_IDX_POSTS" ADD CONSTRAINT "UNIQ_TITLE" UNIQUE \("TITLE"\) USING INDEX "UNIQ_TITLE"/].each do |pattern|
+        expect(explicit_sql).to match(pattern)
+        expect(inline_sql).to match(pattern)
+      end
+    end
   end
 
   describe "load schema" do


### PR DESCRIPTION
### Motivation / Background

Closes #2611.

#2610 (refactor `create_table` to delegate to `AbstractAdapter#create_table`) took the pragmatic route of overriding `supports_indexes_in_create?` to return `true` and looping `td.indexes.each { add_index ... }` after `super`. The conventional reading of `supports_indexes_in_create?` is "the adapter emits indexes inline inside `CREATE TABLE` syntax", which Oracle Database does not — only `PRIMARY KEY` / `UNIQUE` / `FOREIGN KEY` / `CHECK` constraints can appear inline (see the [Oracle Database 23ai SQL Language Reference, CREATE TABLE](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/CREATE-TABLE.html)). The override re-interpreted the predicate as "Rails base, do not emit indexes for me", which kept #2610 focused but left the workaround as a release-blocker.

This PR migrates index emission to the Rails-standard `add_index_options → build_create_index_definition → schema_creation.accept` flow that Rails 7.1 (rails/rails#45625) extracted, so that the workaround override can be removed and the predicate inherits the abstract `false` default. The implementation mirrors the Rails MySQL adapter, which solves the same Ruby-level existence-check requirement (Oracle DDL has no `CREATE INDEX IF NOT EXISTS` form on any supported release).

### Detail

Five commits:

1. **Refactor index column quoting toward Rails three-stage pipeline.** Three related helper refactors that prepare `OracleEnhanced::SchemaCreation` to inherit Rails' three-stage column-quoting pipeline:
   * Extract `column_name_expression?` from `quote_column_name_or_expression` in `OracleEnhanced::Quoting` so the identifier-vs-expression detection can be reused without rerunning the quoting logic. Public-method API and behavior are preserved.
   * Override `quoted_columns_for_index` in `OracleEnhanced::SchemaStatements` (kept public to match Rails' `:nodoc:` public method, so `SchemaCreation`'s `delegate(..., to: :@conn, private: true)` can reach it). Routes per-name quoting through `quote_column_name_or_expression` so functional-index expressions like `"lower(name)"` are not mis-quoted as identifiers (Rails base's `quote_column_name(name)` would).
   * Override `index_column_names` in `OracleEnhanced::SchemaStatements` to always return an `Array` (no-op when input is already an `Array`). Rails' base version short-circuits on `expression_column_name?(column_names)` returning the String for expressions, but Rails' predicate uses `\W` matching, which classifies hyphenated identifiers like `"foo-bar"` as expressions — Oracle accepts those as quotable identifiers, so the visitor must always go through the array branch and let `quote_column_name_or_expression` apply the Oracle-flavored rules.

   No callers exist on the oracle-enhanced side at this commit; subsequent commits wire the new plumbing into the visitor flow.

2. **Add `visit_CreateIndexDefinition` to `OracleEnhanced::SchemaCreation`** — produces the Oracle dialect of the index DDL: `CREATE [UNIQUE] INDEX <name> ON <table> (<cols>) [TABLESPACE <ts>] [<statement_parameters>]`. Mirrors Rails base's array-push + `sql.join(" ")` shape so the two can be diffed side by side. Column quoting goes through `quoted_columns(o)` (Rails base helper) which delegates to the overridden `quoted_columns_for_index` from commit 1.

3. **Rewrite `add_index_options` and `add_index` to the Rails-standard pipeline.** `add_index_options` now returns the `[index_definition, algorithm, if_not_exists]` triple (an `OracleEnhanced::IndexDefinition` populated with Oracle-specific `tablespace` / `statement_parameters`, no `algorithm`, `if_not_exists` passed through from kwargs). `add_index` mirrors Rails MySQL's body — `build_create_index_definition`, `return unless create_index`, `execute schema_creation.accept(create_index)`, then the Oracle-specific `ALTER TABLE ADD CONSTRAINT` for UNIQUE non-functional indexes. `build_create_index_definition` is overridden to do the Ruby-level existence check (raises `ArgumentError` on duplicate without `if_not_exists`, returns `nil` to short-circuit `add_index` when `if_not_exists: true` matches an existing index — preserving the pre-existing oracle-enhanced behavior). Two new private helpers split the responsibilities: `needs_unique_constraint?(unique, columns)` and `add_unique_constraint_sql(table_name, columns, index_name)`.

4. **Drop the `supports_indexes_in_create? = true` override.** The predicate now inherits the abstract `false` default, which is the truthful answer for Oracle. Rails base's `create_table` index-emission branch fires, calling our visitor for the CREATE INDEX SQL. The post-`super` work in `OracleEnhanced::SchemaStatements#create_table` shrinks from "iterate `td.indexes` and call `add_index` per index" to a single `add_inline_unique_constraints(table_name, captured_td)` helper that emits only the trailing `ALTER TABLE ... ADD CONSTRAINT ... UNIQUE` for non-functional UNIQUE inline indexes. The helper reuses `needs_unique_constraint?` and `add_unique_constraint_sql` from commit 3 so the explicit `add_index` path and the inline `t.index` path share one source of truth for the constraint SQL.

5. **Add regression specs for inline index emission.** Five new specs in the existing "miscellaneous options" describe block (which already has the `execute` / `execute_batch` SQL spy):
   * Inline UNIQUE column index emits both `CREATE UNIQUE INDEX` and `ALTER TABLE ... ADD CONSTRAINT ... UNIQUE ... USING INDEX`.
   * Inline UNIQUE functional index emits only `CREATE UNIQUE INDEX`, no constraint.
   * Inline non-unique index emits only `CREATE INDEX`, no constraint.
   * Inline `:tablespace` option flows through to the visitor.
   * Equivalence between `create_table + add_index` and `create_table do |t| t.index unique: true end` — the principle-of-least-surprise invariant.

### Why preserve the trailing `ALTER TABLE ADD CONSTRAINT`

In Oracle, `CREATE UNIQUE INDEX <name>` adds a row to `user_indexes` but **no** row to `user_constraints`. The unique enforcement is at the index level. Without the explicit `ALTER TABLE ... ADD CONSTRAINT <name> UNIQUE (...) USING INDEX <name>`:

* FK references to the column fail with `ORA-02270: no matching unique or primary key for this column-list` — Oracle requires an explicit `UNIQUE` or `PRIMARY KEY` constraint, not a unique index.
* `structure_dump_unique_keys` (which queries `user_constraints` with `constraint_type = 'U'`) returns nothing, so schema dump → load round-trips silently lose the named constraint.
* The `name:` the user supplied applies to the index but not to the constraint (the constraint simply does not exist), violating the implicit user expectation that `add_index :t, :col, unique: true, name: :X` and `t.index :col, unique: true, name: :X` produce equivalent schema artifacts.

These three concerns drove the design choice to keep a small post-`super` constraint loop instead of deleting the loop entirely. The loop is now `add_inline_unique_constraints` (plural — it iterates and may emit zero or many `ALTER TABLE` statements) rather than the previous `add_index` re-emit; the CREATE INDEX itself comes from Rails base via the visitor.

### Behavior contract after this PR

| Form | CREATE INDEX | ALTER TABLE constraint |
|---|---|---|
| `add_index :t, :col, unique: true, name: :n` | ✓ visitor | ✓ `add_unique_constraint_sql` |
| `add_index :t, "lower(col)", unique: true, name: :n` (functional) | ✓ visitor | ✗ |
| `add_index :t, :col, name: :n` (non-unique) | ✓ visitor | ✗ |
| `t.index :col, unique: true, name: :n` (inline) | ✓ visitor (via Rails base inline-index loop) | ✓ `add_inline_unique_constraints` |
| `t.index "lower(col)", unique: true, name: :n` (inline functional) | ✓ visitor | ✗ |
| `t.index :col` (inline non-unique) | ✓ visitor | ✗ |

The explicit `add_index` / inline `t.index` rows produce identical schema artifacts for the same arguments.

### Notes

* `OracleEnhanced::IndexDefinition` is unchanged. It already carried `tablespace`, `parameters`, `statement_parameters` for the read-path (`indexes(table_name)` in `schema_statements.rb`); the write-path now populates them via `add_index_options`.
* `quoted_columns_for_index` is overridden as a public method (matching Rails' `:nodoc:` public method, line 1592 in abstract `schema_statements.rb`). The CI `Compare Ruby visibility against Rails` job enforces this.
* `column_name_expression?` is intentionally **not** named `expression_column_name?` to avoid colliding with Rails' inherited private predicate of that name (which uses `column_name.is_a?(String) && /\W/.match?(column_name)` — classifies hyphenated identifiers as expressions, while oracle-enhanced accepts them as quotable identifiers). The two predicates serve different concerns (Rails' drives index-name derivation; ours drives SQL emission) and keeping the names separate avoids accidentally subverting Rails' name derivation.
* The `:options` (NOLOGGING etc.), `:tablespace`, `:unique` options to `add_index` keep their current semantics; `:order`, `:where`, `:length`, `:using`, `:comment` remain in the `assert_valid_keys` list and continue to be silently ignored at the SQL level (matching the pre-existing behavior — adding genuine support for `:order` is tracked in #2614, follow-on `add_unique_constraint` / `t.unique_constraint` API parity in #2613).
* `add_index_options`'s previous `return nil if if_not_exists` shape is gone — `nil` is incompatible with Rails' `build_create_index_definition`, which destructures the triple unconditionally and would crash on a `nil` `index`. The check moves to the `build_create_index_definition` override.

### Follow-ups (separate issues)

* #2613 — `add_unique_constraint` / `remove_unique_constraint` / `t.unique_constraint` matching the PostgreSQL adapter API (out of scope here; this PR is index-emission migration, not new UNIQUE-constraint DSL).
* #2614 — Honor `:order` option in `add_index` (currently silently ignored; the three-stage pipeline added in commit 1 of this PR is the structural prerequisite).

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added (5 inline-index regression specs).
