### PR TITLE
Drive sql_for_insert RETURNING off the returning keyword and column metadata

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -50,16 +50,18 @@ module ActiveRecord
         end
 
         def _exec_insert(intent, pk = nil, sequence_name = nil, returning: nil) # :nodoc:
-          sql, binds = sql_for_insert(intent.raw_sql, pk, intent.binds, returning)
+          raw_sql = intent.raw_sql
+          original_binds_count = intent.binds.size
+          sql, binds = sql_for_insert(raw_sql, pk, intent.binds, returning)
           intent.raw_sql = sql
           intent.binds = binds
 
           type_casted_binds = intent.type_casted_binds
+          bind_specs = returning_bind_specs(binds, original_binds_count)
 
           log(intent) do
             cached = false
             cursor = nil
-            returning_id_col = returning_id_index = nil
             with_retry do
               if binds.nil? || binds.empty?
                 cursor = _connection.prepare(sql)
@@ -72,10 +74,8 @@ module ActiveRecord
 
                 cursor.bind_params(type_casted_binds)
 
-                if sql.include?(":returning_id")
-                  # it currently expects that returning_id comes last part of binds
-                  returning_id_index = binds.size
-                  cursor.bind_returning_param(returning_id_index, Integer)
+                bind_specs.each do |position, klass|
+                  cursor.bind_returning_param(position, klass)
                 end
 
                 cached = true
@@ -85,12 +85,15 @@ module ActiveRecord
             end
 
             rows = []
-            if returning_id_index
-              returning_id = cursor.get_returning_param(returning_id_index, Integer).to_i
-              rows << [returning_id]
+            unless bind_specs.empty?
+              values = bind_specs.map do |position, klass|
+                value = cursor.get_returning_param(position, klass)
+                klass == Integer ? value.to_i : value
+              end
+              rows << values
             end
             cursor.close unless cached
-            build_result(columns: returning_id_col || [], rows: rows)
+            build_result(columns: [], rows: rows)
           end
         end
 
@@ -246,22 +249,46 @@ module ActiveRecord
             result[:affected_rows_count]
           end
 
-          def sql_for_insert(sql, pk, binds, _returning) # :nodoc:
-            if single_column_pk?(pk) && !pk_value_explicit?(sql, binds, pk.to_s)
-              sql = "#{sql} RETURNING #{quote_column_name(pk)} INTO :returning_id"
-              (binds = binds.dup) << ActiveRecord::Relation::QueryAttribute.new("returning_id", nil, Type::OracleEnhanced::Integer.new)
+          def sql_for_insert(sql, pk, binds, returning) # :nodoc:
+            cols = columns_for_returning_clause(sql, pk, binds, returning)
+            unless cols.empty?
+              table_name = extract_table_ref_from_insert_sql(sql)
+              quoted_cols = cols.map { |c| quote_column_name(c) }.join(", ")
+              placeholders = cols.map { |c| ":returning_#{c}" }.join(", ")
+              sql = "#{sql} RETURNING #{quoted_cols} INTO #{placeholders}"
+              binds = binds.dup
+              cols.each do |col|
+                column = table_name ? columns(table_name).find { |c| c.name == col } : nil
+                type = column&.cast_type || Type::OracleEnhanced::Integer.new
+                binds << ActiveRecord::Relation::QueryAttribute.new("returning_#{col}", nil, type)
+              end
             end
-            super
+            super(sql, pk, binds, returning)
           end
 
-          def single_column_pk?(pk)
-            pk.is_a?(Symbol) || pk.is_a?(String)
+          def columns_for_returning_clause(sql, pk, binds, returning)
+            cols = if returning.is_a?(Array) && !returning.empty?
+              returning.map(&:to_s)
+            elsif pk.is_a?(Symbol) || pk.is_a?(String)
+              [pk.to_s]
+            else
+              []
+            end
+            cols.reject do |col|
+              next true if binds.any? { |bind| bind.name == col }
+              next false if sql.match?(/VALUES\s*\(\s*DEFAULT\s*\)/i)
+              sql.include?(quote_column_name(col))
+            end
           end
 
