### PR TITLE
Use native DROP IF EXISTS on Oracle 23.4+, narrow rescue otherwise

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -253,17 +253,31 @@ module ActiveRecord
           # :sequence_name names a single sequence, so it cannot unambiguously
           # apply across multiple tables; honor it only for single-table drops.
           custom_sequence_name = table_names.size == 1 ? options[:sequence_name] : nil
+          if_exists = options[:if_exists]
+          cascade = options[:force] == :cascade
+
           table_names.each do |table_name|
             schema_cache.clear_data_source_cache!(table_name.to_s)
-            execute "DROP TABLE #{quote_table_name(table_name)}#{' CASCADE CONSTRAINTS' if options[:force] == :cascade}"
             seq_name = custom_sequence_name || default_sequence_name(table_name, nil)
-            execute "DROP SEQUENCE #{quote_table_name(seq_name)}" rescue nil
-          rescue ActiveRecord::StatementInvalid => e
-            raise e unless options[:if_exists]
+
+            drop_if_exists("TABLE", table_name, cascade_constraints: cascade, if_exists: if_exists)
+            drop_if_exists("SEQUENCE", seq_name, if_exists: true)
           ensure
             clear_table_columns_cache(table_name)
             @prefetch_primary_key_cache.delete(table_name.to_s)
           end
+        end
+
+        def drop_if_exists(object_type, name, if_exists: true, cascade_constraints: false) # :nodoc:
+          cascade_clause = " CASCADE CONSTRAINTS" if cascade_constraints
+          if supports_drop_if_exists?
+            if_exists_clause = " IF EXISTS" if if_exists
+            execute "DROP #{object_type}#{if_exists_clause} #{quote_table_name(name)}#{cascade_clause}"
+          else
+            execute "DROP #{object_type} #{quote_table_name(name)}#{cascade_clause}"
+          end
+        rescue ActiveRecord::StatementInvalid => e
+          raise unless if_exists && missing_object_ora_code?(e.message, object_type)
         end
 
         def add_index(table_name, column_name, **options) # :nodoc:
@@ -668,6 +682,28 @@ module ActiveRecord
         end
 
         private
+          # Per-object-kind "does not exist" ORA codes used by `drop_if_exists`.
+          MISSING_OBJECT_ORA_CODES = {
+            "TABLE"             => "ORA-00942",
+            "VIEW"              => "ORA-00942",
+            "SEQUENCE"          => "ORA-02289",
+            "PUBLIC SYNONYM"    => "ORA-01432",
+            "SYNONYM"           => "ORA-01434",
+            "MATERIALIZED VIEW" => "ORA-12003",
+            "PROCEDURE"         => "ORA-04043",
+            "FUNCTION"          => "ORA-04043",
+            "PACKAGE"           => "ORA-04043",
+            "TYPE"              => "ORA-04043",
+            "TRIGGER"           => "ORA-04080",
+            "INDEX"             => "ORA-01418",
+          }.freeze
+          private_constant :MISSING_OBJECT_ORA_CODES
+
+          def missing_object_ora_code?(message, object_type)
+            code = MISSING_OBJECT_ORA_CODES[object_type.to_s.upcase]
+            code && message.include?(code)
+          end
+
           def index_column_names(column_names) # :nodoc:
             column_names.is_a?(Array) ? column_names : Array(column_names)
           end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -519,6 +519,14 @@ module ActiveRecord
         database_version >= "12"
       end
 
+      # Oracle Database 23ai (23.4) introduced the `IF EXISTS` and
+      # `IF NOT EXISTS` clauses for several DDL statements (DROP TABLE,
+      # DROP SEQUENCE, etc.). On older releases the adapter has to rescue
+      # ORA-00942 / ORA-02289 manually for idempotent drops.
+      def supports_drop_if_exists? # :nodoc:
+        database_version >= "23.4"
+      end
+
       # Whether `structure_dump_method: :auto` resolves to +:dbms_metadata+
       # on this connection. `DBMS_METADATA.GET_DDL` itself exists since
       # Oracle 9i, but the constructs the backend depends on (`IDENTITY`

--- a/spec/active_record/connection_adapters/oracle_enhanced/primary_key_trigger_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/primary_key_trigger_spec.rb
@@ -384,7 +384,7 @@ describe "primary_key_trigger" do
     end
 
     after(:each) do
-      tables_to_drop = [@long_table_name, @long_unicode_table_name].compact
+      tables_to_drop = [@long_table_name].compact
       schema_define do
         tables_to_drop.each do |t|
           drop_table t.to_sym, if_exists: true
