### PR TITLE
Add workflow_dispatch trigger to spec-running CI workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -8,6 +8,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
### Motivation / Background

The `test` and `test_11g` workflows run `bundle exec rspec` against an Oracle service container. They previously triggered only on `push`, `pull_request`, and `schedule` — so the only way to start a fresh run on an existing SHA was to push another commit or close-and-reopen the PR.

This becomes a real problem when a workflow run hangs. GitHub Actions occasionally loses contact with a runner mid-job; the resulting workflow run sits in `in_progress` for up to the 6-hour job timeout, and neither the `gh api .../actions/runs/<id>/cancel` API nor the web UI "Cancel run" button reliably moves it out of that state. Even when cancellation does succeed, there is no first-class way to trigger a fresh run without committing more code.

Adding `workflow_dispatch:` to the spec-running workflows means a maintainer (or CI bot) can re-trigger them manually from the Actions tab or via:

```sh
gh workflow run test.yml --ref <branch>
gh workflow run test_11g.yml --ref <branch>
```

### Detail

One commit. Two files touched:

* `.github/workflows/test.yml` — `workflow_dispatch:` added alongside the existing `push` / `pull_request` / `schedule` triggers.
* `.github/workflows/test_11g.yml` — same.

### Workflows intentionally not changed

* `release.yml` — releases are tag-driven and manual re-triggering would risk re-publishing.
* `linting.yml`, `rubocop.yml` — lint workflows finish under a minute; the existing triggers cover practical cases.
* `check_method_signatures.yml`, `check_method_visibility.yml`, `devcontainer.yml`, `jruby_head.yml`, `ruby_head.yml`, `test_11g_ojdbc11.yml` — already declare `workflow_dispatch:`.

### Verification

YAML syntax is unchanged in shape (just one extra `workflow_dispatch:` line). The existing `push` / `pull_request` / `schedule` triggers still match GitHub's allowed event-list format.

After this PR merges, manual re-trigger is available from the Actions tab dropdown ("Run workflow" button) on each of the two workflows.

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [ ] Tests are added — N/A; this PR only adjusts CI workflow triggers. Verification is by inspecting the Actions tab UI after merge.
