### PR TITLE
[measurement only] regression spec for #2637 without the lib fix

### DIFF
--- a/spec/active_record/oracle_enhanced/type/national_character_text_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/national_character_text_spec.rb
@@ -266,5 +266,19 @@ describe "OracleEnhancedAdapter handling of NCLOB columns" do
       @employee.reload
       expect(@employee.comments).to eq(ruby_data)
     end
+
+    it "should respect attr_readonly setting for NCLOB column when prepared_statements is false" do
+      @employee = TestEmployeeReadOnlyNClob.create!(
+        first_name: "First",
+        comments: @nclob_data
+      )
+      expect(@employee).to be_valid
+      @employee.reload
+      expect(@employee.comments).to eq(@nclob_data)
+      @employee.comments = @nclob_data2
+      expect(@employee.save).to be(true)
+      @employee.reload
+      expect(@employee.comments).to eq(@nclob_data)
+    end
   end
 end

--- a/spec/active_record/oracle_enhanced/type/text_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/text_spec.rb
@@ -291,5 +291,19 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
       @employee.reload
       expect(@employee.comments).to eq(ruby_data)
     end
+
+    it "should respect attr_readonly setting for CLOB column when prepared_statements is false" do
+      @employee = TestEmployeeReadOnlyClob.create!(
+        first_name: "First",
+        comments: "initial"
+      )
+      expect(@employee).to be_valid
+      @employee.reload
+      expect(@employee.comments).to eq("initial")
+      @employee.comments = "changed"
+      expect(@employee.save).to be(true)
+      @employee.reload
+      expect(@employee.comments).to eq("initial")
+    end
   end
 end


### PR DESCRIPTION
Throwaway PR to verify the readonly LOB regression specs added in #2637 actually fail on master without the lib fix. Expected outcome: the two new `should respect attr_readonly setting for {C,N}LOB column when prepared_statements is false` examples fail (CLOB readonly + NCLOB readonly), and only those.