### PR TITLE
[measurement only] #2626+#2629 + prepared_statements: false

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -540,10 +540,10 @@ module ActiveRecord
         end
 
         def tablespace(table_name)
-          select_value(<<~SQL.squish, "SCHEMA")
+          select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name.to_s.upcase)])
             SELECT tablespace_name
             FROM all_tables
-            WHERE table_name='#{table_name.to_s.upcase}'
+            WHERE table_name = :table_name
             AND owner = SYS_CONTEXT('userenv', 'current_schema')
           SQL
         end

--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -102,12 +102,12 @@ module ActiveRecord # :nodoc:
 
         def structure_dump_primary_key(table) # :nodoc:
           opts = { name: "", cols: [] }
-          pks = select_all(<<~SQL.squish, "SCHEMA")
+          pks = select_all(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table.upcase)])
             SELECT a.constraint_name, a.column_name, a.position
               FROM all_cons_columns a
               JOIN all_constraints c
                 ON a.constraint_name = c.constraint_name
-             WHERE c.table_name = '#{table.upcase}'
+             WHERE c.table_name = :table_name
                AND c.constraint_type = 'P'
                AND a.owner = c.owner
                AND c.owner = SYS_CONTEXT('userenv', 'current_schema')
@@ -121,12 +121,12 @@ module ActiveRecord # :nodoc:
 
         def structure_dump_unique_keys(table) # :nodoc:
           keys = {}
-          uks = select_all(<<~SQL.squish, "SCHEMA")
+          uks = select_all(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table.upcase)])
             SELECT a.constraint_name, a.column_name, a.position
               FROM all_cons_columns a
               JOIN all_constraints c
                 ON a.constraint_name = c.constraint_name
-             WHERE c.table_name = '#{table.upcase}'
+             WHERE c.table_name = :table_name
                AND c.constraint_type = 'U'
                AND a.owner = c.owner
                AND c.owner = SYS_CONTEXT('userenv', 'current_schema')
@@ -385,9 +385,9 @@ module ActiveRecord # :nodoc:
         end
 
         def drop_sql_for_object(type)
-          objects = select_values(<<~SQL.squish, "SCHEMA")
+          objects = select_values(<<~SQL.squish, "SCHEMA", [bind_string("object_type", type.upcase)])
             SELECT object_name FROM all_objects
-            WHERE object_type = '#{type.upcase}' and owner = SYS_CONTEXT('userenv', 'current_schema')
+            WHERE object_type = :object_type and owner = SYS_CONTEXT('userenv', 'current_schema')
           SQL
           statements = objects.map do |name|
             "DROP #{type.upcase} \"#{name}\""

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -99,7 +99,16 @@ module ActiveRecord
     # * <tt>:privilege</tt> - set "SYSDBA" if you want to connect with this privilege
     # * <tt>:allow_concurrency</tt> - set to "true" if non-blocking mode should be enabled (just for OCI client)
     # * <tt>:prefetch_rows</tt> - how many rows should be fetched at one time to increase performance, defaults to 100
-    # * <tt>:cursor_sharing</tt> - cursor sharing mode to minimize amount of unique statements, no default value
+    # * <tt>:cursor_sharing</tt> - cursor sharing mode. Accepts "exact", "force", "similar", or
+    #   <tt>:default</tt> (the default). With <tt>:default</tt> (or unset) the adapter does not
+    #   run <tt>ALTER SESSION SET cursor_sharing</tt> and the server's instance-level setting
+    #   is kept. Pass an explicit value to issue the corresponding <tt>ALTER SESSION</tt>.
+    #
+    #   NOTE: AR's schema introspection (e.g. <tt>all_tab_columns</tt>) embeds owner/table/column
+    #   names as literals, not bind variables. Without <tt>cursor_sharing = force</tt>, each
+    #   unique combination produces a fresh shared cursor on the server. If this becomes a
+    #   measurable shared-pool problem for installs with very large schemas, set
+    #   <tt>:cursor_sharing => 'force'</tt> explicitly.
     # * <tt>:time_zone</tt> - database session time zone
     #   (it is recommended to set it using ENV['TZ'] which will be then also used for database session time zone)
     # * <tt>:schema</tt> - database schema which holds schema objects.
@@ -856,11 +865,14 @@ module ActiveRecord
       private def configure_connection
         super
 
-        cursor_sharing = (@config[:cursor_sharing] || "force").to_s.upcase
-        unless CURSOR_SHARING_VALUES.include?(cursor_sharing)
-          raise ArgumentError, "Invalid :cursor_sharing value #{@config[:cursor_sharing].inspect}; allowed: #{CURSOR_SHARING_VALUES.join(', ')}"
+        cursor_sharing = @config[:cursor_sharing]
+        unless cursor_sharing.nil? || cursor_sharing == :default
+          cursor_sharing = cursor_sharing.to_s.upcase
+          unless CURSOR_SHARING_VALUES.include?(cursor_sharing)
+            raise ArgumentError, "Invalid :cursor_sharing value #{@config[:cursor_sharing].inspect}; allowed: #{CURSOR_SHARING_VALUES.join(', ')} or :default"
+          end
+          execute("alter session set cursor_sharing = #{cursor_sharing}", "SCHEMA")
         end
