### PR TITLE
Add `:sid` connection option for Oracle SID-based instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,13 +255,27 @@ development:
   password: secret
 ```
 
-`service_name` and `database` are mutually exclusive — supplying both
-raises `ArgumentError`.
+If you are connecting to a SID-based instance (typically a pre-12c
+single-instance deployment such as Oracle 11g XE), use `sid` instead:
 
-The same option is available via `DATABASE_URL` query string:
+```yml
+development:
+  adapter: oracle_enhanced
+  sid: XE
+  host: localhost
+  port: 1521
+  username: user
+  password: secret
+```
+
+`database`, `service_name` and `sid` are mutually exclusive — supplying
+more than one raises `ArgumentError`.
+
+The same options are available via `DATABASE_URL` query string:
 
 ```bash
 DATABASE_URL=oracle-enhanced://user:secret@localhost:1521/?service_name=FREEPDB1
+DATABASE_URL=oracle-enhanced://user:secret@localhost:1521/?sid=XE
 ```
 
 If `TNS_ADMIN` environment variable is pointing to directory where `tnsnames.ora` file is located then you can use TNS connection name in `database` parameter. Otherwise you can directly specify database host, port (defaults to 1521) and database name in the following way:

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -111,12 +111,17 @@ module ActiveRecord
             username = config[:username] && config[:username].to_s
             password = config[:password] && config[:password].to_s
             database = config[:database] && config[:database].to_s || "XE"
+            sid      = config[:sid] && config[:sid].to_s
             host, port = config[:host], config[:port]
             privilege = config[:privilege] && config[:privilege].to_s
 
             # connection using TNS alias, or connection-string from DATABASE_URL
             using_tns_alias = !host && !config[:url] && ENV["TNS_ADMIN"]
-            if database && (using_tns_alias || host == "connection-string")
+            if sid
+              # Oracle SID syntax: `jdbc:oracle:thin:@host:port:SID` -- no `//`,
+              # which is reserved for the EZCONNECT (service-name) form.
+              url = config[:url] || "jdbc:oracle:thin:@#{host || 'localhost'}:#{port || 1521}:#{sid}"
+            elsif database && (using_tns_alias || host == "connection-string")
               url = "jdbc:oracle:thin:@#{database}"
             else
               database = "/#{database}" unless database.start_with?("/")

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -319,13 +319,23 @@ module ActiveRecord
           username = config[:username] && config[:username].to_s
           password = config[:password] && config[:password].to_s
           database = config[:database] && config[:database].to_s
+          sid      = config[:sid] && config[:sid].to_s
           host, port = config[:host], config[:port]
           privilege = config[:privilege] && config[:privilege].to_sym
           async = config[:allow_concurrency]
           prefetch_rows = config[:prefetch_rows] || 100
 
