### PR TITLE
Drop the custom sequence in the with-non-default-:sequence_name spec

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/primary_key_trigger_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/primary_key_trigger_spec.rb
@@ -357,6 +357,10 @@ describe "primary_key_trigger" do
   end
 
   describe "with non-default :sequence_name" do
+    after(:each) do
+      @conn.execute("DROP SEQUENCE test_pk_triggers_s") rescue nil
+    end
+
     it "creates the trigger using the named sequence" do
       schema_define do
         create_table :test_pk_triggers, primary_key_trigger: true, sequence_name: :test_pk_triggers_s do |t|


### PR DESCRIPTION
## Summary

The example `primary_key_trigger with non-default :sequence_name creates the trigger using the named sequence` creates `test_pk_triggers_s` via `sequence_name: :test_pk_triggers_s`, but the file-level `after(:each)` only does `drop_table :test_pk_triggers, if_exists: true` without forwarding `sequence_name:`. The custom sequence outlives the example, and a later iteration's `expect(sequence_exists?(:test_pk_triggers_seq)).to be false` assertion stays correct only because the next assertion `expect(sequence_exists?(:test_pk_triggers_s)).to be true` happens to be already-true from the previous run — the example then surfaces as failed under specific orderings (e.g. `--seed 62492` against the full suite).

## Fix

Add a `describe`-local `after(:each)` that drops `test_pk_triggers_s` explicitly. Wrapped in `rescue nil` so the drop is a no-op when the example never reached `create_table`.

```ruby
describe "with non-default :sequence_name" do
  after(:each) do
    @conn.execute("DROP SEQUENCE test_pk_triggers_s") rescue nil
  end
  ...
end
```

Diff: `+4 / -0 lines, 1 file`.

## Verified locally

- `bundle exec rspec --seed 62492` (the earlier reproducer): 613 examples, 0 failures
- Two consecutive random-seed runs back to back: 613 examples, 0 failures each

## Related

- Companion to #2655 (the recyclebin purge), which removed inventory noise but did not address this real cleanup gap because `test_pk_triggers_s` was a top-level sequence, not a recyclebin entry.