### PR TITLE
Purge the recyclebin at the start of each spec run

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -243,5 +243,14 @@ RSpec.configure do |config|
   config.before(:suite) do
     seed = RSpec.configuration.seed
     puts "==> Randomized with seed #{seed} (reproduce: bundle exec rspec --seed #{seed})"
+
+    # Oracle moves dropped tables to the recyclebin by default, where they
+    # remain (along with their associated identity sequences and PK indexes)
+    # under BIN$... names until the bin is purged. Across many test runs the
+    # bin accumulates and pollutes inventories like `dba_objects` /
+    # `user_objects` even though the tests themselves drop their fixtures.
+    # Start each suite from a clean bin so dropped fixtures actually go away.
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    ActiveRecord::Base.connection.execute("PURGE RECYCLEBIN")
   end
 end


### PR DESCRIPTION
## Summary

Restores the `before(:suite)` `PURGE RECYCLEBIN` that earlier versions of the spec_helper carried. Every test run drops most of its fixtures with plain `drop_table`, which on Oracle moves the table (along with its associated identity sequences and PK indexes) into the connected user's recyclebin under `BIN$...` names. Across many runs the recyclebin accumulates and pollutes DBA-level inventories such as `dba_objects` even though the per-test cleanup hooks themselves are working.

After this PR each suite starts from an empty recyclebin. Post-run inventories reflect only the AR metadata tables (`AR_INTERNAL_METADATA`, `SCHEMA_MIGRATIONS`) and any genuinely-leaked fixtures.

Diff: `+9 lines, 1 file`.

## Why this is the right level of intervention

User-facing dictionary views — `user_tables`, `user_sequences`, `all_tables` (via the schema the test connects as) — don't surface recyclebin entries. So the adapter itself never had a correctness problem here; only DBA-level views like `dba_objects` did. This change tidies up that visibility without touching anything the adapter or spec was actually depending on.

## Cleanup-hook health check

To validate that the spec files' per-test cleanup is genuinely working (and that the `force: true` peppered through `create_table` calls is just defensive overlap, not load-bearing), the full suite was run with this change in place AND with every `force: true` stripped from spec files. Both consecutive runs passed (613 examples, 0 failures, 6 pending each time).

`force: true` stays in the spec files; this PR doesn't touch any of them. The check just confirms the cleanup hooks are not dependent on `force: true` to recover from their own leftover.

## Test plan

- [ ] CI green
- [ ] Local — full suite passes (verified in both modes)