### PR TITLE
Preserve readonly LOB column values on create when prepared_statements is false

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/lob.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/lob.rb
@@ -38,7 +38,7 @@ module ActiveRecord # :nodoc:
 
           def record_lobs_for_create
             @changed_lob_columns = self.class.lob_columns.select do |col|
-              !attributes[col.name].nil? && !self.class.readonly_attributes.to_a.include?(col.name)
+              !attributes[col.name].nil?
             end
           end
 

--- a/spec/active_record/oracle_enhanced/type/national_character_text_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/national_character_text_spec.rb
@@ -266,5 +266,19 @@ describe "OracleEnhancedAdapter handling of NCLOB columns" do
       @employee.reload
       expect(@employee.comments).to eq(ruby_data)
     end
+
+    it "should respect attr_readonly setting for NCLOB column when prepared_statements is false" do
+      @employee = TestEmployeeReadOnlyNClob.create!(
+        first_name: "First",
+        comments: @nclob_data
+      )
+      expect(@employee).to be_valid
+      @employee.reload
+      expect(@employee.comments).to eq(@nclob_data)
+      @employee.comments = @nclob_data2
+      expect(@employee.save).to be(true)
+      @employee.reload
+      expect(@employee.comments).to eq(@nclob_data)
+    end
   end
 end

--- a/spec/active_record/oracle_enhanced/type/text_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/text_spec.rb
@@ -291,5 +291,19 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
       @employee.reload
       expect(@employee.comments).to eq(ruby_data)
     end
+
+    it "should respect attr_readonly setting for CLOB column when prepared_statements is false" do
+      @employee = TestEmployeeReadOnlyClob.create!(
+        first_name: "First",
+        comments: "initial"
+      )
+      expect(@employee).to be_valid
+      @employee.reload
+      expect(@employee.comments).to eq("initial")
+      @employee.comments = "changed"
+      expect(@employee.save).to be(true)
+      @employee.reload
+      expect(@employee.comments).to eq("initial")
+    end
   end
 end


### PR DESCRIPTION
## Summary

Drops the `readonly_attributes` filter from `record_lobs_for_create` so that `before_create` records all populated LOB columns regardless of `attr_readonly`. After `enhanced_write_lobs` runs on `after_create`, the supplied values are persisted (instead of being silently replaced by the `EMPTY_CLOB()` / `EMPTY_BLOB()` placeholder).

## Why

`attr_readonly` is supposed to forbid post-creation updates only — not the initial create. The previous filter applied to both create and update paths, which was the right thing for `record_changed_lobs` (used by `before_update`) but the wrong thing for `record_lobs_for_create`.

The bug only surfaces on `prepared_statements: false` connections; the `prepared_statements: true` path writes LOB data directly via OCI temp-LOB binding during INSERT and the after_create callback is a no-op. That is why nothing in CI flagged this earlier — until #2635 added a workflow that runs the suite with `prepared_statements: false`.

## Tests

The two pre-existing specs already encode the correct expectation:

- `OracleEnhancedAdapter handling of CLOB columns should respect attr_readonly setting for CLOB column`
- `OracleEnhancedAdapter handling of NCLOB columns should respect attr_readonly setting for NCLOB column`

They pass on `prepared_statements: true` (today's default) and, with this fix, also pass on `prepared_statements: false` (covered in CI by #2635). No new spec is added — the existing ones now exercise both arms.

## Test plan

- [ ] CI green on this PR (the regular `test` workflow runs with `prepared_statements: true`)
- [ ] Re-trigger #2635's `test_prepared_statements_false` workflow on this branch — the two readonly specs above should drop out of the failure list

Closes #2636.

Refs #2477, #2485, #2622, #2634, #2635.