### PR TITLE
Skip dictionary lookup in data_source_exists? when schema cache has the table

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -53,6 +53,8 @@ module ActiveRecord
         end
 
         def data_source_exists?(table_name)
+          return true if schema_cache.cached?(table_name.to_s)
+
           (_owner, _table_name) = resolve_data_source_name(table_name)
           true
         rescue

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -862,4 +862,55 @@ describe "OracleEnhancedAdapter" do
       expect(TestComment.where(test_post_id: TestPost.select(:id)).size).to eq(1)
     end
   end
+
+  describe "data_source_exists? schema cache shortcut" do
+    before(:all) do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+      schema_define do
+        create_table :test_data_source_exists, force: true do |t|
+          t.string :title
+        end
+      end
+    end
+
+    after(:all) do
+      schema_define do
+        drop_table :test_data_source_exists, if_exists: true
+      end
+    end
+
+    let(:conn) { ActiveRecord::Base.connection }
+    let(:cache) { ActiveRecord::Base.connection_pool.schema_cache }
+
+    def capture_dictionary_lookup
+      events = []
+      sub = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        events << payload
+      end
+      result = yield
+      [result, events.select { |p| p[:name] == "SCHEMA" }]
+    ensure
+      ActiveSupport::Notifications.unsubscribe(sub) if sub
+    end
+
+    it "fires no SCHEMA query when the table's columns are already in the schema cache" do
+      cache.columns("test_data_source_exists")
+
+      result, schema_queries = capture_dictionary_lookup { conn.data_source_exists?("test_data_source_exists") }
+      expect(result).to be true
+      expect(schema_queries).to be_empty
+    end
+
+    it "falls back to the live lookup for tables not in the schema cache" do
+      cache.clear_data_source_cache!("test_data_source_exists")
+
+      result, schema_queries = capture_dictionary_lookup { conn.data_source_exists?("test_data_source_exists") }
+      expect(result).to be true
+      expect(schema_queries).not_to be_empty
+    end
+
+    it "returns false for non-existing tables not in the cache" do
+      expect(conn.data_source_exists?("test_nonexistent_xyz_table")).to be false
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`connection.data_source_exists?(table_name)` used to always run a data-dictionary lookup via `resolve_data_source_name` (currently a single `all_objects` query, but the implementation has changed before and may change again — see #2566). With a populated schema cache (`db:schema:cache:dump`), Rails has already proven the table exists by loading its columns, so a separate dictionary query is redundant.

This PR short-circuits on `schema_cache.cached?(name)`: if the table's columns are in the cache, the table exists — return `true` without touching the dictionary at all. Tables not in the cache (or after `clear_data_source_cache!`) fall through to the existing live lookup, preserving the original semantics for fresh / invalidated entries.

## What this fixes

The remaining dictionary round trip we saw at Rails boot — Rails' `SchemaMigration#table_exists?` calls `connection.data_source_exists?` directly (bypassing the `SchemaCache` wrapper). With this PR, that one query disappears once the cache is preloaded.

This was identified as out-of-scope follow-up in #2520; this is that follow-up.

## Diff

```diff
 def data_source_exists?(table_name)
+  return true if schema_cache.cached?(table_name.to_s)
+
   (_owner, _table_name) = resolve_data_source_name(table_name)
   true
 rescue
   false
 end
```

## Spec coverage

New `data_source_exists? schema cache shortcut` describe block in `oracle_enhanced_adapter_spec.rb`:

1. **Cache hit** — after `cache.columns(name)` populates the cache, `data_source_exists?` returns `true` and emits **no** SCHEMA-tagged SQL event.
2. **Cache miss** — after `cache.clear_data_source_cache!(name)`, `data_source_exists?` falls back to the live lookup and **does** emit a SCHEMA-tagged SQL event.
3. **Non-existing table** — returns `false` via the rescue path.

The assertion checks `payload[:name] == "SCHEMA"` rather than matching the SQL text against a specific dictionary view (`all_objects`, etc.). This keeps the spec robust against future changes to `resolve_data_source_name` — e.g. if #2566 (or a similar PR) ever lands and switches to `DBMS_UTILITY.NAME_RESOLVE` or another mechanism, the shortcut behavior is still verified mechanism-agnostically.

## Trade-off

`schema_cache.cached?(name)` checks `@columns.key?(name)`, which is the standard "is this table tracked in the schema cache?" signal. If a developer drops a table after `db:schema:cache:dump` and before the app boots, the cache becomes stale and `data_source_exists?` would return `true` for a table that no longer exists. This is the same staleness contract that already applies to every other `SchemaCache`-backed lookup; nothing new about this commit changes that posture.

## Test plan

- [x] New 3 specs pass locally against Oracle Database 23ai Free.
- [x] Full `oracle_enhanced_adapter_spec.rb` suite green (49 examples, 0 failures, 1 pending).
- [x] `bundle exec rubocop` clean.
- [ ] CI green.

Refs #2520.
