### PR TITLE
Always quote identifiers in data_dictionary structure_dump

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -116,7 +116,15 @@ module ActiveRecord # :nodoc:
             opts[:name] = row["constraint_name"]
             opts[:cols][row["position"] - 1] = row["column_name"]
           end
-          opts[:cols].length > 0 ? ",\n CONSTRAINT #{opts[:name]} PRIMARY KEY (#{opts[:cols].join(',')})" : ""
+          # `position` from ALL_CONS_COLUMNS is 1..N and contiguous in
+          # practice, but `compact` is cheap insurance against a sparse
+          # array reaching `quote_column_name(nil)`.
+          quoted_cols = opts[:cols].compact.map { |c| quote_column_name(c) }.join(",")
+          if quoted_cols.empty?
+            ""
+          else
+            ",\n CONSTRAINT #{quote_column_name(opts[:name])} PRIMARY KEY (#{quoted_cols})"
+          end
         end
 
         def structure_dump_unique_keys(table) # :nodoc:
@@ -136,7 +144,8 @@ module ActiveRecord # :nodoc:
             keys[uk["constraint_name"]][uk["position"] - 1] = uk["column_name"]
           end
           keys.map do |k, v|
-            "ALTER TABLE #{table.upcase} ADD CONSTRAINT #{k} UNIQUE (#{v.join(',')})"
+            quoted_cols = v.compact.map { |c| quote_column_name(c) }.join(",")
+            "ALTER TABLE #{quote_table_name(table)} ADD CONSTRAINT #{quote_column_name(k)} UNIQUE (#{quoted_cols})"
           end
         end
 
@@ -146,13 +155,15 @@ module ActiveRecord # :nodoc:
             options = { name: options.name, unique: options.unique }
             index_name = index_name(table_name, column: column_names)
             if Hash === options # legacy support, since this param was a string
-              index_type = options[:unique] ? "UNIQUE" : ""
+              unique = options[:unique]
               index_name = options[:name] || index_name
             else
-              index_type = options
+              # Legacy String form only ever carried "UNIQUE" / ""; BITMAP and
+              # other index_types were never supported via this helper.
+              unique = (options == "UNIQUE")
             end
             quoted_column_names = column_names.map { |e| quote_column_name_or_expression(e) }.join(", ")
-            "CREATE #{index_type} INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} (#{quoted_column_names})"
+            "CREATE#{' UNIQUE' if unique} INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} (#{quoted_column_names})"
           end
         end
 
@@ -285,7 +296,7 @@ module ActiveRecord # :nodoc:
             WHERE owner = SYS_CONTEXT('userenv', 'current_schema') ORDER BY view_name ASC
           SQL
           views.each do |view|
-            structure << "CREATE OR REPLACE FORCE VIEW #{view['view_name']} AS\n #{view['text']}"
+            structure << "CREATE OR REPLACE FORCE VIEW #{quote_table_name(view['view_name'])} AS\n #{view['text']}"
           end
           join_with_statement_token(structure)
         end
@@ -298,7 +309,7 @@ module ActiveRecord # :nodoc:
             WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
           SQL
           synonyms.each do |synonym|
-            structure << "CREATE OR REPLACE SYNONYM #{synonym['synonym_name']} FOR #{synonym['table_owner']}.#{synonym['table_name']}"
+            structure << "CREATE OR REPLACE SYNONYM #{quote_table_name(synonym['synonym_name'])} FOR #{quote_table_name(synonym['table_owner'])}.#{quote_table_name(synonym['table_name'])}"
           end
           join_with_statement_token(structure)
         end

--- a/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
@@ -44,7 +44,7 @@ describe "OracleEnhancedAdapter structure dump" do
 
     it "should dump single primary key" do
       dump = ActiveRecord::Base.lease_connection.structure_dump
-      expect(dump).to match(/CONSTRAINT (.+) PRIMARY KEY \(ID\)\n/)
+      expect(dump).to match(/CONSTRAINT (.+) PRIMARY KEY \("ID"\)\n/)
     end
 
     it "should dump composite primary keys" do
