### PR TITLE
Bump Oracle Instant Client to the latest versions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,25 +14,31 @@ RUN rm -f /etc/apt/sources.list.d/yarn.list \
 # Create directory structure for Oracle
 RUN mkdir -p /opt/oracle
 
-# Download and install Oracle Instant Client based on architecture
+# Download and install Oracle Instant Client based on architecture.
+# x86_64 uses Oracle's version-less "always latest" URLs; arm64 must pin a
+# version because Oracle does not publish version-less arm64 zips.
 WORKDIR /tmp
 RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then \
-        ARCH_SUFFIX="arm64"; \
-        IC_VERSION="23.26.0.0.0"; \
-        IC_PATH="2326000"; \
-    else \
-        ARCH_SUFFIX="x64"; \
         IC_VERSION="23.26.1.0.0"; \
         IC_PATH="2326100"; \
+        BASE_URL="https://download.oracle.com/otn_software/linux/instantclient/${IC_PATH}"; \
+        BASIC="instantclient-basic-linux.arm64-${IC_VERSION}.zip"; \
+        SDK="instantclient-sdk-linux.arm64-${IC_VERSION}.zip"; \
+        SQLPLUS="instantclient-sqlplus-linux.arm64-${IC_VERSION}.zip"; \
+    else \
+        BASE_URL="https://download.oracle.com/otn_software/linux/instantclient"; \
+        BASIC="instantclient-basic-linuxx64.zip"; \
+        SDK="instantclient-sdk-linuxx64.zip"; \
+        SQLPLUS="instantclient-sqlplus-linuxx64.zip"; \
     fi && \
-    wget -q https://download.oracle.com/otn_software/linux/instantclient/${IC_PATH}/instantclient-basic-linux.${ARCH_SUFFIX}-${IC_VERSION}.zip \
-    && wget -q https://download.oracle.com/otn_software/linux/instantclient/${IC_PATH}/instantclient-sdk-linux.${ARCH_SUFFIX}-${IC_VERSION}.zip \
-    && wget -q https://download.oracle.com/otn_software/linux/instantclient/${IC_PATH}/instantclient-sqlplus-linux.${ARCH_SUFFIX}-${IC_VERSION}.zip \
-    && unzip -qo instantclient-basic-linux.${ARCH_SUFFIX}-${IC_VERSION}.zip \
-    && unzip -qo instantclient-sdk-linux.${ARCH_SUFFIX}-${IC_VERSION}.zip \
-    && unzip -qo instantclient-sqlplus-linux.${ARCH_SUFFIX}-${IC_VERSION}.zip \
-    && mv instantclient_23_26 /opt/oracle/instantclient \
+    wget -q "${BASE_URL}/${BASIC}" \
+    && wget -q "${BASE_URL}/${SDK}" \
+    && wget -q "${BASE_URL}/${SQLPLUS}" \
+    && unzip -qo "${BASIC}" \
+    && unzip -qo "${SDK}" \
+    && unzip -qo "${SQLPLUS}" \
+    && mv instantclient_*/ /opt/oracle/instantclient \
     && rm -f instantclient-*.zip
 
 # Set Oracle environment variables

--- a/.github/workflows/check_method_signatures.yml
+++ b/.github/workflows/check_method_signatures.yml
@@ -14,8 +14,6 @@ jobs:
     name: "Compare Ruby method signatures against Rails"
     runs-on: ubuntu-latest
     env:
-      ORACLE_HOME: /opt/oracle/instantclient_23_26
-      LD_LIBRARY_PATH: /opt/oracle/instantclient_23_26
       NLS_LANG: American_America.AL32UTF8
     steps:
       - uses: actions/checkout@v6
@@ -29,13 +27,16 @@ jobs:
           sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
       - name: Download Oracle instant client
         run: |
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-basic-linux.x64-23.26.1.0.0.zip
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-sdk-linux.x64-23.26.1.0.0.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-sdk-linuxx64.zip
       - name: Install Oracle instant client
         run: |
-          sudo unzip instantclient-basic-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
-          sudo unzip -o instantclient-sdk-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
-          echo "/opt/oracle/instantclient_23_26" >> $GITHUB_PATH
+          sudo unzip -q instantclient-basic-linuxx64.zip -d /opt/oracle/
+          sudo unzip -qo instantclient-sdk-linuxx64.zip -d /opt/oracle/
+          ORACLE_HOME=$(find /opt/oracle -name "instantclient_*" -type d | head -1)
+          echo "ORACLE_HOME=$ORACLE_HOME" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$ORACLE_HOME" >> $GITHUB_ENV
+          echo "$ORACLE_HOME" >> $GITHUB_PATH
       - name: Bundle install
         run: |
           bundle install --jobs 4 --retry 3

