### PR TITLE
Honor intent.prepare in _exec_insert to avoid OCI8 half-duplex deadlock

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -61,8 +61,18 @@ module ActiveRecord
             cursor = nil
             returning_id_col = returning_id_index = nil
             with_retry do
-              if binds.nil? || binds.empty?
+              if !intent.prepare || binds.nil? || binds.empty?
                 cursor = _connection.prepare(sql)
+
+                unless binds.nil? || binds.empty?
+                  cursor.bind_params(type_casted_binds)
+
+                  if sql.include?(":returning_id")
+                    # it currently expects that returning_id comes last part of binds
+                    returning_id_index = binds.size
+                    cursor.bind_returning_param(returning_id_index, Integer)
+                  end
+                end
               else
                 unless @statements.key?(sql)
                   @statements[sql] = _connection.prepare(sql)

--- a/spec/active_record/connection_adapters/oracle_enhanced/exec_insert_caching_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/exec_insert_caching_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "timeout"
+
+describe "_exec_insert prepared-statement cache gating" do
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @conn = ActiveRecord::Base.lease_connection
+    @conn.create_table :test_exec_insert_caching, force: true, id: false do |t|
+      t.integer :id, null: false
+      t.string :name
+    end
+    @conn.execute "CREATE SEQUENCE test_exec_insert_caching_seq"
+  end
+
+  after(:all) do
+    @conn.execute "BEGIN EXECUTE IMMEDIATE 'DROP SEQUENCE test_exec_insert_caching_seq'; EXCEPTION WHEN OTHERS THEN NULL; END;"
+    @conn.drop_table :test_exec_insert_caching, if_exists: true
+  end
+
+  # The deadlock this regression guards against requires both the default
+  # cursor_sharing=force *and* an amd64 Oracle Database server; under :exact
+  # or against an arm64 server image the spec would silently pass without
+  # exercising the regression. See #2619.
+  it "does not deadlock when the same raw SQL connection.insert with RETURNING is issued twice" do
+    sql = "INSERT INTO test_exec_insert_caching (id, name) VALUES (test_exec_insert_caching_seq.NEXTVAL, 'alpha')"
+    Timeout.timeout(5) do
+      @conn.insert(sql, nil, "id")
+      @conn.insert(sql, nil, "id")
+    end
+    expect(@conn.select_value("SELECT COUNT(*) FROM test_exec_insert_caching")).to eq(2)
+  end
+end


