### PR TITLE
Respect the database's CURSOR_SHARING setting by default

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -99,7 +99,17 @@ module ActiveRecord
     # * <tt>:privilege</tt> - set "SYSDBA" if you want to connect with this privilege
     # * <tt>:allow_concurrency</tt> - set to "true" if non-blocking mode should be enabled (just for OCI client)
     # * <tt>:prefetch_rows</tt> - how many rows should be fetched at one time to increase performance, defaults to 100
-    # * <tt>:cursor_sharing</tt> - cursor sharing mode to minimize amount of unique statements, no default value
+    # * <tt>:cursor_sharing</tt> - cursor sharing mode. Accepts "exact" or "force"
+    #   (per Oracle's documented values), or <tt>:default</tt> (the new effective default).
+    #   With <tt>:default</tt> (or unset) the adapter does not run <tt>ALTER SESSION SET
+    #   cursor_sharing</tt> and the database's instance-level setting (Oracle's documented
+    #   software default is <tt>EXACT</tt>) is what the session sees. Pass an explicit
+    #   value to issue the corresponding <tt>ALTER SESSION</tt>.
+    #
+    #   NOTE: Connections still configured with <tt>prepared_statements: false</tt> have AR
+    #   interpolate application-SQL literals at the visitor level, so each unique value
+    #   produces a fresh shared cursor on the server. Such installs can keep the legacy
+    #   behavior by setting <tt>:cursor_sharing => 'force'</tt> explicitly here.
     # * <tt>:time_zone</tt> - database session time zone
     #   (it is recommended to set it using ENV['TZ'] which will be then also used for database session time zone)
     # * <tt>:schema</tt> - database schema which holds schema objects.
@@ -847,17 +857,25 @@ module ActiveRecord
         connect
       end
 
+      # Oracle's reference manual documents EXACT and FORCE only (SIMILAR was
+      # removed). The database still accepts SIMILAR at the parser level on
+      # current versions, so it is kept in the allow-list for backward
+      # compatibility while the doc comment for `:cursor_sharing` advertises
+      # only the documented values.
       CURSOR_SHARING_VALUES = %w[EXACT FORCE SIMILAR].freeze
       SCHEMA_IDENTIFIER_PATTERN = /\A[[:alpha:]][\w$#]*\z/
 
       private def configure_connection
         super
 
-        cursor_sharing = (@config[:cursor_sharing] || "force").to_s.upcase
-        unless CURSOR_SHARING_VALUES.include?(cursor_sharing)
-          raise ArgumentError, "Invalid :cursor_sharing value #{@config[:cursor_sharing].inspect}; allowed: #{CURSOR_SHARING_VALUES.join(', ')}"
+        cursor_sharing = @config[:cursor_sharing]
+        unless cursor_sharing.nil? || cursor_sharing == :default
+          cursor_sharing = cursor_sharing.to_s.upcase
+          unless CURSOR_SHARING_VALUES.include?(cursor_sharing)
+            raise ArgumentError, "Invalid :cursor_sharing value #{@config[:cursor_sharing].inspect}; allowed: #{CURSOR_SHARING_VALUES.join(', ')} or :default"
+          end
+          execute("alter session set cursor_sharing = #{cursor_sharing}", "SCHEMA")
         end
-        execute("alter session set cursor_sharing = #{cursor_sharing}", "SCHEMA")
 
         if ORACLE_ENHANCED_CONNECTION == :oci
           time_zone = @config[:time_zone] || ENV["TZ"]

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -36,20 +36,70 @@ describe "OracleEnhancedAdapter establish connection" do
     expect(ActiveRecord::Base.lease_connection).to be_active
   end
 
-  it "should use database default cursor_sharing parameter value force by default" do
-    # Use `SYSTEM_CONNECTION_PARAMS` to query v$parameter
-    ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS)
-    expect(ActiveRecord::Base.lease_connection.select_value("select value from v$parameter where name = 'cursor_sharing'")).to eq("FORCE")
-  end
+  describe "cursor_sharing" do
+    # The test session uses CONNECTION_PARAMS (regular oracle_enhanced user,
+    # no v$ access); SystemObserver is a separate AR connection on SYSTEM used
+    # only to read v$parameter / v$ses_optimizer_env for assertions. Defined
+    # via stub_const so the constant is scoped to each example and cleaned up
+    # automatically by RSpec.
+    before(:each) do
+      stub_const("SystemObserver", Class.new(ActiveRecord::Base) { self.abstract_class = true })
+      SystemObserver.establish_connection(SYSTEM_CONNECTION_PARAMS)
+    end
 
