### PR TITLE
Inline-quote LOB text values for short data on prepared_statements: false

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/quoting.rb
@@ -155,9 +155,9 @@ module ActiveRecord
           when ActiveModel::Type::Binary::Data then
             "empty_blob()"
           when Type::OracleEnhanced::Text::Data then
-            "empty_clob()"
+            quote_lob_text_data(value, prefix: nil)
           when Type::OracleEnhanced::NationalCharacterText::Data then
-            "empty_clob()"
+            quote_lob_text_data(value, prefix: "N")
           else
             super
           end
@@ -202,6 +202,21 @@ module ActiveRecord
         end
 
         private
+          # Inline literal up to the VARCHAR2 limit so SELECT predicates against
+          # CLOB / NCLOB columns work on prepared_statements: false. Beyond that
+          # limit fall back to empty_clob(); large-value comparisons still
+          # require prepared_statements: true.
+          LOB_INLINE_LITERAL_BYTESIZE = 4000
+
+          def quote_lob_text_data(value, prefix:)
+            s = value.to_s
+            # Empty string would become NULL via the '' literal, so keep the
+            # placeholder for the empty case as well as for oversize values.
+            return "empty_clob()" if s.empty? || s.bytesize > LOB_INLINE_LITERAL_BYTESIZE
+            literal = +"'#{quote_string(s)}'"
+            prefix ? +prefix << literal : literal
+          end
+
           def oracle_downcase(column_name)
             return nil if column_name.nil?
             /[a-z]/.match?(column_name) ? column_name : column_name.downcase

--- a/spec/active_record/oracle_enhanced/type/text_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/text_spec.rb
@@ -305,5 +305,20 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
       @employee.reload
       expect(@employee.comments).to eq("initial")
     end
+
+    it "should allow equality on select when prepared_statements is false" do
+      search_data = "ps_false equality marker"
+      Test2Employee.create!(
+        first_name: "First",
+        last_name: "Last",
+        comments: search_data,
+      )
+      Test2Employee.create!(
+        first_name: "First1",
+        last_name: "Last1",
+        comments: "ps_false other data",
+      )
+      expect(Test2Employee.where(comments: search_data)).to have_attributes(count: 1)
+    end
   end
 end


### PR DESCRIPTION
## Summary

Replaces the unconditional `"empty_clob()"` literal returned by `OracleEnhanced::Quoting#quote` for `Type::OracleEnhanced::Text::Data` / `NationalCharacterText::Data` values with an inline string literal when the value fits within the VARCHAR2 literal limit (4000 bytes). Falls back to `empty_clob()` for values larger than the limit **and** for the empty string (which Oracle would otherwise interpret as `NULL` when written as `''`).

## Why

The `empty_clob()` literal is the correct placeholder for an INSERT / UPDATE column whose actual data is later written via `enhanced_write_lobs` (the after_create / after_update `SELECT FOR UPDATE` path). It is the wrong thing to emit when the same serialize/quote chain is reused for a SELECT predicate: an expression like

```sql
WHERE comments = empty_clob()
```

never matches a populated CLOB, so on `prepared_statements: false` connections any `where(clob_col: value)` returns zero rows even when a matching record exists.

`prepared_statements: true` is unaffected — the type_cast / OCI temp-LOB binding path does not go through this `quote` branch.

## Behavior changes

| value | before | after |
|---|---|---|
| short non-empty (≤ 4000 bytes) | `empty_clob()` placeholder + after_(create\|update) write | inline `'...'` literal in INSERT / UPDATE / SELECT |
| empty string `""` | `empty_clob()` placeholder + write | unchanged (avoids Oracle's `'' === NULL`) |
| > 4000 bytes | `empty_clob()` placeholder + write | unchanged |

For short non-empty values the after_create / after_update `enhanced_write_lobs` overwrite is now a benign no-op (the row already has the correct data); for empty strings and for long values the placeholder + write path is preserved exactly.

## Known limitation

`where(clob_col: very_large_value)` (> 4000 bytes) on `prepared_statements: false` still produces `WHERE clob_col = empty_clob()` and matches no rows. Workaround: use `prepared_statements: true` for that query, which binds via OCI temp LOB and works at any size. CLOB equality on > 4000-byte values is unusual in practice (full-text indexes / `LIKE` partials are the typical pattern).

## Tests

Adds `should allow equality on select when prepared_statements is false` inside the existing `with prepared_statements disabled` describe block of `text_spec.rb`. Verified failing on master without the fix and passing with it.

The pre-existing top-level `should allow equality on select` (`text_spec.rb:230`) — which was failing on the `test_prepared_statements_false` workflow #2635 — also returns to green.

Closes #2638.
