### PR TITLE
Add `:service_name` as an alias for `:database` in connection config

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,15 +242,26 @@ development:
   password: secret
 ```
 
-If you're connecting to a service name, indicate the service with a
-leading slash on the database parameter:
+The `database` parameter is interpreted as an Oracle service name. You
+can also use `service_name` as an explicit alias, which reads more
+naturally on PDB-based deployments where the value is unambiguously a
+service name:
 
 ```yml
 development:
   adapter: oracle_enhanced
-  database: /xe
+  service_name: xe
   username: user
   password: secret
+```
+
+`service_name` and `database` are mutually exclusive — supplying both
+raises `ArgumentError`.
+
+The same option is available via `DATABASE_URL` query string:
+
+```bash
+DATABASE_URL=oracle-enhanced://user:secret@localhost:1521/?service_name=xe
 ```
 
 If `TNS_ADMIN` environment variable is pointing to directory where `tnsnames.ora` file is located then you can use TNS connection name in `database` parameter. Otherwise you can directly specify database host, port (defaults to 1521) and database name in the following way:

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ In Rails application `config/database.yml` use oracle_enhanced as adapter name, 
 ```yml
 development:
   adapter: oracle_enhanced
-  database: xe
+  database: FREEPDB1
   username: user
   password: secret
 ```
@@ -250,7 +250,7 @@ service name:
 ```yml
 development:
   adapter: oracle_enhanced
-  service_name: xe
+  service_name: FREEPDB1
   username: user
   password: secret
 ```
@@ -261,7 +261,7 @@ raises `ArgumentError`.
 The same option is available via `DATABASE_URL` query string:
 
 ```bash
-DATABASE_URL=oracle-enhanced://user:secret@localhost:1521/?service_name=xe
+DATABASE_URL=oracle-enhanced://user:secret@localhost:1521/?service_name=FREEPDB1
 ```
 
 If `TNS_ADMIN` environment variable is pointing to directory where `tnsnames.ora` file is located then you can use TNS connection name in `database` parameter. Otherwise you can directly specify database host, port (defaults to 1521) and database name in the following way:
@@ -271,7 +271,7 @@ development:
   adapter: oracle_enhanced
   host: localhost
   port: 1521
-  database: xe
+  database: FREEPDB1
   username: user
   password: secret
 ```
@@ -281,7 +281,7 @@ or you can use Oracle specific format in `database` parameter:
 ```yml
 development:
   adapter: oracle_enhanced
-  database: //localhost:1521/xe
+  database: //localhost:1521/FREEPDB1
   username: user
   password: secret
 ```
@@ -293,7 +293,7 @@ development:
   adapter: oracle_enhanced
   database: "(DESCRIPTION=
     (ADDRESS_LIST=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1521)))
-    (CONNECT_DATA=(SERVICE_NAME=xe))
+    (CONNECT_DATA=(SERVICE_NAME=FREEPDB1))
   )"
   username: user
   password: secret
@@ -304,13 +304,13 @@ If you choose to specify your database connection via the `DATABASE_URL`
 environment variable, note that the adapter name uses a dash instead of an underscore:
 
 ```bash
-DATABASE_URL=oracle-enhanced://localhost/XE
+DATABASE_URL=oracle-enhanced://localhost/FREEPDB1
 ```
 
 You can also specify a connection string via the `DATABASE_URL`, as long as it doesn't have any whitespace:
 
 ```bash
-DATABASE_URL=oracle-enhanced://user:secret@connection-string/(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1521)))(CONNECT_DATA=(SERVICE_NAME=xe)))
+DATABASE_URL=oracle-enhanced://user:secret@connection-string/(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1521)))(CONNECT_DATA=(SERVICE_NAME=FREEPDB1)))
 ```
 
 If you deploy JRuby on Rails application in Java application server that supports JNDI connections then you can specify JNDI connection as well:
@@ -664,7 +664,7 @@ has appropriate privilege to select, insert, update and delete database objects 
 ```yml
 development:
   adapter: oracle_enhanced
-  database: xe
+  database: FREEPDB1
   username: user
   password: secret
   schema: tableowner
@@ -691,7 +691,7 @@ development:
   database: "(DESCRIPTION=
     (ADDRESS_LIST=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1521)))
     (CONNECT_TIMEOUT=5)(TCP_CONNECT_TIMEOUT=5)
-    (CONNECT_DATA=(SERVICE_NAME=xe))
+    (CONNECT_DATA=(SERVICE_NAME=FREEPDB1))
   )"
 ```
 You should set a timeout value dependant on your network topology, and the time needed to establish a TCP connection with your ORACLE
