### PR TITLE
Run test_prepared_statements daily

### DIFF
--- a/.github/workflows/test_prepared_statements.yml
+++ b/.github/workflows/test_prepared_statements.yml
@@ -1,6 +1,8 @@
 name: test_prepared_statements
 
 on:
+  schedule:
+    - cron: "0 0 * * *"  # daily at 00:00 UTC
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

Promotes the `test_prepared_statements` workflow's trigger from
`workflow_dispatch` only to `schedule: cron "0 0 * * *"` plus
`workflow_dispatch`.

## Why

Two manual runs of the workflow against master have completed green:

- post-#2623 manual run: https://github.com/rsim/oracle-enhanced/actions/runs/25038092155
- post-#2624 manual run on master: https://github.com/rsim/oracle-enhanced/actions/runs/25038600606

Both legs (`4.0` and `jruby-10.1.0.0`) pass, the spec suite output banner
confirms `==> Forcing prepared_statements: true via ORACLE_ENHANCED_PREPARED_STATEMENTS`,
and the bug report templates step (enabled in #2624) participates in the
same mode. The workflow is ready to run on a daily schedule so any
future regression in the `prepared_statements: true` arm of the
`cursor_sharing × prepared_statements` matrix (#2622) surfaces within a day.

`workflow_dispatch` is kept so manual triggering remains available.

## Test plan

- [ ] Confirm a scheduled run appears in the Actions tab within 24 hours after merge.

Refs #2622.