### PR TITLE
Wrap insert_fixture LOB write path in a transaction

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -168,8 +168,6 @@ module ActiveRecord
 
         # Inserts the given fixture into the table. Overridden to properly handle lobs.
         def insert_fixture(fixture, table_name) # :nodoc:
-          super
-
           if ActiveRecord::Base.pluralize_table_names
             klass = table_name.to_s.singularize.camelize
           else
@@ -177,8 +175,15 @@ module ActiveRecord
           end
 
           klass = klass.constantize rescue nil
-          if klass.respond_to?(:ancestors) && klass.ancestors.include?(ActiveRecord::Base)
-            write_lobs(table_name, klass, fixture, klass.lob_columns)
+          if klass.respond_to?(:ancestors) && klass.ancestors.include?(ActiveRecord::Base) &&
+              !klass.lob_columns.empty?
+            # write_lobs needs a transaction; SELECT ... FOR UPDATE outside one raises ORA-01002.
+            transaction do
+              super
+              write_lobs(table_name, klass, fixture, klass.lob_columns)
+            end
+          else
+            super
           end
         end
 

--- a/spec/active_record/oracle_enhanced/type/binary_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/binary_spec.rb
@@ -116,4 +116,11 @@ describe "OracleEnhancedAdapter handling of BLOB columns" do
     @employee.reload
     expect(@employee.binary_data).to eq(@binary_data)
   end
+
+  it "insert_fixture writes BLOB content for a model with LOB columns" do
+    @conn.insert_fixture({ "id" => 101, "first_name" => "Fix", "last_name" => "Ture", "binary_data" => @binary_data }, "test_employees")
+    expect(TestEmployee.find(101).binary_data).to eq(@binary_data)
+  ensure
+    TestEmployee.where(id: 101).delete_all
+  end
 end

--- a/spec/active_record/oracle_enhanced/type/text_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/text_spec.rb
@@ -242,6 +242,12 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
     expect(Test2Employee.where(comments: search_data)).to have_attributes(count: 1)
   end
 
+  it "insert_fixture writes CLOB content for a model with LOB columns" do
+    body = "x" * 5000
+    @conn.insert_fixture({ "id" => 101, "first_name" => "Fix", "last_name" => "Ture", "comments" => body }, "test_employees")
+    expect(TestEmployee.find(101).comments).to eq(body)
+  end
+
   describe "with prepared_statements disabled" do
     around(:each) do |example|
       old_prepared_statements = @conn.prepared_statements

--- a/spec/active_record/oracle_enhanced/type/text_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/text_spec.rb
@@ -246,6 +246,8 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
     body = "x" * 5000
     @conn.insert_fixture({ "id" => 101, "first_name" => "Fix", "last_name" => "Ture", "comments" => body }, "test_employees")
     expect(TestEmployee.find(101).comments).to eq(body)
+  ensure
+    TestEmployee.where(id: 101).delete_all
   end
 
   describe "with prepared_statements disabled" do
@@ -296,6 +298,14 @@ describe "OracleEnhancedAdapter handling of CLOB columns" do
       )
       @employee.reload
       expect(@employee.comments).to eq(ruby_data)
+    end
+
+    it "insert_fixture writes CLOB content when prepared_statements is false" do
+      body = "x" * 5000
+      @conn.insert_fixture({ "id" => 102, "first_name" => "Fix", "last_name" => "Ture", "comments" => body }, "test_employees")
+      expect(TestEmployee.find(102).comments).to eq(body)
+    ensure
+      TestEmployee.where(id: 102).delete_all
     end
 
     it "should respect attr_readonly setting for CLOB column when prepared_statements is false" do


### PR DESCRIPTION
## Summary

When a fixture is inserted into a table that has a CLOB or BLOB column,
`OracleEnhanced::DatabaseStatements#insert_fixture` calls `super` (which
inserts the row with `empty_clob()` / `empty_blob()` placeholders) and
then runs `write_lobs`, which issues `SELECT ... FOR UPDATE` against
the just-inserted row to obtain a LOB locator and stream the value via
`write_lob`.

Without an active transaction, the cursor fetch for that
`SELECT ... FOR UPDATE` raises `ORA-01002: fetch out of sequence`. The
`SELECT ... FOR UPDATE` lock requires a transaction; with autocommit
on, the lock isn't held long enough for the fetch to succeed.

This change opens a `transaction` only when the resolved class has
LOB columns, so the `super` insert and the `write_lobs` rewrite become
atomic and the cursor fetch sees a live transaction. If `write_lobs`
raises, the row insert rolls back too — the row is never visible in a
half-written state.

`insert_fixtures_set` already opens its own outer transaction
(`requires_new: true`), so the inner `transaction` here joins it
without an extra savepoint in the bulk-load path.

## Spec coverage

- `text_spec.rb`: insert_fixture CLOB regression (default
  `prepared_statements: true` and inside the `with prepared_statements
  disabled` describe block).
- `binary_spec.rb`: insert_fixture BLOB regression.
- Each spec uses `ensure ... delete_all` so the explicit-id rows do
  not leak.

Closes #2696.

## Test plan

- [x] `bundle exec rubocop`
- [x] `bundle exec rspec spec/active_record/oracle_enhanced/type/text_spec.rb spec/active_record/oracle_enhanced/type/binary_spec.rb` (31/31)
- [x] `ORACLE_ENHANCED_PREPARED_STATEMENTS_FALSE=1 bundle exec rspec spec/active_record/oracle_enhanced/type/text_spec.rb spec/active_record/oracle_enhanced/type/binary_spec.rb` (31/31)
