### PR TITLE
Add unique constraint DSL matching PostgreSQL adapter

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -29,6 +29,10 @@ module ActiveRecord
               statements.concat(o.foreign_keys.map { |fk| accept fk })
             end
 
+            if supports_unique_constraints? && o.respond_to?(:unique_constraints)
+              statements.concat(o.unique_constraints.map { |uc| accept uc })
+            end
+
             create_sql << "(#{statements.join(', ')})" if statements.present?
 
             unless o.temporary
@@ -81,6 +85,25 @@ module ActiveRecord
             super.dup.tap do |sql|
               sql << " DEFERRABLE INITIALLY #{o.deferrable.to_s.upcase}" if o.deferrable
             end
+          end
+
+          def visit_AlterTable(o)
+            sql = super
+            sql << o.unique_constraint_adds.map { |c| visit_AddUniqueConstraint(c) }.join(" ")
+          end
+
+          def visit_UniqueConstraintDefinition(o)
+            cols = Array(o.column).map { |c| quote_column_name(c) }.join(", ")
+            sql = ["CONSTRAINT", quote_column_name(o.name), "UNIQUE", "(#{cols})"]
+
+            sql << "DEFERRABLE INITIALLY #{o.deferrable.to_s.upcase}" if o.deferrable
+            sql << "USING INDEX #{quote_column_name(o.using_index)}" if o.using_index
+
+            sql.join(" ")
+          end
+
+          def visit_AddUniqueConstraint(o)
+            "ADD #{accept(o)}"
           end
 
           def visit_CreateIndexDefinition(o)

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -49,10 +49,38 @@ module ActiveRecord
         end
       end
 
+      UniqueConstraintDefinition = Struct.new(:table_name, :column, :options) do
+        def name
+          options[:name]
+        end
+
+        def deferrable
+          options[:deferrable]
+        end
+
+        def using_index
+          options[:using_index]
+        end
+
+        def export_name_on_schema_dump?
+          !ActiveRecord::SchemaDumper.unique_ignore_pattern.match?(name) if name
+        end
+
+        def defined_for?(name: nil, column: nil, **options)
+          options = options.slice(*self.options.keys)
+
+          (name.nil? || self.name == name.to_s) &&
+            (column.nil? || Array(self.column).map(&:to_s) == Array(column).map(&:to_s)) &&
+            options.all? { |k, v| self.options[k].to_s == v.to_s }
+        end
+      end
+
       class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
         include OracleEnhanced::ColumnMethods
 
         attr_accessor :tablespace, :organization
+        attr_reader :unique_constraints
+
         def initialize(
           conn,
           name,
@@ -66,6 +94,7 @@ module ActiveRecord
         )
           @tablespace = tablespace
           @organization = organization
+          @unique_constraints = []
           super(conn, name, temporary: temporary, options: options, as: as, comment: comment)
         end
 
@@ -82,6 +111,15 @@ module ActiveRecord
         end
         alias :belongs_to :references
 
+        def unique_constraint(column_name, **options)
+          unique_constraints << new_unique_constraint_definition(column_name, options)
+        end
+
+        def new_unique_constraint_definition(column_name, options) # :nodoc:
+          options = @conn.unique_constraint_options(name, column_name, options)
+          UniqueConstraintDefinition.new(name, column_name, options)
+        end
+
         private
           def valid_column_definition_options
             super + [ :as, :sequence_name, :sequence_start_value, :type, :identity, :primary_key_trigger, :trigger_name ]
@@ -89,10 +127,28 @@ module ActiveRecord
       end
 
       class AlterTable < ActiveRecord::ConnectionAdapters::AlterTable
+        attr_reader :unique_constraint_adds
+
+        def initialize(td)
+          super
+          @unique_constraint_adds = []
+        end
+
+        def add_unique_constraint(column_name, options)
+          @unique_constraint_adds << @td.new_unique_constraint_definition(column_name, options)
+        end
       end
 
       class Table < ActiveRecord::ConnectionAdapters::Table
         include OracleEnhanced::ColumnMethods
