### PR TITLE
remove_index: skip DROP CONSTRAINT for non-unique indexes

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -332,8 +332,9 @@ module ActiveRecord
           return if options[:if_exists] && !index_exists?(table_name, column_name, **options)
 
           index_name = index_name_for_remove(table_name, column_name, options)
-          # TODO: It should execute only when index_type == "UNIQUE"
-          execute "ALTER TABLE #{quote_table_name(table_name)} DROP CONSTRAINT #{quote_column_name(index_name)}" rescue nil
+          if unique_constraints(table_name).any? { |uc| uc.name == index_name }
+            execute "ALTER TABLE #{quote_table_name(table_name)} DROP CONSTRAINT #{quote_column_name(index_name)}"
+          end
           execute "DROP INDEX #{quote_column_name(index_name)}"
         end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -625,6 +625,122 @@ describe "OracleEnhancedAdapter schema definition" do
   end
 end
 
+  describe "remove index" do
+    before(:each) do
+      schema_define do
+        create_table :test_employees do |t|
+          t.string :first_name
+          t.string :last_name
+        end
+      end
+    end
+
+    after(:each) do
+      schema_define do
+        drop_table :test_employees, if_exists: true
+      end
+      ActiveRecord::Base.clear_cache!
+    end
+
+    def capture_sql
+      captured = []
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        captured << payload[:sql]
+      end
+      yield
+      captured
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+    end
+
+    it "drops a non-unique index without issuing a DROP CONSTRAINT" do
+      schema_define do
+        add_index :test_employees, :first_name, name: :idx_test_employees_first_name
+      end
+
+      sqls = capture_sql do
+        schema_define do
+          remove_index :test_employees, :first_name
+        end
+      end
+
+      drop_constraint = sqls.find { |s| s =~ /DROP CONSTRAINT.*idx_test_employees_first_name/i }
+      drop_index = sqls.find { |s| s =~ /DROP INDEX.*idx_test_employees_first_name/i }
+
+      expect(drop_constraint).to be_nil
+      expect(drop_index).not_to be_nil
+      expect(@conn.index_exists?(:test_employees, :first_name)).to be(false)
+    end
+
+    it "drops a unique index together with its implicit constraint" do
+      schema_define do
+        add_index :test_employees, :first_name, unique: true, name: :uniq_test_employees_first_name
+      end
+
+      sqls = capture_sql do
+        schema_define do
+          remove_index :test_employees, :first_name
+        end
+      end
+
+      drop_constraint = sqls.find { |s| s =~ /DROP CONSTRAINT.*uniq_test_employees_first_name/i }
+      drop_index = sqls.find { |s| s =~ /DROP INDEX.*uniq_test_employees_first_name/i }
+
+      expect(drop_constraint).not_to be_nil
+      expect(drop_index).not_to be_nil
+      expect(@conn.index_exists?(:test_employees, :first_name)).to be(false)
+      expect(@conn.unique_constraints(:test_employees).map(&:name)).not_to include("uniq_test_employees_first_name")
+    end
+
+    it "honors if_exists: true when the index is missing" do
+      sqls = capture_sql do
+        schema_define do
+          remove_index :test_employees, :first_name, if_exists: true
+        end
+      end
+
+      expect(sqls.none? { |s| s =~ /DROP\s+(INDEX|CONSTRAINT)/i }).to be(true)
+    end
+
+    it "drops a unique functional index without issuing DROP CONSTRAINT" do
+      schema_define do
+        add_index :test_employees, "LOWER(first_name)", unique: true, name: :uniq_lower_first_name
+      end
+
+      sqls = capture_sql do
+        schema_define do
+          remove_index :test_employees, name: :uniq_lower_first_name
+        end
+      end
+
+      drop_constraint = sqls.find { |s| s =~ /DROP CONSTRAINT.*uniq_lower_first_name/i }
+      drop_index = sqls.find { |s| s =~ /DROP INDEX.*uniq_lower_first_name/i }
+
+      expect(drop_constraint).to be_nil
+      expect(drop_index).not_to be_nil
+    end
+
+    it "skips DROP CONSTRAINT after the implicit constraint was manually dropped" do
+      schema_define do
+        add_index :test_employees, :first_name, unique: true, name: :uniq_manual_drop
+      end
+      @conn.execute "ALTER TABLE test_employees DROP CONSTRAINT uniq_manual_drop"
+
+      sqls = capture_sql do
+        schema_define do
+          remove_index :test_employees, name: :uniq_manual_drop
+        end
+      end
+
+      drop_constraint = sqls.find { |s| s =~ /DROP CONSTRAINT/i }
+      drop_index = sqls.find { |s| s =~ /DROP INDEX/i }
+
+      expect(drop_constraint).to be_nil
+      expect(drop_index).not_to be_nil
+      expect(@conn.index_exists?(:test_employees, :first_name)).to be(false)
+    end
+  end
+
   describe "add_index with if_not_exists" do
     before(:each) do
       schema_define do


