### PR TITLE
Verify :schema works when set via DATABASE_URL query string

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -211,6 +211,13 @@ describe "OracleEnhancedConnection" do
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(schema: "oracle_enhanced;DROP TABLE x;--"))
       expect { ActiveRecord::Base.lease_connection }.to raise_error(ArgumentError, /Invalid :schema value/)
     end
+
+    it "honors :schema passed via DATABASE_URL query string" do
+      url = "oracle-enhanced://#{DATABASE_USER}:#{DATABASE_PASSWORD}@#{DATABASE_HOST}:#{DATABASE_PORT}/#{DATABASE_NAME}?schema=#{DATABASE_SCHEMA}"
+      ActiveRecord::Base.establish_connection(url)
+      expect(ActiveRecord::Base.lease_connection.current_schema).to eq(DATABASE_SCHEMA.upcase)
+      expect(ActiveRecord::Base.lease_connection.current_user).to eq(DATABASE_USER.upcase)
+    end
   end
 
   describe "resolving unqualified names with :schema set to a different user" do


### PR DESCRIPTION
## Summary

Closes #2390.

Rails' `ActiveRecord::DatabaseConfigurations::ConnectionUrlResolver` expands query parameters in `DATABASE_URL` into the config hash with symbol keys. A URL of the form

```
oracle-enhanced://user:pass@host:port/db?schema=other
```

lands as `config[:schema] => "other"`, and the adapter's existing connect-time path in `oracle_enhanced_adapter.rb:890` then runs `ALTER SESSION SET CURRENT_SCHEMA = other`. So the feature already works — the issue is purely a documentation / discoverability gap.

This PR adds a spec under the existing "create connection with schema option" describe block that drives the URL form end-to-end against the live Oracle and asserts `current_schema` and `current_user`. The new test:

- documents the supported usage requested in #2390 in executable form, and
- pins the contract so future config-handling changes can not silently break it.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb -e "honors :schema passed via DATABASE_URL query string"` — 1 example, 0 failures.
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb -e "create connection with schema option"` — 5 examples, 0 failures.
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb` — 82 examples, 0 failures, 1 pending (unrelated JRuby-only test).
- [x] `bundle exec rubocop spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb` — clean.
- [ ] CI green.
