### PR TITLE
Print ruby -v in ruby_head workflow to verify JIT enablement

### DIFF
--- a/.github/workflows/ruby_head.yml
+++ b/.github/workflows/ruby_head.yml
@@ -46,6 +46,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           rubygems: latest
+      - name: Show Ruby version and JIT status
+        run: ruby -v
       - name: Create symbolic link for libaio library compatibility
         run: |
           sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1


### PR DESCRIPTION
## Summary
- Adds an explicit `Show Ruby version and JIT status` step right after `Set up Ruby` in `.github/workflows/ruby_head.yml` so each matrix cell's CI log clearly shows which JIT is loaded (`+PRISM`, `+YJIT +PRISM`, or `+ZJIT +PRISM`).
- Validates that the existing `RUBYOPT="-W2 --debug-frozen-string-literal --zjit"` setting really does enable ZJIT — confirmed against the most recent successful run (run id `25137582070`, 2026-04-29), where the `setup-ruby` action's internal `ruby -v` printed `+ZJIT +PRISM` for `*-zjit` jobs, `+YJIT +PRISM` for `*-yjit` jobs, and `+PRISM` only for `*-none` jobs. Without a dedicated step, that proof is buried in `setup-ruby`'s output.

## Test plan
- [ ] Trigger the workflow manually with `gh workflow run ruby_head.yml`
- [ ] Confirm the new `Show Ruby version and JIT status` step prints `+PRISM` only for the three `jit: none` jobs
- [ ] Confirm it prints `+YJIT +PRISM` for the three `jit: yjit` jobs
- [ ] Confirm it prints `+ZJIT +PRISM` for the three `jit: zjit` jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
