### PR TITLE
[WIP] Oracle12 default-visitor regression: FIRST_VALUE+DISTINCT+ORDER BY drops alias_N__ rewrite

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -190,10 +190,11 @@ module ActiveRecord
 
       ##
       # :singleton-method:
-      # By default, OracleEnhanced adapter will use Oracle12 visitor
-      # if database version is Oracle 12.1.
-      # If you wish to use Oracle visitor which is intended to work with Oracle 11.2 or lower
-      # for Oracle 12.1 database you can add the following line to your initializer file:
+      # By default, OracleEnhanced adapter uses `Arel::Visitors::Oracle12`,
+      # which emits `FETCH FIRST n ROWS ONLY` / `OFFSET n ROWS` for limits
+      # and offsets. To opt back into `Arel::Visitors::Oracle` (ROWNUM-based
+      # output, intended for pre-12c servers) on every connection, add the
+      # following line to your initializer:
       #
       #   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.use_old_oracle_visitor = true
       cattr_accessor :use_old_oracle_visitor

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -353,12 +353,7 @@ module ActiveRecord
       end
 
       def supports_fetch_first_n_rows_and_offset?
-        false
-
-        # TODO: At this point the connection is not initialized yet,
-        # so `database_version` raises an error
-        #
-        # !use_old_oracle_visitor && database_version.first >= 12
+        !use_old_oracle_visitor
       end
 
       def supports_datetime_with_precision?

--- a/lib/arel/visitors/oracle12.rb
+++ b/lib/arel/visitors/oracle12.rb
@@ -8,15 +8,22 @@ module Arel # :nodoc: all
       include OracleCommon
 
       private
+        # Oracle raises ORA-02014 when `FETCH FIRST n ROWS ONLY` is combined
+        # with `FOR UPDATE`. When a limit is present alongside a lock, delegate
+        # the whole SELECT to Arel::Visitors::Oracle, whose ROWNUM-based output
+        # is compatible with FOR UPDATE for the simple case and surfaces any
+        # remaining ORA-02014 as a regular StatementInvalid for compound cases
+        # (ORDER BY / GROUP BY / HAVING / OFFSET / DISTINCT) instead of raising
+        # an ArgumentError from an internal visitor that callers cannot avoid.
         def visit_Arel_Nodes_SelectStatement(o, collector)
-          # Oracle does not allow LIMIT clause with select for update
           if o.limit && o.lock
-            raise ArgumentError, <<~MSG
-              Combination of limit and lock is not supported. Because generated SQL statements
-              `SELECT FOR UPDATE and FETCH FIRST n ROWS` generates ORA-02014.
-            MSG
+            return oracle_visitor_for_lock.send(:visit_Arel_Nodes_SelectStatement, o, collector)
           end
           super
+        end
+
+        def oracle_visitor_for_lock
+          @oracle_visitor_for_lock ||= Arel::Visitors::Oracle.new(@connection)
         end
 
         def visit_Arel_Nodes_SelectOptions(o, collector)

--- a/lib/arel/visitors/oracle12.rb
+++ b/lib/arel/visitors/oracle12.rb
@@ -17,7 +17,7 @@ module Arel # :nodoc: all
         # an ArgumentError from an internal visitor that callers cannot avoid.
         def visit_Arel_Nodes_SelectStatement(o, collector)
           if o.limit && o.lock
-            return oracle_visitor_for_lock.send(:visit_Arel_Nodes_SelectStatement, o, collector)
+            return oracle_visitor_for_lock.accept(o, collector)
           end
           super
         end

--- a/lib/arel/visitors/oracle12.rb
+++ b/lib/arel/visitors/oracle12.rb
@@ -17,13 +17,25 @@ module Arel # :nodoc: all
         # an ArgumentError from an internal visitor that callers cannot avoid.
         def visit_Arel_Nodes_SelectStatement(o, collector)
           if o.limit && o.lock
-            return oracle_visitor_for_lock.accept(o, collector)
+            # Arel::Visitors::Oracle's simple-limit branch mutates `o.cores`
+            # by pushing a ROWNUM predicate into the WHERE list. dup the node
+            # so a re-compile of the same statement does not accumulate
+            # `ROWNUM <= n AND ROWNUM <= n AND ...` predicates.
+            return oracle11_visitor.accept(o.dup, collector)
           end
           super
         end
 