@@ -713,7 +713,7 @@ development:
   database: "(DESCRIPTION=
     (ADDRESS_LIST=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1521)))
     (RECV_TIMEOUT=60)(SEND_TIMEOUT=5)
-    (CONNECT_DATA=(SERVICE_NAME=xe))
+    (CONNECT_DATA=(SERVICE_NAME=FREEPDB1))
   )"
 ```
 
@@ -725,7 +725,7 @@ development:
     (ADDRESS_LIST=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1521)))
     (CONNECT_TIMEOUT=5)(TCP_CONNECT_TIMEOUT=5)
     (RECV_TIMEOUT=60)(SEND_TIMEOUT=5)
-    (CONNECT_DATA=(SERVICE_NAME=xe))
+    (CONNECT_DATA=(SERVICE_NAME=FREEPDB1))
   )"
 ```
 

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -278,6 +278,8 @@ module ActiveRecord
       def initialize(config_or_deprecated_connection, deprecated_logger = nil, deprecated_connection_options = nil, deprecated_config = nil) # :nodoc:
         super(config_or_deprecated_connection, deprecated_logger, deprecated_connection_options, deprecated_config)
 
+        resolve_service_name_alias
+
         connect
         @enable_dbms_output = false
         @prefetch_primary_key_cache = {}
@@ -864,6 +866,23 @@ module ActiveRecord
       # only the documented values.
       CURSOR_SHARING_VALUES = %w[EXACT FORCE SIMILAR].freeze
       SCHEMA_IDENTIFIER_PATTERN = /\A[[:alpha:]][\w$#]*\z/
+
+      # `:service_name` is an alias for `:database`. It is the recommended way
+      # to express the Oracle service name a connection should attach to;
+      # `:database` is retained because it is the Active Record convention
+      # and what `DATABASE_URL`'s path resolves into. The two options are
+      # mutually exclusive — supplying both is treated as a configuration
+      # error rather than picking a winner silently.
+      private def resolve_service_name_alias
+        return if @config[:service_name].nil?
+
+        if @config[:database]
+          raise ArgumentError,
+            "Cannot specify both :service_name and :database connection options; they are aliases. Use only one."
+        end
+
+        @config[:database] = @config[:service_name]
+      end
 
       private def configure_connection
         super

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -878,7 +878,7 @@ module ActiveRecord
       # `/`-prefixed values are rejected outright; the prefix was an
       # adapter-side artefact for building EZCONNECT URLs and has no
       # business in a value the user thinks of as a bare service name.
-      private def resolve_service_name_alias
+      def resolve_service_name_alias
         return if @config[:service_name].nil?
 
         if @config[:database]
@@ -893,6 +893,7 @@ module ActiveRecord
 
         @config[:database] = @config[:service_name]
       end
+      private :resolve_service_name_alias
 
       private def configure_connection
         super

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -873,12 +873,22 @@ module ActiveRecord
       # and what `DATABASE_URL`'s path resolves into. The two options are
       # mutually exclusive — supplying both is treated as a configuration
       # error rather than picking a winner silently.
+      #
+      # Unlike `:database`, `:service_name` is a clean greenfield key so
+      # `/`-prefixed values are rejected outright; the prefix was an
+      # adapter-side artefact for building EZCONNECT URLs and has no
+      # business in a value the user thinks of as a bare service name.
       private def resolve_service_name_alias
         return if @config[:service_name].nil?
 
         if @config[:database]
           raise ArgumentError,
             "Cannot specify both :service_name and :database connection options; they are aliases. Use only one."
+        end
+
+        if @config[:service_name].to_s.start_with?("/")
+          raise ArgumentError,
+            "Invalid :service_name value #{@config[:service_name].inspect}; must not start with '/'."
         end
 
         @config[:database] = @config[:service_name]

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -244,6 +244,15 @@ describe "OracleEnhancedConnection" do
       expect { ActiveRecord::Base.lease_connection }
         .to raise_error(ArgumentError, /Cannot specify both :service_name and :database/)
     end
+
+    it "raises ArgumentError when :service_name starts with '/'" do
+      config = CONNECTION_PARAMS.dup
+      config.delete(:database)
+      config[:service_name] = "/#{DATABASE_NAME}"
+      ActiveRecord::Base.establish_connection(config)
+      expect { ActiveRecord::Base.lease_connection }
+        .to raise_error(ArgumentError, %r{Invalid :service_name value .*; must not start with '/'})
+    end
   end
 
   describe "resolving unqualified names with :schema set to a different user" do

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -220,6 +220,32 @@ describe "OracleEnhancedConnection" do
     end
   end
 
+  describe ":service_name option (alias for :database)" do
+    after(:all) do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    end
+
+    it "connects when :service_name is supplied in place of :database" do
+      config = CONNECTION_PARAMS.dup
+      service_name = config.delete(:database)
+      config[:service_name] = service_name
+      ActiveRecord::Base.establish_connection(config)
+      expect(ActiveRecord::Base.lease_connection).to be_active
+    end
+
+    it "honors :service_name passed via DATABASE_URL query string" do
+      url = "oracle-enhanced://#{DATABASE_USER}:#{DATABASE_PASSWORD}@#{DATABASE_HOST}:#{DATABASE_PORT}/?service_name=#{DATABASE_NAME}"
+      ActiveRecord::Base.establish_connection(url)
+      expect(ActiveRecord::Base.lease_connection).to be_active
+    end
+
+    it "raises ArgumentError when both :service_name and :database are set" do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(service_name: DATABASE_NAME))
+      expect { ActiveRecord::Base.lease_connection }
+        .to raise_error(ArgumentError, /Cannot specify both :service_name and :database/)
+    end
+  end
+
   describe "resolving unqualified names with :schema set to a different user" do
     # Pins down the end-to-end contract of the `:schema` connection option:
     #