-        execute("alter session set cursor_sharing = #{cursor_sharing}", "SCHEMA")
 
         if ORACLE_ENHANCED_CONNECTION == :oci
           time_zone = @config[:time_zone] || ENV["TZ"]

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -36,20 +36,58 @@ describe "OracleEnhancedAdapter establish connection" do
     expect(ActiveRecord::Base.lease_connection).to be_active
   end
 
-  it "should use database default cursor_sharing parameter value force by default" do
-    # Use `SYSTEM_CONNECTION_PARAMS` to query v$parameter
-    ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS)
-    expect(ActiveRecord::Base.lease_connection.select_value("select value from v$parameter where name = 'cursor_sharing'")).to eq("FORCE")
-  end
+  describe "cursor_sharing" do
+    # The test session uses CONNECTION_PARAMS (regular oracle_enhanced user,
+    # no v$ access); SystemObserver is a separate AR connection on SYSTEM used
+    # only to read v$parameter / v$ses_optimizer_env for assertions.
+    class SystemObserver < ActiveRecord::Base
+      self.abstract_class = true
+    end
 
-  it "should use modified cursor_sharing value exact" do
-    ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS.merge(cursor_sharing: :exact))
-    expect(ActiveRecord::Base.lease_connection.select_value("select value from v$parameter where name = 'cursor_sharing'")).to eq("EXACT")
-  end
+    before(:each) { SystemObserver.establish_connection(SYSTEM_CONNECTION_PARAMS) }
+    after(:each)  { SystemObserver.remove_connection rescue nil }
 
-  it "should raise ArgumentError for an unsupported cursor_sharing value" do
-    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(cursor_sharing: "not_a_valid_mode"))
-    expect { ActiveRecord::Base.lease_connection }.to raise_error(ArgumentError, /Invalid :cursor_sharing value/)
+    let(:server_default_cursor_sharing) do
+      SystemObserver.connection.select_value(
+        "select upper(value) from v$parameter where name = 'cursor_sharing'"
+      )
+    end
+
+    # v$ses_optimizer_env returns the value lowercase; v$parameter returns it
+    # uppercase. Normalize to uppercase so comparisons are stable across views.
+    def session_cursor_sharing(connection)
+      sid = connection.select_value("select sys_context('userenv', 'sid') from dual").to_i
+      SystemObserver.connection.select_value(
+        "select upper(value) from v$ses_optimizer_env where sid = #{sid} and name = 'cursor_sharing'"
+      )
+    end
+
+    it "does not run ALTER SESSION when :cursor_sharing is unset" do
+      expected = server_default_cursor_sharing
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+      expect(session_cursor_sharing(ActiveRecord::Base.lease_connection)).to eq(expected)
+    end
+
+    it "does not run ALTER SESSION when :cursor_sharing is :default" do
+      expected = server_default_cursor_sharing
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(cursor_sharing: :default))
+      expect(session_cursor_sharing(ActiveRecord::Base.lease_connection)).to eq(expected)
+    end
+
+    it "applies the explicit :cursor_sharing value when set to :force" do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(cursor_sharing: :force))
+      expect(session_cursor_sharing(ActiveRecord::Base.lease_connection)).to eq("FORCE")
+    end
+
+    it "applies the explicit :cursor_sharing value when set to :exact" do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(cursor_sharing: :exact))
+      expect(session_cursor_sharing(ActiveRecord::Base.lease_connection)).to eq("EXACT")
+    end
+
+    it "raises ArgumentError for an unsupported cursor_sharing value" do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(cursor_sharing: "not_a_valid_mode"))
+      expect { ActiveRecord::Base.lease_connection }.to raise_error(ArgumentError, /Invalid :cursor_sharing value/)
+    end
   end
 
   it "should not use JDBC statement caching" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -147,7 +147,8 @@ CONNECTION_PARAMS = {
   host: DATABASE_HOST,
   port: DATABASE_PORT,
   username: DATABASE_USER,
-  password: DATABASE_PASSWORD
+  password: DATABASE_PASSWORD,
+  prepared_statements: false
 }
 
 CONNECTION_PARAMS_WITH_PREPARED_STATEMENTS = CONNECTION_PARAMS.merge(prepared_statements: true)


### PR DESCRIPTION
Throwaway PR to trigger CI for measurement of (prepared_statements: false × cursor_sharing: default + binds) cell.