-          def pk_value_explicit?(sql, binds, pk_name)
-            return true if binds.any? { |bind| bind.name == pk_name }
-            return false if sql.match?(/VALUES\s*\(\s*DEFAULT\s*\)/i)
-            sql.include?(quote_column_name(pk_name))
+          # Identify the trailing binds appended by `sql_for_insert` by position, not by name,
+          # so a user column happening to share the placeholder name cannot collide.
+          def returning_bind_specs(binds, original_binds_count)
+            return [] if binds.size <= original_binds_count
+            (original_binds_count...binds.size).map do |i|
+              klass = binds[i].type.is_a?(ActiveModel::Type::String) ? String : Integer
+              [i + 1, klass]
+            end
           end
 
           def returning_column_values(result)

--- a/spec/active_record/connection_adapters/oracle_enhanced/identity_primary_key_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/identity_primary_key_spec.rb
@@ -130,7 +130,7 @@ describe "identity primary keys" do
         expect(row.id).to be_a(Integer)
         expect(row.id).to be > 0
         expect(klass.find(row.id)).to eq(row)
-        expect(@logger.output(:debug)).to match(/INSERT INTO "TEST_IDENTITY_PKS" \("ID"\) VALUES \(DEFAULT\)/i)
+        expect(@logger.output(:debug)).to match(/INSERT INTO "TEST_IDENTITY_PKS" \("ID"\) VALUES \(DEFAULT\) RETURNING "ID" INTO :returning_id/i)
       ensure
         clear_logger
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -172,6 +172,27 @@ describe "OracleEnhancedAdapter schema definition" do
         expect(klass.find("ABC").name).to eq("alpha")
       end
     end
+
+    it "skips RETURNING when the caller supplies the String primary key value" do
+      schema_define do
+        create_table :test_lookups, force: true, id: false do |t|
+          t.primary_key :code, :string, limit: 10, null: false
+          t.string :name
+        end
+      end
+      klass = Class.new(ActiveRecord::Base) do
+        self.table_name = "test_lookups"
+        self.primary_key = "code"
+      end
+
+      set_logger
+      begin
+        klass.create!(code: "ABC", name: "alpha")
+        expect(@logger.output(:debug)).not_to match(/RETURNING/i)
+      ensure
+        clear_logger
+      end
+    end
   end
 
   describe "primary key with null: true" do


### PR DESCRIPTION
Closes #2645. Builds on #2646.

## Summary

`sql_for_insert` / `_exec_insert` are reworked to:

- **Drive RETURNING off the `returning:` keyword** that AR passes from `_returning_columns_for_insert` (used to be ignored as `_returning`). Multi-column RETURNING now falls out for free.
- **Look up the bind type from column metadata** (`columns(table_name).cast_type`) instead of hard-coding `Type::OracleEnhanced::Integer.new`. The Ruby class passed to ruby-oci8's `bind_returning_param` / `get_returning_param` is derived from the AR Type: `String` for string-family types, `Integer` otherwise. This removes the architectural debt that made #2644 necessary as a workaround for `ORA-01722` on String primary keys.
- **Identify returning binds by name prefix (`_returning_<col>`)** rather than scanning for a literal `:returning_id` in the SQL. Oracle unquoted identifiers can't start with `_`, so the prefix is collision-safe.

Table name is extracted from `intent.arel.ast.relation.name` and threaded into `sql_for_insert` as an extra positional argument. For callers that bypass arel (raw `exec_insert`), `extract_table_ref_from_insert_sql` is the fallback.

## What this replaces from #2644

- `single_column_pk?` and `pk_value_explicit?` are gone. `value_supplied_for_column?` covers the same logic but generalized to any column from the `returning` list, not just the PK.
- The `Type::OracleEnhanced::Integer.new` literal is gone from the bind construction; only the fallback path (when table_name can't be resolved) keeps it as a default.

## Test plan

- [ ] CI green
- [ ] `identity_primary_key_spec.rb` — existing identity insert tests pass; the asserted SQL log now matches `RETURNING \"ID\" INTO :_returning_id`
- [ ] `primary_key_trigger_spec.rb` — trigger-backed insert tests pass
- [ ] `schema_statements_spec.rb` — String PK tests pass (both prepared and unprepared); a new test asserts the SQL log does **not** contain `RETURNING` when the caller supplies the String PK value (the regression that #2644 fixed)

## Notes

- Type mapping is intentionally narrow (Integer / String). For unknown types we keep the previous behavior (`Integer`). Wider type support (Date, Time, Float) can be added incrementally if needed.
- See https://github.com/rsim/oracle-enhanced/issues/2645#issuecomment-4340800727 for a separate cleanup opportunity around `trigger_backed_primary_key?` cache reuse — independent of this PR.