### PR TITLE
Drop vestigial `:`-prefix branch from JDBC connection

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -119,10 +119,7 @@ module ActiveRecord
             if database && (using_tns_alias || host == "connection-string")
               url = "jdbc:oracle:thin:@#{database}"
             else
-              unless database.match?(/^(:|\/)/)
-                # assume database is a SID if no colon or slash are supplied (backward-compatibility)
-                database = "/#{database}"
-              end
+              database = "/#{database}" unless database.start_with?("/")
               url = config[:url] || "jdbc:oracle:thin:@//#{host || 'localhost'}:#{port || 1521}#{database}"
             end
 


### PR DESCRIPTION
## Summary

Removes a five-line dead-code branch in `OracleEnhanced::JDBCConnection.new_connection`. The change is mechanical — the existing `unless database.match?(/^(:|\/)/)` guard is replaced with the simpler `unless database.start_with?("/")` guard already used by the OCI side (`oci_connection.rb:335`).

## Why

The `(:|\/)` regex dates back to `b16bb1d0` (2012-07, "Allow slash-prefixed database name in database.yml for using a service name in jruby"). At that time:

- Oracle 11g XE was the common free target and used **SID** `XE`
- The default JDBC URL form was `jdbc:oracle:thin:@host:port:SID` (no `//`)
- `database: ":ORCL"` produced a valid SID URL: `jdbc:oracle:thin:@host:port:ORCL`

`c3341667` (2020-07, "Support JDBC Thin-style service name syntax") flipped the default to service-name syntax. Two changes landed together:

  - the prepended prefix changed from `:` to `/`
  - the URL prefix changed from `@host:port` to `@//host:port`

The `(:|\/)` regex was *not* updated, so since 2020 the `:`-prefix branch has produced URLs of the form

```
jdbc:oracle:thin:@//host:port:ORCL
```

which is not a recognized form in [Oracle's JDBC URL specification](https://docs.oracle.com/en/database/oracle/oracle-database/18/jjdbc/data-sources-and-URLs.html#GUID-EF07727C-50AB-4DCE-8EDC-57F0927FF61A) — the `//` prefix is exclusive to Thin-style service-name syntax (`@//host:port/SERVICE_NAME`); SID syntax is `@host:port:SID` with no `//`.

## Empirical verification across JDBC driver versions

To rule out a JDBC-driver-version dependency, I exercised four URL forms against a fresh `gvenzl/oracle-xe:11` container (Oracle Database 11g Express Edition 11.2.0.2.0) using **five ojdbc8 versions** spanning 12c through 23ai:

| URL the adapter would emit | Path it represents | ojdbc8 12.2.0.1 | ojdbc8 18.3.0.0 | ojdbc8 19.20.0.0 | ojdbc8 21.11.0.0 | ojdbc8 23.3.0.23.09 |
|---|---|---|---|---|---|---|
| `jdbc:oracle:thin:@//127.0.0.1:1521:XE` | **`database: ":XE"` today (master, broken)** | ❌ ORA-17002 (Invalid port number) | ❌ ORA-17002 (could not resolve identifier) | ❌ ORA-17002 | ❌ ORA-17002 | ❌ ORA-12154 (no such TNS alias) |
| `jdbc:oracle:thin:@//127.0.0.1:1521/:XE` | **`database: ":XE"` AFTER this PR** | ❌ ORA-12514 | ❌ ORA-12514 | ❌ ORA-12514 | ❌ ORA-12514 | ❌ ORA-12514 |
| `jdbc:oracle:thin:@//127.0.0.1:1521/XE` | `database: "XE"` (recommended form) | ✅ Connected | ✅ Connected | ✅ Connected | ✅ Connected | ✅ Connected |
| `jdbc:oracle:thin:@127.0.0.1:1521:XE` | What a future explicit `sid:` config key would emit | ✅ Connected | ✅ Connected | ✅ Connected | ✅ Connected | ✅ Connected |

The error number varies — 12c parses the URL as if `1521:XE` were the port; 18c through 21c treat the whole thing as a TNS-alias lookup; 23ai is more explicit about the alias-lookup fallback — but the outcome is uniform: **every JDBC driver version from 12c forward refuses to connect for the URL the broken `:`-prefix branch emits**. The path has been dead in practice, not just per spec, since the 2020 commit landed.

The behavior change for `database: ":SID"` input from this PR is "fail with ORA-12514 instead of ORA-17002 / ORA-12154" — both are hard errors, no working configuration is regressing.

For the OCI side (which this PR does not touch): on Oracle 23ai the OCI driver hits `ORA-01017` / `ORA-12514` for `database: ":FREEPDB1"`. On 11g XE the OCI driver was lenient enough to connect (it accepts the `/:XE` connection string), but `oci_connection.rb` was already on `start_with?("/")` and is unaffected by this change.

## What changes

```diff
-              unless database.match?(/^(:|\/)/)
-                # assume database is a SID if no colon or slash are supplied (backward-compatibility)
-                database = "/#{database}"
-              end
+              database = "/#{database}" unless database.start_with?("/")
```

After this change:
- `database: "ORCL"` and `database: "/ORCL"` continue to produce `jdbc:oracle:thin:@//host:port/ORCL` (service-name URL, unchanged).
- `database: ":ORCL"` produces `jdbc:oracle:thin:@//host:port/:ORCL`. Per the table above, the URL fails with `ORA-12514` across every tested JDBC driver. The pre-fix URL was failing with `ORA-17002` / `ORA-12154`.

A follow-up will add an explicit `sid:` config key that builds the correct `jdbc:oracle:thin:@host:port:SID` URL (no `//`) for deployments that actually need SID-based connections — see #2667.

## No spec ever exercised this path

`git log -S 'database: ":'` against the entire repo history returns **zero hits**. That is the proximate reason the 2020 regression sat unnoticed for 5+ years.

## Test plan

- [x] `bundle exec rubocop lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb` — clean.
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb` — 82 examples, 0 failures, 1 pending (unrelated).
- [x] JDBC URL probe across 5 ojdbc8 versions (12.2 → 23.3) against a live Oracle 11g XE container.
- [ ] CI green (including the JRuby legs that actually exercise this file).
