### PR TITLE
Unify dictionary queries on plain select_value(s) with bind variables

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -572,7 +572,7 @@ module ActiveRecord
       # +all_constraints+ is required to avoid disabling PK prefetch on tables
       # that combine a sequence-backed PK with a non-PK identity column.
       def identity_primary_key?(owner, desc_table_name) # :nodoc:
-        select_values_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("table_name", desc_table_name)]).any?
+        select_values(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("table_name", desc_table_name)]).any?
           SELECT 1
           FROM all_tab_identity_cols itc
           JOIN all_cons_columns cc
@@ -595,7 +595,7 @@ module ActiveRecord
       # do not flip +prefetch_primary_key?+ to false on tables that still
       # rely on Rails-side sequence prefetch.
       def trigger_backed_primary_key?(owner, desc_table_name) # :nodoc:
-        select_values_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("table_name", desc_table_name)]).any?
+        select_values(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("table_name", desc_table_name)]).any?
           SELECT 1
           FROM all_triggers t
           WHERE t.owner = :owner
@@ -740,7 +740,7 @@ module ActiveRecord
       def pk_and_sequence_for(table_name, owner = nil, desc_table_name = nil) # :nodoc:
         (owner, desc_table_name) = resolve_data_source_name(table_name)
 
-        seqs = select_values_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("sequence_name", default_sequence_name(desc_table_name, nil))])
+        seqs = select_values(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("sequence_name", default_sequence_name(desc_table_name, nil))])
           select us.sequence_name
           from all_sequences us
           where us.sequence_owner = :owner
@@ -748,7 +748,7 @@ module ActiveRecord
         SQL
 
         # changed back from user_constraints to all_constraints for consistency
-        pks = select_values_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("table_name", desc_table_name)])
+        pks = select_values(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("table_name", desc_table_name)])
           SELECT cc.column_name
             FROM all_constraints c, all_cons_columns cc
            WHERE c.owner = :owner
@@ -782,7 +782,7 @@ module ActiveRecord
       def primary_keys(table_name) # :nodoc:
         (_owner, desc_table_name) = resolve_data_source_name(table_name)
 
-        pks = select_values_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("table_name", desc_table_name)])
+        pks = select_values(<<~SQL.squish, "SCHEMA", [bind_string("table_name", desc_table_name)])
           SELECT cc.column_name
             FROM all_constraints c, all_cons_columns cc
            WHERE c.owner = SYS_CONTEXT('userenv', 'current_schema')
@@ -813,7 +813,7 @@ module ActiveRecord
       end
 
       def temporary_table?(table_name) # :nodoc:
-        select_value_forcing_binds(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name.upcase)]) == "Y"
+        select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name.upcase)]) == "Y"
           SELECT
           temporary FROM all_tables WHERE table_name = :table_name and owner = SYS_CONTEXT('userenv', 'current_schema')
         SQL
@@ -973,22 +973,6 @@ module ActiveRecord
       # create bind object for type String
       def bind_string(name, value)
         ActiveRecord::Relation::QueryAttribute.new(name, value, Type::OracleEnhanced::String.new)
-      end
-
-      # call select_values using binds even if surrounding SQL preparation/execution is done + # with conn.unprepared_statement (like AR.to_sql)
-      def select_values_forcing_binds(arel, name, binds)
-        # remove possible force of unprepared SQL during dictionary access
-        unprepared_statement_forced = prepared_statements_disabled_cache.include?(object_id)
-        prepared_statements_disabled_cache.delete(object_id) if unprepared_statement_forced
-
-        select_values(arel, name, binds)
-      ensure
-        # Restore unprepared_statement setting for surrounding SQL
-        prepared_statements_disabled_cache.add(object_id) if unprepared_statement_forced
-      end
-
-      def select_value_forcing_binds(arel, name, binds)
-        single_value_from_rows(select_values_forcing_binds(arel, name, binds))
       end
 
       ActiveRecord::Type.register(:boolean, Type::OracleEnhanced::Boolean, adapter: :oracle_enhanced)


### PR DESCRIPTION
## Summary

Extends the bind-variable pattern introduced in #2629 to the remaining `all_*` / `user_*` dictionary queries that were still routing through the `select_values_forcing_binds` / `select_value_forcing_binds` helpers. After this PR every dictionary query in `OracleEnhancedAdapter` calls plain `select_values(sql, name, binds)` / `select_value(sql, name, binds)` with a `:placeholder` raw SQL and an explicit `binds` array — one consistent shape across the file.

As a result, the two helpers `select_values_forcing_binds` and `select_value_forcing_binds` no longer have any callers and are removed.

| Method | Helper used before | Now |
|---|---|---|
| `identity_primary_key?` | `select_values_forcing_binds` | `select_values` |
| `trigger_backed_primary_key?` | `select_values_forcing_binds` | `select_values` |
| `pk_and_sequence_for` (×2) | `select_values_forcing_binds` | `select_values` |
| `primary_keys` | `select_values_forcing_binds` | `select_values` |
| `temporary_table?` | `select_value_forcing_binds` | `select_value` |
| (helper definitions, `private`) | — | (deleted) |

Diff: `+6 / -22 lines, 1 file`.

## Why the unification is safe now

The `_forcing_binds` helpers were added in #2125 (2021) to make dictionary queries use bind variables even inside an `unprepared_statement do ... end` block, by temporarily removing the connection from `prepared_statements_disabled_cache` so AR's visitor wouldn't inline the binds.

Two recent changes made that mechanism unnecessary:

1. **#2629** finished converting the remaining literal-interpolated dictionary queries to raw SQL with `:placeholder` markers and explicit `binds` arrays. AR's visitor isn't involved on the raw-SQL-with-binds path, so there is nothing to inline — the `prepared_statements_disabled_cache` trick had nothing to defend against on that path.
2. **#2651** made `OracleEnhanced::DatabaseStatements#perform_query` honor `prepared_statements?` directly. Inside an `unprepared_statement` block, dictionary queries now prepare-bind-exec-close one-shot instead of caching the cursor in `@statements`, but bind values still flow to the server. SQL-text matching keeps the shared cursor reusable in the database's shared pool — the original server-side cursor-sharing goal of #2125 is preserved without the helper.

The helpers were defined under `private` and were not part of the documented adapter API.

## Test plan

- [ ] CI green (default `prepared_statements: true` workflow)
- [ ] Daily `master test_prepared_statements_false` workflow green after merge
- [ ] Local — full suite passes in both modes (verified):
  - `prepared_statements: true`  → 613 examples, 0 failures, 7 pending
  - `prepared_statements: false` → 613 examples, 0 failures, 8 pending

## Related

- Builds on #2629 (dictionary queries to binds), #2651 (`prepared_statements?` in `perform_query`), #2626 (respect DB's `cursor_sharing`).
- Original helper PR: #2125