-        def oracle_visitor_for_lock
-          @oracle_visitor_for_lock ||= Arel::Visitors::Oracle.new(@connection)
+        def oracle11_visitor
+          @oracle11_visitor ||= begin
+            visitor = Arel::Visitors::Oracle.new(@connection)
+            # Suppress order_hacks for this delegation path: a query routed
+            # through Oracle12 should not unexpectedly pick up the FIRST_VALUE/
+            # alias_N__ ORDER BY rewrite just because it combined .limit
+            # with .lock.
+            visitor.define_singleton_method(:order_hacks) { |o| o }
+            visitor
+          end
         end
 
         def visit_Arel_Nodes_SelectOptions(o, collector)

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle12_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle12_spec.rb
@@ -31,11 +31,14 @@ describe "Arel::Visitors::Oracle12" do
   end
 
   describe "locking" do
-    it "raises ArgumentError if limit and lock are used" do
+    it "falls back to Arel::Visitors::Oracle (ROWNUM) when limit and lock are combined" do
       stmt = Arel::Nodes::SelectStatement.new
       stmt.limit = Arel::Nodes::Limit.new(10)
       stmt.lock = Arel::Nodes::Lock.new(Arel.sql("FOR UPDATE"))
-      expect { compile(stmt) }.to raise_error(ArgumentError)
+      sql = compile(stmt)
+      expect(sql).to match(/ROWNUM/)
+      expect(sql).to match(/FOR UPDATE/)
+      expect(sql).not_to match(/FETCH FIRST/)
     end
 
     it "defaults to FOR UPDATE when locking" do

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle12_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle12_spec.rb
@@ -41,6 +41,19 @@ describe "Arel::Visitors::Oracle12" do
       expect(sql).not_to match(/FETCH FIRST/)
     end
 
+    it "compiles compound limit+lock+ORDER BY without raising; lets Oracle return ORA-02014 at execute time" do
+      stmt = Arel::Nodes::SelectStatement.new
+      stmt.orders << Arel::Nodes::SqlLiteral.new("foo")
+      stmt.limit = Arel::Nodes::Limit.new(10)
+      stmt.lock = Arel::Nodes::Lock.new(Arel.sql("FOR UPDATE"))
+      expect { compile(stmt) }.not_to raise_error
+      sql = compile(stmt)
+      expect(sql).to match(/ROWNUM/)
+      expect(sql).to match(/FOR UPDATE/)
+      expect(sql).to match(/ORDER BY/)
+      expect(sql).not_to match(/FETCH FIRST/)
+    end
+
     it "defaults to FOR UPDATE when locking" do
       node = Arel::Nodes::Lock.new(Arel.sql("FOR UPDATE"))
       expect(compile(node)).to be_like "FOR UPDATE"

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle12_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle12_spec.rb
@@ -54,6 +54,16 @@ describe "Arel::Visitors::Oracle12" do
       expect(sql).not_to match(/FETCH FIRST/)
     end
 
+    it "preserves the source SelectStatement on repeated compilation" do
+      stmt = Arel::Nodes::SelectStatement.new
+      stmt.limit = Arel::Nodes::Limit.new(10)
+      stmt.lock = Arel::Nodes::Lock.new(Arel.sql("FOR UPDATE"))
+      first = compile(stmt)
+      second = compile(stmt)
+      expect(first).to eq(second)
+      expect(second.scan(/ROWNUM/).size).to eq(1)
+    end
+
     it "defaults to FOR UPDATE when locking" do
       node = Arel::Nodes::Lock.new(Arel.sql("FOR UPDATE"))
       expect(compile(node)).to be_like "FOR UPDATE"

--- a/spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb
@@ -93,4 +93,36 @@ describe "OracleEnhancedAdapter#columns_for_distinct" do
       expect(sql).not_to match(/alias_0__ DESC/)
     end
   end
