### PR TITLE
Phase 1b: deprecate `/`-prefixed and reject `:`-prefixed `:database` values

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -868,19 +868,6 @@ module ActiveRecord
       SCHEMA_IDENTIFIER_PATTERN = /\A[[:alpha:]][\w$#]*\z/
       SID_IDENTIFIER_PATTERN = /\A[\w$#]+\z/
 
-      # `:service_name` and `:sid` are explicit aliases for `:database` —
-      # `:service_name` for an Oracle service name (the modern, PDB-mandatory
-      # form) and `:sid` for an Oracle SID (legacy single-instance / 11g-era
-      # form). `:database` is retained because it is the Active Record
-      # convention and what `DATABASE_URL`'s path resolves into; it has been
-      # interpreted as a service name by this adapter since c3341667 (2020-07).
-      #
-      # The three options are mutually exclusive. Supplying more than one is
-      # a configuration error rather than a silent precedence choice.
-      #
-      # Unlike `:database`, both `:service_name` and `:sid` are clean
-      # greenfield keys so `/`- or `:`-prefixed values (adapter-side artefacts
-      # for building EZCONNECT URLs) are rejected outright.
       def resolve_database_aliases
         service_name = @config[:service_name]
         sid          = @config[:sid]
@@ -905,6 +892,27 @@ module ActiveRecord
         if sid && !sid.to_s.match?(SID_IDENTIFIER_PATTERN)
           raise ArgumentError,
             "Invalid :sid value #{sid.inspect}; must be an Oracle SID (alphanumeric, underscore, $, #)."
+        end
+
+        if @config[:database].to_s.start_with?(":")
+          raise ArgumentError,
+            "Setting `:database` to a value that starts with `:` " \
+            "(#{@config[:database].inspect}) is not supported. The leading " \
+            "colon was a SID marker on pre-2020 JDBC URLs and produces a " \
+            "malformed connection on the current adapter. Use the explicit " \
+            "`:sid` option instead (e.g. `sid: " \
+            "#{@config[:database].to_s.delete_prefix(':').inspect}`)."
+        end
+
+        if @config[:database].to_s.start_with?("/")
+          OracleEnhanced.deprecator.warn(
+            "Setting `:database` to a value that starts with `/` " \
+            "(#{@config[:database].inspect}) is deprecated and will raise " \
+            "in a future major version. The leading slash is an adapter " \
+            "artefact from when `:database` was prepended into an EZCONNECT " \
+            "URL; the slash is no longer needed. Use the same value without " \
+            "the leading `/`, or use the explicit `:service_name` option."
+          )
         end
       end
       private :resolve_database_aliases

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -330,6 +330,46 @@ describe "OracleEnhancedConnection" do
     end
   end
 
+  describe "`:database` value with leading `/`" do
+    after(:all) do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    end
+
+    it "still connects (behaviour unchanged)" do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(database: "/#{DATABASE_NAME}"))
+      ActiveRecord::ConnectionAdapters::OracleEnhanced.deprecator.silence do
+        expect(ActiveRecord::Base.lease_connection).to be_active
+      end
+    end
+
+    it "emits an OracleEnhanced.deprecator warning naming the recommended replacements" do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(database: "/#{DATABASE_NAME}"))
+      expect {
+        ActiveRecord::Base.lease_connection
+      }.to output(/DEPRECATION WARNING: Setting `:database` to a value that starts with `\/`.*:service_name/m).to_stderr
+    end
+
+    it "does not warn when :database has no leading slash" do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+      expect {
+        ActiveRecord::Base.lease_connection
+      }.not_to output(/value that starts with `\//).to_stderr
+    end
+  end
+
+  describe "`:database` value with leading `:`" do
+    after(:all) do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    end
+
+    it "raises ArgumentError pointing at the :sid option" do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(database: ":#{DATABASE_NAME}"))
+      expect {
+        ActiveRecord::Base.lease_connection
+      }.to raise_error(ArgumentError, /Setting `:database` to a value that starts with `:`.*`:sid` option/m)
+    end
+  end
+
   describe "resolving unqualified names with :schema set to a different user" do
     # Pins down the end-to-end contract of the `:schema` connection option:
     #


### PR DESCRIPTION
## Summary

Phase 1b of the cleanup tracked in #2667. Two adjustments to `resolve_database_aliases` in `oracle_enhanced_adapter.rb`:

- **`:database` starting with `/`** — emit a deprecation warning via `OracleEnhanced.deprecator.warn` naming `:service_name` (and the bare-value form) as the recommended replacements. Connection still proceeds; the warning is informational.
- **`:database` starting with `:`** — raise `ArgumentError` immediately, pointing at the `:sid` option that #2669 added.

## Why the asymmetric treatment

The two prefixes have very different histories:

| Prefix | Introduced | Status today |
|---|---|---|
| `/`-prefix on `:database` | #201 (2012-07, "Allow service names in jruby without specifying a url") — needed because JRuby could not use service names without an undocumented `url:` config | Still works. Since #2035 (2020-07) it produces the same URL as a bare value, so the slash is redundant adapter scaffolding |
| `:`-prefix on `:database` | The SID-syntax marker on pre-2020 JDBC URLs | Has been **broken since 2020**. The cross-version JDBC verification in #2666 (5 ojdbc8 versions × 11g XE) showed every driver from 12.2 forward refuses the resulting URL with `ORA-12154` / `ORA-12514`. No working configuration can have been reaching this path |

So:
- `/`-prefix has real users → conservative deprecation warning, removal in a future major.
- `:`-prefix has had no working users since 2020 → reject outright, save the user from a confusing `ORA-12514` and direct them at `:sid`.

## Test plan

Validation specs need no live connection:

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb -e "leading"` — 4 examples, 0 failures (warning emitted on `/`-prefix, no warning on bare value, connection still active under deprecator silence, ArgumentError on `:`-prefix).
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb` — 98 examples, 0 failures, 3 pending (2 SID skips on 23ai + 1 unrelated JRuby-only test).
- [x] `bundle exec rubocop lib/active_record/connection_adapters/oracle_enhanced_adapter.rb spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb` — clean.
- [ ] CI green.

## Refs

- #2667 — overall cleanup direction (Phase 1b)
- #2666 — cross-version JDBC verification of the `:`-prefix breakage
- #2668, #2669 — Phase 1a / Phase 2 (`:service_name`, `:sid` keys)
- #201 (commit `b16bb1d0`, 2012-07, "Allow service names in jruby without specifying a url") — original PR that introduced the `/`-prefix path
- #2035 (commit `c3341667`, 2020-07, "Support JDBC service name syntax") — the PR that flipped `:database` interpretation to service-name and made `/`-prefix redundant