### PR DESCRIPTION
## Summary

Phase 1a of the cleanup tracked in #2667. Adds `:service_name` as an explicit alias for `:database`, with no other behavior change.

`:database` is the Active Record convention and what `DATABASE_URL`'s path resolves into, but on Oracle since #2035 (`c3341667`, 2020-07, "Support JDBC service name syntax") the value is interpreted as a service name. `:database` reads naturally for SID-style deployments and obscures intent on PDB-based deployments where the value is unambiguously a service name.

## What changes

- New `resolve_service_name_alias` runs once at adapter `initialize` time, after `super` and before `connect`. If `@config[:service_name]` is set:
  - if `@config[:database]` is also set, raise `ArgumentError` (mutually exclusive — surface misconfiguration immediately rather than silently picking a winner);
  - if the value starts with `/`, raise `ArgumentError` (`:service_name` is a greenfield key; the `/` was an adapter-side artifact for building EZCONNECT URLs and has no business in a value the user thinks of as a bare service name);
  - otherwise copy the value into `@config[:database]`.
- All downstream paths (OCI/JDBC connection construction, `configure_connection`, `dbconsole`, etc.) read the resolved value through `@config[:database]` without further changes.
- `README.md`: the "leading slash on the `database` parameter" example (a 2012-era escape hatch from when the JDBC URL default was SID syntax) is replaced with a `service_name:` example and a matching `DATABASE_URL` query-string form. The other `database:` forms shown later in the section (full EZCONNECT `//host:port/db` and TNS connect descriptor) are unrelated to the `/`-prefix magic and are unchanged.

## Side benefit: `DATABASE_URL` support

Rails' `ConnectionUrlResolver` places query-string parameters into symbol-keyed entries on the config hash (the same mechanism that makes `?schema=...` work — see #2390 / #2665). Because `:service_name` resolution happens at adapter init, this PR also unlocks

```
oracle-enhanced://user:pass@host:port/?service_name=ORCLPDB1
```

with no extra plumbing. A spec pins this end-to-end.

## Compatibility note: 11g XE

Service-name connection works on Oracle 11g XE too. The 11g XE listener registers `XE` both as a SID and as a service name (verified via `lsnrctl status` against a `gvenzl/oracle-xe:11` container), so `service_name: "XE"` resolves to a working connection just like the JDBC URL form `jdbc:oracle:thin:@//host:port/XE` does. `:service_name` is therefore a usable form across every supported Oracle version, not only on PDB-based deployments.

## What this PR does NOT do (deliberately)

- It does not add `:sid:`. Adding SID support is more involved (it needs a different JDBC URL form and a TNS connect descriptor on OCI) and is tracked separately in #2667 as Phase 2.
- It does not deprecate the leading-`/` form on `:database` values. That is a behavior change for existing `database: "/ORCL"` configs and warrants its own PR (the deprecation copy and timeline can be debated independently). The README example pointing users at `/`-prefix is removed in this PR; the actual deprecation warning is Phase 1b.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb -e ":service_name option"` — 4 examples, 0 failures (positive case, DATABASE_URL query string, mutual-exclusion error, `/`-prefix rejection).
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb` — full file passes; only the 1 unrelated JRuby-only spec is pending.
- [x] `bundle exec rubocop lib/active_record/connection_adapters/oracle_enhanced_adapter.rb spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb` — clean.
- [ ] CI green.

## Refs

- #2667 — overall cleanup direction
- #2390, #2665 — same Rails mechanism used by `?schema=...`
- #2035 (`c3341667`, 2020-07, "Support JDBC service name syntax") — the PR that made the Oracle adapter interpret `:database` as a service name by default

