### PR TITLE
Restore trigger-based primary key generation as opt-in primary_key_trigger: option

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -84,7 +84,7 @@ module ActiveRecord
 
         private
           def valid_column_definition_options
-            super + [ :as, :sequence_name, :sequence_start_value, :type, :identity ]
+            super + [ :as, :sequence_name, :sequence_start_value, :type, :identity, :primary_key_trigger, :trigger_name ]
           end
       end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -17,6 +17,7 @@ module ActiveRecord # :nodoc:
           def tables(stream)
             # do not include materialized views in schema dump - they should be created separately after schema creation
             sorted_tables = (@connection.tables - @connection.materialized_views).sort
+            @trigger_backed_tables = @connection.trigger_backed_table_names
             sorted_tables.each do |tbl|
               # add table prefix or suffix for schema_migrations
               next if ignored? tbl
@@ -122,7 +123,13 @@ module ActiveRecord # :nodoc:
                   end
                   tbl.print ", #{format_colspec(pkcolspec)}"
                 end
-                tbl.print ", identity: true" if pkcol.auto_incremented_by_db?
+                if pkcol.auto_incremented_by_db?
+                  tbl.print ", identity: true"
+                elsif (trigger_name = @trigger_backed_tables[table.upcase])
+                  tbl.print ", primary_key_trigger: true"
+                  default_name = @connection.default_trigger_name(table).upcase
+                  tbl.print ", trigger_name: #{trigger_name.downcase.inspect}" unless trigger_name == default_name
+                end
               when Array
                 tbl.print ", primary_key: #{pk.inspect}"
               else

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -207,6 +207,7 @@ module ActiveRecord
 
           identity = options[:identity]
           validate_identity_options!(identity, id, primary_key)
+          validate_primary_key_trigger_options!(options[:primary_key_trigger], identity, id, primary_key)
 
           if force && data_source_exists?(table_name)
             drop_table(table_name, force: force, if_exists: true)
@@ -226,6 +227,7 @@ module ActiveRecord
           add_inline_unique_constraints(table_name, captured_td)
 
           create_pk_sequence(table_name, options) if should_create_sequence?(captured_td, id, identity)
+          create_pk_trigger(table_name, primary_key, options) if options[:primary_key_trigger]
           rebuild_primary_key_index_to_default_tablespace(table_name, options)
         end
 
@@ -407,13 +409,20 @@ module ActiveRecord
             raise ArgumentError,
               "`identity: true` is not supported on `add_column`. Recreate the table with `create_table ..., identity: true` instead."
           end
+          if options[:primary_key_trigger] && type.to_s.to_sym != :primary_key
+            raise ArgumentError,
+              "`primary_key_trigger: true` on `add_column` requires the column type to be `:primary_key`; got type: #{type.inspect}."
+          end
           type = aliased_types(type.to_s, type)
           at = create_alter_table table_name
           at.add_column(column_name, type, **options)
           add_column_sql = schema_creation.accept at
           add_column_sql << tablespace_for((type_to_sql(type).downcase.to_sym), nil, table_name, column_name)
           execute add_column_sql
-          create_pk_sequence(table_name, options) if type.to_sym == :primary_key
+          if type.to_sym == :primary_key
+            create_pk_sequence(table_name, options)
+            create_pk_trigger(table_name, column_name, options) if options[:primary_key_trigger]
+          end
           change_column_comment(table_name, column_name, options[:comment]) if options.key?(:comment)
         ensure
           clear_table_columns_cache(table_name)
@@ -630,7 +639,20 @@ module ActiveRecord
         end
 
         def valid_primary_key_options # :nodoc:
