### PR TITLE
Drop redundant @conn reassignments in schema_statements_spec.rb inner before blocks

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -11,7 +11,6 @@ describe "OracleEnhancedAdapter schema definition" do
 
   describe "option to create sequence when adding a column" do
     before do
-      @conn = ActiveRecord::Base.lease_connection
       schema_define do
         create_table :keyboards, force: true, id: false do |t|
           t.string      :name
@@ -30,7 +29,6 @@ describe "OracleEnhancedAdapter schema definition" do
 
   describe "table and sequence creation with non-default primary key" do
     before(:all) do
-      @conn = ActiveRecord::Base.lease_connection
       schema_define do
         create_table :keyboards, force: true, id: false do |t|
           t.primary_key :key_number
@@ -67,10 +65,6 @@ describe "OracleEnhancedAdapter schema definition" do
   end
 
   describe "primary_key inside create_table block with type and keyword options" do
-    before(:all) do
-      @conn = ActiveRecord::Base.lease_connection
-    end
-
     after(:each) do
       schema_define do
         drop_table :test_lookups, if_exists: true
@@ -202,7 +196,6 @@ describe "OracleEnhancedAdapter schema definition" do
     # `super` call and silently letting the invalid combination
     # through.
     before(:all) do
-      @conn = ActiveRecord::Base.lease_connection
       schema_define do
         create_table :test_pk_null_check, force: true do |t|
           t.string :name
@@ -288,10 +281,6 @@ describe "OracleEnhancedAdapter schema definition" do
       ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.default_sequence_start_value = @saved_sequence_start_value
     end
 
-    before(:all) do
-      @conn = ActiveRecord::Base.lease_connection
-    end
-
     before(:each) do
       save_default_sequence_start_value
     end
@@ -352,10 +341,6 @@ describe "OracleEnhancedAdapter schema definition" do
           t.string      :last_name, comment: column_comments[:last_name]
         end
       end
-    end
-
-    before(:all) do
-      @conn = ActiveRecord::Base.lease_connection
     end
 
     before(:each) do
@@ -431,10 +416,6 @@ describe "OracleEnhancedAdapter schema definition" do
   end
 
   describe "drop tables" do
-    before(:each) do
-      @conn = ActiveRecord::Base.lease_connection
-    end
-
     after(:each) do
       schema_define do
         drop_table :multi_drop_posts, if_exists: true
@@ -465,7 +446,6 @@ describe "OracleEnhancedAdapter schema definition" do
 
   describe "rename tables and sequences" do
     before(:each) do
-      @conn = ActiveRecord::Base.lease_connection
       schema_define do
         create_table  :test_employees, force: true do |t|
           t.string    :first_name
@@ -548,10 +528,6 @@ describe "OracleEnhancedAdapter schema definition" do
   end
 
   describe "add index" do
-    before(:all) do
-      @conn = ActiveRecord::Base.lease_connection
-    end
-
     it "should return default index name if it is not larger than 30 characters" do
       expect(@conn.index_name("employees", column: "first_name")).to eq("index_employees_on_first_name")
     end
@@ -601,7 +577,6 @@ describe "OracleEnhancedAdapter schema definition" do
 
   describe "rename index" do
   before(:each) do
-    @conn = ActiveRecord::Base.lease_connection
     schema_define do
       create_table  :test_employees do |t|
         t.string    :first_name
@@ -652,7 +627,6 @@ end
 
   describe "add_index with if_not_exists" do
     before(:each) do
-      @conn = ActiveRecord::Base.lease_connection
       schema_define do
         create_table :test_posts, force: true do |t|
           t.string :title
@@ -681,10 +655,6 @@ end
   end
 
   describe "create_table with if_not_exists" do
-    before(:each) do
-      @conn = ActiveRecord::Base.lease_connection
-    end
-
     after(:each) do
       schema_define { drop_table :test_posts, if_exists: true }
     end
@@ -727,7 +697,6 @@ end
 
   describe "add timestamps" do
     before(:each) do
-      @conn = ActiveRecord::Base.lease_connection
       schema_define do
         create_table :test_employees, force: true
       end
@@ -1007,8 +976,6 @@ end
 
   describe "primary key in table definition" do
     before do
-      @conn = ActiveRecord::Base.lease_connection
-
       class ::TestPost < ActiveRecord::Base
       end
     end
@@ -1133,10 +1100,6 @@ end
   end
 
   describe "disable referential integrity" do
-    before(:all) do
-      @conn = ActiveRecord::Base.lease_connection
-    end
-
     before(:each) do
       schema_define do
         create_table :test_posts, force: true do |t|
@@ -1180,7 +1143,6 @@ end
 
   describe "synonyms" do
     before(:all) do
-      @conn = ActiveRecord::Base.lease_connection
       @username = CONNECTION_PARAMS[:username]
       schema_define do
         create_table :test_posts, force: true do |t|
@@ -1486,7 +1448,6 @@ end
 
   describe "materialized views" do
     before(:all) do
-      @conn = ActiveRecord::Base.lease_connection
       schema_define do
         create_table  :test_employees, force: true do |t|
           t.string    :first_name
@@ -1516,7 +1477,6 @@ end
 
   describe "miscellaneous options" do
     before(:all) do
-      @conn = ActiveRecord::Base.lease_connection
       # `before(:each)` below stubs `execute` to capture DDL into a string
       # without running it. `Schema.define` (which `schema_define` wraps)
       # writes to `AR_INTERNAL_METADATA`, and the table's CREATE goes through
@@ -1711,7 +1671,6 @@ end
     }
 
     before do
-      @conn = ActiveRecord::Base.lease_connection
       ActiveRecord::Base.connection_pool.schema_migration.create_table
     end
 


### PR DESCRIPTION
#2678 added a top-level `before(:all) do; @conn = ActiveRecord::Base.lease_connection; end` to `schema_statements_spec.rb` so virtual-columns describe blocks could reach `@conn` from their own `before(:each)`. With that one assignment covering the whole file, the 19 inner `@conn = ActiveRecord::Base.lease_connection` reassignments scattered across `describe` blocks are now redundant — each one resets `@conn` to the same value the outer `before(:all)` already set, with no test in the file mutating the connection between examples.

## Changes

- 19 inner `@conn = ActiveRecord::Base.lease_connection` lines removed.
- 7 of those were the only line in their enclosing `before do … end` block, so the entire block is removed; the other 12 sites strip just the line and leave the surrounding setup intact.
- One adjacent `Layout/EmptyLinesAroundBlockBody` rubocop offense (introduced where a block was removed) auto-corrected.

## Maintenance assumption

This change presupposes that **the connection leased in the top-level `before(:all)` stays valid for every example in the file**. That holds today: there is no `ActiveRecord::Base.remove_connection` in `schema_statements_spec.rb`, the only `establish_connection` is the file-top setup itself, and the other `ActiveRecord::Base.*` calls (`clear_cache!`, `table_name_prefix=` / `table_name_suffix=`) don't replace the connection.

If a future test in this file ever needs to call `remove_connection` or re-establish against different `CONNECTION_PARAMS`, the new test (or its enclosing `describe`) must reassign `@conn = ActiveRecord::Base.lease_connection` so subsequent examples don't keep using the stale lease. Reviewers and future contributors should treat the file-level `@conn` as a single shared lease, not as a per-example fresh fetch.

## Test plan

- [x] `bundle exec rspec` on Oracle 23ai — 703 examples, 0 failures, 11 pending (same baseline as #2678).
- [x] `bundle exec rubocop` — clean.
- [ ] CI green on all matrix rows.

Follow-up to #2678; non-functional spec cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

