### PR TITLE
Drop `rescue nil` guard for `partial_updates =` in procedures_spec

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb
@@ -316,7 +316,7 @@ describe "OracleEnhancedAdapter custom methods for create, update and destroy" d
   end
 
   it "should log update record" do
-    (TestEmployee.partial_updates = false) rescue nil
+    TestEmployee.partial_updates = false
     @employee = TestEmployee.create(
       first_name: "First",
       last_name: "Last",


### PR DESCRIPTION
## Summary

`spec/.../procedures_spec.rb` has one line that the rescue-nil sweep PRs (#2687 / #2690) intentionally **don't** touch, because the rationale is unrelated to fixture cleanup:

```ruby
(TestEmployee.partial_updates = false) rescue nil
```

This is a defensive guard for an ActiveRecord configuration setter, not an idempotent-cleanup `rescue nil` on a DROP statement. It deserves its own PR, since the reasoning is entirely about the historical churn of the `partial_updates=` / `partial_writes=` API in upstream Rails.

## History

| commit | what changed |
|---|---|
| 84b83686 (2008) | Line first added as `TestEmployee.partial_updates = false` (no rescue) |
| 8f5029c7 (2008) | "Adapted spec tests so that they run both on Rails 2.1.0 and Rails 2.0.2" — `rescue nil` added because Rails 2.0.2 did not yet have `partial_updates=` |
| 7d1a4ba7 (Rails ~3.x) | Rails renamed `partial_updates` → `partial_writes`; spec follows |
| 0b1cebf0 (#2189, 2021) | rails/rails#42355 (Rails 7.0) deprecated `partial_writes` in favor of `partial_updates` / `partial_inserts`. Spec flips back to `partial_updates =`. The `rescue nil` is kept as a precaution while Rails was in transition |
| this PR | Drop the `rescue nil` |

## Why now

oracle-enhanced now depends on `activerecord ~> 8.2.0.alpha`. On Rails 8 `partial_writes=` has been removed entirely and `partial_updates=` is the stable public API:

```ruby
irb> ActiveRecord::Base.respond_to?(:partial_writes=)   #=> false
irb> ActiveRecord::Base.respond_to?(:partial_updates=)  #=> true
```

So the guard hides nothing useful — and a future API rename would be better surfaced as a `NoMethodError` than silently swallowed.

## Change

```diff
-    (TestEmployee.partial_updates = false) rescue nil
+    TestEmployee.partial_updates = false
```

If the API ever goes away the spec will fail loudly instead of silently no-opping.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb` — 16 examples, 0 failures
- [x] `bundle exec rubocop` — clean

Ref: rails/rails#42355 (the deprecate / rename PR), #2189 (the previous oracle-enhanced touch on this line), #2687 / #2690 (the broader rescue-nil sweep PRs that intentionally exclude this site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
