### PR TITLE
Mark trigger-backed primary key columns as auto-populated

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column.rb
@@ -6,9 +6,10 @@ module ActiveRecord
       class Column < ActiveRecord::ConnectionAdapters::Column
         delegate :virtual, to: :sql_type_metadata, allow_nil: true
 
-        def initialize(*, identity: false, **) # :nodoc:
+        def initialize(*, identity: false, trigger_assigned: false, **) # :nodoc:
           super
           @identity = identity
+          @trigger_assigned = trigger_assigned
         end
 
         def virtual?
@@ -19,15 +20,20 @@ module ActiveRecord
           @identity
         end
 
+        def auto_populated?
+          super || @trigger_assigned
+        end
+
         def ==(other)
           other.is_a?(Column) &&
             super &&
-            auto_incremented_by_db? == other.auto_incremented_by_db?
+            auto_incremented_by_db? == other.auto_incremented_by_db? &&
+            @trigger_assigned == other.instance_variable_get(:@trigger_assigned)
         end
         alias :eql? :==
 
         def hash
-          [super, @identity].hash
+          [super, @identity, @trigger_assigned].hash
         end
       end
     end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -240,6 +240,8 @@ module ActiveRecord
           execute "RENAME #{quote_table_name(table_name)} TO #{quote_table_name(new_name)}"
           execute "RENAME #{default_sequence_name(table_name, nil)} TO #{default_sequence_name(new_name, nil)}" rescue nil
           @prefetch_primary_key_cache.delete(table_name.to_s)
+          clear_table_columns_cache(table_name)
+          clear_table_columns_cache(new_name)
 
           rename_table_indexes(table_name, new_name, **options)
         end
@@ -821,14 +823,29 @@ module ActiveRecord
             type_metadata = OracleEnhanced::TypeMetadata.new(fetch_type_metadata(field["sql_type"]), virtual: is_virtual)
             default_value = extract_value_from_default(field["data_default"])
             default_value = nil if is_virtual || is_identity
