### PR TITLE
Recreate primary_key_trigger on rename_table to avoid ORA-04098

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -239,6 +239,7 @@ module ActiveRecord
           schema_cache.clear_data_source_cache!(new_name.to_s)
           execute "RENAME #{quote_table_name(table_name)} TO #{quote_table_name(new_name)}"
           execute "RENAME #{default_sequence_name(table_name, nil)} TO #{default_sequence_name(new_name, nil)}" rescue nil
+          rename_pk_trigger(table_name, new_name)
           @prefetch_primary_key_cache.delete(table_name.to_s)
           clear_table_columns_cache(table_name)
           clear_table_columns_cache(new_name)
@@ -892,6 +893,22 @@ module ActiveRecord
                 END IF;
               END;
             SQL
+          end
+
+          def rename_pk_trigger(old_table_name, new_table_name)
+            existing = trigger_backed_table_names[new_table_name.to_s.upcase]
+            return unless existing
+
+            pk_column = primary_keys(new_table_name).first
+            return unless pk_column
+
+            default_old = default_trigger_name(old_table_name).upcase
+            if existing.upcase == default_old
+              create_pk_trigger(new_table_name, pk_column, {})
+              execute "DROP TRIGGER #{quote_table_name(existing)}" rescue nil
+            else
+              create_pk_trigger(new_table_name, pk_column, trigger_name: existing.downcase)
+            end
           end
 
           def rebuild_primary_key_index_to_default_tablespace(table_name, options)

--- a/spec/active_record/connection_adapters/oracle_enhanced/primary_key_trigger_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/primary_key_trigger_spec.rb
@@ -553,4 +553,101 @@ describe "primary_key_trigger" do
       expect(stream.string).not_to include("primary_key_trigger")
     end
   end
+
+  describe "rename_table on a trigger-backed table" do
+    after(:each) do
+      ActiveRecord::Migration.suppress_messages do
+        schema_define do
+          drop_table :test_pk_triggers_renamed, if_exists: true
+        end
+      end
+    end
+
+    it "lets INSERT continue to work after rename" do
+      schema_define do
+        create_table :test_pk_triggers, primary_key_trigger: true do |t|
+          t.string :name
+        end
+      end
+      schema_define do
+        rename_table :test_pk_triggers, :test_pk_triggers_renamed
+      end
+
+      expect {
+        @conn.execute("INSERT INTO test_pk_triggers_renamed (name) VALUES ('after-rename')")
+      }.not_to raise_error
+      expect(@conn.select_value("SELECT id FROM test_pk_triggers_renamed WHERE name = 'after-rename'")).to be > 0
+    end
+
+    it "renames the trigger to follow the new table when the trigger uses the default name" do
+      schema_define do
+        create_table :test_pk_triggers, primary_key_trigger: true do |t|
+          t.string :name
+        end
+      end
+      expect(trigger_exists?(:test_pk_triggers_pkt)).to be true
+
+      schema_define do
+        rename_table :test_pk_triggers, :test_pk_triggers_renamed
+      end
+
+      expect(trigger_exists?(:test_pk_triggers_pkt)).to be false
+      expect(trigger_exists?(:test_pk_triggers_renamed_pkt)).to be true
+    end
+
+    it "preserves a custom trigger_name and refreshes only its body" do
+      schema_define do
+        create_table :test_pk_triggers, primary_key_trigger: true, trigger_name: "custom_pkt" do |t|
+          t.string :name
+        end
+      end
+      expect(trigger_exists?(:custom_pkt)).to be true
+
+      schema_define do
+        rename_table :test_pk_triggers, :test_pk_triggers_renamed
+      end
+
+      expect(trigger_exists?(:custom_pkt)).to be true
+      expect(trigger_exists?(:test_pk_triggers_renamed_pkt)).to be false
+      # The custom-named trigger should still fire and pull from the renamed sequence.
+      expect {
+        @conn.execute("INSERT INTO test_pk_triggers_renamed (name) VALUES ('with-custom-trigger')")
+      }.not_to raise_error
+    end
+
+    it "does not touch any trigger when the table has no primary_key_trigger" do
+      schema_define do
+        create_table :test_pk_triggers do |t|
+          t.string :name
+        end
+      end
+
+      schema_define do
+        rename_table :test_pk_triggers, :test_pk_triggers_renamed
+      end
+
+      expect(trigger_exists?(:test_pk_triggers_pkt)).to be false
+      expect(trigger_exists?(:test_pk_triggers_renamed_pkt)).to be false
+    end
+
+    it "is round-tripped by SchemaDumper after rename" do
+      schema_define do
+        create_table :test_pk_triggers, primary_key_trigger: true do |t|
+          t.string :name
+        end
+      end
+      schema_define do
+        rename_table :test_pk_triggers, :test_pk_triggers_renamed
+      end
+
+      stream = StringIO.new
+      ActiveRecord::SchemaDumper.ignore_tables = @conn.data_sources - ["test_pk_triggers_renamed"]
+      ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection_pool, stream)
+      ActiveRecord::SchemaDumper.ignore_tables = []
+
+      expect(stream.string).to include("primary_key_trigger: true")
+      # The default trigger name was renamed; no explicit :trigger_name should be needed.
+      expect(stream.string).not_to include("trigger_name:")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`rename_table` renames the table and the table's sequence, but never touched the `BEFORE INSERT` trigger that `primary_key_trigger: true` emits. Because the trigger body references the sequence by name (`<old>_seq.NEXTVAL`) and the sequence has just been renamed, the trigger compiles invalid (`ORA-04098`) and the next `INSERT` against the renamed table fails.