@@ -421,8 +421,8 @@ describe "primary_key_trigger" do
       # "é" is 2 bytes in UTF-8. Build a name whose pre-truncation byte length
       # exceeds the budget so the slice has to land in the middle of a
       # multibyte character on its first attempt.
-      @long_unicode_table_name = "é" * ((max / 2) + 5)
-      derived = @conn.default_trigger_name(@long_unicode_table_name)
+      long_unicode_table_name = "é" * ((max / 2) + 5)
+      derived = @conn.default_trigger_name(long_unicode_table_name)
       expect(derived.bytesize).to be <= max
       expect(derived).to be_valid_encoding
       expect(derived).to end_with("_pkt")


### PR DESCRIPTION
## Summary

`drop_table` previously paired `execute "DROP TABLE …"` with `rescue ActiveRecord::StatementInvalid; raise unless options[:if_exists]`, plus an unconditional `rescue nil` on the sequence drop. Both swallow **every** database error — privilege failures, ORA-00972 identifier-too-long on 11g, syntax errors, etc. — and let specs assert against half-built fixtures.

A concrete case from PR #2686 review: a spec that created identifiers longer than 30 characters silently failed on Oracle 11g with `ORA-00972 (identifier is too long)`. The error was swallowed by the `if_exists` catch-all, taking days of investigation to diagnose because no error was visible anywhere.

## Approach

**On Oracle 23.4 and later** (which added `IF EXISTS` to DDL syntax), use it directly:

```sql
DROP TABLE [IF EXISTS] table_name [CASCADE CONSTRAINTS]
DROP SEQUENCE IF EXISTS seq_name
```

No Ruby-side rescue is needed — Oracle silently no-ops if the object is absent, and any other failure (privileges, syntax, identifier length) propagates naturally.

**On older releases** (11g / 12c / 19c / 23.3 and earlier), the adapter still rescues, but narrows the catch to the per-object-kind ORA code that idempotent cleanup actually expects. The full mapping (covering future call sites beyond `drop_table` itself) is captured in the private constant `MISSING_OBJECT_ORA_CODES`:

| object kind         | "does not exist" ORA code |
|---------------------|---------------------------|
| TABLE / VIEW        | `ORA-00942`               |
| SEQUENCE            | `ORA-02289`               |
| PUBLIC SYNONYM      | `ORA-01432`               |
| SYNONYM             | `ORA-01434`               |
| MATERIALIZED VIEW   | `ORA-12003`               |
| PROCEDURE / FUNCTION / PACKAGE / TYPE | `ORA-04043` |
| TRIGGER             | `ORA-04080`               |
| INDEX               | `ORA-01418`               |

Anything else (which `rescue ActiveRecord::StatementInvalid` and `rescue nil` were silently absorbing) now propagates.

## New public helper

This PR exposes a reusable adapter helper:

```ruby
drop_if_exists(object_type, name, if_exists: true, cascade_constraints: false)
```

`drop_table` is its first caller. Spec helpers and follow-up sweeps (e.g. PR #2687) can reuse it to drop sequences / synonyms / mviews idempotently without re-implementing the pre-23.4 rescue dance.

A `supports_drop_if_exists?` capability helper guards the version gate (`database_version >= "23.4"`).

## References

- Oracle Database 23ai SQL Language Reference, **DROP TABLE**: <https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/DROP-TABLE.html> (`DROP TABLE [ IF EXISTS ] [ schema. ] table …`)
- Oracle Database 23ai New Features Guide, **IF [NOT] EXISTS Syntax Support**: <https://docs.oracle.com/en/database/oracle/oracle-database/23/nfcoa/>

## Spec follow-up

The narrowed rescue exposed one dead-fixture cleanup attempt in `primary_key_trigger_spec.rb`: an example exercises only the Ruby helper `default_trigger_name` (no table is created) but stored the multibyte name in `@long_unicode_table_name`, which the `after(:each)` hook then tried to drop. Master's catch-all swallowed the resulting `ORA-00972`. Localized the variable so the cleanup loop simply doesn't see it.

## Test plan

- [x] `bundle exec rspec` full suite — 747 examples, 0 failures, 12 pending (CRuby 4.0.3 / Oracle 23.26.1)
- [x] `bundle exec rubocop` — clean
- [x] CI green on test_11g (exercises the pre-23.4 rescue path) and Oracle 23ai

Related: PR #2687 (sweep `rescue nil` from spec cleanup) — the longer-term goal of replacing silent failure with narrow, intentional handling. This PR fixes the adapter side; #2687 fixes the spec side and will rebase to use this `drop_if_exists` helper once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