@@ -59,7 +59,7 @@ describe "OracleEnhancedAdapter structure dump" do
         add CONSTRAINT pk_id_title PRIMARY KEY (id, title)
       SQL
       dump = ActiveRecord::Base.lease_connection.structure_dump
-      expect(dump).to match(/CONSTRAINT (.+) PRIMARY KEY \(ID,TITLE\)\n/)
+      expect(dump).to match(/CONSTRAINT (.+) PRIMARY KEY \("ID","TITLE"\)\n/)
     end
 
     it "should dump foreign keys" do
@@ -124,7 +124,7 @@ describe "OracleEnhancedAdapter structure dump" do
       @conn.execute "create or replace VIEW test_posts_view_z as select * from test_posts"
       @conn.execute "create or replace VIEW test_posts_view_a as select * from test_posts_view_z"
       dump = ActiveRecord::Base.lease_connection.structure_dump.gsub(/\n|\s+/, " ")
-      expect(dump).to match(/CREATE OR REPLACE FORCE VIEW TEST_POSTS_VIEW_A.*CREATE OR REPLACE FORCE VIEW TEST_POSTS_VIEW_Z/)
+      expect(dump).to match(/CREATE OR REPLACE FORCE VIEW "TEST_POSTS_VIEW_A".*CREATE OR REPLACE FORCE VIEW "TEST_POSTS_VIEW_Z"/)
     end
 
     it "should dump virtual columns" do
@@ -171,10 +171,10 @@ describe "OracleEnhancedAdapter structure dump" do
           add CONSTRAINT uk_foo_foo_id UNIQUE (foo, foo_id)
       SQL
       dump = ActiveRecord::Base.lease_connection.structure_dump_unique_keys("test_posts")
-      expect(dump).to eq(["ALTER TABLE TEST_POSTS ADD CONSTRAINT UK_FOO_FOO_ID UNIQUE (FOO,FOO_ID)"])
+      expect(dump).to eq([%(ALTER TABLE "TEST_POSTS" ADD CONSTRAINT "UK_FOO_FOO_ID" UNIQUE ("FOO","FOO_ID"))])
 
       dump = ActiveRecord::Base.lease_connection.structure_dump
-      expect(dump).to match(/CONSTRAINT UK_FOO_FOO_ID UNIQUE \(FOO,FOO_ID\)/)
+      expect(dump).to match(/CONSTRAINT "UK_FOO_FOO_ID" UNIQUE \("FOO","FOO_ID"\)/)
     end
 
     it "should dump indexes" do
@@ -187,8 +187,8 @@ describe "OracleEnhancedAdapter structure dump" do
       SQL
 
       dump = ActiveRecord::Base.lease_connection.structure_dump
