### PR TITLE
[DRAFT] Restore Arel `In` and `NoIn` support

### DIFF
--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -137,6 +137,59 @@ module Arel # :nodoc: all
           collector
         end
 
+        def visit_Arel_Nodes_In(o, collector)
+          attr, values = o.left, o.right
+
+          if Array === values
+            unless values.empty?
+              values.delete_if { |value| unboundable?(value) }
+            end
+
+            return collector << "1=0" if values.empty?
+          end
+
+          in_clause_length = @connection.in_clause_length
+
+          if !Array === values || values.length <= in_clause_length
+            visit(attr, collector) << " IN ("
+            visit(values, collector) << ")"
+          else
+            collector << "("
+            values.each_slice(in_clause_length).each_with_index do |valuez, i|
+              collector << " OR " unless i == 0
+              visit(attr, collector) << " IN ("
+              visit(valuez, collector) << ")"
+            end
+            collector << ")"
+          end
+        end
+
+        def visit_Arel_Nodes_NotIn(o, collector)
+          attr, values = o.left, o.right
+
+          if Array === values
+            unless values.empty?
+              values.delete_if { |value| unboundable?(value) }
+            end
+
+            return collector << "1=1" if values.empty?
+          end
+
+          in_clause_length = @connection.in_clause_length
+
+          if !Array === values || values.length <= in_clause_length
+            visit(attr, collector) << " NOT IN ("
+            visit(values, collector) << ")"
+          else
+            values.each_slice(in_clause_length).each_with_index do |valuez, i|
+              collector << " AND " unless i == 0
+              visit(attr, collector) << " NOT IN ("
+              visit(valuez, collector) << ")"
+            end
+            collector
+          end
+        end
+
         def visit_Arel_Nodes_UpdateStatement(o, collector)
           # Oracle does not allow ORDER BY/LIMIT in UPDATEs.
           if o.orders.any? && o.limit.nil?

--- a/lib/arel/visitors/oracle12.rb
+++ b/lib/arel/visitors/oracle12.rb
@@ -88,6 +88,59 @@ module Arel # :nodoc: all
           end
         end
 
+        def visit_Arel_Nodes_In(o, collector)
+          attr, values = o.left, o.right
+
+          if Array === values
+            unless values.empty?
+              values.delete_if { |value| unboundable?(value) }
+            end
+
+            return collector << "1=0" if values.empty?
+          end
+
+          in_clause_length = @connection.in_clause_length
+
+          if !Array === values || values.length <= in_clause_length
+            visit(attr, collector) << " IN ("
+            visit(values, collector) << ")"
+          else
+            collector << "("
+            values.each_slice(in_clause_length).each_with_index do |valuez, i|
+              collector << " OR " unless i == 0
+              visit(attr, collector) << " IN ("
+              visit(valuez, collector) << ")"
+            end
+            collector << ")"
+          end
+        end
+
+        def visit_Arel_Nodes_NotIn(o, collector)
+          attr, values = o.left, o.right
+
+          if Array === values
+            unless values.empty?
+              values.delete_if { |value| unboundable?(value) }
+            end
+
+            return collector << "1=1" if values.empty?
+          end
+
+          in_clause_length = @connection.in_clause_length
+
+          if !Array === values || values.length <= in_clause_length
+            visit(attr, collector) << " NOT IN ("
+            visit(values, collector) << ")"
+          else
+            values.each_slice(in_clause_length).each_with_index do |valuez, i|
+              collector << " AND " unless i == 0
+              visit(attr, collector) << " NOT IN ("
+              visit(valuez, collector) << ")"
+            end
+            collector
+          end
+        end
+
         def visit_Arel_Nodes_UpdateStatement(o, collector)
           # Oracle does not allow ORDER BY/LIMIT in UPDATEs.
           if o.orders.any? && o.limit.nil?

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -272,6 +272,38 @@ describe "OracleEnhancedAdapter" do
       posts = TestPost.where(id: [*@ids, nil]).to_a
       expect(posts.size).to eq(@ids.size)
     end
+
+    # some frameworks like baby_squeel construct Arel objects directly
+    it "should allow more than 1000 items using Arel::Nodes::In" do
+      table = TestPost.arel_table
+      in_node = Arel::Nodes::In.new(table[:id], @ids)
+      query = table.where(in_node).project(Arel.star)
+
+      sql = query.to_sql
+      posts = TestPost.connection.select_all(sql).to_a
+      expect(posts.size).to eq(@ids.size)
+
+      # SQL contains multiple IN clauses (split due to 1000 limit)
+      expect(sql.scan(/IN \(/).size).to be > 1
+    end
+
+    it "should allow more than 1000 items using raw Arel::Nodes::NotIn" do
+      ids = @ids.dup
+      non_not_in = ids.pop
+
+      table = TestPost.arel_table
+      not_in_node = Arel::Nodes::NotIn.new(table[:id], ids)
+      query = table.where(not_in_node).project(Arel.star)
+
+      sql = query.to_sql
+      posts = TestPost.connection.select_all(sql).to_a
+
+      expect(posts.size).to eq(1)
+      expect(posts.first["id"]).to eq(non_not_in)
+
+      # SQL contains multiple NOT IN clauses (split due to 1000 limit)
+      expect(sql.scan(/NOT IN \(/).size).to be > 1
+    end
   end
 
   describe "with statement pool" do


### PR DESCRIPTION
Update: sorry, it seemed like a minor fix and didn't run all tests locally but it seems it requires more attention.

in #2075 and 94057806bc8a3b8b4efbc4af1e360178e1c25465 the Arel methods `visit_Arel_Nodes_In` and `visit_Arel_Nodes_NotIn` were removed because Rails stopped using them by default but these are still accessible code paths when Arel is directly used.

That can be the user constructing queries with Arel directly or some framework like baby_squeel doing it.

This commit restores the two methods and adds tests to make sure low-level Arel usage is still supported in the long-run.