-  it "should use modified cursor_sharing value exact" do
-    ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS.merge(cursor_sharing: :exact))
-    expect(ActiveRecord::Base.lease_connection.select_value("select value from v$parameter where name = 'cursor_sharing'")).to eq("EXACT")
-  end
+    after(:each) { SystemObserver.remove_connection rescue nil }
 
-  it "should raise ArgumentError for an unsupported cursor_sharing value" do
-    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(cursor_sharing: "not_a_valid_mode"))
-    expect { ActiveRecord::Base.lease_connection }.to raise_error(ArgumentError, /Invalid :cursor_sharing value/)
+    let(:server_default_cursor_sharing) do
+      SystemObserver.connection.select_value(
+        "select upper(value) from v$parameter where name = 'cursor_sharing'"
+      )
+    end
+
+    # v$ses_optimizer_env returns the value lowercase; v$parameter returns it
+    # uppercase. Normalize to uppercase so comparisons are stable across views.
+    def session_cursor_sharing(connection)
+      sid = connection.select_value("select sys_context('userenv', 'sid') from dual").to_i
+      SystemObserver.connection.select_value(
+        "select upper(value) from v$ses_optimizer_env where sid = #{sid} and name = 'cursor_sharing'"
+      )
+    end
+
+    it "does not run ALTER SESSION when :cursor_sharing is unset" do
+      expected = server_default_cursor_sharing
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+      expect(session_cursor_sharing(ActiveRecord::Base.lease_connection)).to eq(expected)
+    end
+
+    it "does not run ALTER SESSION when :cursor_sharing is :default" do
+      expected = server_default_cursor_sharing
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(cursor_sharing: :default))
+      expect(session_cursor_sharing(ActiveRecord::Base.lease_connection)).to eq(expected)
+    end
+
+    it "applies the explicit :cursor_sharing value when set to :force" do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(cursor_sharing: :force))
+      expect(session_cursor_sharing(ActiveRecord::Base.lease_connection)).to eq("FORCE")
+    end
+
+    it "applies the explicit :cursor_sharing value when set to :exact" do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(cursor_sharing: :exact))
+      expect(session_cursor_sharing(ActiveRecord::Base.lease_connection)).to eq("EXACT")
+    end
+
+    it "applies the explicit :cursor_sharing value when set to a String 'force'" do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(cursor_sharing: "force"))
+      expect(session_cursor_sharing(ActiveRecord::Base.lease_connection)).to eq("FORCE")
+    end
+
+    it "applies the explicit :cursor_sharing value when set to a String 'exact'" do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(cursor_sharing: "exact"))
+      expect(session_cursor_sharing(ActiveRecord::Base.lease_connection)).to eq("EXACT")
+    end
+
+    it "raises ArgumentError for an unsupported cursor_sharing value" do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(cursor_sharing: "not_a_valid_mode"))
+      expect { ActiveRecord::Base.lease_connection }.to raise_error(ArgumentError, /Invalid :cursor_sharing value/)
+    end
   end
 
   it "should not use JDBC statement caching" do


### PR DESCRIPTION
## Summary

Stops applying `cursor_sharing = force` from the adapter at session login. Introduces `:default` as the new effective default for the `:cursor_sharing` connection option; with it (or unset) the adapter does not run any `ALTER SESSION SET cursor_sharing` and the database's instance-level setting is what the session sees. Explicit values (`'exact'`, `'force'`) continue to issue the corresponding `ALTER SESSION`.