+
+        def unique_constraint(...)
+          @base.add_unique_constraint(name, ...)
+        end
+
+        def remove_unique_constraint(...)
+          @base.remove_unique_constraint(name, ...)
+        end
       end
     end
   end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -28,6 +28,7 @@ module ActiveRecord # :nodoc:
             sorted_tables.each do |tbl|
               next if ignored? tbl
               foreign_keys(tbl, stream)
+              divergent_unique_constraints(tbl, stream)
             end
 
             # add synonyms in local schema
@@ -48,6 +49,8 @@ module ActiveRecord # :nodoc:
 
           def _indexes(table, stream)
             if (indexes = @connection.indexes(table)).any?
+              indexes = reject_unique_constraint_indexes(table, indexes)
+
               add_index_statements = indexes.filter_map do |index|
                 case index.type
                 when nil
@@ -79,11 +82,66 @@ module ActiveRecord # :nodoc:
 
           def indexes_in_create(table, stream)
             if (indexes = @connection.indexes(table)).any?
+              indexes = reject_unique_constraint_indexes(table, indexes)
+
               index_statements = indexes.map do |index|
                 "    t.index #{index_parts(index).join(', ')}" unless index.type == "CTXSYS.CONTEXT"
               end
               stream.puts index_statements.compact.sort.join("\n")
             end
+          end
+
+          # Filter only indexes that back a same-name (non-divergent) unique constraint.
+          # Divergent constraints are emitted post-create_table via add_unique_constraint,
+          # so their backing index must remain in the t.index emission.
+          def reject_unique_constraint_indexes(table, indexes)
+            return indexes unless @connection.supports_unique_constraints?
+
+            unique_constraints = @connection.unique_constraints(table)
+            return indexes if unique_constraints.empty?
+
+            backing_index_names = unique_constraints.filter_map { |uc| uc.using_index ? nil : uc.name }
+            indexes.reject { |index| backing_index_names.include?(index.name) }
+          end
+
+          # Inline only same-name unique constraints. Divergent ones (using_index != name)
+          # need the backing index to exist first, so they are emitted as add_unique_constraint
+          # statements after the create_table block via divergent_unique_constraints.
+          def unique_constraints_in_create(table, stream)
+            return unless @connection.supports_unique_constraints?
+
+            inline_ucs = @connection.unique_constraints(table).reject { |uc| uc.using_index }
+            return if inline_ucs.empty?
+
+            statements = inline_ucs.map do |uc|
+              parts = [ uc.column.inspect ]
+              parts << "deferrable: #{uc.deferrable.inspect}" if uc.deferrable
+              parts << "name: #{uc.name.inspect}" if uc.export_name_on_schema_dump?
+
+              "    t.unique_constraint #{parts.join(', ')}"
+            end
+            stream.puts statements.sort.join("\n")
+          end
+
+          def divergent_unique_constraints(table, stream)
+            return unless @connection.supports_unique_constraints?
+
+            ucs = @connection.unique_constraints(table).select { |uc| uc.using_index }
+            return if ucs.empty?
+
+            statements = ucs.map do |uc|
+              parts = [
+                remove_prefix_and_suffix(table).inspect,
+                uc.column.inspect,
+              ]
+              parts << "deferrable: #{uc.deferrable.inspect}" if uc.deferrable
+              parts << "using_index: #{uc.using_index.inspect}"
+              parts << "name: #{uc.name.inspect}" if uc.export_name_on_schema_dump?
+
+              "  add_unique_constraint #{parts.join(', ')}"
+            end
+            stream.puts statements.sort.join("\n")
+            stream.puts
           end
 
           def index_parts(index)
@@ -154,6 +212,7 @@ module ActiveRecord # :nodoc:
               end
 
               indexes_in_create(table, tbl)
+              unique_constraints_in_create(table, tbl)
 
               tbl.puts "  end"
               tbl.puts

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -612,6 +612,102 @@ module ActiveRecord
           end
         end
 
