### PR TITLE
Fix NCLOB INSERT failure when prepared_statements is false

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -157,7 +157,7 @@ module ActiveRecord
           when Type::OracleEnhanced::Text::Data then
             "empty_clob()"
           when Type::OracleEnhanced::NationalCharacterText::Data then
-            "empty_nclob()"
+            "empty_clob()"
           else
             super
           end

--- a/spec/active_record/oracle_enhanced/type/national_character_text_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/national_character_text_spec.rb
@@ -227,4 +227,44 @@ describe "OracleEnhancedAdapter handling of NCLOB columns" do
     @employee.reload
     expect(@employee.comments).to eq(length: { is: 2 })
   end
+
+  describe "with prepared_statements disabled" do
+    around(:each) do |example|
+      old_prepared_statements = @conn.prepared_statements
+      @conn.instance_variable_set(:@prepared_statements, false)
+      example.run
+      @conn.instance_variable_set(:@prepared_statements, old_prepared_statements)
+    end
+
+    it "should create record with NCLOB data when prepared_statements is false" do
+      @employee = TestEmployee.create!(
+        first_name: "First",
+        last_name: "Last",
+        comments: @nclob_data
+      )
+      @employee.reload
+      expect(@employee.comments).to eq(@nclob_data)
+    end
+
+    it "should create record with empty NCLOB when prepared_statements is false" do
+      @employee = TestEmployee.create!(
+        first_name: "First",
+        last_name: "Last",
+        comments: ""
+      )
+      @employee.reload
+      expect(@employee.comments).to eq("")
+    end
+
+    it "should create record with serialized NCLOB data when prepared_statements is false" do
+      ruby_data = { "test" => ["ruby", :data, 123] }
+      @employee = Test2Employee.create!(
+        first_name: "First",
+        last_name: "Last",
+        comments: ruby_data
+      )
+      @employee.reload
+      expect(@employee.comments).to eq(ruby_data)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fixes a long-standing bug surfaced when running with `prepared_statements: false`: any INSERT/UPDATE touching an NCLOB column trips
`ORA-00904: "EMPTY_NCLOB": invalid identifier`.

`OracleEnhanced::Quoting#quote` returned the literal string `"empty_nclob()"` for `Type::OracleEnhanced::NationalCharacterText::Data` values. Oracle does not provide an `EMPTY_NCLOB()` function — only `EMPTY_BLOB()` and `EMPTY_CLOB()` are documented (see [Oracle SQL Language Reference](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/EMPTY_BLOB-EMPTY_CLOB.html)). NCLOB columns accept `EMPTY_CLOB()` because Oracle implicitly converts CLOB to NCLOB.

Verified locally against Oracle Database 23.26.1:

```
SQL> select empty_nclob() from dual;
ERROR at line 1: ORA-00904: "EMPTY_NCLOB": invalid identifier

SQL> select empty_clob() from dual;
(succeeds)
```

## Why this stayed hidden

On `prepared_statements: true` connections (the AbstractAdapter default and the default the spec suite has been running with) the `type_cast` path binds an `OCI8::NCLOB` instance directly via OCI and never sends the `empty_nclob()` literal to the server. Only `prepared_statements: false` connections take the SQL-interpolation path through `quote`, which is where the bad literal was emitted.

`prepared_statements: false` becomes the active configuration in any Rails 8+ app that has `config.active_record.query_log_tags_enabled = true` (Rails 8 default), via `ActiveRecord.disable_prepared_statements`. So the bug is reachable from default Rails 8 dev environments — same setup that motivated #2477 / #2485 for CLOB/BLOB.

## Tests

Adds a `with prepared_statements disabled` describe block to `spec/active_record/oracle_enhanced/type/national_character_text_spec.rb`, mirroring the block #2485 added to `text_spec.rb` for CLOB/BLOB. Without the fix, every example in the new block fails with `ORA-00904: "EMPTY_NCLOB"`. With the fix, all pass.

## Related

- #272 (2015) — original report of the same `ORA-00904: "EMPTY_NCLOB"` shape on UPDATE; closed without a code fix at the time
- #2477 / #2485 (2026-02) — same issue for CLOB/BLOB, fixed for those two types but did not extend to NCLOB
- #2622 — broader test-coverage gap that allowed this to stay latent