### PR TITLE
Restore the :returning_id-logging spec disabled pending #2619

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/primary_key_trigger_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/primary_key_trigger_spec.rb
@@ -330,7 +330,6 @@ describe "primary_key_trigger" do
     end
 
     it "does not raise NoMethodError for :returning_id Symbol when logging" do
-      skip "see #2619: ruby-oci8 + cursor_sharing=force x RETURNING INTO :returning_id half-duplex deadlock"
       set_logger
       @conn.reconnect! unless @conn.active?
       @conn.insert("INSERT INTO test_pk_triggers (name) VALUES ('alpha')", nil, "id")


### PR DESCRIPTION
## Summary

Removes the `skip` added in [`45f8b2bb`](https://github.com/rsim/oracle-enhanced/commit/45f8b2bb) (part of #2615). The spec — `primary_key_trigger_spec.rb` — "does not raise NoMethodError for :returning_id Symbol when logging" was disabled because it reproduced the SQL*Net half-duplex deadlock cataloged in #2619 under the adapter's then-default `cursor_sharing = force`.

## Why now

#2626 stopped the adapter from issuing `ALTER SESSION SET cursor_sharing = force`. The session inherits the database's instance-level setting, which is Oracle's documented default `EXACT` on virtually all installations. Without `force`, the database does not rewrite the surrounding literal in `INSERT INTO ... VALUES ('alpha') RETURNING ID INTO :returning_id`, so the `#2619` deadlock combination (ruby-oci8 + cursor_sharing=force + RETURNING-into-bind on the same parsed cursor executed twice) is no longer reachable from the default test configuration.

`#2619` itself is a server-side condition that has not gone away — anyone who explicitly opts back in with `cursor_sharing: 'force'` can still hit it on amd64 Oracle Database. But for the default test configuration this PR's spec exercises, the trigger is gone.

Diff: `+0 / -1 line, 1 file`.

## Verified locally

Single test, both connection modes:

  * `prepared_statements: true`  → 1 example, 0 failures
  * `prepared_statements: false` → 1 example, 0 failures

## Related

- The deadlock report: #2619
- Adapter-side workaround: #2620 (already merged)
- Made the deadlock unreachable from the default config: #2626
- Original `skip` commit being reverted: [`45f8b2bb`](https://github.com/rsim/oracle-enhanced/commit/45f8b2bb) (in #2615)