### PR TITLE
Stabilize miscellaneous options spec against missing AR_INTERNAL_METADATA

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -1520,6 +1520,14 @@ end
   describe "miscellaneous options" do
     before(:all) do
       @conn = ActiveRecord::Base.lease_connection
+      # `before(:each)` below stubs `execute` to capture DDL into a string
+      # without running it. `Schema.define` (which `schema_define` wraps)
+      # writes to `AR_INTERNAL_METADATA`, and the table's CREATE goes through
+      # the stubbed `execute` — but the follow-up SELECT goes through
+      # `perform_query`, which is not stubbed and raises ORA-00942 unless the
+      # table already exists. Ensure it exists once here, before any test in
+      # this block runs.
+      ActiveRecord::Schema.define { }
     end
 
     before(:each) do


### PR DESCRIPTION
## Summary

The `miscellaneous options` describe block in `schema_statements_spec.rb` stubs `execute` in `before(:each)` to capture DDL into a string instead of running it. That stubbing makes the block fragile: a fresh schema (or one where some earlier test happened not to create `AR_INTERNAL_METADATA`) leaves every test in the block failing with `ORA-00942` on `AR_INTERNAL_METADATA`.

This was hit on the daily `prepared_statements: false` CI run: https://github.com/rsim/oracle-enhanced/actions/runs/25107259967/job/73571588250 (12 failures, all ORA-00942 against `AR_INTERNAL_METADATA`, in `OracleEnhancedAdapter schema definition miscellaneous options`).

## Why it fails

`Schema.define` (which `schema_define` wraps) goes through `ActiveRecord::InternalMetadata#create_table_and_set_flags`:

1. `create_table_unless_exists` for `AR_INTERNAL_METADATA` → emits `CREATE TABLE` through the **stubbed** `execute` → not actually run.
2. `update_or_create_entry` → SELECT on `AR_INTERNAL_METADATA` through `perform_query` → **not** stubbed → reaches the DB → ORA-00942 if the table doesn't exist.

The block usually passes only because some earlier-running test in the suite happened to create `AR_INTERNAL_METADATA` for real on the test schema. With certain RSpec seeds (e.g. `--seed 34445`) and certain schema histories, the table can be missing when the block starts and every test in it fails.

## Fix

Trigger `ActiveRecord::Schema.define { }` once in `before(:all)` — *before* the per-test stub is installed — so `AR_INTERNAL_METADATA` is real on the DB by the time the stub kicks in. `create_table_unless_exists` in subsequent stubbed `schema_define` calls then sees the table exists and short-circuits, so no DDL needs to flow through the stub for it.

8 added lines, 1 changed file.

## Reproduction (without this PR, on master)

```sh
# 1. Force AR_INTERNAL_METADATA to be missing.
sqlplus oracle_enhanced/oracle_enhanced@//localhost:1521/FREEPDB1 <<'SQL'
DROP TABLE ar_internal_metadata PURGE;
SQL

# 2. Run the affected describe block.
ORACLE_ENHANCED_PREPARED_STATEMENTS_FALSE=1 \
  bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb \
                    -e "miscellaneous options"
```

Expected on master without this PR:

```
Finished in 0.10985 seconds (files took 0.3251 seconds to load)
14 examples, 12 failures
```

The same `ORA-00942: table or view "ORACLE_ENHANCED"."AR_INTERNAL_METADATA" does not exist` is what the linked CI job reports for all 12 failing examples.

## Verification (with this PR applied, locally)

Same procedure — drop `AR_INTERNAL_METADATA` first, then run:

```sh
# Targeted block:
ORACLE_ENHANCED_PREPARED_STATEMENTS_FALSE=1 \
  bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb \
                    -e "miscellaneous options"
# => 14 examples, 0 failures

# Full suite with the originally-failing seed:
ORACLE_ENHANCED_PREPARED_STATEMENTS_FALSE=1 \
  bundle exec rspec --seed 34445
# => 608 examples, 0 failures, 6 pending
```

## Test plan

- [ ] CI green
- [ ] Daily `master test_prepared_statements_false` workflow re-run is green after merge (the workflow that surfaced this in the linked run)