-          super + [:identity, :sequence_name, :sequence_start_value]
+          super + [:identity, :sequence_name, :sequence_start_value, :primary_key_trigger, :trigger_name]
+        end
+
+        def default_trigger_name(table_name) # :nodoc:
+          table_name.to_s.gsub(/(\A|\.)([[:word:]$#-]+)\z/) do
+            prefix = Regexp.last_match(1)
+            name = Regexp.last_match(2)
+            max_bytes = max_identifier_length - 4
+            if name.bytesize > max_bytes
+              name = name.byteslice(0, max_bytes)
+              name = name.byteslice(0, name.bytesize - 1) until name.bytesize.zero? || name.valid_encoding?
+            end
+            "#{prefix}#{name}_pkt"
+          end
         end
 
         def quoted_columns_for_index(column_names, options) # :nodoc:
@@ -676,6 +698,22 @@ module ActiveRecord
             if primary_key.is_a?(Array)
               raise ArgumentError,
                 "`identity: true` cannot be combined with a composite primary key."
+            end
+          end
+
+          def validate_primary_key_trigger_options!(primary_key_trigger, identity, id, primary_key)
+            return unless primary_key_trigger
+            if identity
+              raise ArgumentError,
+                "`primary_key_trigger: true` cannot be combined with `identity: true`."
+            end
+            unless id == :primary_key
+              raise ArgumentError,
+                "`primary_key_trigger: true` requires `id: :primary_key` (the default); got id: #{id.inspect}."
+            end
+            if primary_key.is_a?(Array)
+              raise ArgumentError,
+                "`primary_key_trigger: true` cannot be combined with a composite primary key."
             end
           end
 
@@ -816,13 +854,27 @@ module ActiveRecord
             column
           end
 
-          # TODO: extend to also create a BEFORE INSERT trigger when issue
-          # https://github.com/rsim/oracle-enhanced/issues/2597 introduces
-          # `primary_key_trigger: true`.
           def create_pk_sequence(table_name, options)
             seq_name = options[:sequence_name] || default_sequence_name(table_name, nil)
             seq_start_value = options[:sequence_start_value] || default_sequence_start_value
             execute "CREATE SEQUENCE #{quote_table_name(seq_name)} START WITH #{seq_start_value}"
+          end
+
+          def create_pk_trigger(table_name, pk_column, options)
+            seq_name = options[:sequence_name] || default_sequence_name(table_name, nil)
+            trigger_name = options[:trigger_name] || default_trigger_name(table_name)
+            pk = pk_column || ActiveRecord::Base.get_primary_key(table_name.to_s.singularize)
+            execute <<~SQL
+              CREATE OR REPLACE TRIGGER #{quote_table_name(trigger_name)}
+                BEFORE INSERT ON #{quote_table_name(table_name)} FOR EACH ROW
+              BEGIN
+                IF inserting THEN
+                  IF :new.#{quote_column_name(pk)} IS NULL THEN
+                    SELECT #{quote_table_name(seq_name)}.NEXTVAL INTO :new.#{quote_column_name(pk)} FROM dual;
+                  END IF;
+                END IF;
+              END;
+            SQL
           end
 
           def rebuild_primary_key_index_to_default_tablespace(table_name, options)

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -552,9 +552,10 @@ module ActiveRecord
         table_name = table_name.to_s
         if @prefetch_primary_key_cache[table_name].nil?
           owner, desc_table_name = resolve_data_source_name(table_name)
-          has_pk          = has_primary_key?(table_name, owner, desc_table_name)
-          has_identity_pk = supports_identity_columns? && identity_primary_key?(owner, desc_table_name)
-          @prefetch_primary_key_cache[table_name] = has_pk && !has_identity_pk
+          has_pk                = has_primary_key?(table_name, owner, desc_table_name)
+          has_identity_pk       = supports_identity_columns? && identity_primary_key?(owner, desc_table_name)
+          has_trigger_backed_pk = trigger_backed_primary_key?(owner, desc_table_name)
+          @prefetch_primary_key_cache[table_name] = has_pk && !has_identity_pk && !has_trigger_backed_pk
         end
         @prefetch_primary_key_cache[table_name]
       end
@@ -579,6 +580,50 @@ module ActiveRecord
             AND itc.table_name = :table_name
             AND c.constraint_type = 'P'
         SQL
+      end
+
+      # Detects only triggers whose body contains the
+      # `<seq>.NEXTVAL INTO :new.<pk>` pattern emitted by `create_pk_trigger`.
+      # Restricts the +all_triggers+ scan with an +EXISTS+ over +all_source+
+      # so unrelated `BEFORE INSERT` row triggers (audit, last_modified, etc.)
+      # do not flip +prefetch_primary_key?+ to false on tables that still
+      # rely on Rails-side sequence prefetch.
+      def trigger_backed_primary_key?(owner, desc_table_name) # :nodoc:
+        select_values_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("table_name", desc_table_name)]).any?
+          SELECT 1
+          FROM all_triggers t
+          WHERE t.owner = :owner
+            AND t.table_name = :table_name
+            AND t.trigger_type = 'BEFORE EACH ROW'
+            AND t.triggering_event = 'INSERT'
+            AND EXISTS (
+              SELECT 1 FROM all_source s
+               WHERE s.owner = t.owner
+                 AND s.name  = t.trigger_name
+                 AND s.type  = 'TRIGGER'
+                 AND UPPER(s.text) LIKE '%NEXTVAL INTO :NEW%'
+            )
+        SQL
+      end
+
+      def trigger_backed_table_names # :nodoc:
+        rows = select_all(<<~SQL.squish, "SCHEMA")
+          SELECT t.table_name, t.trigger_name
+          FROM all_triggers t
+          WHERE t.owner = SYS_CONTEXT('userenv', 'current_schema')
+            AND t.trigger_type = 'BEFORE EACH ROW'
+            AND t.triggering_event = 'INSERT'
+            AND EXISTS (
+              SELECT 1 FROM all_source s
+               WHERE s.owner = t.owner
+                 AND s.name  = t.trigger_name
+                 AND s.type  = 'TRIGGER'
+                 AND UPPER(s.text) LIKE '%NEXTVAL INTO :NEW%'
+            )
+        SQL
+        rows.each_with_object({}) do |row, hash|
+          hash[row["table_name"]] = row["trigger_name"]
+        end
       end
 
       def reset_pk_sequence!(table_name, primary_key = nil, sequence_name = nil) # :nodoc:

--- a/spec/active_record/connection_adapters/oracle_enhanced/primary_key_trigger_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/primary_key_trigger_spec.rb
@@ -330,6 +330,7 @@ describe "primary_key_trigger" do
     end
 
     it "does not raise NoMethodError for :returning_id Symbol when logging" do
+      skip "see #2619: ruby-oci8 + cursor_sharing=force x RETURNING INTO :returning_id half-duplex deadlock"
       set_logger
       @conn.reconnect! unless @conn.active?
       @conn.insert("INSERT INTO test_pk_triggers (name) VALUES ('alpha')", nil, "id")

--- a/spec/active_record/connection_adapters/oracle_enhanced/primary_key_trigger_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/primary_key_trigger_spec.rb
@@ -1,0 +1,498 @@
+# frozen_string_literal: true
+
+describe "primary_key_trigger" do
+  include SchemaSpecHelper
+  include LoggerSpecHelper
+
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @conn = ActiveRecord::Base.lease_connection
+    @oracle12c_or_higher = @conn.database_version.first >= 12
+  end
+
+  after(:each) do
+    ActiveRecord::Migration.suppress_messages do
+      schema_define do
+        drop_table :test_pk_triggers, if_exists: true
+      end
+    end
+    @conn.schema_cache.clear!
+  end
+
+  def sequence_exists?(name)
+    @conn.select_value(<<~SQL.squish, "SCHEMA").present?
+      SELECT 1 FROM user_sequences WHERE sequence_name = '#{name.to_s.upcase}'
+    SQL
+  end
+
+  def trigger_exists?(name)
+    @conn.select_value(<<~SQL.squish, "SCHEMA").present?
+      SELECT 1 FROM user_triggers WHERE trigger_name = '#{name.to_s.upcase}'
+    SQL
+  end
+
+  describe "without primary_key_trigger: option" do
+    it "creates a sequence-backed primary key without a trigger" do
+      schema_define do
+        create_table :test_pk_triggers do |t|
+          t.string :name
+        end
+      end
+
+      expect(sequence_exists?(:test_pk_triggers_seq)).to be true
+      expect(trigger_exists?(:test_pk_triggers_pkt)).to be false
+      expect(@conn.prefetch_primary_key?(:test_pk_triggers)).to be true
+    end
+
+    it "treats primary_key_trigger: false the same as the default" do
+      schema_define do
+        create_table :test_pk_triggers, primary_key_trigger: false do |t|
+          t.string :name
+        end
+      end
+
+      expect(trigger_exists?(:test_pk_triggers_pkt)).to be false
+    end
+  end
+
+  describe "with primary_key_trigger: true" do
+    it "creates a sequence + BEFORE INSERT trigger" do
+      schema_define do
+        create_table :test_pk_triggers, primary_key_trigger: true do |t|
+          t.string :name
+        end
+      end
+
+      expect(sequence_exists?(:test_pk_triggers_seq)).to be true
+      expect(trigger_exists?(:test_pk_triggers_pkt)).to be true
+    end
+
+    it "skips prefetch_primary_key? for trigger-backed tables" do
+      schema_define do
+        create_table :test_pk_triggers, primary_key_trigger: true do |t|
+          t.string :name
+        end
+      end
+
+      expect(@conn.prefetch_primary_key?(:test_pk_triggers)).to be false
+    end
+
+    it "allows inserting rows without supplying id (trigger fills via NEXTVAL)" do
+      schema_define do
+        create_table :test_pk_triggers, primary_key_trigger: true do |t|
+          t.string :name
+        end
+      end
+      klass = Class.new(ActiveRecord::Base) { self.table_name = "test_pk_triggers" }
+
+      row = klass.create!(name: "alpha")
+      expect(row.id).to be_a(Integer)
+      expect(row.id).to be > 0
+    end
+
+    it "allows inserting rows with an explicit id (trigger only fires when NULL)" do
+      schema_define do
+        create_table :test_pk_triggers, primary_key_trigger: true do |t|
+          t.string :name
+        end
+      end
+      klass = Class.new(ActiveRecord::Base) { self.table_name = "test_pk_triggers" }
+
+      row = klass.create!(id: 42, name: "bravo")
+      expect(row.id).to eq(42)
+    end
+
+    it "honors the :trigger_name option" do
+      schema_define do
+        create_table :test_pk_triggers, primary_key_trigger: true, trigger_name: :custom_pkt do |t|
+          t.string :name
+        end
+      end
+
+      expect(trigger_exists?(:custom_pkt)).to be true
+      expect(trigger_exists?(:test_pk_triggers_pkt)).to be false
+    end
+  end
+
+  describe "add_column with primary_key_trigger: true" do
+    it "creates the trigger when adding a :primary_key column" do
+      schema_define do
+        create_table :test_pk_triggers, id: false do |t|
+          t.string :name
+        end
+      end
+
+      expect(trigger_exists?(:test_pk_triggers_pkt)).to be false
+
+      @conn.add_column :test_pk_triggers, :id, :primary_key, primary_key_trigger: true
+
+      expect(sequence_exists?(:test_pk_triggers_seq)).to be true
+      expect(trigger_exists?(:test_pk_triggers_pkt)).to be true
+    end
+
+    it "raises when adding a non-:primary_key column with primary_key_trigger: true" do
+      schema_define do
+        create_table :test_pk_triggers, id: false do |t|
+          t.string :name
+        end
+      end
+
+      expect {
+        @conn.add_column :test_pk_triggers, :id, :integer, primary_key_trigger: true
+      }.to raise_error(ArgumentError, /requires the column type to be `:primary_key`/)
+    end
+  end
+
+  describe "prefetch_primary_key? cache invalidation" do
+    it "is invalidated when a trigger-backed table is dropped and recreated as plain sequence-backed" do
+      schema_define do
+        create_table :test_pk_triggers, primary_key_trigger: true do |t|
+          t.string :name
+        end
+      end
+      expect(@conn.prefetch_primary_key?(:test_pk_triggers)).to be false
+
+      schema_define do
+        drop_table :test_pk_triggers
+        create_table :test_pk_triggers do |t|
+          t.string :name
+        end
+      end
+      expect(@conn.prefetch_primary_key?(:test_pk_triggers)).to be true
+    end
+
+    it "is invalidated when a sequence-backed table is dropped and recreated as trigger-backed" do
+      schema_define do
+        create_table :test_pk_triggers do |t|
+          t.string :name
+        end
+      end
+      expect(@conn.prefetch_primary_key?(:test_pk_triggers)).to be true
+
+      schema_define do
+        drop_table :test_pk_triggers
+        create_table :test_pk_triggers, primary_key_trigger: true do |t|
+          t.string :name
+        end
+      end
+      expect(@conn.prefetch_primary_key?(:test_pk_triggers)).to be false
+    end
+  end
+
+  describe "invalid primary_key_trigger: true combinations" do
+    it "raises when combined with id: false" do
+      expect {
+        @conn.create_table :test_pk_triggers, primary_key_trigger: true, id: false, force: true do |t|
+          t.string :name
+        end
+      }.to raise_error(ArgumentError, /requires `id: :primary_key`/)
+    end
+
+    it "raises when combined with id: :integer" do
+      expect {
+        @conn.create_table :test_pk_triggers, primary_key_trigger: true, id: :integer, force: true do |t|
+          t.string :name
+        end
+      }.to raise_error(ArgumentError, /requires `id: :primary_key`/)
+    end
+
+    it "raises when combined with id: :uuid" do
+      expect {
+        @conn.create_table :test_pk_triggers, primary_key_trigger: true, id: :uuid, force: true do |t|
+          t.string :name
+        end
+      }.to raise_error(ArgumentError, /requires `id: :primary_key`/)
+    end
+
+    it "raises when combined with a composite primary key" do
+      expect {
+        @conn.create_table :test_pk_triggers, primary_key_trigger: true, primary_key: [:a, :b], force: true do |t|
+          t.string :a
+          t.string :b
+        end
+      }.to raise_error(ArgumentError, /composite primary key/)
+    end
+
+    it "raises when combined with identity: true" do
+      skip "requires Oracle 12.1+" unless @oracle12c_or_higher
+
+      expect {
+        @conn.create_table :test_pk_triggers, primary_key_trigger: true, identity: true, force: true do |t|
+          t.string :name
+        end
+      }.to raise_error(ArgumentError, /cannot be combined with `identity: true`/)
+    end
+  end
+
+  describe "schema_dumper roundtrip" do
+    it "emits primary_key_trigger: true for trigger-backed tables" do
+      schema_define do
+        create_table :test_pk_triggers, primary_key_trigger: true do |t|
+          t.string :name
+        end
+      end
+
+      stream = StringIO.new
+      ActiveRecord::SchemaDumper.ignore_tables = @conn.data_sources - ["test_pk_triggers"]
+      ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection_pool, stream)
+      ActiveRecord::SchemaDumper.ignore_tables = []
+
+      expect(stream.string).to include('create_table "test_pk_triggers"')
+      expect(stream.string).to include("primary_key_trigger: true")
+    end
+
+    it "does not emit primary_key_trigger: true for plain sequence-backed tables" do
+      schema_define do
+        create_table :test_pk_triggers do |t|
+          t.string :name
+        end
+      end
+
+      stream = StringIO.new
+      ActiveRecord::SchemaDumper.ignore_tables = @conn.data_sources - ["test_pk_triggers"]
+      ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection_pool, stream)
+      ActiveRecord::SchemaDumper.ignore_tables = []
+
+      expect(stream.string).to include('create_table "test_pk_triggers"')
+      expect(stream.string).not_to include("primary_key_trigger")
+    end
+
+    it "does not emit primary_key_trigger: true for identity tables" do
+      skip "requires Oracle 12.1+" unless @oracle12c_or_higher
+
+      schema_define do
+        create_table :test_pk_triggers, identity: true do |t|
+          t.string :name
+        end
+      end
+
+      stream = StringIO.new
+      ActiveRecord::SchemaDumper.ignore_tables = @conn.data_sources - ["test_pk_triggers"]
+      ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection_pool, stream)
+      ActiveRecord::SchemaDumper.ignore_tables = []
+
+      expect(stream.string).to include('create_table "test_pk_triggers"')
+      expect(stream.string).to include("identity: true")
+      expect(stream.string).not_to include("primary_key_trigger")
+    end
+
+    it "emits :trigger_name when non-default" do
+      schema_define do
+        create_table :test_pk_triggers, primary_key_trigger: true, trigger_name: :custom_pkt do |t|
+          t.string :name
+        end
+      end
+
+      stream = StringIO.new
+      ActiveRecord::SchemaDumper.ignore_tables = @conn.data_sources - ["test_pk_triggers"]
+      ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection_pool, stream)
+      ActiveRecord::SchemaDumper.ignore_tables = []
+
+      expect(stream.string).to include("primary_key_trigger: true")
+      expect(stream.string).to include('trigger_name: "custom_pkt"')
+    end
+
+    it "does not emit :trigger_name when matching the default" do
+      schema_define do
+        create_table :test_pk_triggers, primary_key_trigger: true do |t|
+          t.string :name
+        end
+      end
+
+      stream = StringIO.new
+      ActiveRecord::SchemaDumper.ignore_tables = @conn.data_sources - ["test_pk_triggers"]
+      ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection_pool, stream)
+      ActiveRecord::SchemaDumper.ignore_tables = []
+
+      expect(stream.string).to include("primary_key_trigger: true")
+      expect(stream.string).not_to include("trigger_name:")
+    end
+  end
+
+  describe "low-level INSERT with primary_key_trigger: true" do
+    before(:each) do
+      schema_define do
+        create_table :test_pk_triggers, primary_key_trigger: true do |t|
+          t.string :name
+        end
+      end
+    end
+
+    it "populates primary key when raw INSERT does not supply id" do
+      expect {
+        @conn.execute "INSERT INTO test_pk_triggers (name) VALUES ('alpha')"
+      }.not_to raise_error
+    end
+
+    it "returns the generated id from connection.insert" do
+      insert_id = Array(@conn.insert("INSERT INTO test_pk_triggers (name) VALUES ('alpha')", nil, "id")).first
+      expect(@conn.select_value("SELECT test_pk_triggers_seq.currval FROM dual")).to eq(insert_id)
+    end
+
+    it "does not raise NoMethodError for :returning_id Symbol when logging" do
+      set_logger
+      @conn.reconnect! unless @conn.active?
+      @conn.insert("INSERT INTO test_pk_triggers (name) VALUES ('alpha')", nil, "id")
+      expect(@logger.output(:error)).not_to match(/Could not log .*NoMethodError.*returning_id/)
+      clear_logger
+    end
+  end
+
+  describe "with non-default :primary_key" do
+    it "uses the named primary key column with the trigger" do
+      schema_define do
+        create_table :test_pk_triggers, primary_key_trigger: true, primary_key: "employee_id" do |t|
+          t.string :name
+        end
+      end
+      klass = Class.new(ActiveRecord::Base) do
+        self.table_name = "test_pk_triggers"
+        self.primary_key = "employee_id"
+      end
+
+      row = klass.create!(name: "alpha")
+      expect(row.employee_id).to be_a(Integer)
+      expect(row.employee_id).to be > 0
+    end
+  end
+
+  describe "with non-default :sequence_name" do
+    it "creates the trigger using the named sequence" do
+      schema_define do
+        create_table :test_pk_triggers, primary_key_trigger: true, sequence_name: :test_pk_triggers_s do |t|
+          t.string :name
+        end
+      end
+
+      expect(sequence_exists?(:test_pk_triggers_s)).to be true
+      expect(sequence_exists?(:test_pk_triggers_seq)).to be false
+      klass = Class.new(ActiveRecord::Base) do
+        self.table_name = "test_pk_triggers"
+        self.sequence_name = :test_pk_triggers_s
+      end
+      row = klass.create!(name: "alpha")
+      expect(row.id).to be_a(Integer)
+    end
+  end
+
+  describe "long identifiers" do
+    before do
+      skip "requires extended identifier length (Oracle 12.2+)" if @conn.max_identifier_length < 128
+    end
+
+    after(:each) do
+      tables_to_drop = [@long_table_name, @long_unicode_table_name].compact
+      schema_define do
+        tables_to_drop.each do |t|
+          drop_table t.to_sym, if_exists: true
+        end
+      end
+      @conn.schema_cache.clear!
+    end
+
+    it "computes default_trigger_name with byte-bounded truncation" do
+      max = @conn.max_identifier_length
+      @long_table_name = "a" * (max - 4)
+      derived = @conn.default_trigger_name(@long_table_name)
+      expect(derived.bytesize).to be <= max
+      expect(derived).to end_with("_pkt")
+    end
+
+    it "creates the trigger with a truncated default name when the table name fills the budget" do
+      max = @conn.max_identifier_length
+      @long_table_name = "a" * max
+      table_name_local = @long_table_name
+      schema_define do
+        create_table table_name_local.to_sym, primary_key_trigger: true do |t|
+          t.string :name
+        end
+      end
+
+      derived = @conn.default_trigger_name(@long_table_name)
+      expect(derived.bytesize).to be <= max
+      expect(trigger_exists?(derived)).to be true
+    end
+
+    it "byteslices the trigger name at a UTF-8 codepoint boundary for multibyte table names" do
+      max = @conn.max_identifier_length
+      # "é" is 2 bytes in UTF-8. Build a name whose pre-truncation byte length
+      # exceeds the budget so the slice has to land in the middle of a
+      # multibyte character on its first attempt.
+      @long_unicode_table_name = "é" * ((max / 2) + 5)
+      derived = @conn.default_trigger_name(@long_unicode_table_name)
+      expect(derived.bytesize).to be <= max
+      expect(derived).to be_valid_encoding
+      expect(derived).to end_with("_pkt")
+    end
+  end
+
+  describe "manual trigger creation via raw DDL" do
+    it "accepts the PL/SQL block syntax for CREATE OR REPLACE TRIGGER" do
+      schema_define do
+        create_table :test_pk_triggers do |t|
+          t.string :name
+        end
+      end
+
+      expect do
+        @conn.execute <<~SQL
+          CREATE OR REPLACE TRIGGER test_pk_triggers_pkt
+            BEFORE INSERT ON test_pk_triggers FOR EACH ROW
+          BEGIN
+            IF inserting THEN
+              IF :new.id IS NULL THEN
+                SELECT test_pk_triggers_seq.NEXTVAL INTO :new.id FROM dual;
+              END IF;
+            END IF;
+          END;
+        SQL
+      end.not_to raise_error
+    end
+  end
+
+  describe "trigger_backed_primary_key? false-positive guard" do
+    it "ignores BEFORE INSERT row triggers that do not fill the PK from a sequence" do
+      schema_define do
+        create_table :test_pk_triggers do |t|
+          t.string :name
+          t.string :note
+        end
+      end
+
+      @conn.execute <<~SQL
+        CREATE OR REPLACE TRIGGER test_pk_triggers_audit
+          BEFORE INSERT ON test_pk_triggers FOR EACH ROW
+        BEGIN
+          :new.note := 'audited';
+        END;
+      SQL
+
+      expect(@conn.prefetch_primary_key?(:test_pk_triggers)).to be true
+    end
+
+    it "does not emit primary_key_trigger: in the schema dump for those tables" do
+      schema_define do
+        create_table :test_pk_triggers do |t|
+          t.string :name
+          t.string :note
+        end
+      end
+
+      @conn.execute <<~SQL
+        CREATE OR REPLACE TRIGGER test_pk_triggers_audit
+          BEFORE INSERT ON test_pk_triggers FOR EACH ROW
+        BEGIN
+          :new.note := 'audited';
+        END;
+      SQL
+
+      stream = StringIO.new
+      ActiveRecord::SchemaDumper.ignore_tables = @conn.data_sources - ["test_pk_triggers"]
+      ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection_pool, stream)
+      ActiveRecord::SchemaDumper.ignore_tables = []
+
+      expect(stream.string).to include('create_table "test_pk_triggers"')
+      expect(stream.string).not_to include("primary_key_trigger")
+    end
+  end
+end