+        # Returns an array of unique constraints for the given table.
+        # The unique constraints are represented as UniqueConstraintDefinition objects.
+        def unique_constraints(table_name) # :nodoc:
+          (_owner, desc_table_name) = resolve_data_source_name(table_name)
+
+          rows = select_all(<<~SQL.squish, "SCHEMA", [bind_string("desc_table_name", desc_table_name)])
+            SELECT c.constraint_name AS name,
+                   c.index_name,
+                   c.deferrable,
+                   c.deferred,
+                   cc.column_name,
+                   cc.position
+              FROM all_constraints c
+              JOIN all_cons_columns cc
+                ON cc.owner = c.owner
+               AND cc.constraint_name = c.constraint_name
+             WHERE c.owner = SYS_CONTEXT('userenv', 'current_schema')
+               AND c.table_name = :desc_table_name
+               AND c.constraint_type = 'U'
+             ORDER BY c.constraint_name, cc.position
+          SQL
+
+          grouped = rows.group_by { |row| row["name"] }
+          grouped.map do |name, group|
+            columns = group.sort_by { |r| r["position"] }.map { |r| oracle_downcase(r["column_name"]) }
+            sample = group.first
+            constraint_name = oracle_downcase(name)
+            index_name = oracle_downcase(sample["index_name"])
+
+            options = { name: constraint_name }
+            options[:deferrable] = extract_foreign_key_deferrable(sample["deferrable"], sample["deferred"])
+            if index_name && index_name != constraint_name
+              options[:using_index] = index_name
+            end
+
+            OracleEnhanced::UniqueConstraintDefinition.new(oracle_downcase(table_name), columns, options)
+          end
+        end
+
+        # Adds a new unique constraint to the table.
+        #
+        #   add_unique_constraint :sections, :position, name: "uniq_position", deferrable: :deferred
+        #
+        # generates:
+        #
+        #   ALTER TABLE "sections" ADD CONSTRAINT uniq_position UNIQUE ("position") DEFERRABLE INITIALLY DEFERRED
+        #
+        # If you want the constraint to attach to an existing unique index, use +:using_index+.
+        # Oracle, unlike PostgreSQL, allows the constraint name to differ from its backing index.
+        #
+        #   add_unique_constraint :sections, name: "uniq_position", using_index: "index_sections_on_position"
+        def add_unique_constraint(table_name, column_name = nil, **options)
+          # Oracle's UNIQUE constraint syntax requires the column list even with USING INDEX.
+          if column_name.nil? && options[:using_index]
+            index = indexes(table_name).detect { |idx| idx.name.to_s == options[:using_index].to_s }
+            raise ArgumentError, "No index '#{options[:using_index]}' found on '#{table_name}'" unless index
+            column_name = index.columns
+          end
+
+          options = unique_constraint_options(table_name, column_name, options)
+
+          if unique_constraints(table_name).any? { |uc| uc.name == options[:name].to_s }
+            raise ArgumentError, "Table '#{table_name}' already has a unique constraint named '#{options[:name]}'"
+          end
+
+          at = create_alter_table(table_name)
+          at.add_unique_constraint(column_name, options)
+
+          execute schema_creation.accept(at)
+        end
+
+        def unique_constraint_options(table_name, column_name, options) # :nodoc:
+          assert_valid_deferrable(options[:deferrable])
+
+          if column_name && Array(column_name).any? { |c| c.to_s.include?("(") }
+            raise ArgumentError, "Unique constraints do not support expression columns. Use add_index with :unique => true for functional uniqueness."
+          end
+
+          options = options.dup
+          options[:name] ||= unique_constraint_name(table_name, column: column_name, **options)
+          options
+        end
+
+        # Removes the given unique constraint from the table.
+        #
+        #   remove_unique_constraint :sections, name: "uniq_position"
+        #
+        # The +column_name+ parameter will be ignored if present. It can be helpful
+        # to provide this in a migration's +change+ method so it can be reverted.
+        # In that case, +column_name+ will be used by #add_unique_constraint.
+        def remove_unique_constraint(table_name, column_name = nil, **options)
+          unique_name_to_delete = unique_constraint_for!(table_name, column: column_name, **options).name
+
+          execute "ALTER TABLE #{quote_table_name(table_name)} DROP CONSTRAINT #{quote_column_name(unique_name_to_delete)}"
+        end
+
         # REFERENTIAL INTEGRITY ====================================
 
         def disable_referential_integrity(&block) # :nodoc:
