### PR TITLE
Cover insert_fixture for CPK + CLOB

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/composite_primary_key_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/composite_primary_key_spec.rb
@@ -376,5 +376,11 @@ describe "OracleEnhancedAdapter composite primary key" do
         expect(CpkDoc.find([3, 3]).data).to eq(data)
       end
     end
+
+    it "insert_fixture writes a CLOB body for a CPK model" do
+      body = "y" * 5000
+      @conn.insert_fixture({ "author_id" => 7, "id" => 9, "body" => body }, "cpk_docs")
+      expect(CpkDoc.find([7, 9]).body).to eq(body)
+    end
   end
 end


### PR DESCRIPTION
## Summary

Adds the spec case originally listed as test #4 under the umbrella
issue #2694:

> insert_fixture against a CPK + LOB table (covers the insert_fixture
> call site).

The case was deferred when the umbrella PR landed because the
`insert_fixture` LOB write was independently broken with
`ORA-01002: fetch out of sequence` (#2696). That bug was fixed in
#2698 with a transaction wrap. Both fixes are now on master, so the
CPK + CLOB `insert_fixture` path is exercisable end-to-end.

(Re-opening of #2699, which was closed and had its branch deleted.)

## Spec

A single `it` added to the existing `CLOB / BLOB columns` describe
block in `composite_primary_key_spec.rb`, reusing the `cpk_docs` /
`CpkDoc` scaffolding that #2697 already set up. No production code
changes.

## Test plan

- [x] `bundle exec rubocop`
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/composite_primary_key_spec.rb` (43/43)
- [x] `ORACLE_ENHANCED_PREPARED_STATEMENTS_FALSE=1 bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/composite_primary_key_spec.rb` (43/43)
