### PR TITLE
Sweep rescue nil from remaining specs (+ remove_context_index if_exists:)

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/context_index.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/context_index.rb
@@ -126,18 +126,21 @@ module ActiveRecord
           execute sql
         end
 
-        # Drop full text index with Oracle specific CONTEXT index type
+        # Drop full text index with Oracle specific CONTEXT index type.
+        # Pass `if_exists: true` to tolerate the index already being absent
+        # (rescues only ORA-01418 "specified index does not exist").
         def remove_context_index(table_name, options = {})
           unless Hash === options # if column names passed as argument
             options = { column: Array(options) }
           end
+          if_exists = options[:if_exists]
           index_name = options[:name] || index_name(table_name,
             column: options[:index_column] || options[:column], identifier_max_length: 25)
-          execute "DROP INDEX #{index_name}"
+          drop_if_exists("INDEX", index_name, if_exists: if_exists)
           drop_ctx_preference(default_datastore_name(index_name))
           drop_ctx_preference(default_storage_name(index_name))
           procedure_name = default_datastore_procedure(index_name)
-          execute "DROP PROCEDURE #{quote_table_name(procedure_name)}" rescue nil
+          drop_if_exists("PROCEDURE", procedure_name, if_exists: true)
           drop_index_column_trigger(index_name)
         end
 
@@ -291,7 +294,7 @@ module ActiveRecord
 
           def drop_index_column_trigger(index_name)
             trigger_name = default_index_column_trigger_name(index_name)
-            execute "DROP TRIGGER #{quote_table_name(trigger_name)}" rescue nil
+            drop_if_exists("TRIGGER", trigger_name, if_exists: true)
           end
 
           def default_datastore_procedure(index_name)

--- a/spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb
@@ -204,8 +204,8 @@ describe "OracleEnhancedAdapter context index" do
     end
 
     after(:each) do
-      @conn.remove_context_index :posts, name: "post_and_comments_index" rescue nil
-      @conn.remove_context_index :posts, index_column: :all_text rescue nil
+      @conn.remove_context_index :posts, name: "post_and_comments_index", if_exists: true
+      @conn.remove_context_index :posts, index_column: :all_text, if_exists: true
       Post.destroy_all
     end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/dbms_metadata_structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/dbms_metadata_structure_dump_spec.rb
@@ -178,11 +178,11 @@ describe "OracleEnhancedAdapter DBMS_METADATA structure dump" do
   describe "structure_dump_db_stored_code (DBMS_METADATA path)" do
     before(:each) do
       skip "requires Oracle 12.1+ for the DBMS_METADATA path" unless @conn.use_dbms_metadata_dump?
-      @conn.execute "DROP PACKAGE test_dbms_metadata_pkg" rescue nil
+      @conn.drop_if_exists("PACKAGE", "test_dbms_metadata_pkg")
     end
 
     after(:each) do
-      @conn.execute "DROP PACKAGE test_dbms_metadata_pkg" rescue nil
+      @conn.drop_if_exists("PACKAGE", "test_dbms_metadata_pkg")
     end
 
     it "emits a PACKAGE BODY only once" do

--- a/spec/active_record/connection_adapters/oracle_enhanced/quoting_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/quoting_spec.rb
@@ -200,8 +200,8 @@ describe "OracleEnhancedAdapter quoting" do
           drop_table "CamelCase", if_exists: true
         end
       end
-      Object.send(:remove_const, "WarehouseThing") rescue nil
-      Object.send(:remove_const, "CamelCase") rescue nil
+      Object.send(:remove_const, "WarehouseThing") if Object.const_defined?("WarehouseThing")
+      Object.send(:remove_const, "CamelCase") if Object.const_defined?("CamelCase")
     end
 
     it "should allow creation of a table with non alphanumeric characters" do

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -130,8 +130,8 @@ describe "OracleEnhancedAdapter schema dump" do
 
     after(:each) do
       schema_define do
-        remove_foreign_key :test_comments, :test_posts rescue nil
-        remove_foreign_key :test_comments, name: "comments_posts_baz_fooz_fk" rescue nil
+        remove_foreign_key :test_comments, :test_posts, if_exists: true
+        remove_foreign_key :test_comments, name: "comments_posts_baz_fooz_fk", if_exists: true
       end
     end
 
@@ -326,7 +326,7 @@ describe "OracleEnhancedAdapter schema dump" do
 
   describe "materialized views" do
     after(:each) do
-      @conn.execute "DROP MATERIALIZED VIEW test_posts_mv" rescue nil
+      @conn.drop_if_exists("MATERIALIZED VIEW", "test_posts_mv")
       drop_test_posts_table
     end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -1459,7 +1459,7 @@ end
     end
 
     after(:all) do