@@ -812,6 +908,26 @@ module ActiveRecord
             return if !deferrable || %i(immediate deferred).include?(deferrable)
 
             raise ArgumentError, "deferrable must be `:immediate` or `:deferred`, got: `#{deferrable.inspect}`"
+          end
+
+          def unique_constraint_name(table_name, **options)
+            options.fetch(:name) do
+              column_or_index = Array(options[:column] || options[:using_index]).map(&:to_s)
+              identifier = "#{table_name}_#{column_or_index * '_and_'}_unique"
+              hashed_identifier = OpenSSL::Digest::SHA256.hexdigest(identifier).first(10)
+
+              "uniq_rails_#{hashed_identifier}"
+            end
+          end
+
+          def unique_constraint_for(table_name, **options)
+            name = unique_constraint_name(table_name, **options) unless options.key?(:column)
+            unique_constraints(table_name).detect { |uc| uc.defined_for?(name: name, **options) }
+          end
+
+          def unique_constraint_for!(table_name, column: nil, **options)
+            unique_constraint_for(table_name, column: column, **options) ||
+              raise(ArgumentError, "Table '#{table_name}' has no unique constraint for #{column || options}")
           end
 
           def create_alter_table(name)

--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -129,8 +129,10 @@ module ActiveRecord # :nodoc:
 
         def structure_dump_unique_keys(table) # :nodoc:
           keys = {}
+          metadata = {}
           uks = select_all(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table.upcase)])
-            SELECT a.constraint_name, a.column_name, a.position
+            SELECT a.constraint_name, a.column_name, a.position,
+                   c.index_name, c.deferrable, c.deferred
               FROM all_cons_columns a
               JOIN all_constraints c
                 ON a.constraint_name = c.constraint_name
@@ -142,10 +144,19 @@ module ActiveRecord # :nodoc:
           uks.each do |uk|
             keys[uk["constraint_name"]] ||= []
             keys[uk["constraint_name"]][uk["position"] - 1] = uk["column_name"]
+            metadata[uk["constraint_name"]] ||= uk
           end
           keys.map do |k, v|
             quoted_cols = v.compact.map { |c| quote_column_name(c) }.join(",")
-            "ALTER TABLE #{quote_table_name(table)} ADD CONSTRAINT #{quote_column_name(k)} UNIQUE (#{quoted_cols})"
+            sql = +"ALTER TABLE #{quote_table_name(table)} ADD CONSTRAINT #{quote_column_name(k)} UNIQUE (#{quoted_cols})"
+            row = metadata[k]
+            if row["deferrable"] == "DEFERRABLE"
+              sql << " DEFERRABLE INITIALLY #{row['deferred'] == 'DEFERRED' ? 'DEFERRED' : 'IMMEDIATE'}"
+            end
+            if row["index_name"] && row["index_name"] != k
+              sql << " USING INDEX #{quote_column_name(row["index_name"])}"
+            end
+            sql
           end
         end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -482,6 +482,10 @@ module ActiveRecord
         true
       end
 
+      def supports_unique_constraints?
+        true
+      end
+
       def supports_optimizer_hints?
         true
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -324,6 +324,102 @@ describe "OracleEnhancedAdapter schema dump" do
     end
   end
 
