### PR TITLE
Honor prepared_statements: false in perform_query and _exec_insert

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -66,22 +66,25 @@ module ActiveRecord
               if binds.nil? || binds.empty?
                 cursor = _connection.prepare(sql)
               else
-                unless @statements.key?(sql)
-                  @statements[sql] = _connection.prepare(sql)
+                if prepared_statements?
+                  @statements[sql] ||= _connection.prepare(sql)
+                  cursor = @statements[sql]
+                  cached = true
+                else
+                  cursor = _connection.prepare(sql)
                 end
-
-                cursor = @statements[sql]
 
                 cursor.bind_params(type_casted_binds)
 
                 bind_specs.each do |position, klass|
                   cursor.bind_returning_param(position, klass)
                 end
-
-                cached = true
               end
 
               cursor.exec_update
+            rescue
+              (cursor.close rescue nil) if cursor && !cached
+              raise
             end
 
             rows = []
@@ -306,16 +309,20 @@ module ActiveRecord
               if binds.nil? || binds.empty?
                 cursor = raw_connection.prepare(sql)
               else
-                unless @statements.key? sql
-                  @statements[sql] = raw_connection.prepare(sql)
+                if prepared_statements?
+                  @statements[sql] ||= raw_connection.prepare(sql)
+                  cursor = @statements[sql]
+                  cached = true
+                else
+                  cursor = raw_connection.prepare(sql)
                 end
 
-                cursor = @statements[sql]
                 cursor.bind_params(type_casted_binds)
-
-                cached = true
               end
               cursor.exec
+            rescue
+              (cursor.close rescue nil) if cursor && !cached
+              raise
             end
 
             columns = cursor.get_col_names.map do |col_name|
@@ -343,7 +350,7 @@ module ActiveRecord
             _connection.with_retry do
               yield
             rescue
-              @statements.clear
+              @statements.clear if prepared_statements?
               raise
             end
           end

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -300,6 +300,7 @@ describe "OracleEnhancedAdapter" do
     end
 
     it "should clear older cursors when statement limit is reached" do
+      skip "applies only when prepared statements are enabled" unless @conn.prepared_statements?
       binds = [ActiveRecord::Relation::QueryAttribute.new("id", 1, ActiveRecord::Type::OracleEnhanced::Integer.new)]
       # free statement pool from dictionary selections  to ensure next selects will increase statement pool
       @statements.clear
@@ -311,10 +312,19 @@ describe "OracleEnhancedAdapter" do
     end
 
     it "should cache UPDATE statements with bind variables" do
+      skip "applies only when prepared statements are enabled" unless @conn.prepared_statements?
       expect {
         binds = [ActiveRecord::Relation::QueryAttribute.new("id", 1, ActiveRecord::Type::OracleEnhanced::Integer.new)]
         @conn.exec_query("UPDATE test_posts SET id = :id", "SQL", binds)
       }.to change(@statements, :length).by(+1)
+    end
+
+    it "should not cache UPDATE statements with bind variables when prepared_statements is false" do
+      skip "applies only when prepared statements are disabled" if @conn.prepared_statements?
+      expect {
+        binds = [ActiveRecord::Relation::QueryAttribute.new("id", 1, ActiveRecord::Type::OracleEnhanced::Integer.new)]
+        @conn.exec_query("UPDATE test_posts SET id = :id", "SQL", binds)
+      }.not_to change(@statements, :length)
     end
 
     it "should not cache UPDATE statements without bind variables" do


### PR DESCRIPTION
## Summary

`OracleEnhanced::DatabaseStatements#perform_query` and `#_exec_insert` previously took the same branch whenever binds were present — cache the cursor in `@statements[sql]`, bind values, execute — regardless of the connection's `prepared_statements` flag. As a result, even connections configured with `prepared_statements: false` (or running inside an `unprepared_statement do ... end` block) had their bind-ful queries prepared and **cached client-side**.

This PR adds a `prepared_statements?` branch on the bind-present path so that `prepared_statements: false` connections prepare-and-execute one-shot (no cache), matching PostgreSQL's `exec_params` path and the spirit of the AR setting.

```ruby
if prepared_statements?
  @statements[sql] ||= raw_connection.prepare(sql)   # cached, reused
  cursor = @statements[sql]
  cached = true
else
  cursor = raw_connection.prepare(sql)               # one-shot
end
cursor.bind_params(type_casted_binds)
```

`cursor.close unless cached` at the tail already releases the one-shot cursor. The Oracle DB shared pool may still recognize the SQL text and reuse its parsed plan, but no client-side handle is retained.

## Why

- **Honor the user's intent.** A connection configured with `prepared_statements: false` was, until now, still keeping prepared cursor handles for every distinct bind-ful SQL text. That's inconsistent with the AR contract.
- **Make the cost of bound dictionary queries (#2629) visible to `prepared_statements: false` callers.** Without this branch, the cached client-side handle was masking the per-call parsing the user explicitly opted into.
- **Match PG/MySQL behavior.** PostgreSQL routes `intent.prepare` false through `exec_params` (parameterized but not prepared). Oracle now has the analogous path through OCI8 / JDBC's prepare-bind-exec-close lifecycle.

## Backend coverage

OCI8 and JDBC both expose the same `Cursor` abstraction with `prepare(sql) → bind_params → exec → close`. The branch lives in the shared `database_statements.rb`, so the change applies uniformly to both backends with no per-backend duplication.

## Spec adjustments

The two existing statement-pool specs in `oracle_enhanced_adapter_spec.rb` asserted that bind-ful queries grow `@statements`. That's now specific to `prepared_statements: true`:

- `should clear older cursors when statement limit is reached` — gated on `@conn.prepared_statements?`
- `should cache UPDATE statements with bind variables` — gated on `@conn.prepared_statements?`

Plus a new symmetric spec for the new path:

- `should not cache UPDATE statements with bind variables when prepared_statements is false` — asserts the pool size doesn't grow.

## Test plan

- [ ] CI green (default `prepared_statements: true` workflow)
- [ ] Daily `master test_prepared_statements_false` workflow green after merge
- [ ] Local: full suite passes in both modes (verified):
  - `prepared_statements: true`  → 609 examples, 0 failures, 7 pending
  - `prepared_statements: false` → 609 examples, 0 failures, 8 pending (one extra `pending` is the now-skipped `prepared_statements: true`-only assertion)