--- a/.github/workflows/check_method_visibility.yml
+++ b/.github/workflows/check_method_visibility.yml
@@ -14,8 +14,6 @@ jobs:
     name: "Compare Ruby visibility against Rails"
     runs-on: ubuntu-latest
     env:
-      ORACLE_HOME: /opt/oracle/instantclient_23_26
-      LD_LIBRARY_PATH: /opt/oracle/instantclient_23_26
       NLS_LANG: American_America.AL32UTF8
     steps:
       - uses: actions/checkout@v6
@@ -29,13 +27,16 @@ jobs:
           sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
       - name: Download Oracle instant client
         run: |
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-basic-linux.x64-23.26.1.0.0.zip
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-sdk-linux.x64-23.26.1.0.0.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-sdk-linuxx64.zip
       - name: Install Oracle instant client
         run: |
-          sudo unzip instantclient-basic-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
-          sudo unzip -o instantclient-sdk-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
-          echo "/opt/oracle/instantclient_23_26" >> $GITHUB_PATH
+          sudo unzip -q instantclient-basic-linuxx64.zip -d /opt/oracle/
+          sudo unzip -qo instantclient-sdk-linuxx64.zip -d /opt/oracle/
+          ORACLE_HOME=$(find /opt/oracle -name "instantclient_*" -type d | head -1)
+          echo "ORACLE_HOME=$ORACLE_HOME" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$ORACLE_HOME" >> $GITHUB_ENV
+          echo "$ORACLE_HOME" >> $GITHUB_PATH
       - name: Bundle install
         run: |
           bundle install --jobs 4 --retry 3

--- a/.github/workflows/jruby_head.yml
+++ b/.github/workflows/jruby_head.yml
@@ -10,8 +10,6 @@ jobs:
     name: "jruby-head"
     runs-on: ubuntu-latest
     env:
-      ORACLE_HOME: /opt/oracle/instantclient_23_26
-      LD_LIBRARY_PATH: /opt/oracle/instantclient_23_26
       NLS_LANG: AMERICAN_AMERICA.AL32UTF8
       TNS_ADMIN: ./ci/network/admin
       DATABASE_NAME: FREEPDB1
@@ -47,18 +45,21 @@ jobs:
           sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
       - name: Download Oracle instant client
         run: |
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-basic-linux.x64-23.26.1.0.0.zip
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-sdk-linux.x64-23.26.1.0.0.zip
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-sqlplus-linux.x64-23.26.1.0.0.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-sdk-linuxx64.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-sqlplus-linuxx64.zip
       - name: Install Oracle instant client
         run: |
-          sudo unzip instantclient-basic-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
-          sudo unzip -o instantclient-sdk-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
-          sudo unzip -o instantclient-sqlplus-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
-          echo "/opt/oracle/instantclient_23_26" >> $GITHUB_PATH
+          sudo unzip -q instantclient-basic-linuxx64.zip -d /opt/oracle/
+          sudo unzip -qo instantclient-sdk-linuxx64.zip -d /opt/oracle/
+          sudo unzip -qo instantclient-sqlplus-linuxx64.zip -d /opt/oracle/
+          ORACLE_HOME=$(find /opt/oracle -name "instantclient_*" -type d | head -1)
+          echo "ORACLE_HOME=$ORACLE_HOME" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$ORACLE_HOME" >> $GITHUB_ENV
+          echo "$ORACLE_HOME" >> $GITHUB_PATH
       - name: Install JDBC Driver
         run: |
-          wget -q https://download.oracle.com/otn-pub/otn_software/jdbc/23261/ojdbc17.jar -O ./lib/ojdbc17.jar
+          cp "$ORACLE_HOME/ojdbc17.jar" ./lib/ojdbc17.jar
       - name: Enable Oracle native network encryption in the server container
         run: |
           ORACLE_CONTAINER=$(docker ps --filter "ancestor=gvenzl/oracle-free" -q)

--- a/.github/workflows/ruby_head.yml
+++ b/.github/workflows/ruby_head.yml
@@ -55,16 +55,16 @@ jobs:
           wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-sqlplus-linuxx64.zip
       - name: Install Oracle instant client
         run: |
