### PR TITLE
Honor ORACLE_ENHANCED_PREPARED_STATEMENTS in bug report templates

### DIFF
--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -38,6 +38,12 @@ CONNECTION_PARAMS = {
   password: DATABASE_PASSWORD
 }
 
+# Mirrors rails/rails MYSQL_PREPARED_STATEMENTS convention.
+if ENV["ORACLE_ENHANCED_PREPARED_STATEMENTS"]
+  CONNECTION_PARAMS[:prepared_statements] = true
+  puts "==> Forcing prepared_statements: true via ORACLE_ENHANCED_PREPARED_STATEMENTS"
+end
+
 ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
 
 ActiveRecord::Base.logger = Logger.new(STDOUT)

--- a/guides/bug_report_templates/active_record_gem_spec.rb
+++ b/guides/bug_report_templates/active_record_gem_spec.rb
@@ -37,6 +37,12 @@ CONNECTION_PARAMS = {
   password: DATABASE_PASSWORD
 }
 
+# Mirrors rails/rails MYSQL_PREPARED_STATEMENTS convention.
+if ENV["ORACLE_ENHANCED_PREPARED_STATEMENTS"]
+  CONNECTION_PARAMS[:prepared_statements] = true
+  puts "==> Forcing prepared_statements: true via ORACLE_ENHANCED_PREPARED_STATEMENTS"
+end
+
 ActiveRecord::Base.logger = Logger.new(STDOUT)
 
 describe "bug test" do


### PR DESCRIPTION
## Summary

Follow-up to #2623. Adds the same `ORACLE_ENHANCED_PREPARED_STATEMENTS` env-var hook to both bug report templates so they participate in the `prepared_statements: true` matrix the same way the spec suite does.

## Why

`test_prepared_statements.yml` (added in #2623) sets `ORACLE_ENHANCED_PREPARED_STATEMENTS: "1"` at the workflow level, so every step in that job runs with the env var present — including the final `Run bug report templates` step. The spec suite picks it up through `spec/spec_helper.rb`, but the two templates (`active_record_gem.rb`, `active_record_gem_spec.rb`) define their own `CONNECTION_PARAMS` literals and ignored the env. After this PR they honor it the same way and print the same `==> Forcing prepared_statements: true via ORACLE_ENHANCED_PREPARED_STATEMENTS` startup banner.

## Test plan

- [ ] Re-trigger the `test_prepared_statements` workflow on this branch via Actions UI; confirm the `Run bug report templates` step output now contains the forcing banner.

Refs #2622.