### PR TITLE
Enable ZJIT (experimental) in the ruby_head workflow

### DIFF
--- a/.github/workflows/ruby_head.yml
+++ b/.github/workflows/ruby_head.yml
@@ -6,16 +6,17 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    name: "ruby-${{ matrix.ruby }}-yjit-enabled: ${{ matrix.yjit-enabled }}"
+    name: "ruby-${{ matrix.ruby }}-${{ matrix.jit }}"
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.jit == 'zjit' }}
     strategy:
       fail-fast: false
       matrix:
         ruby: ['head', 'debug', 'asan']
-        yjit-enabled: [0, 1]
+        jit: ['none', 'yjit', 'zjit']
     env:
-      RUBY_YJIT_ENABLE: ${{ matrix.yjit-enabled }}
-      RUBYOPT: "-W2 --debug-frozen-string-literal"
+      RUBY_YJIT_ENABLE: ${{ matrix.jit == 'yjit' && '1' || '0' }}
+      RUBYOPT: "-W2 --debug-frozen-string-literal${{ matrix.jit == 'zjit' && ' --zjit' || '' }}"
       NLS_LANG: AMERICAN_AMERICA.AL32UTF8
       TNS_ADMIN: ./ci/network/admin
       DATABASE_NAME: FREEPDB1


### PR DESCRIPTION
## Summary

- Replace the `yjit-enabled: [0, 1]` matrix axis in `.github/workflows/ruby_head.yml` with a three-value `jit: [none, yjit, zjit]` axis so the daily ruby-head workflow exercises ZJIT alongside the existing YJIT-on / YJIT-off variants.
- ZJIT and YJIT are mutually exclusive: `RUBY_YJIT_ENABLE` is `1` only for the `yjit` cell, and `--zjit` is appended to `RUBYOPT` only for the `zjit` cell.
- Mark the `zjit` cells `continue-on-error: ${{ matrix.jit == 'zjit' }}` so the workflow surfaces ZJIT regressions without failing — ZJIT shipped in Ruby 4.0 as an experimental method-based JIT and may still regress on ruby-head.

Resulting matrix (9 jobs, three of them experimental):

| ruby  | jit  | YJIT env | RUBYOPT additions | experimental |
|-------|------|----------|-------------------|--------------|
| head  | none | 0        | (none)            | no           |
| head  | yjit | 1        | (none)            | no           |
| head  | zjit | 0        | `--zjit`          | yes          |
| debug | none | 0        | (none)            | no           |
| debug | yjit | 1        | (none)            | no           |
| debug | zjit | 0        | `--zjit`          | yes          |
| asan  | none | 0        | (none)            | no           |
| asan  | yjit | 1        | (none)            | no           |
| asan  | zjit | 0        | `--zjit`          | yes          |

## Test plan

- [ ] Trigger the workflow manually (`gh workflow run ruby_head.yml --ref enable-zjit-ruby-head`) once merged into a runnable branch and confirm 9 jobs are scheduled with names `ruby-<variant>-<jit>`.
- [ ] Confirm `zjit` cells run with `--zjit` and do not fail the overall workflow when ZJIT errors out on ruby-head.
- [ ] Confirm `yjit` cells still set `RUBY_YJIT_ENABLE=1` and `none` cells set `RUBY_YJIT_ENABLE=0` with no `--zjit` flag.