### PR DESCRIPTION
## Summary

  Re-gate the prepared-statement cache in `_exec_insert` on `intent.prepare`, the Rails 8.2 QueryIntent
  successor to `without_prepared_statement?`. PostgreSQL uses the same gate (`rails/rails`@`3d7458f`
  `postgresql/database_statements.rb:167`).

  This restores the behavior `_exec_insert` had before the `prepared_statements` config was dropped from
  the cache decision, and incidentally avoids reaching a SQL\*Net half-duplex deadlock in the OCI / Oracle
  Instant Client client path that surfaces under a specific combination of conditions (see #2619).

  ## Where the deadlock comes from, where this PR sits

  Issue #2619 narrows the deadlock to behavior in the OCI / Instant Client layer that has not been
  classified or acknowledged by the upstream owner; whether it is a defect, a documented limitation, or a
  configuration interaction is still open. All of the following must hold for it to manifest:

  1. The Oracle Database **server** is **amd64 (x86_64)**. The arm64 build of the same release does not
  reproduce it.
  2. The session has `CURSOR_SHARING = FORCE` (the adapter default).
  3. A single SQL statement contains both a literal that the server will rewrite and a `RETURNING ... INTO
  :out_bind` clause.
  4. The same parsed cursor is executed at least twice.

  Removing any one of (2)–(4), or running against an arm64 server, avoids the deadlock.

  **Cross-version server reproduction.** The same conditions reproduce unchanged on every amd64 Oracle
  Database server tested:

  | Server | Edition | Image source |
  |---|---|---|
  | 11.2.0.2.0 | 11g Express | `gvenzl/oracle-xe:11` |
  | 19.3.0.0.0 | 19c Enterprise Edition | built from `oracle/docker-images` + Oracle-provided
  `LINUX.X64_193000_db_home.zip` |
  | 21.3.0.0.0 | 21c Enterprise Edition | built from `oracle/docker-images` + Oracle-provided
  `LINUX.X64_213000_db_home.zip` |
  | 23.26.1.0.0 | 26ai Free | `gvenzl/oracle-free:23.26.1` |

  The 19c / 21c images were built directly from Oracle's `oracle/docker-images` repository using
  Oracle-provided installer ZIPs, so the behavior is not specific to community-maintained packaging.
  Reproduction across releases from 2014 to 2025 indicates this is not a recent regression.

  **Client-side dimensions checked and ruled out as discriminators.** Verified across Instant Client 23.3 /
   23.4 / 23.6 / 23.7 / 23.8 / 23.9 / 23.26.0 / 23.26.1 and ruby-oci8 2.2.14 (gem release) / master tip —
  none of those affect reproduction.

  **Negative control (same OCI library, no reproduction).** The same `INSERT ... RETURNING ... INTO :rid`
  issued twice from SQL\*Plus under `CURSOR_SHARING=FORCE` returns normally each time. SQL\*Plus is itself
  an OCI client, but it parses each statement freshly per command — at the protocol level the second
  `INSERT` is a *new* parse + execute, not a re-execute of the existing statement handle, so condition (4)
  above is not met. This is the same mechanism by which the workarounds below — and this PR — avoid the
  deadlock.

  #2619 lists four independent workarounds (W1–W4) that each break one of the conditions above:

  - **W1** — set `CURSOR_SHARING = EXACT` for the session
  - **W2** — bind every literal as an explicit IN bind
  - **W3** — close and re-parse the cursor between successive `exec` calls
  - **W4** — adapter-level: take the `connection.insert` raw-SQL path through a fresh cursor on every call

  This PR is W4. It fixes the cache decision in `_exec_insert` and only incidentally side-steps the OCI
  deadlock for typical Rails callers; the underlying OCI / Instant Client behavior itself is not addressed
  here and is best tracked / classified at that layer.

  ## How it surfaced

  Three things lined up:

  1. A set of pre-2018 specs that issue the same raw-SQL INSERT with `RETURNING ... INTO :returning_id`
  more than once on the same adapter were removed in 2017 (commit
  [`ef321a15`](https://github.com/rsim/oracle-enhanced/commit/ef321a15) "Drop trigger based primary key
  support").

  2. While those specs were absent, the Rails 8 support work landed via
  [#2425](https://github.com/rsim/oracle-enhanced/pull/2425) (merged 2025-06-21). That PR included commit
  [`baf9fd48`](https://github.com/rsim/oracle-enhanced/commit/baf9fd48) "Rails 8 support", which replaced
  `_exec_insert`'s cache gate

     ```ruby
     if without_prepared_statement?(binds)  # fresh cursor
     else                                   # cached cursor
     end
     ```

     with the predicate

     ```ruby
     if binds.nil? || binds.empty?  # fresh cursor
     else                            # cached cursor
     end
     ```

     The PR description and commit message record this as following the upstream removal of
  `without_prepared_statement?` in
  [`rails/rails@2306c10e`](https://github.com/rails/rails/commit/2306c10e7a9397f8096e49def97ed47125a4499f);
   the practical effect on the cache predicate (no longer factoring in `prepared_statements`) is not
  discussed there. After the change, any caller with non-empty binds goes through the cached-cursor branch.

  3. The same pre-2018 spec patterns were restored in 2026 as part of porting the trigger-based primary-key
   option (#2615), and ran against the post-`baf9fd48` cache decision for the first time.

  Under that combination, plus the four conditions in the section above, the second `exec` on the cached
  cursor produced the SQL\*Net half-duplex deadlock — server stuck on `SQL*Net more data from client`,
  client stuck in `OCIStmtExecute → ... → nttfprd → read()`.

  ## Fix

  Reintroduce the prepared-statements check using `intent.prepare`, the Rails 8.2 QueryIntent successor to
  `without_prepared_statement?`. PostgreSQL gates on the same flag (rails-3d7458fecf49
  postgresql/database_statements.rb:167).

  For raw SQL paths, `intent.prepare` is left as its default `false` (set by `connection.insert` in
  abstract/database_statements.rb), so the fresh-cursor path runs and the cached-cursor combination above
  is not reached.

  Behavior after this change:

  - `klass.create!(attrs)` (Arel insert, `prepared_statements=true`) keeps the cached path.
  - `connection.insert("INSERT ...", nil, "id")` (raw SQL) takes the fresh-cursor path and never reuses a
  cursor with a stale OCI bind state.
  - Connections with `prepared_statements: false` always use fresh cursors, matching the pre-`baf9fd48`
  behavior.

  ## Tradeoff

  This moves raw-SQL `connection.insert` paths to a fresh cursor on every call, giving up the cached-cursor
   reuse benefit for those calls. Acceptable because:

  - Issuing the exact same raw SQL string through `connection.insert` twice in a row is uncommon in Rails
  application code; model paths go through Arel and parameterise their bind values, so the cached path
  still applies to them.
  - A SQL\*Net deadlock that wedges the rest of the suite is a larger problem than losing per-call cursor
  reuse on a rarely exercised path.

  The cached path is preserved unchanged for ORM (Arel-based) inserts, which are the high-volume callers.

  ## Regression spec

  `spec/active_record/connection_adapters/oracle_enhanced/exec_insert_caching_spec.rb` issues the same
  `INSERT ... NEXTVAL ... RETURNING "ID" INTO :returning_id` SQL twice through `connection.insert`. Without
   the fix, the second exec hits the deadlock and trips the spec's 5-second `Timeout`; with the fix, it
  completes well under 100ms. A short comment in the spec documents the dependency on `cursor_sharing =
  force` being the adapter default plus an amd64 Oracle Database server, so a future change in defaults —
  or running CI exclusively against arm64 servers — does not silently turn the regression test into a
  no-op.

  ## Test plan

  - [x] `bundle exec rspec
  spec/active_record/connection_adapters/oracle_enhanced/exec_insert_caching_spec.rb` passes (~0.1s) with
  the fix applied.
  - [x] Same spec fails after 5 seconds (`Timeout::ExitException` inside `OCI8::Cursor#__execute`) when the
   fix is reverted, confirming the test exercises the regression.
  - [ ] Full CI on Oracle Free 23ai (amd64 server image).

  Closes #2619.