-            OracleEnhanced::Column.new(oracle_downcase(field["name"]),
+            column_name = oracle_downcase(field["name"])
+            trigger_assigned = trigger_assigned_pk_columns(table_name).include?(column_name)
+            OracleEnhanced::Column.new(column_name,
                              lookup_cast_type(field["sql_type"]),
                              default_value,
                              type_metadata,
                              field["nullable"] == "Y",
                              comment: field["column_comment"],
-                             identity: is_identity
+                             identity: is_identity,
+                             trigger_assigned: trigger_assigned
             )
+          end
+
+          def trigger_assigned_pk_columns(table_name)
+            @trigger_assigned_pk_cache[table_name.to_s] ||= begin
+              owner, desc_table_name = resolve_data_source_name(table_name.to_s)
+              if trigger_backed_primary_key?(owner, desc_table_name)
+                pks = primary_keys(table_name)
+                pks.size == 1 ? pks : []
+              else
+                []
+              end
+            end
           end
 
           def tablespace_for(obj_type, tablespace_option, table_name = nil, column_name = nil)

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -272,6 +272,7 @@ module ActiveRecord
         @enable_dbms_output = false
         @prefetch_primary_key_cache = {}
         @columns_cache = {}
+        @trigger_assigned_pk_cache = {}
         @notice_receiver_sql_warnings = []
 
         configure_connection
@@ -289,11 +290,6 @@ module ActiveRecord
       # https://github.com/rsim/oracle-enhanced/pull/1900
       def self.database_exists?(config)
         raise NotImplementedError
-      end
-
-      def return_value_after_insert?(column) # :nodoc:
-        # TODO: Return true if there this column will be populated (e.g by a sequence)
-        super
       end
 
       # Opens a database console session via sqlplus.
@@ -726,6 +722,7 @@ module ActiveRecord
 
       def clear_table_columns_cache(table_name)
         @columns_cache[table_name.to_s] = nil
+        @trigger_assigned_pk_cache.delete(table_name.to_s)
       end
 
       # Find a table's primary key and sequence.

--- a/spec/active_record/connection_adapters/oracle_enhanced/primary_key_trigger_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/primary_key_trigger_spec.rb
@@ -451,6 +451,61 @@ describe "primary_key_trigger" do
     end
   end
 
+  describe "auto_populated? on the primary key column" do
+    it "reports true for a trigger-backed primary key" do
+      schema_define do
+        create_table :test_pk_triggers, primary_key_trigger: true do |t|
+          t.string :name
+        end
+      end
+
+      pk_column = @conn.columns(:test_pk_triggers).find { |c| c.name == "id" }
+      expect(pk_column.auto_populated?).to be true
+    end
+
+    it "reports false for a plain sequence-backed primary key" do
+      schema_define do
+        create_table :test_pk_triggers do |t|
+          t.string :name
+        end
+      end
+
+      pk_column = @conn.columns(:test_pk_triggers).find { |c| c.name == "id" }
+      expect(pk_column.auto_populated?).to be false
+    end
+
+    it "reports false when only an unrelated BEFORE INSERT trigger exists" do
+      schema_define do
+        create_table :test_pk_triggers do |t|
+          t.string :name
+          t.string :note
+        end
+      end
+
+      @conn.execute <<~SQL
+        CREATE OR REPLACE TRIGGER test_pk_triggers_audit
+          BEFORE INSERT ON test_pk_triggers FOR EACH ROW
+        BEGIN
+          :new.note := 'audited';
+        END;
+      SQL
+
+      pk_column = @conn.columns(:test_pk_triggers).find { |c| c.name == "id" }
+      expect(pk_column.auto_populated?).to be false
+    end
+
+    it "drives _returning_columns_for_insert for trigger-backed tables" do
+      schema_define do
+        create_table :test_pk_triggers, primary_key_trigger: true do |t|
+          t.string :name
+        end
+      end
+      klass = Class.new(ActiveRecord::Base) { self.table_name = "test_pk_triggers" }
+
+      expect(klass._returning_columns_for_insert(@conn)).to eq(["id"])
+    end
+  end
+
   describe "trigger_backed_primary_key? false-positive guard" do
     it "ignores BEFORE INSERT row triggers that do not fill the PK from a sequence" do
       schema_define do

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -68,14 +68,14 @@ describe "OracleEnhancedAdapter" do
       it "should get columns from database at first time" do
         @conn.clear_table_columns_cache(:test_employees)
         expect(TestEmployee.lease_connection.columns("test_employees").map(&:name)).to eq(@column_names)
-        expect(@logger.logged(:debug).last).to match(/select .* from all_tab_cols/im)
+        expect(@logger.logged(:debug).join("\n")).to match(/select .* from all_tab_cols/im)
       end
 
       it "should not get columns from database at second time" do
         TestEmployee.lease_connection.columns("test_employees")
         @logger.clear(:debug)
         expect(TestEmployee.lease_connection.columns("test_employees").map(&:name)).to eq(@column_names)
-        expect(@logger.logged(:debug).last).not_to match(/select .* from all_tab_cols/im)
+        expect(@logger.logged(:debug).join("\n")).not_to match(/select .* from all_tab_cols/im)
       end
 
       it "should get primary key from database at first time" do


### PR DESCRIPTION
First step toward #2645.

## Summary

- `OracleEnhanced::Column` carries a new `trigger_assigned` flag alongside the existing `identity` flag. `auto_populated?` returns true when either is set.
- This makes AR's `_returning_columns_for_insert` (added in Rails 7.1, rails/rails#48241) report the primary key as a returning target for trigger-backed tables explicitly, instead of relying on the `Array(primary_key)` fallback in `model_schema.rb`.
- `new_column_from_field` resolves the trigger flag through a per-table cache (`@trigger_assigned_pk_cache`), reusing `trigger_backed_primary_key?` and `primary_keys`. The cache is invalidated alongside `@columns_cache` (`clear_table_columns_cache`), and `rename_table` now also clears the columns cache for both the old and new names.
- The previously stubbed `return_value_after_insert?` override is removed; AR's default delegates to `column.auto_populated?`, which now covers identity, trigger-backed, and (transparently) sequence-prefetched primary keys.

## Why this is split out from #2645

The full refactor in #2645 changes how `sql_for_insert` decides which columns to RETURN and what type to bind them as. Driving that off the `returning` keyword requires AR to first hand us a correct `returning` list. Today that list is correct only by accident for trigger-backed tables (the `Array(primary_key)` fallback). This PR makes it correct on purpose — without changing any RETURNING behavior on the wire — so the follow-up PR can rely on it.

## Design notes

- **`identity` and `trigger_assigned` are kept orthogonal.** `validate_primary_key_trigger_options!` already rejects `primary_key_trigger: true` + `identity: true` at `create_table` time, but the two flags model physically distinct schema features (DDL identity column vs. inferred BEFORE INSERT trigger). Schema introspection on a DB built outside this adapter could in theory observe arbitrary configurations, and the flags also flow through `==` / `hash` separately. `auto_populated?` evaluates `super || @trigger_assigned`, so co-occurrence is harmless.
- **Cache overlap with `trigger_backed_primary_key?` is left for #2645.** `trigger_assigned_pk_columns(table_name).any?` and `trigger_backed_primary_key?(owner, desc)` overlap (composite-PK + trigger excepted), and they cache independently — so calling `columns(t)` followed by `prefetch_primary_key?(t)` runs the trigger detection query twice. Not worth fixing on its own; the cleanup belongs with the larger refactor in #2645 when the table → column → type metadata path is wired through. See https://github.com/rsim/oracle-enhanced/issues/2645#issuecomment-4340800727.

## Test plan

- [ ] CI green
- [ ] New `auto_populated? on the primary key column` describe block in `primary_key_trigger_spec.rb` passes (trigger-backed → true, plain sequence-backed → false, unrelated audit trigger → false, `_returning_columns_for_insert` returns `["id"]` for trigger-backed)
- [ ] No regression in existing `primary_key_trigger_spec.rb`, `identity_primary_key_spec.rb`, or `schema_statements_spec.rb`