### PR TITLE
Remove has_primary_key?

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -914,10 +914,6 @@ module ActiveRecord
         end
       end
 
-      def has_primary_key?(table_name, owner = nil, desc_table_name = nil) # :nodoc:
-        primary_keys(table_name).any?
-      end
-
       def primary_keys(table_name) # :nodoc:
         (_owner, desc_table_name) = resolve_data_source_name(table_name)
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/composite_primary_key_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/composite_primary_key_spec.rb
@@ -93,10 +93,6 @@ describe "OracleEnhancedAdapter composite primary key" do
       schema_define { drop_table :test_no_pks, if_exists: true }
     end
 
-    it "has_primary_key? returns true for a composite-PK table" do
-      expect(@conn.has_primary_key?("uber_barcodes")).to be true
-    end
-
     it "pk_and_sequence_for returns nil for a composite-PK table" do
       expect(@conn.pk_and_sequence_for("uber_barcodes")).to be_nil
     end


### PR DESCRIPTION
## Summary

Remove `OracleEnhancedAdapter#has_primary_key?` entirely. The method was an oracle-enhanced override of an abstract-adapter method that Rails itself removed in [commit d1521719c5](https://github.com/rails/rails/commit/d1521719c5) ("Removed support for accessing attributes on a has_and_belongs_to_many join table", 2011-01-16) when the HABTM attribute-access path that needed it was retired. oracle-enhanced kept the override, but it has been dead surface for 14+ years.

## Why now / why outright removal

- **Zero in-tree callers.** The only previous user, the original `prefetch_primary_key?` cache-fill path, was refactored into `prefetch_primary_key_from_dictionary` and now goes through `primary_keys(table_name)` directly.
- **Not in the Rails abstract API.** Current Rails callers use `primary_key(table_name)` / `primary_keys(table_name)` instead.
- **`# :nodoc:`** — no API contract is being broken.
- **The body** had also already lost its `(owner, desc_table_name)` arguments (carried over from `pk_and_sequence_for`'s historical signature, never functional because `pk_and_sequence_for` itself unconditionally re-resolves them via `resolve_data_source_name`). The only thing left would have been a one-line wrapper around `primary_keys(table_name).any?` — not worth keeping.
- **The single spec assertion** added in #2693 (`expect(@conn.has_primary_key?("uber_barcodes")).to be true`) duplicated the immediately preceding `primary_keys` assertion; removed alongside the method.

## Diff

```diff
- def has_primary_key?(table_name, owner = nil, desc_table_name = nil) # :nodoc:
-   primary_keys(table_name).any?
- end
-
  def primary_keys(table_name) # :nodoc:
```

(Plus the deletion of one redundant spec line.)

## Test plan

- [x] `bundle exec rspec` — full suite, 803 examples, 0 failures, 12 pre-existing pending
- [x] `bundle exec rubocop` — clean
- [x] No remaining references to `has_primary_key?` in `lib/` or `spec/`