### PR DESCRIPTION
### Motivation / Background

Closes #2597.

Trigger-based primary-key generation was removed in [`61f8a305`](https://github.com/rsim/oracle-enhanced/commit/61f8a305) (2018, adapter 6.0) without a deprecation cycle. Several user reports since then (#2426, #2431, #2468) re-implemented the missing functionality in user space; #2597 captured the demand and proposed restoring it as a symmetric opt-in.

This PR is **Phase 3** of the primary-key-generation work. The three phases:

* **Phase 1** (#2579, merged) — `create_table :foo, identity: true` for Oracle 12.1+ (`GENERATED BY DEFAULT AS IDENTITY`).
* **Phase 2** (#2596, draft) — auto-enable `identity:` in `Migration[8.2]+`.
* **Phase 3** (this PR, #2597) — restore trigger-based PK generation as `create_table :foo, primary_key_trigger: true`.

```ruby
create_table :foo                              # sequence + prefetch (default, unchanged)
create_table :foo, identity: true              # GENERATED BY DEFAULT AS IDENTITY (Phase 1)
create_table :foo, primary_key_trigger: true   # sequence + BEFORE INSERT trigger + RETURNING (this PR)
```

### Detail

Two commits:

1. **`Restore trigger-based primary key generation as opt-in primary_key_trigger:`** — the feature commit. Wires the option allowlist, validators, emitter, prefetch detection, schema-dump round-trip, and regression specs in a single self-contained change.
2. **`Skip :returning_id logging spec pending #2619`** — temporarily marks the restored Symbol-bind logging regression test as `skip` because it trips an unrelated SQL\*Net half-duplex deadlock between ruby-oci8 and Oracle when `cursor_sharing=force` is combined with `RETURNING ... INTO :returning_id`. The deadlock is diagnosed and tracked in #2619; the adapter-side fix is in #2620. Once #2620 lands, a follow-up commit on this branch will remove the skip.

The feature commit covers:

* **`:primary_key_trigger` and `:trigger_name` allowlist** — added to `valid_primary_key_options` and `valid_column_definition_options` so Rails' `validate_create_table_options!` accepts the new keys via both `create_table` and `add_column`.
* **`validate_primary_key_trigger_options!` validator** — mirrors `validate_identity_options!`. Rejects `id != :primary_key`, composite primary key, and the `identity: true` combination. *Stricter than pre-2018* (which silently accepted these and produced broken schemas); see "Difference from pre-2018" below. Wired into `create_table`. `add_column` independently rejects `primary_key_trigger: true` on non-`:primary_key` column types so `add_column :foo, :bar, :integer, primary_key_trigger: true` fails fast instead of silently no-oping.
* **`create_pk_trigger(table_name, pk_column, options)` emitter** — emits the `CREATE OR REPLACE TRIGGER ... BEFORE INSERT ON ... FOR EACH ROW` PL/SQL block as a single `execute` call. Default trigger name comes from `default_trigger_name(table_name)`, exposed as a public `:nodoc:` helper alongside `default_sequence_name`. Truncation is byte-bounded with a `valid_encoding?` back-off — *fixes a latent multibyte bug from the pre-2018 char-indexed truncation*. Called from both `create_table` (alongside `create_pk_sequence`) and `add_column` (PK column path) so `add_column :foo, :id, :primary_key, primary_key_trigger: true` works the same way as `create_table primary_key_trigger: true`.
* **`prefetch_primary_key?` short-circuit + `trigger_backed_primary_key?(owner, desc_table_name)` detection** — the cache value becomes `has_pk && !has_identity_pk && !has_trigger_backed_pk`. The detection query restricts the `all_triggers` scan with an `EXISTS` over `all_source` matching `NEXTVAL INTO :NEW`, so unrelated `BEFORE INSERT` row triggers (audit, last_modified, ...) do not flip prefetch off on tables that still rely on Rails-side sequence prefetch. With prefetch off, `sql_for_insert` (added in #2579) automatically appends `RETURNING <pk> INTO :returning_id` — no INSERT-side changes needed.
* **`SchemaDumper` round-trip via `trigger_backed_table_names`** — same body filter as the prefetch query. Bulk fetch `{table_name => trigger_name}` once at dump start (1 query, not N), look up per-table during dump. Emit `, primary_key_trigger: true` for trigger-backed tables; emit `, trigger_name: "..."` only when the actual trigger name differs from the default `<table>_pkt`.
* **Regression specs** — new `primary_key_trigger_spec.rb`, mirror of `identity_primary_key_spec.rb`. Coverage groups:
   - Default (no option) and `primary_key_trigger: false` — sequence-only, prefetch on.
   - `primary_key_trigger: true` — sequence + trigger created, prefetch off, INSERT without/with explicit id, `:trigger_name` override.
   - `add_column` paths — success on `:primary_key` type, rejection on other types via the `add_column` validator.
   - `prefetch_primary_key?` cache invalidation across drop-and-recreate, both directions.
   - Invalid combinations — `id: false` / `id: :integer` / `id: :uuid` / composite primary key / `identity: true` — all raise `ArgumentError`.
   - schema_dumper round-trip — emits `primary_key_trigger: true` for trigger-backed, not for plain or identity, with `trigger_name:` only when non-default.
   - **False-positive guard** — tables with unrelated `BEFORE INSERT` row triggers retain `prefetch_primary_key? = true` and are not emitted as `primary_key_trigger: true` in schema dumps, ensuring the body filter actually scopes detection.
   - **Restored from the 2018 deletion**: low-level INSERT via `@conn.execute` and `@conn.insert(SQL, nil, "id")`; non-default `:primary_key`; non-default `:sequence_name`; `:returning_id Symbol` regression guard from #2426 (currently skipped pending #2619 / #2620); manual PL/SQL trigger DDL acceptance.
   - **Long identifiers (Oracle 12.2+)** — verifies `default_trigger_name` truncates to fit `max_identifier_length`, byte-bounded, multibyte-safe.

### Why preserve the trailing `RETURNING` flow rather than reinvent it

`OracleEnhanced::DatabaseStatements#sql_for_insert` already handles the trigger-backed case identically to the identity case: when no PK bind is supplied, it appends `RETURNING <pk> INTO :returning_id` to the INSERT and reads the value back through the `returning_id` out-bind. Once `prefetch_primary_key?` returns false for a trigger-backed table, Rails ships the INSERT without the PK column bound, and the existing flow fires. No INSERT-side code change in this PR.

### Difference from pre-2018

The pre-2018 implementation accepted any combination silently and produced broken schemas for invalid ones (e.g. `primary_key_trigger: true, id: :uuid` — the trigger does `SELECT <seq>.NEXTVAL INTO :new.<pk> FROM dual` and assumes a numeric column). Phase 1 (#2579) made the same call for `identity:` and required `id: :primary_key`; Phase 3 mirrors it for the same reason — fail fast at create-table time rather than at first-insert time.

The pre-2018 dumper emitted a separate `add_primary_key_trigger "test_posts"` line after `create_table`. The new dumper emits `, primary_key_trigger: true` *inline* on the `create_table` line, matching the `identity: true` shape and avoiding a public `add_primary_key_trigger` method that would duplicate the create_table form.

The default trigger name (`<table>_pkt`) is unchanged from pre-2018. The truncation logic is rewritten to be byte-bounded with `valid_encoding?` back-off (matching `default_sequence_name`) — a multibyte table name no longer risks producing an invalid UTF-8 trigger name. Identifier limit comes from `max_identifier_length` (30 on Oracle 11g/12.1, 128 on 12.2+) rather than the pre-2018 `IDENTIFIER_MAX_LENGTH = 30` constant; long-table-name specs verify this on extended-identifier databases.

`rename_table` does not rename or recreate the trigger — same as pre-2018. Users renaming a table whose primary key is trigger-backed need to drop and recreate the trigger explicitly (the sequence rename that `rename_table` still performs leaves the trigger body referencing the old sequence name and turns it ORA-04098 invalid on the next insert). Out of scope for this PR.

### Behavior contract after this PR

| Form | sequence | trigger | prefetch_primary_key? | INSERT path |
|---|---|---|---|---|
| `create_table :foo` (default) | ✓ | ✗ | true | Rails computes id from sequence, sends as bind |
| `create_table :foo, identity: true` (Phase 1) | ✗ | ✗ | false | Rails sends INSERT without id; identity column generates it; RETURNING reads back |
| `create_table :foo, primary_key_trigger: true` (this PR) | ✓ | ✓ | false | Rails sends INSERT without id; trigger pulls from sequence into `:new.id`; RETURNING reads back |
| `create_table :foo, identity: true, primary_key_trigger: true` | — | — | — | `ArgumentError` at create_table time (mutual exclusion) |

`add_column :foo, :id, :primary_key, primary_key_trigger: true` produces the same artifacts as the third row, applied to an existing table. `add_column :foo, :bar, :integer, primary_key_trigger: true` raises `ArgumentError` (the column type must be `:primary_key`).

### Notes

* No public `add_primary_key_trigger` / `has_primary_key_trigger?` method is restored. The Phase 3 issue scopes the API to `create_table primary_key_trigger:` only; if a user needs to add a trigger separately to an existing table, they call `add_column :foo, :id, :primary_key, primary_key_trigger: true` (which goes through the same `create_pk_trigger` path).
* No version gate. Trigger-based PKs work on every Oracle version this adapter targets.
* The `validate_primary_key_trigger_options!` mutual-exclusion check lives only on the trigger side (does not double-check from `validate_identity_options!`). Whichever validator is consulted first raises; this avoids a circular cross-check that would always re-detect the same condition twice.
* `trigger_backed_primary_key?` is intentionally narrow: it only matches triggers whose body contains `NEXTVAL INTO :NEW`, the exact pattern emitted by `create_pk_trigger`. Tables with unrelated `BEFORE INSERT` row triggers (audit, last_modified, ...) keep `prefetch_primary_key? = true` and are not emitted as trigger-backed in schema dumps. False negatives — user-handwritten PK-fill triggers with different formatting — fall back to Rails-side prefetch, which is harmless because the trigger's own `IS NULL` guard skips when Rails supplies the id.

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added (full mirror of identity_primary_key_spec.rb plus restored pre-2018 low-level tests, new long-identifier and false-positive guard specs).