### PR TITLE
Mark HomogeneousIn collector as not preparable

### DIFF
--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -94,6 +94,7 @@ module Arel # :nodoc: all
         # To avoid ORA-01795: maximum number of expressions in a list is 1000
         # tell ActiveRecord to limit us to 1000 ids at a time
         def visit_Arel_Nodes_HomogeneousIn(o, collector)
+          collector.preparable = false
           in_clause_length = @connection.in_clause_length
           values = o.casted_values.map { |v| @connection.quote(v) }
           operator =

--- a/lib/arel/visitors/oracle12.rb
+++ b/lib/arel/visitors/oracle12.rb
@@ -47,6 +47,7 @@ module Arel # :nodoc: all
         # To avoid ORA-01795: maximum number of expressions in a list is 1000
         # tell ActiveRecord to limit us to 1000 ids at a time
         def visit_Arel_Nodes_HomogeneousIn(o, collector)
+          collector.preparable = false
           in_clause_length = @connection.in_clause_length
           values = o.casted_values.map { |v| @connection.quote(v) }
           operator =

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel_visitor_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel_visitor_spec.rb
@@ -6,7 +6,8 @@ describe "Arel::Visitors::Oracle12" do
   end
 
   let(:visitor) { Arel::Visitors::Oracle12.new(ActiveRecord::Base.connection) }
-  let(:table) { Arel::Table.new(:users) }
+  let(:type_caster) { Class.new { def type_for_attribute(_name) = ActiveRecord::Type::Value.new }.new }
+  let(:table) { Arel::Table.new(:users, type_caster: type_caster) }
 
   describe "visit_Arel_Nodes_HomogeneousIn" do
     it "marks the collector as not preparable" do
@@ -14,7 +15,7 @@ describe "Arel::Visitors::Oracle12" do
       collector = Arel::Collectors::SQLString.new
       collector.preparable = true
       visitor.accept(node, collector)
-      expect(collector.preparable).to eq(false)
+      expect(collector.preparable).to be(false)
     end
   end
 end
@@ -25,7 +26,8 @@ describe "Arel::Visitors::Oracle" do
   end
 
   let(:visitor) { Arel::Visitors::Oracle.new(ActiveRecord::Base.connection) }
-  let(:table) { Arel::Table.new(:users) }
+  let(:type_caster) { Class.new { def type_for_attribute(_name) = ActiveRecord::Type::Value.new }.new }
+  let(:table) { Arel::Table.new(:users, type_caster: type_caster) }
 
   describe "visit_Arel_Nodes_HomogeneousIn" do
     it "marks the collector as not preparable" do
@@ -33,7 +35,7 @@ describe "Arel::Visitors::Oracle" do
       collector = Arel::Collectors::SQLString.new
       collector.preparable = true
       visitor.accept(node, collector)
-      expect(collector.preparable).to eq(false)
+      expect(collector.preparable).to be(false)
     end
   end
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel_visitor_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel_visitor_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+describe "Arel::Visitors::Oracle12" do
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+  end
+
+  let(:visitor) { Arel::Visitors::Oracle12.new(ActiveRecord::Base.connection) }
+  let(:table) { Arel::Table.new(:users) }
+
+  describe "visit_Arel_Nodes_HomogeneousIn" do
+    it "marks the collector as not preparable" do
+      node = Arel::Nodes::HomogeneousIn.new([1, 2, 3], table[:id], :in)
+      collector = Arel::Collectors::SQLString.new
+      collector.preparable = true
+      visitor.accept(node, collector)
+      expect(collector.preparable).to eq(false)
+    end
+  end
+end
+
+describe "Arel::Visitors::Oracle" do
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+  end
+
+  let(:visitor) { Arel::Visitors::Oracle.new(ActiveRecord::Base.connection) }
+  let(:table) { Arel::Table.new(:users) }
+
+  describe "visit_Arel_Nodes_HomogeneousIn" do
+    it "marks the collector as not preparable" do
+      node = Arel::Nodes::HomogeneousIn.new([1, 2, 3], table[:id], :in)
+      collector = Arel::Collectors::SQLString.new
+      collector.preparable = true
+      visitor.accept(node, collector)
+      expect(collector.preparable).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`Arel::Visitors::ToSql#visit_Arel_Nodes_HomogeneousIn` in Rails main ([`to_sql.rb:332-352`](https://github.com/rails/rails/blob/main/activerecord/lib/arel/visitors/to_sql.rb#L332-L352)) sets `collector.preparable = false` so AR's statement cache does not retain the resulting SQL.

The Oracle visitors (`Arel::Visitors::Oracle12`, `Arel::Visitors::Oracle`) override `visit_Arel_Nodes_HomogeneousIn` to inline literal values and chunk against `in_clause_length` to dodge `ORA-01795: maximum number of expressions in a list is 1000`, but never set the `preparable` flag. Since Oracle's override produces SQL whose literal contents vary with the value set, leaving `preparable` at the inherited default churns AR's statement cache for what is fundamentally a non-cacheable shape.

This PR sets `collector.preparable = false` at the head of both Oracle overrides, matching upstream's contract for the same node.

## Why

Upstream's regression test for the upstream behavior lives at `activerecord/test/cases/arel/visitors/to_sql_test.rb:544-550` (`is not preparable when an array`). The Oracle override has been silently diverging since the chunking logic was added. The fix is a 1-line addition per visitor.

## Test plan

- [ ] New rspec under `spec/active_record/connection_adapters/oracle_enhanced/arel_visitor_spec.rb` exercises both `Oracle12` and `Oracle` visitors and asserts `collector.preparable` becomes `false`. Verified by inspection; the local Mac's ruby-oci8 hits a SIGSEGV on connection setup so CI is the validating run.
- [ ] CI green