+  describe "unique constraints" do
+    before(:each) do
+      schema_define do
+        create_table :test_sections, force: true do |t|
+          t.string :title
+          t.integer :position
+        end
+      end
+    end
+
+    after(:each) do
+      schema_define do
+        drop_table :test_sections, if_exists: true
+      end
+    end
+
+    it "dumps a stand-alone unique constraint as t.unique_constraint" do
+      schema_define do
+        add_unique_constraint :test_sections, :position, name: "uniq_position_dump"
+      end
+      output = dump_table_schema "test_sections"
+      expect(output).to match(/t\.unique_constraint \["position"\], name: "uniq_position_dump"/)
+    end
+
+    it "dumps a divergent constraint via post-create_table add_unique_constraint and keeps the t.index line" do
+      schema_define do
+        add_index :test_sections, :position, name: :idx_div_dump
+      end
+      schema_define do
+        add_unique_constraint :test_sections, name: "uniq_div_dump", using_index: :idx_div_dump
+      end
+      output = dump_table_schema "test_sections"
+      expect(output).to match(/t\.index \["position"\], name: "idx_div_dump"/)
+      expect(output).to match(/add_unique_constraint "test_sections", \["position"\], using_index: "idx_div_dump", name: "uniq_div_dump"/)
+      expect(output).not_to match(/t\.unique_constraint .*using_index/)
+    end
+
+    it "round-trips a divergent unique constraint through dump and load" do
+      schema_define do
+        add_index :test_sections, :position, name: :idx_div_rt
+      end
+      schema_define do
+        add_unique_constraint :test_sections, name: "uniq_div_rt", using_index: :idx_div_rt, deferrable: :deferred
+      end
+
+      dumped = dump_table_schema "test_sections"
+      schema_define do
+        drop_table :test_sections, if_exists: true
+      end
+
+      # Extract the body inside ActiveRecord::Schema[...].define(version: ...) do ... end
+      # so loading does not insert the dumped version into schema_migrations.
+      body = dumped[/ActiveRecord::Schema\[.+?\]\.define\(version: \d+\) do\n(.+)\nend\s*\z/m, 1]
+      schema_define { instance_eval(body) }
+
+      uc = @conn.unique_constraints(:test_sections).detect { |u| u.name == "uniq_div_rt" }
+      expect(uc).not_to be_nil
+      expect(uc.using_index).to eq("idx_div_rt")
+      expect(uc.deferrable).to eq(:deferred)
+      expect(@conn.indexes(:test_sections).map(&:name)).to include("idx_div_rt")
+    end
+
+    it "does not double-emit t.index unique: true for an index that backs a unique constraint" do
+      schema_define do
+        add_index :test_sections, :position, unique: true, name: :uniq_via_idx
+      end
+      output = dump_table_schema "test_sections"
+      expect(output).not_to match(/t\.index .*"uniq_via_idx".*unique: true/)
+      expect(output).to match(/t\.unique_constraint .*name: "uniq_via_idx"/)
+    end
+
+    it "should include deferrable initially deferred unique constraint in schema dump" do
+      schema_define do
+        add_unique_constraint :test_sections, :position, name: "uniq_def_dump", deferrable: :deferred
+      end
+      output = dump_table_schema "test_sections"
+      expect(output).to match(/t\.unique_constraint .*deferrable: :deferred.*name: "uniq_def_dump"/)
+    end
+
+    it "should include deferrable initially immediate unique constraint in schema dump" do
+      schema_define do
+        add_unique_constraint :test_sections, :position, name: "uniq_imm_dump", deferrable: :immediate
+      end
+      output = dump_table_schema "test_sections"
+      expect(output).to match(/t\.unique_constraint .*deferrable: :immediate.*name: "uniq_imm_dump"/)
+    end
+
+    it "should not emit deferrable option when unique constraint is not deferrable" do
+      schema_define do
+        add_unique_constraint :test_sections, :position, name: "uniq_plain_dump"
+      end
+      output = dump_table_schema "test_sections"
+      expect(output).to match(/t\.unique_constraint \["position"\], name: "uniq_plain_dump"$/)
+    end
+  end
+
   describe "materialized views" do
     after(:each) do
       @conn.drop_if_exists("MATERIALIZED VIEW", "test_posts_mv")

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -912,6 +912,196 @@ end
     end
   end
 
