### PR TITLE
Add regression spec for Rails RestartParentTransaction on Oracle

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -694,6 +694,14 @@ describe "OracleEnhancedAdapter" do
       Thread.report_on_exception, @original_report_on_exception = false, Thread.report_on_exception
     end
 
+    before(:each) do
+      set_logger
+    end
+
+    after(:each) do
+      clear_logger
+    end
+
     it "supports with_lock without raising ArgumentError (#2237)" do
       post = TestPost.create!(title: "lock me")
       expect {
@@ -727,6 +735,21 @@ describe "OracleEnhancedAdapter" do
           thread.join
         end
       }.to raise_error(ActiveRecord::Deadlocked)
+    end
+
+    it "restarts the parent transaction on nested rollback without issuing a SAVEPOINT" do
+      TestPost.transaction do
+        TestPost.transaction(requires_new: true) do
+          TestPost.create!(title: "inner")
+          raise ActiveRecord::Rollback
+        end
+        TestPost.create!(title: "outer")
+      end
+      expect(TestPost.where(title: "inner").count).to eq 0
+      expect(TestPost.where(title: "outer").count).to eq 1
+      sql_log = @logger.logged(:debug)
+      expect(sql_log.grep(/INSERT INTO.*TEST_POSTS/i)).not_to be_empty
+      expect(sql_log.grep(/SAVEPOINT/i)).to be_empty
     end
 
     after(:all) do


### PR DESCRIPTION
## Summary

Add a regression spec confirming that Rails' `RestartParentTransaction` (rails/rails#44526) works correctly on Oracle. **No production code changes.**

The spec asserts:

- An immediately-nested `transaction(requires_new: true)` inside an outer `transaction do ... end`, with `raise ActiveRecord::Rollback` in the inner block and a subsequent DML in the outer block, yields:
  - The inner row did **not** persist (rollback succeeded).
  - The outer row **did** persist after the inner rollback (the parent transaction stayed alive across the restart).
  - **No `SAVEPOINT` SQL** was logged — i.e. Rails selected `RestartParentTransaction` over `SavepointTransaction`.

## Why no production code change (= why not override `supports_restart_db_transaction?`)

Rails picks `RestartParentTransaction` whenever the parent is `restartable?` (joinable && !dirty), **independent of `supports_restart_db_transaction?`**. The capability flag only switches the *implementation* of the restart:

- `true` → `connection.restart_db_transaction` (one optimized call)
- `false` → `connection.rollback_db_transaction` + `parent.materialize!` (the default fallback)

For Oracle, the fallback path already does the right thing:

- It issues a single `ROLLBACK`.
- `materialize!` re-applies the parent's isolation level by calling `begin_isolated_db_transaction(isolation_level)` again, re-issuing `SET TRANSACTION ISOLATION LEVEL ...`.

Overriding `supports_restart_db_transaction?` to `true` was explored in #2525 — that approach saves only two local `setAutoCommit()` calls per restart (no DB round-trip on JDBC or OCI8), but in exchange the adapter must thread an `@transaction_isolation` instance variable through `begin_db_transaction`, `begin_isolated_db_transaction`, `commit_db_transaction`, `exec_rollback_db_transaction`, and `exec_restart_db_transaction` so the restart can re-issue `SET TRANSACTION ISOLATION LEVEL` (Oracle's bare `ROLLBACK` drops it; Postgres uses `ROLLBACK AND CHAIN` to preserve it).

**The added complexity is not justified by the marginal saving.** This PR takes the simpler route: rely on Rails' fallback, which is correct as-is for Oracle, and add a regression spec so the behavior stays guaranteed.

## Test plan

- [x] New spec passes locally against Oracle Database 23ai Free.
- [x] Full rspec suite green locally (no regressions).
- [x] `bundle exec rubocop` clean.
- [ ] CI green.

Closes #2270.

(Supersedes #2525.)