This PR re-emits the trigger body after the sequence rename so it points at the renamed sequence, and renames default-named triggers to follow the new table.

## Reproduction (before this PR)

```ruby
create_table :foo, primary_key_trigger: true do |t|
  t.string :name
end
rename_table :foo, :bar

# Next insert fails with ORA-04098 (trigger body references foo_seq, which no
# longer exists after rename_table renamed it to bar_seq):
Bar.create!(name: "x")  # => ActiveRecord::StatementInvalid: ORA-04098
```

## Background — long-standing latent bug

The first version of `rename_table` in this repository ([commit 1b8281d1](https://github.com/rsim/oracle-enhanced/commit/1b8281d1) — "Modify directory structure", predating the 2018 trigger-removal in [61f8a305](https://github.com/rsim/oracle-enhanced/commit/61f8a305)) already renamed the sequence. Pre-2018 — when sequence + trigger PKs were the default — the trigger-rename gap would have hit the same `ORA-04098` had anyone exercised the `rename_table` + default-PK path. The 2018 deletion hid the issue; #2615 restored opt-in trigger-based PKs and called out the `rename_table` gap as out of scope:

> `rename_table` does not rename or recreate the trigger — same as pre-2018. Users renaming a table whose primary key is trigger-backed need to drop and recreate the trigger explicitly (the sequence rename that `rename_table` still performs leaves the trigger body referencing the old sequence name and turns it ORA-04098 invalid on the next insert). Out of scope for this PR.

This PR closes that gap.

## Detail

A new private helper `rename_pk_trigger(old, new)` is called from `rename_table` after the sequence rename:

1. Looks up the existing trigger via `trigger_backed_table_names[NEW.upcase]`. Oracle auto-updates `all_triggers.table_name` when the table is renamed, so the lookup uses the new name. Returns early if the table has no trigger-backed PK.
2. When the trigger uses the default `<old>_pkt` name → recreate it as `<new>_pkt` (via `create_pk_trigger` with no explicit `:trigger_name`) and drop the old trigger. After this, the schema dumper emits the renamed table with `primary_key_trigger: true` alone — no `:trigger_name` override needed.
3. When the trigger has a user-customized name → keep the name and just refresh the body in place via `CREATE OR REPLACE TRIGGER`. Renaming a user-chosen identifier behind their back would be surprising.

`trigger_backed_table_names` only matches triggers whose body contains `NEXTVAL INTO :NEW` (added in #2615), so unrelated `BEFORE INSERT` row triggers (audit, `last_modified`, ...) are **not** touched — same false-positive guard as the rest of the trigger-backed-PK detection.

## Spec coverage

Five new cases under `describe "rename_table on a trigger-backed table"` in `primary_key_trigger_spec.rb`:

1. **`INSERT` after rename succeeds** — the regression test for `ORA-04098`.
2. **Default-named trigger is renamed** — `<old>_pkt` becomes `<new>_pkt`, old trigger is dropped.
3. **Custom-named trigger is preserved** — `trigger_name: "custom_pkt"` survives the rename; body is refreshed in place.
4. **Plain sequence-backed tables are untouched** — no trigger created/dropped when there's no `primary_key_trigger`.
5. **Schema dump round-trips** — the renamed table dumps as `primary_key_trigger: true` (no `trigger_name:` override needed).

## Test plan

- [x] All 41 specs in `primary_key_trigger_spec.rb` pass locally against Oracle Database 23ai Free.
- [x] `bundle exec rubocop` clean.
- [ ] CI green.