-      expect(dump).to match(/CREATE UNIQUE INDEX "?IX_TEST_POSTS_FOO_ID"? ON "?TEST_POSTS"? \("?FOO_ID"?\)/i)
-      expect(dump).to match(/CREATE  INDEX "?IX_TEST_POSTS_FOO"? ON "?TEST_POSTS"? \("?FOO"?\)/i)
+      expect(dump).to match(/CREATE UNIQUE INDEX "IX_TEST_POSTS_FOO_ID" ON "TEST_POSTS" \("FOO_ID"\)/)
+      expect(dump).to match(/CREATE INDEX "IX_TEST_POSTS_FOO" ON "TEST_POSTS" \("FOO"\)/)
       expect(dump).not_to match(/CREATE UNIQUE INDEX "?UK_TEST_POSTS_/i)
     end
 
@@ -200,8 +200,8 @@ describe "OracleEnhancedAdapter structure dump" do
       SQL
 
       dump = ActiveRecord::Base.lease_connection.structure_dump
-      expect(dump).to match(/CREATE  INDEX "?IX_TEST_POSTS_FOO_FOO_ID"? ON "?TEST_POSTS"? \("?FOO"?, "?FOO_ID"?\)/i)
-      expect(dump).to match(/CREATE  INDEX "?IX_TEST_POSTS_FUNCTION"? ON "?TEST_POSTS"? \(TO_CHAR\(LENGTH\("?FOO"?\)\)\|\|"?FOO"?\)/i)
+      expect(dump).to match(/CREATE INDEX "IX_TEST_POSTS_FOO_FOO_ID" ON "TEST_POSTS" \("FOO", "FOO_ID"\)/)
+      expect(dump).to match(/CREATE INDEX "IX_TEST_POSTS_FUNCTION" ON "TEST_POSTS" \(TO_CHAR\(LENGTH\("FOO"\)\)\|\|"FOO"\)/)
     end
 
     it "should dump RAW columns" do
@@ -533,7 +533,7 @@ describe "OracleEnhancedAdapter structure dump" do
 
     it "emits a non-PUBLIC CREATE OR REPLACE SYNONYM with a single space before SYNONYM" do
       output = @conn.send(:structure_dump_synonyms)
-      expect(output).to include("CREATE OR REPLACE SYNONYM TEST_SYNONYM FOR ")
+      expect(output).to include(%(CREATE OR REPLACE SYNONYM "TEST_SYNONYM" FOR ))
       expect(output).not_to match(/PUBLIC/)
       expect(output).not_to match(/REPLACE\s{2,}SYNONYM/)
     end


### PR DESCRIPTION
## Summary

`structure_dump` (the `:data_dictionary` backend) emits identifiers inconsistently: tables and columns inside `CREATE TABLE` / `CREATE INDEX` are quoted, but PRIMARY KEY column lists, UNIQUE-constraint `ALTER TABLE` statements, view names, and synonym names are not. The result is gratuitous diff noise across runs.

This PR makes the four remaining places consistently quote identifiers:

- `structure_dump_primary_key` — constraint name + PK column list
- `structure_dump_unique_keys` — table name + constraint name + column list
- `structure_dump_views` — view name
- `structure_dump_synonyms` — synonym name + owner-qualified target

It also:

- drops the stray double space in `CREATE  INDEX`. The space is now emitted explicitly by the template (`CREATE#{' UNIQUE' if unique} INDEX ...`) so a future edit cannot silently produce `CREATE UNIQUEINDEX`.
- compacts the PK / unique-key column lists before quoting so a sparse `position` array (defensive only — `ALL_CONS_COLUMNS.position` is contiguous in practice) cannot reach `quote_column_name(nil)`.

### Before

```
ALTER TABLE TEST_POSTS ADD CONSTRAINT UK_FOO_FOO_ID UNIQUE (FOO,FOO_ID)
CREATE  INDEX "IX_TEST_POSTS_FOO" ON "TEST_POSTS" ("FOO")
CREATE OR REPLACE FORCE VIEW TEST_VIEW AS ...
CREATE OR REPLACE SYNONYM TEST_SYNONYM FOR ORACLE_ENHANCED.TEST_TARGET
CONSTRAINT SYS_C0012345 PRIMARY KEY (ID,TITLE)
```

### After

```
ALTER TABLE "TEST_POSTS" ADD CONSTRAINT "UK_FOO_FOO_ID" UNIQUE ("FOO","FOO_ID")
CREATE INDEX "IX_TEST_POSTS_FOO" ON "TEST_POSTS" ("FOO")
CREATE OR REPLACE FORCE VIEW "TEST_VIEW" AS ...
CREATE OR REPLACE SYNONYM "TEST_SYNONYM" FOR "ORACLE_ENHANCED"."TEST_TARGET"
CONSTRAINT "SYS_C0012345" PRIMARY KEY ("ID","TITLE")
```

## Background

The unquoted identifiers were noticed while exploring a `DBMS_METADATA`-based `structure_dump` backend in #2513. That work is still under review; this PR is independent of whether #2513 is ultimately adopted, and stands on its own as a consistency fix for the existing path.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb` — green
- [x] `bundle exec rspec` full suite — 734 examples, 0 failures, 11 pending
- [x] `bundle exec rubocop` — clean