| `:cursor_sharing` in config | What the adapter does |
|---|---|
| not set, or `:default` | no `ALTER SESSION` (database's instance-level setting kept) |
| explicit value (`'force'`, `'exact'`) | `ALTER SESSION SET cursor_sharing = value` |
| anything else | `ArgumentError` |

## Why

Oracle's documented software default for [`CURSOR_SHARING`](https://docs.oracle.com/en/database/oracle/oracle-database/26/refrn/CURSOR_SHARING.html) is `EXACT`. Most users running an Oracle Database have not changed it from `EXACT`, and many are not even aware that `oracle_enhanced` has been silently overriding it to `FORCE` at the session level since 2009 ([`ebb60f3`](https://github.com/rsim/oracle-enhanced/commit/ebb60f3)).

The implicit `force` default made sense at the time it was added: Active Record didn't bind literals yet, so the adapter sent SQL with literals inlined, and `force` was the only way the server could collapse that into a single shared cursor.

That premise no longer holds:

- The AbstractAdapter default for `prepared_statements` became `true` in Rails 7.1 ([rails/rails#45945](https://github.com/rails/rails/pull/45945), [commit `a0fd15ee7e`](https://github.com/rails/rails/commit/a0fd15ee7e348a0250f9dbb90c147453d193e4cd)) — `oracle_enhanced` inherits this default. With `prepared_statements: true`, Active Record binds application SQL literals before sending, so the server sees identical SQL text regardless of bind values, and `force`'s rewrite has nothing left to do for that traffic.
- All `all_*` / `user_*` dictionary queries inside `oracle_enhanced` itself are now bind-driven (#2629 finished the last four), so dictionary access doesn't depend on `force` for shared-cursor reuse either.
- Keeping `force` on by default also keeps connections exposed to the #2619 hang combination on amd64 Oracle Database (cached cursor + a literal the server rewrites + `RETURNING ... INTO`). #2620 removed the exposure for the typical Rails ORM path; dropping the implicit `force` default removes it for raw-SQL callers too.

After this PR, sessions run with whatever `CURSOR_SHARING` the database is configured with — for almost all installations that means the documented Oracle default `EXACT`, which is what users were already (unknowingly) running on the server level. The adapter simply stops imposing its own value on top.

## Opting in to the legacy behavior

Anyone who actually relied on `force` — typically connections still configured with `prepared_statements: false`, where Active Record interpolates application-SQL literals at the visitor level — can opt back in with one line in `database.yml`:

```yaml
production:
  adapter: oracle_enhanced
  # ...
  cursor_sharing: force
```

(Setting `prepared_statements: false` is independent and orthogonal — having both, just one, or neither is a deliberate choice.)

## CI matrix — Run RSpec duration (seconds)

`Run RSpec` step only (Oracle Client install / container start excluded; identical across rows). Lower is better; numbers within ±10s on this CI are noise.

|  | `prepared_statements: true` (adapter default) | `prepared_statements: false` (explicit) |
|---|---|---|
| `cursor_sharing: 'force'` (today's adapter-imposed default) | **3.3**: 122 / **3.4**: 125 / **4.0**: 134 / **jruby**: 180 | **3.3**: 128 / **3.4**: 143 / **4.0**: 149 / **jruby**: 163 |
| `:default` (proposed default, after #2629 merged) | **3.3**: 147 / **3.4**: 133 / **4.0**: 123 / **jruby**: 158 | **3.3**: 149 / **3.4**: 149 / **4.0**: 135 / **jruby**: 192 |

Sources of each cell:
- `(true, force)` — master baseline before this PR, avg of 5 recent runs
- `(true, :default)` — measurement run #25042855383 (combined branch of #2626 and #2629; #2629 is now in master)
- `(false, force)` — measurement run #25043429031 (master with `prepared_statements: false` hard-coded into `CONNECTION_PARAMS` for measurement)
- `(false, :default)` — measurement run #25043431071 (same hard-coded variant on the combined branch)

Both rows are within noise. The earlier observation that `:default` alone (without #2629) regressed by +20–43% is preserved in [this comment](https://github.com/rsim/oracle-enhanced/pull/2626#issuecomment-4333527698) for the record; #2629 already cancelled that out.

## Tests

- New `describe \"cursor_sharing\"` block in `connection_spec.rb` covers: unset (default), `:default`, explicit `:force`, explicit `:exact`, and the existing `ArgumentError` for unsupported values.
- Test sessions use the regular `CONNECTION_PARAMS` user. Observation goes through a separate `SystemObserver` AR connection (SYSTEM) reading `v$parameter` and `v$ses_optimizer_env` (both normalized to upper-case so the comparison is stable across views), since the regular user has no `v$` access by default.

## Doc update

The `:cursor_sharing` doc comment in `oracle_enhanced_adapter.rb` is updated to describe the new default, the accepted values including `:default`, and the explicit `cursor_sharing: 'force'` opt-in for the legacy behavior.

## References

- Oracle Database 26 *Database Reference* — [CURSOR_SHARING](https://docs.oracle.com/en/database/oracle/oracle-database/26/refrn/CURSOR_SHARING.html) (documented default `EXACT`; `FORCE` and `EXACT` are the only valid values; `SIMILAR` was removed)
- Rails — [rails/rails#45945](https://github.com/rails/rails/pull/45945) makes `prepared_statements: true` the AbstractAdapter default starting with Rails 7.1
- `oracle_enhanced` — original 2009 commit introducing the `force` default: [`ebb60f3`](https://github.com/rsim/oracle-enhanced/commit/ebb60f3)

Refs #2622, #2628.