### PR DESCRIPTION
## Summary

Closes #2703.

`remove_index` previously emitted an `ALTER TABLE ... DROP CONSTRAINT <index_name>` (with `rescue nil`) before every `DROP INDEX`, regardless of the index's type. For a non-unique index — the common case — that DDL always raised `ORA-02443: Cannot drop constraint - nonexistent constraint`, got swallowed, and added a wasted round-trip to Oracle. The source already flagged this:

```ruby
# TODO: It should execute only when index_type == "UNIQUE"
execute "ALTER TABLE ... DROP CONSTRAINT #{index_name}" rescue nil
execute "DROP INDEX #{index_name}"
```

## Changes

Look up `unique_constraints(table_name)` and emit `DROP CONSTRAINT` only when a UNIQUE constraint sharing the target index name actually exists. The `rescue nil` is removed — any error from the constraint drop now surfaces as a real exception.

The gate is intentionally on **constraint existence**, not on the index's `unique` attribute. That choice keeps remove_index correct for several legitimate states where a unique index has no backing constraint:

- functional unique indexes (`add_index :t, "LOWER(c)", unique: true` — `add_inline_unique_constraints` skips the trailing constraint per `needs_unique_constraint?`)
- constraints manually dropped after `add_index unique: true`
- the future state from #2702 Phase 2, where `add_index unique: true` no longer creates the implicit constraint at all

Querying `unique_constraints` for the constraint's existence is `add_index unique: true`-independent: when its behavior changes, `remove_index` keeps working unchanged.

## Behavior matrix

| Setup | Before | After |
|---|---|---|
| Plain non-unique index | `DROP CONSTRAINT` (rescued) + `DROP INDEX` | `DROP INDEX` only |
| `add_index :col, unique: true, name: :n` | `DROP CONSTRAINT` + `DROP INDEX` | `DROP CONSTRAINT` + `DROP INDEX` (unchanged) |
| Functional unique index | `DROP CONSTRAINT` (rescued) + `DROP INDEX` | `DROP INDEX` only |
| Unique index whose constraint was manually dropped | `DROP CONSTRAINT` (rescued) + `DROP INDEX` | `DROP INDEX` only |
| Constraint drop fails for a real reason (privilege, lock, …) | silently swallowed | exception propagates |

## Specs

New `describe "remove index"` block (none existed for `remove_index` before):

- Non-unique remove emits only `DROP INDEX`, no `DROP CONSTRAINT`.
- Unique remove emits both, leaves no leftover constraint in `unique_constraints(table)`.
- `if_exists: true` against a missing index emits no DDL.
- Unique functional index remove emits only `DROP INDEX`.
- Implicit constraint manually dropped beforehand: remove emits only `DROP INDEX` (no spurious `DROP CONSTRAINT` attempt that would have been swallowed by `rescue nil` previously).

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb -e "remove index"` (5 examples)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb` — 172 examples, 0 failures (1 pre-existing pending unrelated)
- [x] `bundle exec rubocop` — clean
- [ ] CI on full matrix (3.3 / 3.4 / 4.0 / jruby)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

