### PR TITLE
[measurement only] regression spec for #2642 without the lib fix

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -154,6 +154,24 @@ describe "OracleEnhancedAdapter schema definition" do
       expect { klass.create!(code: "ABC", name: "alpha") }.not_to raise_error
       expect(klass.find("ABC").name).to eq("alpha")
     end
+
+    it "inserts via the Rails insert path on a String primary key when prepared_statements is false" do
+      schema_define do
+        create_table :test_lookups, force: true, id: false do |t|
+          t.primary_key :code, :string, limit: 10, null: false
+          t.string :name
+        end
+      end
+      klass = Class.new(ActiveRecord::Base) do
+        self.table_name = "test_lookups"
+        self.primary_key = "code"
+      end
+
+      @conn.unprepared_statement do
+        expect { klass.create!(code: "ABC", name: "alpha") }.not_to raise_error
+        expect(klass.find("ABC").name).to eq("alpha")
+      end
+    end
   end
 
   describe "primary key with null: true" do


### PR DESCRIPTION
Verify the unprepared_statement-block spec from #2642 actually fails on master without the lib fix. Expected: only the new `inserts via the Rails insert path on a String primary key when prepared_statements is false` example fails (1 failure).