+  describe "unique constraints" do
+    before(:each) do
+      schema_define do
+        create_table :test_sections, force: true do |t|
+          t.string :title
+          t.integer :position
+        end
+      end
+    end
+
+    after(:each) do
+      schema_define do
+        drop_table :test_sections, if_exists: true
+      end
+      ActiveRecord::Base.clear_cache!
+    end
+
+    it "adds a unique constraint with an explicit name" do
+      schema_define do
+        add_unique_constraint :test_sections, :position, name: "uniq_position"
+      end
+      ucs = @conn.unique_constraints(:test_sections)
+      expect(ucs.size).to eq(1)
+      expect(ucs.first.name).to eq("uniq_position")
+      expect(ucs.first.column).to eq(["position"])
+    end
+
+    it "auto-generates a constraint name when none is supplied" do
+      schema_define do
+        add_unique_constraint :test_sections, :position
+      end
+      ucs = @conn.unique_constraints(:test_sections)
+      expect(ucs.size).to eq(1)
+      expect(ucs.first.name).to match(/\Auniq_rails_[0-9a-f]{10}\z/)
+    end
+
+    it "allows attaching a unique constraint to an existing index via :using_index" do
+      schema_define do
+        add_index :test_sections, :position, unique: true, name: :idx_existing_unique
+      end
+      # The trailing constraint added by add_index already shares the index name; drop it
+      # so we can re-attach a constraint with a different name pointing at the same index.
+      @conn.execute "ALTER TABLE test_sections DROP CONSTRAINT idx_existing_unique"
+      schema_define do
+        add_unique_constraint :test_sections, name: "uniq_via_idx", using_index: :idx_existing_unique
+      end
+      uc = @conn.unique_constraints(:test_sections).detect { |u| u.name == "uniq_via_idx" }
+      expect(uc).not_to be_nil
+      expect(uc.using_index).to eq("idx_existing_unique")
+    end
+
+    it "emits DEFERRABLE INITIALLY DEFERRED when :deferrable is :deferred" do
+      schema_define do
+        add_unique_constraint :test_sections, :position, name: "uniq_deferred", deferrable: :deferred
+      end
+      uc = @conn.unique_constraints(:test_sections).detect { |u| u.name == "uniq_deferred" }
+      expect(uc.deferrable).to eq(:deferred)
+    end
+
+    it "emits DEFERRABLE INITIALLY IMMEDIATE when :deferrable is :immediate" do
+      schema_define do
+        add_unique_constraint :test_sections, :position, name: "uniq_immediate", deferrable: :immediate
+      end
+      uc = @conn.unique_constraints(:test_sections).detect { |u| u.name == "uniq_immediate" }
+      expect(uc.deferrable).to eq(:immediate)
+    end
+
+    it "should add non-deferrable unique constraint when deferrable option is omitted" do
+      schema_define do
+        add_unique_constraint :test_sections, :position, name: "uniq_nondef"
+      end
+      uc = @conn.unique_constraints(:test_sections).detect { |u| u.name == "uniq_nondef" }
+      expect(uc.deferrable).to be(false)
+    end
+
+    it "supports deferrable + using_index together against a non-unique backing index" do
+      schema_define do
+        add_index :test_sections, :position, name: :idx_def_nonu
+      end
+      schema_define do
+        add_unique_constraint :test_sections, name: "uniq_def_using", using_index: :idx_def_nonu, deferrable: :deferred
+      end
+      uc = @conn.unique_constraints(:test_sections).detect { |u| u.name == "uniq_def_using" }
+      expect(uc.deferrable).to eq(:deferred)
+      expect(uc.using_index).to eq("idx_def_nonu")
+    end
+
+    it "raises ArgumentError on invalid :deferrable value" do
+      expect {
+        schema_define do
+          add_unique_constraint :test_sections, :position, name: "uniq_bad", deferrable: true
+        end
+      }.to raise_error(ArgumentError, /deferrable must be `:immediate` or `:deferred`/)
+    end
+
+    it "raises ArgumentError when an expression column is supplied" do
+      expect {
+        schema_define do
+          add_unique_constraint :test_sections, "LOWER(title)", name: "uniq_expr"
+        end
+      }.to raise_error(ArgumentError, /do not support expression columns/)
+    end
+
+    it "raises ArgumentError when a constraint with the same name already exists" do
+      schema_define do
+        add_unique_constraint :test_sections, :position, name: "uniq_dup"
+      end
+      expect {
+        schema_define do
+          add_unique_constraint :test_sections, :title, name: "uniq_dup"
+        end
+      }.to raise_error(ArgumentError, /already has a unique constraint named 'uniq_dup'/)
+    end
+
+    it "removes a unique constraint by name" do
+      schema_define do
+        add_unique_constraint :test_sections, :position, name: "uniq_rm_by_name"
+        remove_unique_constraint :test_sections, name: "uniq_rm_by_name"
+      end
+      expect(@conn.unique_constraints(:test_sections).map(&:name)).not_to include("uniq_rm_by_name")
+    end
+
+    it "removes a unique constraint by column" do
+      schema_define do
+        add_unique_constraint :test_sections, :position, name: "uniq_rm_by_col"
+        remove_unique_constraint :test_sections, :position
+      end
+      expect(@conn.unique_constraints(:test_sections).map(&:name)).not_to include("uniq_rm_by_col")
+    end
+
+    it "drains t.unique_constraint declared inline in create_table" do
+      schema_define do
+        drop_table :test_sections, if_exists: true
+        create_table :test_sections, force: true do |t|
+          t.string :title
+          t.integer :position
+          t.unique_constraint :position, name: "uniq_inline"
+        end
+      end
+      uc = @conn.unique_constraints(:test_sections).detect { |u| u.name == "uniq_inline" }
+      expect(uc).not_to be_nil
+      expect(uc.column).to eq(["position"])
+    end
+
+    it "supports t.unique_constraint inside change_table" do
+      schema_define do
+        change_table :test_sections do |t|
+          t.unique_constraint :position, name: "uniq_change"
+        end
+      end
+      uc = @conn.unique_constraints(:test_sections).detect { |u| u.name == "uniq_change" }
+      expect(uc).not_to be_nil
+    end
+
+    it "supports composite columns via add_unique_constraint" do
+      schema_define do
+        add_unique_constraint :test_sections, [:title, :position], name: "uniq_composite"
+      end
+      uc = @conn.unique_constraints(:test_sections).detect { |u| u.name == "uniq_composite" }
+      expect(uc).not_to be_nil
+      expect(uc.column).to eq(["title", "position"])
+    end
+
+    it "supports composite columns via inline t.unique_constraint" do
+      schema_define do
+        drop_table :test_sections, if_exists: true
+        create_table :test_sections, force: true do |t|
+          t.string :title
+          t.integer :position
+          t.unique_constraint [:title, :position], name: "uniq_inline_composite"
+        end
+      end
+      uc = @conn.unique_constraints(:test_sections).detect { |u| u.name == "uniq_inline_composite" }
+      expect(uc).not_to be_nil
+      expect(uc.column).to eq(["title", "position"])
+    end
+
+    it "preserves divergent constraint and index names on round-trip" do
+      schema_define do
+        add_index :test_sections, :position, unique: true, name: :idx_div
+      end
+      @conn.execute "ALTER TABLE test_sections DROP CONSTRAINT idx_div"
+      schema_define do
+        add_unique_constraint :test_sections, name: "uniq_div", using_index: :idx_div
+      end
+      uc = @conn.unique_constraints(:test_sections).detect { |u| u.name == "uniq_div" }
+      expect(uc.using_index).to eq("idx_div")
+    end
+  end
+
   describe "lob in table definition" do
     before do
       class ::TestPost < ActiveRecord::Base


