### PR TITLE
Add CI workflow forcing prepared_statements: true

### DIFF
--- a/.github/workflows/test_prepared_statements.yml
+++ b/.github/workflows/test_prepared_statements.yml
@@ -1,0 +1,95 @@
+name: test_prepared_statements
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [
+          '4.0',
+          'jruby-10.1.0.0',
+        ]
+        include:
+          - ruby: 'jruby-10.1.0.0'
+            jruby_opts: '--dev'
+    env:
+      JRUBY_OPTS: ${{ matrix.jruby_opts }}
+      NLS_LANG: AMERICAN_AMERICA.AL32UTF8
+      TNS_ADMIN: ./ci/network/admin
+      DATABASE_NAME: FREEPDB1
+      TZ: Europe/Riga
+      DATABASE_SYS_PASSWORD: Oracle18
+      DATABASE_HOST: localhost
+      DATABASE_PORT: 1521
+      ORACLE_ENHANCED_PREPARED_STATEMENTS: "1"
+
+    services:
+      oracle:
+        image: gvenzl/oracle-free:latest
+        ports:
+          - 1521:1521
+        env:
+          TZ: Europe/Riga
+          ORACLE_PASSWORD: Oracle18
+        options: >-
+          --health-cmd healthcheck.sh
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          rubygems: latest
+      - name: Create symbolic link for libaio library compatibility
+        run: |
+          sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
+      - name: Download Oracle instant client
+        run: |
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-sdk-linuxx64.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-sqlplus-linuxx64.zip
+      - name: Install Oracle instant client
+        run: |
+          sudo unzip -q instantclient-basic-linuxx64.zip -d /opt/oracle/
+          sudo unzip -qo instantclient-sdk-linuxx64.zip -d /opt/oracle/
+          sudo unzip -qo instantclient-sqlplus-linuxx64.zip -d /opt/oracle/
+          ORACLE_HOME=$(find /opt/oracle -name "instantclient_*" -type d | head -1)
+          echo "ORACLE_HOME=$ORACLE_HOME" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$ORACLE_HOME" >> $GITHUB_ENV
+          echo "$ORACLE_HOME" >> $GITHUB_PATH
+      - name: Install JDBC Driver
+        run: |
+          cp "$ORACLE_HOME/ojdbc17.jar" ./lib/ojdbc17.jar
+      - name: Enable Oracle native network encryption in the server container
+        run: |
+          ORACLE_CONTAINER=$(docker ps --filter "ancestor=gvenzl/oracle-free" -q)
+          docker exec -u oracle "$ORACLE_CONTAINER" bash -c "
+            SQLNET=\$ORACLE_HOME/network/admin/sqlnet.ora
+            grep -q ENCRYPTION_SERVER \$SQLNET 2>/dev/null || echo 'SQLNET.ENCRYPTION_SERVER = REQUESTED' >> \$SQLNET
+            grep -q ENCRYPTION_TYPES_SERVER \$SQLNET 2>/dev/null || echo 'SQLNET.ENCRYPTION_TYPES_SERVER = (AES256)' >> \$SQLNET
+          "
+      - name: Create database user
+        run: |
+          ./ci/setup_accounts.sh
+      - name: Bundle install
+        run: |
+          bundle install --jobs 4 --retry 3
+      - name: Show Gemfile.lock
+        run: |
+          cat Gemfile.lock
+      - name: Run RSpec
+        run: |
+          bundle exec rspec
+      - name: Run bug report templates
+        run: |
+          cd guides/bug_report_templates
+          ruby active_record_gem.rb
+          ruby active_record_gem_spec.rb

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -150,6 +150,14 @@ CONNECTION_PARAMS = {
   password: DATABASE_PASSWORD
 }
 
+CONNECTION_PARAMS_WITH_PREPARED_STATEMENTS = CONNECTION_PARAMS.merge(prepared_statements: true)
+
+# Mirrors rails/rails MYSQL_PREPARED_STATEMENTS convention.
+if ENV["ORACLE_ENHANCED_PREPARED_STATEMENTS"]
+  CONNECTION_PARAMS[:prepared_statements] = true
+  puts "==> Forcing prepared_statements: true via ORACLE_ENHANCED_PREPARED_STATEMENTS"
+end
+
 CONNECTION_WITH_SCHEMA_PARAMS = {
   adapter: "oracle_enhanced",
   database: DATABASE_NAME,


### PR DESCRIPTION
## Summary

- Add `CONNECTION_PARAMS_WITH_PREPARED_STATEMENTS` in `spec/spec_helper.rb` and an env-var hook (`ORACLE_ENHANCED_PREPARED_STATEMENTS`) that, when set, makes every spec using `CONNECTION_PARAMS` run with `prepared_statements: true` and prints a startup banner.
- Add `.github/workflows/test_prepared_statements.yml` (CRuby 4.0 + JRuby 10.1.0.0, `gvenzl/oracle-free:latest`) that sets the env var and runs the full RSpec suite.

The naming, presence-check pattern, and startup banner mirror Rails' `MYSQL_PREPARED_STATEMENTS` convention used in `rails/rails` `activerecord/test/config.example.yml` and `activerecord/test/support/connection.rb`. Relevant precedents:

- [`rails/buildkite-config#128`](https://github.com/rails/buildkite-config/pull/128) — env-var passthrough so the flag actually reaches the CI container
- [`rails/rails#53697`](https://github.com/rails/rails/pull/53697) — log `with prepared statements` at suite start so it is visible from the CI banner that the toggle took effect

## Why

`spec/spec_helper.rb`'s `CONNECTION_PARAMS` does not set `prepared_statements`, so the existing CI inherits the Rails default (currently `true`) implicitly. There is no spec or workflow that asserts the suite still passes if Rails' default ever changes, and no spec exercises a `prepared_statements: false` arm via `establish_connection`. This gap is part of what #2622 calls out (the missing `cursor_sharing × prepared_statements` matrix coverage that allowed #2619 to surface as late as it did).

This PR puts the first half of that matrix (the explicit `prepared_statements: true` arm) on the CI grid. The `prepared_statements: false` arm is left for a follow-up.

## Plan

1. Land this PR. Trigger is `workflow_dispatch` only; run it once manually on this branch to confirm green.
2. After green, follow up to switch trigger to `schedule` (daily) so future regressions surface within a day.

## Test plan

- [ ] Trigger the new workflow manually via the Actions UI on this branch and verify both matrix legs (`4.0`, `jruby-10.1.0.0`) pass.
- [ ] Confirm the spec suite output banner contains `==> Forcing prepared_statements: true via ORACLE_ENHANCED_PREPARED_STATEMENTS`.

Refs #2622.