-          sudo unzip instantclient-basic-linuxx64.zip -d /opt/oracle/
-          sudo unzip -o instantclient-sdk-linuxx64.zip -d /opt/oracle/
-          sudo unzip -o instantclient-sqlplus-linuxx64.zip -d /opt/oracle/
+          sudo unzip -q instantclient-basic-linuxx64.zip -d /opt/oracle/
+          sudo unzip -qo instantclient-sdk-linuxx64.zip -d /opt/oracle/
+          sudo unzip -qo instantclient-sqlplus-linuxx64.zip -d /opt/oracle/
           ORACLE_HOME=$(find /opt/oracle -name "instantclient_*" -type d | head -1)
           echo "ORACLE_HOME=$ORACLE_HOME" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=$ORACLE_HOME" >> $GITHUB_ENV
           echo "$ORACLE_HOME" >> $GITHUB_PATH
       - name: Install JDBC Driver
         run: |
-          cp /opt/oracle/instantclient_23_26/ojdbc17.jar ./lib/
+          cp "$ORACLE_HOME/ojdbc17.jar" ./lib/
       - name: Create database user
         run: |
           ./ci/setup_accounts.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,6 @@ jobs:
             jruby_opts: '--dev'
     env:
       JRUBY_OPTS: ${{ matrix.jruby_opts }}
-      ORACLE_HOME: /opt/oracle/instantclient_23_26
-      LD_LIBRARY_PATH: /opt/oracle/instantclient_23_26
       NLS_LANG: AMERICAN_AMERICA.AL32UTF8
       TNS_ADMIN: ./ci/network/admin
       DATABASE_NAME: FREEPDB1
@@ -60,18 +58,21 @@ jobs:
           sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
       - name: Download Oracle instant client
         run: |
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-basic-linux.x64-23.26.1.0.0.zip
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-sdk-linux.x64-23.26.1.0.0.zip
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-sqlplus-linux.x64-23.26.1.0.0.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-sdk-linuxx64.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-sqlplus-linuxx64.zip
       - name: Install Oracle instant client
         run: |
-          sudo unzip instantclient-basic-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
-          sudo unzip -o instantclient-sdk-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
-          sudo unzip -o instantclient-sqlplus-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
-          echo "/opt/oracle/instantclient_23_26" >> $GITHUB_PATH
+          sudo unzip -q instantclient-basic-linuxx64.zip -d /opt/oracle/
+          sudo unzip -qo instantclient-sdk-linuxx64.zip -d /opt/oracle/
+          sudo unzip -qo instantclient-sqlplus-linuxx64.zip -d /opt/oracle/
+          ORACLE_HOME=$(find /opt/oracle -name "instantclient_*" -type d | head -1)
+          echo "ORACLE_HOME=$ORACLE_HOME" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$ORACLE_HOME" >> $GITHUB_ENV
+          echo "$ORACLE_HOME" >> $GITHUB_PATH
       - name: Install JDBC Driver
         run: |
-          wget -q https://download.oracle.com/otn-pub/otn_software/jdbc/23261/ojdbc17.jar -O ./lib/ojdbc17.jar
+          cp "$ORACLE_HOME/ojdbc17.jar" ./lib/ojdbc17.jar
       - name: Enable Oracle native network encryption in the server container
         run: |
           ORACLE_CONTAINER=$(docker ps --filter "ancestor=gvenzl/oracle-free" -q)

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -29,8 +29,8 @@ jobs:
             jruby_opts: '--dev'
     env:
       JRUBY_OPTS: ${{ matrix.jruby_opts }}
-      ORACLE_HOME: /opt/oracle/instantclient_21_15
-      LD_LIBRARY_PATH: /opt/oracle/instantclient_21_15
+      ORACLE_HOME: /opt/oracle/instantclient_21_21
+      LD_LIBRARY_PATH: /opt/oracle/instantclient_21_21
       NLS_LANG: AMERICAN_AMERICA.AL32UTF8
       TNS_ADMIN: ./ci/network/admin
       DATABASE_NAME: XE
@@ -64,26 +64,26 @@ jobs:
           sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
       - name: Download Oracle instant client
         run: |
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2115000/instantclient-basic-linux.x64-21.15.0.0.0dbru.zip
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2115000/instantclient-sqlplus-linux.x64-21.15.0.0.0dbru.zip
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2115000/instantclient-sdk-linux.x64-21.15.0.0.0dbru.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/2121000/instantclient-basic-linux.x64-21.21.0.0.0dbru.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/2121000/instantclient-sqlplus-linux.x64-21.21.0.0.0dbru.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/2121000/instantclient-sdk-linux.x64-21.21.0.0.0dbru.zip
       - name: Install Oracle instant client
         run: |
           sudo mkdir -p /opt/oracle/