-      @conn.execute("drop materialized view sum_test_employees") rescue nil
+      @conn.drop_if_exists("MATERIALIZED VIEW", "sum_test_employees")
       schema_define do
         drop_table :sum_test_employees, if_exists: true
         drop_table :test_employees, if_exists: true

--- a/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
@@ -36,21 +36,14 @@ describe "OracleEnhancedAdapter structure dump" do
     end
 
     after(:each) do
+      @conn.drop_if_exists("VIEW", "test_posts_view_a")
+      @conn.drop_if_exists("VIEW", "test_posts_view_z")
       @conn.drop_table :test_posts
       @conn.drop_table :foos
-      @conn.execute "DROP SEQUENCE test_posts_seq" rescue nil
-      @conn.execute "ALTER TABLE test_posts drop CONSTRAINT fk_test_post_foo" rescue nil
-      @conn.execute "DROP TRIGGER test_post_trigger" rescue nil
-      @conn.execute "DROP TYPE TEST_TYPE" rescue nil
-      @conn.execute "DROP TABLE bars" rescue nil
-      @conn.execute "ALTER TABLE foos drop CONSTRAINT UK_BAZ" rescue nil
-      @conn.execute "ALTER TABLE foos drop CONSTRAINT UK_FOOZ_BAZ" rescue nil
-      @conn.execute "ALTER TABLE foos drop column fooz_id" rescue nil
-      @conn.execute "ALTER TABLE foos drop column baz_id" rescue nil
-      @conn.execute "ALTER TABLE test_posts drop column fooz_id" rescue nil
-      @conn.execute "ALTER TABLE test_posts drop column baz_id" rescue nil
-      @conn.execute "DROP VIEW test_posts_view_z" rescue nil
-      @conn.execute "DROP VIEW test_posts_view_a" rescue nil
+      @conn.drop_table :bars, if_exists: true
+      @conn.drop_if_exists("SEQUENCE", "test_posts_seq")
+      @conn.drop_if_exists("TRIGGER", "test_post_trigger")
+      @conn.drop_if_exists("TYPE", "TEST_TYPE")
       Object.send(:remove_const, "TestPost") if defined?(TestPost)
       ActiveRecord::Base.clear_cache!
     end
@@ -470,15 +463,15 @@ describe "OracleEnhancedAdapter structure dump" do
     end
 
     after(:each) do
+      @conn.drop_if_exists("VIEW", "full_drop_test_view")
+      @conn.drop_if_exists("MATERIALIZED VIEW", "full_drop_test_mview")
+      @conn.drop_if_exists("SYNONYM", "full_drop_test_synonym")
+      @conn.drop_if_exists("PACKAGE", "full_drop_test_package")
+      @conn.drop_if_exists("FUNCTION", "full_drop_test_function")
+      @conn.drop_if_exists("PROCEDURE", "full_drop_test_procedure")
+      @conn.drop_if_exists("TYPE", "full_drop_test_type")
       @conn.drop_table :full_drop_test
       @conn.drop_table :full_drop_test_temp
-      @conn.execute "DROP VIEW FULL_DROP_TEST_VIEW" rescue nil
-      @conn.execute "DROP MATERIALIZED VIEW FULL_DROP_TEST_MVIEW" rescue nil
-      @conn.execute "DROP SYNONYM FULL_DROP_TEST_SYNONYM" rescue nil
-      @conn.execute "DROP PACKAGE FULL_DROP_TEST_PACKAGE" rescue nil
-      @conn.execute "DROP FUNCTION FULL_DROP_TEST_FUNCTION" rescue nil
-      @conn.execute "DROP PROCEDURE FULL_DROP_TEST_PROCEDURE" rescue nil
-      @conn.execute "DROP TYPE FULL_DROP_TEST_TYPE" rescue nil
     end
 
     it "should contain correct sql" do
@@ -540,7 +533,7 @@ describe "OracleEnhancedAdapter structure dump" do
     end
 
     after do
-      @conn.execute("DROP SYNONYM test_synonym") rescue nil
+      @conn.drop_if_exists("SYNONYM", "test_synonym")
       @conn.drop_table :test_synonym_target, if_exists: true
     end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -4,8 +4,7 @@ describe "OracleEnhancedAdapter date and datetime type detection based on attrib
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
     @conn = ActiveRecord::Base.lease_connection