+          # connection using a SID -- OCI has no SID form for EZCONNECT, so
+          # build a TNS connect descriptor inline and pass it as the
+          # connection-string. Lets `:sid` work without requiring a
+          # tnsnames.ora entry.
+          connection_string = if sid
+            host ||= "localhost"
+            host = "[#{host}]" if /^[^\[].*:/.match?(host)  # IPv6
+            port ||= 1521
+            "(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=#{host})(PORT=#{port}))(CONNECT_DATA=(SID=#{sid})))"
           # using a connection string via DATABASE_URL
-          connection_string = if host == "connection-string"
+          elsif host == "connection-string"
             database
           # connection using host, port and database name
           elsif host || port

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -278,7 +278,7 @@ module ActiveRecord
       def initialize(config_or_deprecated_connection, deprecated_logger = nil, deprecated_connection_options = nil, deprecated_config = nil) # :nodoc:
         super(config_or_deprecated_connection, deprecated_logger, deprecated_connection_options, deprecated_config)
 
-        resolve_service_name_alias
+        resolve_database_aliases
 
         connect
         @enable_dbms_output = false
@@ -866,34 +866,48 @@ module ActiveRecord
       # only the documented values.
       CURSOR_SHARING_VALUES = %w[EXACT FORCE SIMILAR].freeze
       SCHEMA_IDENTIFIER_PATTERN = /\A[[:alpha:]][\w$#]*\z/
+      SID_IDENTIFIER_PATTERN = /\A[\w$#]+\z/
 
-      # `:service_name` is an alias for `:database`. It is the recommended way
-      # to express the Oracle service name a connection should attach to;
-      # `:database` is retained because it is the Active Record convention
-      # and what `DATABASE_URL`'s path resolves into. The two options are
-      # mutually exclusive — supplying both is treated as a configuration
-      # error rather than picking a winner silently.
+      # `:service_name` and `:sid` are explicit aliases for `:database` —
+      # `:service_name` for an Oracle service name (the modern, PDB-mandatory
+      # form) and `:sid` for an Oracle SID (legacy single-instance / 11g-era
+      # form). `:database` is retained because it is the Active Record
+      # convention and what `DATABASE_URL`'s path resolves into; it has been
+      # interpreted as a service name by this adapter since c3341667 (2020-07).
       #
-      # Unlike `:database`, `:service_name` is a clean greenfield key so
-      # `/`-prefixed values are rejected outright; the prefix was an
-      # adapter-side artefact for building EZCONNECT URLs and has no
-      # business in a value the user thinks of as a bare service name.
-      def resolve_service_name_alias
-        return if @config[:service_name].nil?
+      # The three options are mutually exclusive. Supplying more than one is
+      # a configuration error rather than a silent precedence choice.
+      #
+      # Unlike `:database`, both `:service_name` and `:sid` are clean
+      # greenfield keys so `/`- or `:`-prefixed values (adapter-side artefacts
+      # for building EZCONNECT URLs) are rejected outright.
+      def resolve_database_aliases
+        service_name = @config[:service_name]
+        sid          = @config[:sid]
 
-        if @config[:database]
+        competitors = []
+        competitors << ":database"     if @config[:database]
+        competitors << ":service_name" if service_name
+        competitors << ":sid"          if sid
+        if competitors.size > 1
           raise ArgumentError,
-            "Cannot specify both :service_name and :database connection options; they are aliases. Use only one."
+            "Cannot specify more than one of #{competitors.join(', ')}; they are mutually exclusive."
         end
 
-        if @config[:service_name].to_s.start_with?("/")
-          raise ArgumentError,
-            "Invalid :service_name value #{@config[:service_name].inspect}; must not start with '/'."
+        if service_name
+          if service_name.to_s.start_with?("/")
+            raise ArgumentError,
+              "Invalid :service_name value #{service_name.inspect}; must not start with '/'."
+          end
+          @config[:database] = service_name
         end
 
-        @config[:database] = @config[:service_name]
+        if sid && !sid.to_s.match?(SID_IDENTIFIER_PATTERN)
+          raise ArgumentError,
+            "Invalid :sid value #{sid.inspect}; must be an Oracle SID (alphanumeric, underscore, $, #)."
+        end
       end
-      private :resolve_service_name_alias
+      private :resolve_database_aliases
 
       private def configure_connection
         super

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -242,7 +242,7 @@ describe "OracleEnhancedConnection" do
     it "raises ArgumentError when both :service_name and :database are set" do
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(service_name: DATABASE_NAME))
       expect { ActiveRecord::Base.lease_connection }
-        .to raise_error(ArgumentError, /Cannot specify both :service_name and :database/)
+        .to raise_error(ArgumentError, /Cannot specify more than one of :database, :service_name/)
     end
 
     it "raises ArgumentError when :service_name starts with '/'" do
@@ -252,6 +252,81 @@ describe "OracleEnhancedConnection" do
       ActiveRecord::Base.establish_connection(config)
       expect { ActiveRecord::Base.lease_connection }
         .to raise_error(ArgumentError, %r{Invalid :service_name value .*; must not start with '/'})
+    end
+  end
+
+  describe ":sid option" do
+    after(:all) do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    end
+
+    # Live SID connection — only runs against Oracle 11g XE in the
+    # `test_11g` CI workflow, where DATABASE_NAME=XE happens to refer to
+    # both the SID and the registered service name. Modern PDB-based
+    # deployments cannot be reached by SID, so the test is skipped there.
+    it "connects when :sid is supplied" do
+      skip "SID-based connection requires a SID-registered instance (Oracle 11g XE)" unless DATABASE_NAME.casecmp?("XE")
+      config = CONNECTION_PARAMS.dup
+      config.delete(:database)
+      config[:sid] = DATABASE_NAME
+      ActiveRecord::Base.establish_connection(config)
+      expect(ActiveRecord::Base.lease_connection).to be_active
+    end
+
+    it "honors :sid passed via DATABASE_URL query string" do
+      skip "SID-based connection requires a SID-registered instance (Oracle 11g XE)" unless DATABASE_NAME.casecmp?("XE")
+      url = "oracle-enhanced://#{DATABASE_USER}:#{DATABASE_PASSWORD}@#{DATABASE_HOST}:#{DATABASE_PORT}/?sid=#{DATABASE_NAME}"
+      ActiveRecord::Base.establish_connection(url)
+      expect(ActiveRecord::Base.lease_connection).to be_active
+    end
+
+    it "raises ArgumentError when both :sid and :database are set" do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(sid: DATABASE_NAME))
+      expect { ActiveRecord::Base.lease_connection }
+        .to raise_error(ArgumentError, /Cannot specify more than one of :database, :sid/)
+    end
+
+    it "raises ArgumentError when both :sid and :service_name are set" do
+      config = CONNECTION_PARAMS.dup
+      config.delete(:database)
+      config[:service_name] = DATABASE_NAME
+      config[:sid] = DATABASE_NAME
+      ActiveRecord::Base.establish_connection(config)
+      expect { ActiveRecord::Base.lease_connection }
+        .to raise_error(ArgumentError, /Cannot specify more than one of :service_name, :sid/)
+    end
+
+    it "raises ArgumentError when all three of :database, :service_name and :sid are set" do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(service_name: DATABASE_NAME, sid: DATABASE_NAME))
+      expect { ActiveRecord::Base.lease_connection }
+        .to raise_error(ArgumentError, /Cannot specify more than one of :database, :service_name, :sid/)
+    end
+
+    it "raises ArgumentError when :sid starts with '/'" do
+      config = CONNECTION_PARAMS.dup
+      config.delete(:database)
+      config[:sid] = "/#{DATABASE_NAME}"
+      ActiveRecord::Base.establish_connection(config)
+      expect { ActiveRecord::Base.lease_connection }
+        .to raise_error(ArgumentError, /Invalid :sid value/)
+    end
+
+    it "raises ArgumentError when :sid starts with ':'" do
+      config = CONNECTION_PARAMS.dup
+      config.delete(:database)
+      config[:sid] = ":#{DATABASE_NAME}"
+      ActiveRecord::Base.establish_connection(config)
+      expect { ActiveRecord::Base.lease_connection }
+        .to raise_error(ArgumentError, /Invalid :sid value/)
+    end
+
+    it "raises ArgumentError when :sid contains a TNS connect descriptor" do
+      config = CONNECTION_PARAMS.dup
+      config.delete(:database)
+      config[:sid] = "(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=foo)(PORT=1521))(CONNECT_DATA=(SID=XE)))"
+      ActiveRecord::Base.establish_connection(config)
+      expect { ActiveRecord::Base.lease_connection }
+        .to raise_error(ArgumentError, /Invalid :sid value/)
     end
   end
 