-          sudo unzip instantclient-basic-linux.x64-21.15.0.0.0dbru.zip -d /opt/oracle
-          sudo unzip -o instantclient-sqlplus-linux.x64-21.15.0.0.0dbru.zip -d /opt/oracle
-          sudo unzip -o instantclient-sdk-linux.x64-21.15.0.0.0dbru.zip -d /opt/oracle
-          echo "/opt/oracle/instantclient_21_15" >> $GITHUB_PATH
+          sudo unzip -q instantclient-basic-linux.x64-21.21.0.0.0dbru.zip -d /opt/oracle
+          sudo unzip -qo instantclient-sqlplus-linux.x64-21.21.0.0.0dbru.zip -d /opt/oracle
+          sudo unzip -qo instantclient-sdk-linux.x64-21.21.0.0.0dbru.zip -d /opt/oracle
+          echo "/opt/oracle/instantclient_21_21" >> $GITHUB_PATH
 
       - name: Install JDBC Driver
         run: |
           wget -q https://download.oracle.com/otn-pub/otn_software/jdbc/23261/ojdbc17.jar -O ./lib/ojdbc17.jar
       - name: Configure ORA_TZFILE to match Oracle 11g server
         run: |
-          # Oracle 11g XE uses timezone file v14; Instant Client 21.15 embeds
-          # v35. This mismatch causes ORA-01805 when fetching DATE/TIMESTAMP
-          # values. Copy the v14 files from the 11g container and point the
-          # Instant Client at them via ORA_TZFILE.
+          # Oracle 11g XE uses timezone file v14; the 21.x Instant Client
+          # embeds a newer file. The mismatch causes ORA-01805 when fetching
+          # DATE/TIMESTAMP values. Copy the v14 files from the 11g container
+          # and point the Instant Client at them via ORA_TZFILE.
           ORACLE_CONTAINER="${{ job.services.oracle.id }}"
           sudo mkdir -p "$ORACLE_HOME/oracore/zoneinfo"
           docker cp "$ORACLE_CONTAINER":/u01/app/oracle/product/11.2.0/xe/oracore/zoneinfo/timezlrg_14.dat /tmp/timezlrg_14.dat

--- a/.github/workflows/test_11g_ojdbc11.yml
+++ b/.github/workflows/test_11g_ojdbc11.yml
@@ -15,8 +15,8 @@ jobs:
           'jruby-10.1.0.0',
         ]
     env:
-      ORACLE_HOME: /opt/oracle/instantclient_21_15
-      LD_LIBRARY_PATH: /opt/oracle/instantclient_21_15
+      ORACLE_HOME: /opt/oracle/instantclient_21_21
+      LD_LIBRARY_PATH: /opt/oracle/instantclient_21_21
       NLS_LANG: AMERICAN_AMERICA.AL32UTF8
       TNS_ADMIN: ./ci/network/admin
       DATABASE_NAME: XE
@@ -51,25 +51,25 @@ jobs:
           sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
       - name: Download Oracle instant client
         run: |
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2115000/instantclient-basic-linux.x64-21.15.0.0.0dbru.zip
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2115000/instantclient-sqlplus-linux.x64-21.15.0.0.0dbru.zip
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2115000/instantclient-sdk-linux.x64-21.15.0.0.0dbru.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/2121000/instantclient-basic-linux.x64-21.21.0.0.0dbru.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/2121000/instantclient-sqlplus-linux.x64-21.21.0.0.0dbru.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/2121000/instantclient-sdk-linux.x64-21.21.0.0.0dbru.zip
       - name: Install Oracle instant client
         run: |
           sudo mkdir -p /opt/oracle/
-          sudo unzip instantclient-basic-linux.x64-21.15.0.0.0dbru.zip -d /opt/oracle
-          sudo unzip -o instantclient-sqlplus-linux.x64-21.15.0.0.0dbru.zip -d /opt/oracle
-          sudo unzip -o instantclient-sdk-linux.x64-21.15.0.0.0dbru.zip -d /opt/oracle
-          echo "/opt/oracle/instantclient_21_15" >> $GITHUB_PATH
+          sudo unzip -q instantclient-basic-linux.x64-21.21.0.0.0dbru.zip -d /opt/oracle
+          sudo unzip -qo instantclient-sqlplus-linux.x64-21.21.0.0.0dbru.zip -d /opt/oracle
+          sudo unzip -qo instantclient-sdk-linux.x64-21.21.0.0.0dbru.zip -d /opt/oracle
+          echo "/opt/oracle/instantclient_21_21" >> $GITHUB_PATH
       - name: Install JDBC Driver
         run: |