+
+  # Regression coverage for Oracle12-as-default: the order_hacks rewrite is
+  # only defined on Arel::Visitors::Oracle, so when `@conn.visitor` resolves
+  # to Arel::Visitors::Oracle12 the alias_N__ rewrite drops out of the outer
+  # ORDER BY for FIRST_VALUE-style DISTINCT queries.
+  describe "integration with default `@conn.visitor` (Oracle12)" do
+    def compile_distinct_order(distinct_columns, order)
+      projection = "DISTINCT #{distinct_columns.join(', ')}, " \
+                   "#{@conn.columns_for_distinct(distinct_columns, [order])}"
+      stmt = Arel::Nodes::SelectStatement.new
+      stmt.cores.first.projections << Arel::Nodes::SqlLiteral.new(projection)
+      stmt.orders << (order.is_a?(String) ? Arel::Nodes::SqlLiteral.new(order) : order)
+      @conn.visitor.accept(stmt, Arel::Collectors::SQLString.new).value
+    end
+
+    it "preserves DESC NULLS LAST in the outer ORDER BY for a raw SQL order" do
+      sql = compile_distinct_order(["posts.id"], "posts.created_at DESC NULLS LAST")
+      expect(sql).to include("ORDER BY alias_0__ DESC NULLS LAST")
+    end
+
+    it "preserves DESC NULLS LAST in the outer ORDER BY for an Arel ordering node" do
+      order_node = Arel::Table.new(:posts)[:created_at].desc.nulls_last
+      sql = compile_distinct_order(["posts.id"], order_node)
+      expect(sql).to include("ORDER BY alias_0__ DESC NULLS LAST")
+    end
+
+    it "preserves NULLS FIRST without emitting DESC for an ASC-with-nulls order" do
+      sql = compile_distinct_order(["posts.id"], "posts.created_at ASC NULLS FIRST")
+      expect(sql).to match(/ORDER BY alias_0__ NULLS FIRST\b/)
+      expect(sql).not_to match(/alias_0__ DESC/)
+    end
+  end
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb
@@ -65,13 +65,15 @@ describe "OracleEnhancedAdapter#columns_for_distinct" do
   end
 
   describe "integration with Arel::Visitors::Oracle#order_hacks" do
+    let(:oracle_visitor) { Arel::Visitors::Oracle.new(@conn) }
+
     def compile_distinct_order(distinct_columns, order)
       projection = "DISTINCT #{distinct_columns.join(', ')}, " \
                    "#{@conn.columns_for_distinct(distinct_columns, [order])}"
       stmt = Arel::Nodes::SelectStatement.new
       stmt.cores.first.projections << Arel::Nodes::SqlLiteral.new(projection)
       stmt.orders << (order.is_a?(String) ? Arel::Nodes::SqlLiteral.new(order) : order)
-      @conn.visitor.accept(stmt, Arel::Collectors::SQLString.new).value
+      oracle_visitor.accept(stmt, Arel::Collectors::SQLString.new).value
     end
 
     it "preserves DESC NULLS LAST in the outer ORDER BY for a raw SQL order" do

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -856,6 +856,11 @@ describe "OracleEnhancedConnection" do
     end
 
     it "should not reconnect and execute query if connection is lost and auto retry is disabled" do
+      # On Oracle 23ai, `SELECT ... FETCH FIRST n ROWS ONLY` (emitted by
+      # Arel::Visitors::Oracle12) is transparently recovered by the server
+      # after `ALTER SYSTEM KILL SESSION`, so the adapter never sees an
+      # OCIError and the expected StatementInvalid is never raised.
+      skip "Oracle 23ai transparently recovers FETCH FIRST queries after session kill" if ActiveRecord::Base.connection.database_version.first >= 23
       Post.create!
       ActiveRecord::Base.lease_connection.auto_retry = false
       kill_current_session

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -694,6 +694,14 @@ describe "OracleEnhancedAdapter" do
       Thread.report_on_exception, @original_report_on_exception = false, Thread.report_on_exception
     end
 
