### PR TITLE
Strengthen YAML round trip coverage for OracleEnhanced::Column metadata

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_cache_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_cache_spec.rb
@@ -5,6 +5,24 @@ require "tempfile"
 describe "OracleEnhancedAdapter schema cache" do
   include SchemaSpecHelper
 
+  PERMITTED_YAML_CLASSES = [
+    ActiveRecord::ConnectionAdapters::OracleEnhanced::Column,
+    ActiveRecord::ConnectionAdapters::OracleEnhanced::IndexDefinition,
+    ActiveRecord::ConnectionAdapters::OracleEnhanced::TypeMetadata,
+    ActiveRecord::ConnectionAdapters::SqlTypeMetadata,
+    ActiveRecord::ConnectionAdapters::SchemaCache,
+    ActiveRecord::Type::Integer,
+    ActiveRecord::Type::String,
+    ActiveRecord::Type::DateTime,
+    ActiveRecord::Type::Boolean,
+    ActiveRecord::Type::Decimal,
+    ActiveRecord::Type::Text,
+    ActiveRecord::Type::OracleEnhanced::Integer,
+    ActiveRecord::Type::OracleEnhanced::String,
+    ActiveRecord::Type::OracleEnhanced::Text,
+    Symbol,
+  ].freeze
+
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
     schema_define do
@@ -139,13 +157,25 @@ describe "OracleEnhancedAdapter schema cache" do
       expect(original).not_to be_nil
 
       yaml = YAML.dump(original)
-      restored = YAML.unsafe_load(yaml)
+      restored = YAML.safe_load(yaml, permitted_classes: PERMITTED_YAML_CLASSES, aliases: true)
 
       expect(restored).to be_a(ActiveRecord::ConnectionAdapters::OracleEnhanced::Column)
       expect(restored.instance_variable_get(:@identity)).to eq(original.instance_variable_get(:@identity))
       expect(restored.instance_variable_get(:@trigger_assigned)).to eq(original.instance_variable_get(:@trigger_assigned))
       expect(restored.auto_incremented_by_db?).to eq(original.auto_incremented_by_db?)
       expect(restored.auto_populated?).to eq(original.auto_populated?)
+    end
+
+    it "leaves @identity and @trigger_assigned undefined when YAML predates these keys" do
+      original = schema_cache.columns("test_schema_cache_posts").find { |c| c.name == "id" }
+      yaml = YAML.dump(original)
+
+      old_yaml = yaml.lines.reject { |l| l.start_with?("identity:", "trigger_assigned:") }.join
+      restored = YAML.safe_load(old_yaml, permitted_classes: PERMITTED_YAML_CLASSES, aliases: true)
+
+      expect(restored).to be_a(ActiveRecord::ConnectionAdapters::OracleEnhanced::Column)
+      expect(restored.instance_variable_defined?(:@identity)).to be false
+      expect(restored.instance_variable_defined?(:@trigger_assigned)).to be false
     end
 
     it "returns true for a sequence-backed primary key without firing catalog SQL" do
@@ -180,6 +210,15 @@ describe "OracleEnhancedAdapter schema cache" do
         expect(result).to be false
         expect(catalog).to be_empty
       end
+
+      it "carries trigger_assigned = true through the YAML round trip" do
+        original = schema_cache.columns("test_schema_cache_legacy_posts").find { |c| c.name == "id" }
+        expect(original.auto_populated?).to be true
+
+        restored = YAML.safe_load(YAML.dump(original), permitted_classes: PERMITTED_YAML_CLASSES, aliases: true)
+        expect(restored.auto_populated?).to be true
+        expect(restored.instance_variable_get(:@trigger_assigned)).to be true
+      end
     end
 
     context "with an identity primary key" do
@@ -206,6 +245,15 @@ describe "OracleEnhancedAdapter schema cache" do
         result, catalog = capture_pk_lookup { conn.prefetch_primary_key?("test_schema_cache_identity_posts") }
         expect(result).to be false
         expect(catalog).to be_empty
+      end
+
+      it "carries identity = true through the YAML round trip" do
+        original = schema_cache.columns("test_schema_cache_identity_posts").find { |c| c.name == "id" }
+        expect(original.auto_incremented_by_db?).to be true
+
+        restored = YAML.safe_load(YAML.dump(original), permitted_classes: PERMITTED_YAML_CLASSES, aliases: true)
+        expect(restored.auto_incremented_by_db?).to be true
+        expect(restored.instance_variable_get(:@identity)).to be true
       end
     end
 
@@ -267,7 +315,7 @@ describe "OracleEnhancedAdapter schema cache" do
       tmpfile = Tempfile.new(["schema_cache", ".yml"])
       begin
         schema_cache.dump_to(tmpfile.path)
-        reloaded = YAML.unsafe_load_file(tmpfile.path)
+        reloaded = YAML.safe_load_file(tmpfile.path, permitted_classes: PERMITTED_YAML_CLASSES, aliases: true)
 
         cols = reloaded.instance_variable_get(:@columns)["test_schema_cache_posts"]
         expect(cols).not_to be_nil


### PR DESCRIPTION
## Summary

The existing YAML round trip spec for `OracleEnhanced::Column` (added in #2520) only exercises the `false / false` path on a sequence-backed PK. So a regression that:

- turned `@identity` or `@trigger_assigned` from `true` to `false` during round trip, **or**
- started defaulting those ivars to `false` (instead of leaving them undefined) when the YAML payload predates the keys

…would silently pass review and land in production, where it would mis-classify identity / trigger PKs as sequence-backed and let ActiveRecord prefetch a sequence value into a column that the database is going to fill itself — yielding `INSERT` errors.

This PR adds three regression specs that close those gaps.

## What's added

Three new specs in `spec/active_record/connection_adapters/oracle_enhanced/schema_cache_spec.rb`:

1. **`carries trigger_assigned = true through the YAML round trip`** — inside the `with a trigger-backed primary key` context, asserts the column's `auto_populated?` and `@trigger_assigned` both survive `YAML.dump` / `YAML.unsafe_load` as `true`.
2. **`carries identity = true through the YAML round trip`** — inside the `with an identity primary key` context, asserts `auto_incremented_by_db?` and `@identity` both survive YAML round trip as `true`.
3. **`leaves @identity and @trigger_assigned undefined when YAML predates these keys`** — strips the `identity:` / `trigger_assigned:` lines from a freshly dumped YAML to simulate a dump produced before these keys were serialized, then asserts neither ivar is defined on the loaded column. This exercises the `unless coder["identity"].nil?` guard in `OracleEnhanced::Column#init_with` that lets the schema-cache shortcut fall through to the live dictionary lookup for old dumps.

## Why each test matters

| Regression | Without this PR | With this PR |
|---|---|---|
| `@identity = true` flips to `false` on YAML round trip | passes silently → identity table gets sequence prefetch → `INSERT` conflict | spec fails |
| `@trigger_assigned = true` flips to `false` on YAML round trip | passes silently → trigger table gets sequence prefetch → trigger fires anyway, but Rails passes a redundant id which the trigger's `IS NULL` guard skips — masks the bug, still hides the regression | spec fails |
| `init_with` starts defaulting missing keys to `false` (regression of `unless coder[...].nil?`) | old dumps would be mis-classified as `@identity = false`, schema-cache shortcut would silently return wrong answers | spec fails |

## Test plan

- [x] All 22 specs in `schema_cache_spec.rb` pass locally against Oracle Database 23ai Free (was 19 before this PR).
- [x] `bundle exec rubocop` clean.
- [ ] CI green.

Refs #2520.