-          wget -q https://download.oracle.com/otn-pub/otn_software/jdbc/23261/ojdbc11.jar -O ./lib/ojdbc11.jar
+          cp "$ORACLE_HOME/ojdbc11.jar" ./lib/ojdbc11.jar
       - name: Configure ORA_TZFILE to match Oracle 11g server
         run: |
-          # Oracle 11g XE uses timezone file v14; Instant Client 21.15 embeds
-          # v35. This mismatch causes ORA-01805 when fetching DATE/TIMESTAMP
-          # values. Copy the v14 files from the 11g container and point the
-          # Instant Client at them via ORA_TZFILE.
+          # Oracle 11g XE uses timezone file v14; the 21.x Instant Client
+          # embeds a newer file. The mismatch causes ORA-01805 when fetching
+          # DATE/TIMESTAMP values. Copy the v14 files from the 11g container
+          # and point the Instant Client at them via ORA_TZFILE.
           ORACLE_CONTAINER="${{ job.services.oracle.id }}"
           sudo mkdir -p "$ORACLE_HOME/oracore/zoneinfo"
           docker cp "$ORACLE_CONTAINER":/u01/app/oracle/product/11.2.0/xe/oracore/zoneinfo/timezlrg_14.dat /tmp/timezlrg_14.dat

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,13 +51,13 @@ is the recommended way to work on the adapter.
    "Dev Containers: Reopen in Container".
 4. VS Code builds and starts the environment automatically. This
    includes Ruby 4.0, Oracle Database Free (latest), Oracle Instant
-   Client 23.26, and all gems from `bundle install`.
+   Client (latest 23.x), and all gems from `bundle install`.
 
 ### What's included
 
 - **Ruby**: 4.0
 - **Oracle Database**: Free (latest)
-- **Oracle Instant Client**: 23.26
+- **Oracle Instant Client**: latest 23.x
 - **Database configuration**:
   - Port `1521` is forwarded from the container
   - Service name: `FREEPDB1`


### PR DESCRIPTION
## Summary

- Switch the modern (23.x) workflows and the devcontainer Dockerfile (x86_64 branch) to Oracle's version-less Instant Client download URLs so we automatically pick up new 23.x minors. ORACLE_HOME / LD_LIBRARY_PATH / PATH are derived dynamically from the extracted directory.
- Bump the 11g compatibility workflows from `21.15.0.0.0dbru` to `21.21.0.0.0dbru` (latest 21.x — Oracle does not publish a version-less 21.x URL, so this line still needs an explicit pin).
- Bump the devcontainer arm64 pin from `23.26.0.0.0` to `23.26.1.0.0` so it matches the patch level the version-less x86_64 URL serves today (Oracle does not publish a version-less arm64 zip).
- Drop the redundant `/jdbc/23261/ojdbc{11,17}.jar` wgets where the Instant Client zip already ships the matching driver. The single download that remains is `test_11g.yml`'s `ojdbc17.jar`, because the 21.x zip does not include `ojdbc17.jar` and Oracle has no version-less JDBC URL.
- Pass `-q` to all `unzip` invocations so the install step does not spam CI logs with file lists.

Today the version-less 23.x URL is byte-identical to the previously pinned `2326100/...23.26.1.0.0.zip` (verified central-directory contents both yield `instantclient_23_26/` files dated 2026-01-17), so this is forward-compatibility, not a same-day version uplift.

## Test plan

- [x] `test` matrix (4.0 / 3.4 / 3.3 / jruby-10.1.0.0) passes with the version-less 23.x download
- [x] `check_method_signatures`, `check_method_visibility` pass (basic + sdk only, no sqlplus)
- [x] `test_11g` matrix (4.0 / 3.4 / 3.3 / jruby-10.1.0.0) passes against the new `21.21.0.0.0dbru` pin
- [x] `Yamllint` passes
- [x] devcontainer build job passes
- [ ] `jruby_head` (scheduled-only): exercises the version-less 23.x download + `cp $ORACLE_HOME/ojdbc17.jar`
- [ ] `test_11g_ojdbc11` (scheduled-only): exercises the `cp $ORACLE_HOME/ojdbc11.jar` shortcut against 21.21
- [ ] `ruby_head` (scheduled-only): exercises the `cp "$ORACLE_HOME/ojdbc17.jar"` cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