+    it "supports with_lock without raising ArgumentError (#2237)" do
+      post = TestPost.create!(title: "lock me")
+      expect {
+        post.with_lock { post.update(title: "locked and updated") }
+      }.not_to raise_error
+      expect(post.reload.title).to eq("locked and updated")
+    end
+
     it "Raises Deadlocked when a deadlock is encountered" do
       expect {
         barrier = Concurrent::CyclicBarrier.new(2)

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -695,7 +695,6 @@ describe "OracleEnhancedAdapter" do
     end
 
     it "Raises Deadlocked when a deadlock is encountered" do
-      skip "Skip temporary due to #1599" if ActiveRecord::Base.lease_connection.supports_fetch_first_n_rows_and_offset?
       expect {
         barrier = Concurrent::CyclicBarrier.new(2)
 


### PR DESCRIPTION
## Status

Draft. **Red** stage of a TDD-style red/green pair:

- This PR (red): adds a failing-by-design unit test that documents the regression exposed by #2573.
- Follow-up PR (green): fixes the regression so the test passes.

## Why

#2573 makes `Arel::Visitors::Oracle12` the default visitor for every connection (previously the default was effectively `Arel::Visitors::Oracle` because `supports_fetch_first_n_rows_and_offset?` was hardcoded to `false`).

`Arel::Visitors::Oracle#order_hacks` rewrites the outer `ORDER BY` of a DISTINCT query whose projection list contains `FIRST_VALUE(...) AS alias_0__` so the ORDER BY references the `alias_0__` column instead of the inner expression. `Arel::Visitors::Oracle12` does **not** define `order_hacks`, so once it becomes the default visitor the rewrite drops out and Oracle raises **ORA-01791 ("not a SELECTed expression")** at execute time.

`columns_for_distinct` is what produces the `FIRST_VALUE(...) AS alias_0__` projection, so any AR query that goes through that helper (e.g. `Model.distinct.order(:created_at)` in shapes that AR materialises with a window function) is potentially affected.

## What this PR adds

A new describe block in `spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb`:

```
describe "integration with default `@conn.visitor` (Oracle12)" do
```

— mirrors the three assertions in the existing `"integration with Arel::Visitors::Oracle#order_hacks"` block but routes through `@conn.visitor` (= the default visitor on master after #2573) instead of a manually-constructed `Arel::Visitors::Oracle`. All three currently fail:

```
1) ... preserves DESC NULLS LAST in the outer ORDER BY for a raw SQL order
   expected "... ORDER BY posts.created_at DESC NULLS LAST"
   to include "ORDER BY alias_0__ DESC NULLS LAST"

2) ... preserves DESC NULLS LAST in the outer ORDER BY for an Arel ordering node
   expected "... ORDER BY posts.created_at DESC NULLS LAST"
   to include "ORDER BY alias_0__ DESC NULLS LAST"

3) ... preserves NULLS FIRST without emitting DESC for an ASC-with-nulls order
   expected "... ORDER BY posts.created_at ASC NULLS FIRST"
   to match /ORDER BY alias_0__ NULLS FIRST\b/
```

The existing `"integration with Arel::Visitors::Oracle#order_hacks"` block stays as it was — pinned to a manually-constructed Oracle visitor — so the file is intentionally a mix of green and red.

## What this PR does NOT do

It does not fix the regression. The likely fix is to hoist `order_hacks` and `split_order_string` from `Arel::Visitors::Oracle` into `Arel::Visitors::OracleCommon` (the module both visitors include) and call `o = order_hacks(o)` from `Arel::Visitors::Oracle12#visit_Arel_Nodes_SelectStatement` before delegating to `super`. That fix lives in a follow-up PR; this one is just the failing test that locks the contract.

## Why a separate PR

- Keeps #2573's scope tight on the `limit + lock` `ArgumentError` removal.
- Makes the regression visible to CI and reviewers without entangling it with a fix that may need its own discussion (e.g. how generic `order_hacks` should be in `OracleCommon`, whether the rewrite should be opt-in, what to do if the user is on `use_old_oracle_visitor = true`).
- Lets us measure how often the Oracle12-without-order_hacks path is actually hit in real applications before deciding the urgency of the green PR — the red examples here are visitor-compile assertions (no live DB). If the wider integration suite turns this into ORA-01791 in many places, the green PR is urgent; if not, this stays open as a known-issue marker for a while.

## Refs

- #2573 — the PR that exposes the regression (this branch is forked off `fix-2395-fetch-first-n-rows`)
- The regression was flagged by Copilot CLI during review of #2573.
