### PR TITLE
Support composite primary keys in write_lobs

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -217,13 +217,11 @@ module ActiveRecord
         end
 
         # Writes LOB values from attributes for specified columns
-        # TODO: composite primary key support — the +id+ lookup and the +WHERE+
-        # clause below assume a scalar +klass.primary_key+. For CPK models with
-        # CLOB/BLOB columns, fixture insertion and the post-save LOB rewrite
-        # path will fail. Handle the +Array+ case by zipping columns/values and
-        # building a multi-column predicate.
         def write_lobs(table_name, klass, attributes, columns) # :nodoc:
-          id = quote(attributes[klass.primary_key])
+          pk_predicate = Array(klass.primary_key).map { |pk|
+            "#{quote_column_name(pk)} = #{quote(attributes[pk])}"
+          }.join(" AND ")
+
           columns.each do |col|
             value = attributes[col.name]
             # changed sequence of next two lines - should check if value is nil before converting to yaml
@@ -234,7 +232,7 @@ module ActiveRecord
             uncached do
               unless lob_record = select_one(sql = <<~SQL.squish, "Writable Large Object")
                 SELECT #{quote_column_name(col.name)} FROM #{quote_table_name(table_name)}
-                WHERE #{quote_column_name(klass.primary_key)} = #{id} FOR UPDATE
+                WHERE #{pk_predicate} FOR UPDATE
               SQL
                 raise ActiveRecord::RecordNotFound, "statement #{sql} returned no rows"
               end

--- a/spec/active_record/connection_adapters/oracle_enhanced/composite_primary_key_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/composite_primary_key_spec.rb
@@ -38,10 +38,17 @@ describe "OracleEnhancedAdapter composite primary key" do
         t.string  :title
         t.integer :revision
       end
+      create_table :cpk_docs, primary_key: [:author_id, :id], force: true do |t|
+        t.integer :author_id
+        t.integer :id
+        t.text    :body
+        t.binary  :data
+      end
     end
 
     stub_const("UberBarcode", Class.new(ActiveRecord::Base) { self.table_name = "uber_barcodes" })
     stub_const("CpkBook", Class.new(ActiveRecord::Base) { self.table_name = "cpk_books" })
+    stub_const("CpkDoc", Class.new(ActiveRecord::Base) { self.table_name = "cpk_docs" })
   end
 
   after(:each) do
@@ -50,6 +57,7 @@ describe "OracleEnhancedAdapter composite primary key" do
       drop_table :barcodes_reverse, if_exists: true
       drop_table :travels,          if_exists: true
       drop_table :cpk_books,        if_exists: true
+      drop_table :cpk_docs,         if_exists: true
     end
     @conn.schema_cache.clear!
   end
@@ -338,6 +346,35 @@ describe "OracleEnhancedAdapter composite primary key" do
     it "destroy removes only the matching mixed-type row" do
       @jp100.destroy
       expect(UberBarcode.pluck(:region, :code)).to eq([["US", 200]])
+    end
+  end
+
+  describe "CLOB / BLOB columns" do
+    it "create! persists a CLOB body above the inline VARCHAR2 limit" do
+      body = "x" * 5000
+      CpkDoc.create!(id: [1, 1], body: body)
+      expect(CpkDoc.find([1, 1]).body).to eq(body)
+    end
+
+    describe "with prepared_statements disabled" do
+      around(:each) do |example|
+        old_prepared_statements = @conn.prepared_statements
+        @conn.instance_variable_set(:@prepared_statements, false)
+        example.run
+        @conn.instance_variable_set(:@prepared_statements, old_prepared_statements)
+      end
+
+      it "create! writes a CLOB body via write_lobs when prepared_statements is false" do
+        body = "x" * 5000
+        CpkDoc.create!(id: [2, 2], body: body)
+        expect(CpkDoc.find([2, 2]).body).to eq(body)
+      end
+
+      it "create! writes a BLOB data column via write_lobs when prepared_statements is false" do
+        data = ("\x00\x01\x02\x03".b * 1500)
+        CpkDoc.create!(id: [3, 3], data: data)
+        expect(CpkDoc.find([3, 3]).data).to eq(data)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Build the `SELECT ... FOR UPDATE` predicate in `write_lobs` from each
primary-key component, so `CpkModel.create!` with a CLOB or BLOB
column works when the post-save LOB rewrite path runs (the case the
TODO from #2693 flagged). The single-PK SQL stays byte-identical via
`Array(klass.primary_key)`, so existing scalar-PK behavior is unchanged.

Adds `cpk_docs` (CPK + CLOB + BLOB) coverage to
`composite_primary_key_spec.rb`, exercising both the default
`prepared_statements: true` path and the `prepared_statements: false`
post-save rewrite path for both CLOB and BLOB.

Closes #2694.

## Related

The `insert_fixture` LOB call site is broken on this Ruby /
ActiveRecord-main combination by an unrelated `ORA-01002` (the
`SELECT ... FOR UPDATE` cursor fetch outside a transaction). It
reproduces with a single-column primary key as well, so the fix lives
in #2698 (closes #2696). Once that lands, a CPK + LOB `insert_fixture`
test can be added on top of this PR's `cpk_docs` setup.

## Test plan

- [x] `bundle exec rubocop`
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/composite_primary_key_spec.rb` (42/42)
- [x] `ORACLE_ENHANCED_PREPARED_STATEMENTS_FALSE=1 bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/composite_primary_key_spec.rb` (42/42)
- [x] `bundle exec rspec spec/active_record/oracle_enhanced/type/text_spec.rb` (21/21, single-PK LOB regression)