-    @conn.execute "DROP TABLE test_employees" rescue nil
-    @conn.execute "DROP SEQUENCE test_employees_seq" rescue nil
+    @conn.drop_table "test_employees", if_exists: true
     @conn.execute <<~SQL
       CREATE TABLE test_employees (
         employee_id   NUMBER(6,0) PRIMARY KEY,


### PR DESCRIPTION
## Summary

Continues the cleanup begun in PR #2687 (which swept `connection_spec.rb`). Replaces the `@conn.execute "DROP …" rescue nil` and friends pattern across the remaining spec files. The bare `rescue nil` swallows **every** error — privilege failures, ORA-00972 identifier-too-long on 11g, syntax errors — and lets specs assert against half-built fixtures (case in point: PR #2686 spent days chasing an `ORA-00972` that the catch-all had hidden).

## Two commits

### 1. `Support if_exists: on remove_context_index` (`3109cd8f`) — lib + spec

ActiveRecord's `remove_index` accepts `if_exists: true` so callers can issue idempotent cleanup without rescuing themselves; the Oracle Enhanced `remove_context_index` helper had no such option, so spec cleanup paths used `rescue nil`. This commit adds the option:

```ruby
remove_context_index :posts, name: "post_and_comments_index", if_exists: true
```

`if_exists:` is forwarded to `drop_if_exists("INDEX", index_name, if_exists: …)` (rescues only ORA-01418 "specified index does not exist"). The auxiliary trigger and procedure cleanup inside `remove_context_index` are also routed through `drop_if_exists` (always `if_exists: true` since they're conditionally created), replacing inline `rescue nil` in those private helpers.

The `drop_ctx_preference` PL/SQL call is left as-is — Oracle Text returns DRG-* codes, not ORA-*, and narrowing it cleanly requires a separate per-code audit.

### 2. `Sweep rescue nil cleanup paths across remaining specs` (`9fedcdd8`) — six spec files

| File | Pattern → replacement |
|---|---|
| `oracle_enhanced_data_types_spec.rb` | DROP TABLE + DROP SEQUENCE → `drop_table(name, if_exists: true)` (default `<table>_seq` is cleaned up by `drop_table` itself) |
| `oracle_enhanced/dbms_metadata_structure_dump_spec.rb` | DROP PACKAGE → `drop_if_exists("PACKAGE", name)` |
| `oracle_enhanced/schema_dumper_spec.rb` | `remove_foreign_key … rescue nil` → `remove_foreign_key …, if_exists: true`; DROP MV → `drop_if_exists("MATERIALIZED VIEW", …)` |
| `oracle_enhanced/schema_statements_spec.rb` | DROP MV → `drop_if_exists("MATERIALIZED VIEW", …)` |
| `oracle_enhanced/quoting_spec.rb` | `Object.send(:remove_const, "X") rescue nil` → `Object.send(:remove_const, "X") if Object.const_defined?("X")` |
| `oracle_enhanced/structure_dump_spec.rb` | DROP VIEW/MV/SYN/PKG/FUNC/PROC/TYPE/TRIGGER → `drop_if_exists("<TYPE>", name)`; ALTER TABLE … DROP CONSTRAINT/COLUMN lines simplified out (constraints/columns disappear with their parent tables) |

## Net behavior

The same expected misses are still tolerated, but unexpected failures (privileges, syntax, identifier limit, etc.) now propagate instead of being silently absorbed.

## Test plan

- [x] `bundle exec rspec` full suite — 748 examples, 0 failures, 12 pending (CRuby 4.0.3 / Oracle 23ai 23.26.1)
- [x] `bundle exec rubocop` — clean
- [x] Each touched file run individually green

## Out of scope

A handful of `rescue nil` callsites remain in the spec suite that this PR does not touch:

- `oracle_enhanced_adapter_spec.rb`
- `oracle_enhanced/primary_key_trigger_spec.rb` (single SEQUENCE drop — minor)
- `oracle_enhanced/schema_cache_spec.rb` (5 `drop_table … rescue nil` — easy follow-up)
- `oracle_enhanced/connection_spec.rb:50` (`SystemObserver.remove_connection rescue nil` — AR pool teardown, different pattern)
- `oracle_enhanced/type/timestamp_spec.rb:30` (already has `if_exists: true`, just trailing `rescue nil` to drop)
- `oracle_enhanced/procedures_spec.rb:319` (`(TestEmployee.partial_updates = false) rescue nil` — handled in a separate PR; the rationale is unrelated to fixture cleanup)

Will land as follow-ups so this PR stays focused on the original eight files identified in #2687's description.

Ref: PR #2686 (the original case where `rescue nil` hid an ORA-00972 identifier-too-long failure on 11g), PR #2687 (the connection_spec.rb half), PR #2688 (the `drop_if_exists` adapter helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