### PR DESCRIPTION
## Summary

Closes #2613.

Adds the `add_unique_constraint` / `remove_unique_constraint` / `t.unique_constraint` API surface to oracle-enhanced, mirroring the PostgreSQL adapter so multi-DB Rails apps targeting Oracle as a secondary backend no longer need adapter branches around UNIQUE-constraint identity. Express constraint identity independently of index identity:

```ruby
add_unique_constraint :sections, :position, name: :uniq_position, deferrable: :deferred
add_unique_constraint :sections, name: :uniq_div, using_index: :idx_div   # divergent names
remove_unique_constraint :sections, name: :uniq_position
create_table(:sections) { |t| t.unique_constraint :position, name: :uniq_inline }
```

## Changes

- `OracleEnhanced::UniqueConstraintDefinition` Struct mirroring PG's shape (`name`, `column`, `using_index`, `deferrable`, `defined_for?`).
- `OracleEnhanced::TableDefinition#unique_constraint` (inline DSL) and `OracleEnhanced::AlterTable#add_unique_constraint`; `Table#unique_constraint` / `#remove_unique_constraint` delegators.
- `OracleEnhanced::SchemaStatements`:
  - public: `add_unique_constraint`, `remove_unique_constraint`, `unique_constraints(table)`
  - private helpers: `unique_constraint_options`, `unique_constraint_name` (Digest::SHA256, `uniq_rails_<10hex>`), `unique_constraint_for` / `_for!`
  - When `:using_index` is supplied without `column_name`, columns are resolved from the existing index — Oracle requires the column list even with `USING INDEX`, unlike PostgreSQL.
