### PR TITLE
Add CI workflow forcing prepared_statements: false

### DIFF
--- a/.github/workflows/test_prepared_statements_false.yml
+++ b/.github/workflows/test_prepared_statements_false.yml
@@ -1,0 +1,90 @@
+name: test_prepared_statements_false
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [
+          '4.0',
+          'jruby-10.1.0.0',
+        ]
+        include:
+          - ruby: 'jruby-10.1.0.0'
+            jruby_opts: '--dev'
+    env:
+      JRUBY_OPTS: ${{ matrix.jruby_opts }}
+      NLS_LANG: AMERICAN_AMERICA.AL32UTF8
+      TNS_ADMIN: ./ci/network/admin
+      DATABASE_NAME: FREEPDB1
+      TZ: Europe/Riga
+      DATABASE_SYS_PASSWORD: Oracle18
+      DATABASE_HOST: localhost
+      DATABASE_PORT: 1521
+      ORACLE_ENHANCED_PREPARED_STATEMENTS_FALSE: "1"
+
+    services:
+      oracle:
+        image: gvenzl/oracle-free:latest
+        ports:
+          - 1521:1521
+        env:
+          TZ: Europe/Riga
+          ORACLE_PASSWORD: Oracle18
+        options: >-
+          --health-cmd healthcheck.sh
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          rubygems: latest
+      - name: Create symbolic link for libaio library compatibility
+        run: |
+          sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
+      - name: Download Oracle instant client
+        run: |
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-sdk-linuxx64.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-sqlplus-linuxx64.zip
+      - name: Install Oracle instant client
+        run: |
+          sudo unzip -q instantclient-basic-linuxx64.zip -d /opt/oracle/
+          sudo unzip -qo instantclient-sdk-linuxx64.zip -d /opt/oracle/
+          sudo unzip -qo instantclient-sqlplus-linuxx64.zip -d /opt/oracle/
+          ORACLE_HOME=$(find /opt/oracle -name "instantclient_*" -type d | head -1)
+          echo "ORACLE_HOME=$ORACLE_HOME" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$ORACLE_HOME" >> $GITHUB_ENV
+          echo "$ORACLE_HOME" >> $GITHUB_PATH
+      - name: Install JDBC Driver
+        run: |
+          cp "$ORACLE_HOME/ojdbc17.jar" ./lib/ojdbc17.jar
+      - name: Enable Oracle native network encryption in the server container
+        run: |
+          ORACLE_CONTAINER=$(docker ps --filter "ancestor=gvenzl/oracle-free" -q)
+          docker exec -u oracle "$ORACLE_CONTAINER" bash -c "
+            SQLNET=\$ORACLE_HOME/network/admin/sqlnet.ora
+            grep -q ENCRYPTION_SERVER \$SQLNET 2>/dev/null || echo 'SQLNET.ENCRYPTION_SERVER = REQUESTED' >> \$SQLNET
+            grep -q ENCRYPTION_TYPES_SERVER \$SQLNET 2>/dev/null || echo 'SQLNET.ENCRYPTION_TYPES_SERVER = (AES256)' >> \$SQLNET
+          "
+      - name: Create database user
+        run: |
+          ./ci/setup_accounts.sh
+      - name: Bundle install
+        run: |
+          bundle install --jobs 4 --retry 3
+      - name: Show Gemfile.lock
+        run: |
+          cat Gemfile.lock
+      - name: Run RSpec
+        run: |
+          bundle exec rspec

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -150,6 +150,11 @@ CONNECTION_PARAMS = {
   password: DATABASE_PASSWORD
 }
 
+if ENV["ORACLE_ENHANCED_PREPARED_STATEMENTS_FALSE"]
+  CONNECTION_PARAMS[:prepared_statements] = false
+  puts "==> Forcing prepared_statements: false via ORACLE_ENHANCED_PREPARED_STATEMENTS_FALSE"
+end
+
 CONNECTION_WITH_SCHEMA_PARAMS = {
   adapter: "oracle_enhanced",
   database: DATABASE_NAME,


### PR DESCRIPTION
## Summary

Adds:
- `ORACLE_ENHANCED_PREPARED_STATEMENTS_FALSE` env-var hook in `spec/spec_helper.rb` that, when set, forces `prepared_statements: false` into `CONNECTION_PARAMS` and prints a startup banner.
- `.github/workflows/test_prepared_statements_false.yml` (CRuby 4.0 + JRuby 10.1.0.0, `gvenzl/oracle-free:latest`) that sets the env var and runs the full RSpec suite.

## Why

The \`prepared_statements: false\` arm has accumulated multiple bugs over the years precisely because nothing in CI exercised it:

- #272 (2015) — `ORA-00904: "EMPTY_NCLOB"` on UPDATE
- #2477 / #2485 (2026-02) — CLOB/BLOB inserts fail on `prepared_statements: false`; partially fixed but did not extend to NCLOB
- #2634 (this round) — NCLOB INSERT/UPDATE still trips `ORA-00904: "EMPTY_NCLOB"` because `OracleEnhanced::Quoting#quote` returned the literal `"empty_nclob()"` (Oracle has no `EMPTY_NCLOB()` function). Surfaced only because we hard-coded `prepared_statements: false` for an unrelated measurement.

`prepared_statements: false` is reachable from the default Rails 8+ development environment (any app with `config.active_record.query_log_tags_enabled = true` flips `ActiveRecord.disable_prepared_statements`), so the arm is real for real users — it just has no CI floor.

The matching `ORACLE_ENHANCED_PREPARED_STATEMENTS=1` (force true) hook that #2623 added and #2627 reverted is intentionally not reintroduced here: that arm collapsed once the cursor_sharing default stopped depending on `prepared_statements` (#2626), and CI duplicating the AbstractAdapter default did not earn its keep. The `false` arm is a distinct code path that does.

## Expected initial CI result on this branch

**Failing**, with the failures concentrated in the NCLOB describe block in `spec/active_record/oracle_enhanced/type/national_character_text_spec.rb`:

```
ORA-00904: "EMPTY_NCLOB": invalid identifier
```

That is exactly the bug #2634 fixes. The expectation is:

1. Land #2634 first (1-line `quoting.rb` fix from `empty_nclob()` to `empty_clob()` plus a regression spec).
2. Re-trigger this workflow on this branch — should go green.
3. Merge this PR.
4. Promote trigger from `workflow_dispatch` to `schedule: cron "0 0 * * *"` in a follow-up.

So this PR is intentionally held until #2634 lands.

## Test plan

- [ ] Run this workflow manually on this branch — confirm failures are NCLOB-only and match the #2634 signature.
- [ ] After #2634 lands, rebase / re-run — confirm green.
- [ ] Follow-up PR to switch trigger to `schedule`.

Refs #2622, #2634.