### PR TITLE
Cleanup `:database` leading-`/` deprecation warning

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1062,13 +1062,16 @@ module ActiveRecord
         end
 
         if @config[:database].to_s.start_with?("/")
+          trimmed = @config[:database].to_s.delete_prefix("/")
           OracleEnhanced.deprecator.warn(
             "Setting `:database` to a value that starts with `/` " \
             "(#{@config[:database].inspect}) is deprecated and will raise " \
             "in a future major version. The leading slash is an adapter " \
             "artefact from when `:database` was prepended into an EZCONNECT " \
-            "URL; the slash is no longer needed. Use the same value without " \
-            "the leading `/`, or use the explicit `:service_name` option."
+            "URL; the slash is no longer needed. Use `database: " \
+            "#{trimmed.inspect}` or `service_name: #{trimmed.inspect}` " \
+            "instead (no leading slash on either).",
+            caller_locations(2)
           )
         end
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -138,9 +138,11 @@ describe "OracleEnhancedAdapter establish connection" do
   end
 
   it "should connect to database using service_name" do
-    ActiveRecord::Base.establish_connection(SERVICE_NAME_CONNECTION_PARAMS)
-    expect(ActiveRecord::Base.lease_connection).not_to be_nil
-    expect(ActiveRecord::Base.lease_connection.class).to eq(ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter)
+    ActiveRecord::ConnectionAdapters::OracleEnhanced.deprecator.silence do
+      ActiveRecord::Base.establish_connection(SERVICE_NAME_CONNECTION_PARAMS)
+      expect(ActiveRecord::Base.lease_connection).not_to be_nil
+      expect(ActiveRecord::Base.lease_connection.class).to eq(ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter)
+    end
   end
 end
 
@@ -346,7 +348,16 @@ describe "OracleEnhancedConnection" do
       ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(database: "/#{DATABASE_NAME}"))
       expect {
         ActiveRecord::Base.lease_connection
-      }.to output(/DEPRECATION WARNING: Setting `:database` to a value that starts with `\/`.*:service_name/m).to_stderr
+      }.to output(
+        %r{DEPRECATION WARNING: Setting `:database`.*starts with `/`.*database: "#{DATABASE_NAME}".*service_name: "#{DATABASE_NAME}"}mo
+      ).to_stderr
+    end
+
+    it "points the 'called from' frame at the user's call site, not adapter internals" do
+      ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(database: "/#{DATABASE_NAME}"))
+      expect {
+        ActiveRecord::Base.lease_connection
+      }.to output(%r{called from .*\bconnection_spec\.rb:\d+}).to_stderr
     end
 
     it "does not warn when :database has no leading slash" do


### PR DESCRIPTION
## Summary

Three small fixes around the deprecation warning emitted when `:database` starts with `/`. Surfaced by the test_23ai job on PR #2688 ([example log](https://github.com/rsim/oracle-enhanced/actions/runs/25322906303/job/74236175905?pr=2688)) which prints:

```
DEPRECATION WARNING: Setting `:database` to a value that starts with `/` ("/FREEPDB1") is deprecated and will raise in a future major version. The leading slash is an adapter artefact from when `:database` was prepended into an EZCONNECT URL; the slash is no longer needed. Use the same value without the leading `/`, or use the explicit `:service_name` option. (called from ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter#initialize at /home/runner/work/oracle-enhanced/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:413)
```

Two things are wrong with that line in our test output:

1. **`(called from … oracle_enhanced_adapter.rb:413)` is internal plumbing**, not actionable for the user. They want the spec / app call site instead.
2. **The "use the explicit `:service_name` option" half is ambiguous** — does `:service_name` itself want a leading slash or not?

And separately, the spec that triggers it (`should connect to database using service_name` via `SERVICE_NAME_CONNECTION_PARAMS`'s legacy `database: "/FREEPDB1"`) leaks the warning into rspec output.

## Changes

**1. Bump the callstack frame.** `OracleEnhanced.deprecator.warn` now receives `caller_locations(2)` explicitly:

```ruby
OracleEnhanced.deprecator.warn(
  "...",
  caller_locations(2)
)
```

That skips `resolve_database_aliases` and our `#initialize`. ActiveSupport::Deprecation's `extract_callstack` then walks up past anything inside the activesupport-sibling-gem directory (which covers ActiveRecord and our own gem when bundled), landing on the user's `establish_connection` / `database.yml` call site. After the change the warning's tail reads:

```
(called from block (4 levels) in <top (required)> at .../spec/.../connection_spec.rb:350)
```

**2. Spell out the recommended replacements concretely.** The new message constructs the trimmed value once and shows both alternatives with concrete kwarg examples — mirroring the style of the sibling `:sid` error message above it:

```
... the slash is no longer needed. Use `database: "FREEPDB1"` or `service_name: "FREEPDB1"` instead (no leading slash on either).
```

No more ambiguity about whether `:service_name` wants a leading slash.

**3. Suppress the warning in the noisy spec.** `should connect to database using service_name` (which deliberately exercises the deprecated codepath) is wrapped in `OracleEnhanced.deprecator.silence do ... end`. The dedicated "emits an OracleEnhanced.deprecator warning" example below it (which asserts on the warning text) remains, and gains a sibling example locking in the new frame-skip behavior:

```ruby
it "points the 'called from' frame at the user's call site, not adapter internals" do
  ActiveRecord::Base.establish_connection(CONNECTION_PARAMS.merge(database: "/#{DATABASE_NAME}"))
  expect {
    ActiveRecord::Base.lease_connection
  }.to output(%r{called from .*\bconnection_spec\.rb:\d+}).to_stderr
end
```

## Test plan

- [x] `bundle exec rspec spec/.../connection_spec.rb` — 99 examples, 0 failures, 4 pending (against Oracle 23ai 23.26.1)
- [x] `bundle exec rspec` full suite — 748 examples, 0 failures, 12 pending
- [x] `bundle exec rubocop` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)