- `OracleEnhanced::SchemaCreation`: `visit_TableDefinition` now drains `o.unique_constraints` (so inline `t.unique_constraint` emits inside `CREATE TABLE`); new `visit_AlterTable` extension, `visit_UniqueConstraintDefinition`, `visit_AddUniqueConstraint`. Clause order is `UNIQUE (cols) DEFERRABLE INITIALLY ... USING INDEX idx` per Oracle's `constraint_state` grammar (reversing this triggers `ORA-01735`).
- `OracleEnhanced::SchemaDumper`: same-name unique constraints (where the backing index shares the constraint name) are emitted inline as `t.unique_constraint` inside `create_table`, and the matching `t.index` line is suppressed. Divergent constraints (where the backing index has a separately-named identity — Oracle allows this; PostgreSQL does not) are emitted as `add_unique_constraint` statements in the post-`create_table` pass next to `add_foreign_key`, with the `t.index` line for the backing index kept so it exists by the time the constraint references it.
- `structure_dump_unique_keys` extended to emit `DEFERRABLE INITIALLY ...` and `USING INDEX idx` (when the index name diverges from the constraint name) so SQL structure dumps round-trip too.
- `supports_unique_constraints?` returns `true`.

## Oracle vs PostgreSQL semantic decisions

1. **Implicit index** when `:using_index` is omitted: emit bare `ALTER TABLE t ADD CONSTRAINT n UNIQUE (col)` (PG-style) and let Oracle pick the implicit index. The dumper reads back the actual index name from `all_constraints.index_name` and emits `using_index:` only when it diverges from the constraint name.
2. **Constraint name ≠ index name**: allowed (Oracle supports it; PG does not). Dumper emits both `name:` and `using_index:` whenever they differ.
3. **Duplicate-constraint conflict**: raises `ArgumentError` if a UNIQUE constraint with the resolved name already exists (symmetric with `add_index`'s duplicate-name behavior).
4. **Functional/expression columns**: rejected with `ArgumentError` early — Oracle's `ALTER TABLE ... ADD CONSTRAINT ... UNIQUE (...)` only takes column names. Functional uniqueness must use `add_index :col, unique: true`.
5. **deferrable + using_index**: Oracle requires the backing index to be **non-unique** (deferrable allows mid-transaction duplicates). With a unique index Oracle rejects via `ORA-14196`; this is database-level behavior, surfaced as a `StatementInvalid` to the user.

## Deferrable parity (mirrors #2594)

- `add_unique_constraint :t, :col, deferrable: :deferred | :immediate` round-trips via `unique_constraints(table)`.
- `add_unique_constraint :t, :col` (no `:deferrable`) → `uc.deferrable == false`.
- `add_unique_constraint :t, :col, deferrable: true` → `ArgumentError` via existing `assert_valid_deferrable`.
- Schema dump emits `deferrable: :deferred` / `:immediate`; omitted when not deferrable.

## Out of scope

- CHECK constraints (separate concept, already supported).
- EXCLUSION constraints (PG-only).
- `nulls_not_distinct` (PG-only — Oracle has no equivalent).
- Rewriting historical migrations that used `add_index :col, unique: true, name: :n` to switch to the new form.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb -e "unique constraints"` (18 examples)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb -e "unique constraints"` (7 examples)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb` — 207 examples, 0 failures (2 pre-existing pending unrelated to this PR)
- [x] `bundle exec rubocop` — clean
- [ ] CI against supported Oracle versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)



