### PR TITLE
Bind literals in dictionary queries

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -542,10 +542,10 @@ module ActiveRecord
         end
 
         def tablespace(table_name)
-          select_value(<<~SQL.squish, "SCHEMA")
+          select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name.to_s.upcase)])
             SELECT tablespace_name
             FROM all_tables
-            WHERE table_name='#{table_name.to_s.upcase}'
+            WHERE table_name = :table_name
             AND owner = SYS_CONTEXT('userenv', 'current_schema')
           SQL
         end

--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -102,12 +102,12 @@ module ActiveRecord # :nodoc:
 
         def structure_dump_primary_key(table) # :nodoc:
           opts = { name: "", cols: [] }
-          pks = select_all(<<~SQL.squish, "SCHEMA")
+          pks = select_all(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table.upcase)])
             SELECT a.constraint_name, a.column_name, a.position
               FROM all_cons_columns a
               JOIN all_constraints c
                 ON a.constraint_name = c.constraint_name
-             WHERE c.table_name = '#{table.upcase}'
+             WHERE c.table_name = :table_name
                AND c.constraint_type = 'P'
                AND a.owner = c.owner
                AND c.owner = SYS_CONTEXT('userenv', 'current_schema')
@@ -121,12 +121,12 @@ module ActiveRecord # :nodoc:
 
         def structure_dump_unique_keys(table) # :nodoc:
           keys = {}
-          uks = select_all(<<~SQL.squish, "SCHEMA")
+          uks = select_all(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table.upcase)])
             SELECT a.constraint_name, a.column_name, a.position
               FROM all_cons_columns a
               JOIN all_constraints c
                 ON a.constraint_name = c.constraint_name
-             WHERE c.table_name = '#{table.upcase}'
+             WHERE c.table_name = :table_name
                AND c.constraint_type = 'U'
                AND a.owner = c.owner
                AND c.owner = SYS_CONTEXT('userenv', 'current_schema')
@@ -385,9 +385,9 @@ module ActiveRecord # :nodoc:
         end
 
         def drop_sql_for_object(type)
-          objects = select_values(<<~SQL.squish, "SCHEMA")
+          objects = select_values(<<~SQL.squish, "SCHEMA", [bind_string("object_type", type.upcase)])
             SELECT object_name FROM all_objects
-            WHERE object_type = '#{type.upcase}' and owner = SYS_CONTEXT('userenv', 'current_schema')
+            WHERE object_type = :object_type and owner = SYS_CONTEXT('userenv', 'current_schema')
           SQL
           statements = objects.map do |name|
             "DROP #{type.upcase} \"#{name}\""


### PR DESCRIPTION
## Summary

Replaces literal interpolation with bind variables in the four remaining dictionary queries that were still building per-call SQL text in `oracle_enhanced/{schema_statements,structure_dump}.rb`. With this change the same SQL text is reused across calls, so the server can share a single cursor regardless of which table / object is being inspected.

| File | Method | Bound parameter |
|---|---|---|
| `schema_statements.rb` | `tablespace` | `:table_name` |
| `structure_dump.rb` | `structure_dump_primary_key` | `:table_name` |
| `structure_dump.rb` | `structure_dump_unique_keys` | `:table_name` |
| `structure_dump.rb` | `drop_sql_for_object` | `:object_type` |

The remaining `all_*` / `user_*` queries in those files (and in `oracle_enhanced_adapter.rb`) either already use binds or have no per-call literal interpolation (`SYS_CONTEXT('userenv', 'current_schema')` for owner, fixed `secondary = 'N'`, etc.).

## Why

Without binding, each unique value embedded in the WHERE clause produces a fresh shared cursor on the server. The legacy session-level `cursor_sharing = force` default masked this by getting the server to rewrite literals into system-generated binds (`:"SYS_B_0"` ...). #2626 removes that default, which surfaces the per-call cursor cost on schemas with many tables/objects (the spec suite alone showed +20-43% on the Run RSpec step).

With these queries bound at the call sites, removing the cursor_sharing default no longer regresses CI runtime.

## Execution path: always prepared, regardless of `prepared_statements:` setting

These queries reach `OracleEnhanced::DatabaseStatements#perform_query` as a raw SQL string (`<<~SQL.squish`) plus an explicit `binds:` array. AR's `to_sql_and_binds` only substitutes literals for **Arel-driven** queries (via `Arel::Collectors::SubstituteBinds` when `prepared_statements?` is false); for raw SQL with explicit binds, the SQL and binds pass through unchanged. `perform_query` itself does not consult the connection's `prepared_statements` flag — it always calls `raw_connection.prepare(sql)`, caches the cursor in `@statements[sql]`, and binds via `bind_params`.

Net effect: **the four queries modified here are executed as prepared statements with bind variables in both `prepared_statements: true` and `prepared_statements: false` connections.** This is consistent with how the existing `bind_string` callers in `oracle_enhanced_adapter.rb` and `oracle_enhanced/schema_statements.rb` already behave, so the PR doesn't introduce a new exception — it simply enrolls four more dictionary queries in the existing pattern.

If a user genuinely wants per-call parsed cursors for these queries (e.g. to honor the spirit of `prepared_statements: false` even for SCHEMA queries), that would require splitting `perform_query` into a "prepare-and-cache" vs "prepare-without-cache" branch, which is out of scope for this PR and tracked as a separate follow-up.

## Test plan

- [ ] CI green on this branch
- [ ] On the combined #2626 + this PR, the Run RSpec step duration returns to within ~5% of master baseline (the +20-43% regression observed on #2626 alone should disappear)

Closes #2628.