### PR DESCRIPTION
## Summary

Phase 2 of the cleanup tracked in #2667. Adds an explicit `:sid` connection-config key for legacy SID-based deployments (typically pre-12c single-instance setups such as Oracle 11g XE), alongside the `:service_name` alias from #2668.

**This PR depends on #2668** (it picks up the rebased `:service_name` work and extends `resolve_service_name_alias` into the more general `resolve_database_aliases`). Review/merge once #2668 lands.

## What changes

- New `:sid` config key, validated at adapter `initialize` time. The three options — `:database`, `:service_name`, `:sid` — are now mutually exclusive: supplying more than one raises `ArgumentError`. `:sid` values must match `SID_IDENTIFIER_PATTERN` (alphanumeric, `_`, `$`, `#`); `/`-prefixed, `:`-prefixed, or TNS-descriptor values are rejected outright.
- **JDBC** (`jdbc_connection.rb`): when `:sid` is set, build `jdbc:oracle:thin:@host:port:SID` (the standard SID URL form, no `//`), distinct from the EZCONNECT service-name form `@//host:port/SERVICE`.
- **OCI** (`oci_connection.rb`): when `:sid` is set, build a TNS connect descriptor inline:
  ```
  (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=...)(PORT=...))(CONNECT_DATA=(SID=...)))
  ```
  No `tnsnames.ora` entry required. The IPv6 bracket-wrapping used in the EZCONNECT branch is deliberately not applied here because TNS descriptors take bare IPv6 addresses (`(HOST=2001:db8::1)`).
- The alias-resolution helper from #2668 is renamed `resolve_service_name_alias` → `resolve_database_aliases` since it now handles two aliases.

## DATABASE_URL support

Comes free via Rails' `ConnectionUrlResolver` — the same mechanism that wires up `?service_name=` in #2668 and `?schema=` in #2665:

```
DATABASE_URL=oracle-enhanced://user:pass@host:port/?sid=XE
```

A spec pins this end-to-end against an 11g XE container.

## Test plan

Live SID specs are gated on `DATABASE_NAME == "XE"` so they only run against the `test_11g` CI workflow (and other 11g XE setups). Modern PDB-based deployments cannot be reached by SID, so on those environments the live SID tests `skip` rather than fail. Validation specs (mutual exclusion, `/`-prefix / `:`-prefix / TNS-descriptor rejection) need no live connection and run everywhere.

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb -e ":sid option"` against Oracle 23ai (FREEPDB1) — 8 examples, 0 failures, 2 pending (the `skip`-gated live tests).
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb -e ":sid option"` against `gvenzl/oracle-xe:11` (DATABASE_NAME=XE) — 8 examples, 0 failures (validation + live SID + DATABASE_URL `?sid=XE` all pass).
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb` (full file) on 23ai — 94 examples, 0 failures, 3 pending (2 SID skips + 1 unrelated JRuby-only test).
- [x] `bundle exec rubocop lib/active_record/connection_adapters/ spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb` — clean (25 files inspected).
- [ ] CI green, including `test_11g` and `test_11g_ojdbc11` (which actually exercise the live SID path).

## Refs

- #2667 — overall cleanup direction (Phase 2)
- #2668 — Phase 1a (`:service_name` alias) — this PR is stacked on top
- #2390, #2665 — same Rails mechanism used by `?schema=...`
- Oracle JDBC URL formats: https://docs.oracle.com/en/database/oracle/oracle-database/18/jjdbc/data-sources-and-URLs.html
