### PR TITLE
remove_index: friendly error when a divergent unique constraint references the index

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -331,8 +331,15 @@ module ActiveRecord
         def remove_index(table_name, column_name = nil, **options) # :nodoc:
           return if options[:if_exists] && !index_exists?(table_name, column_name, **options)
 
-          index_name = index_name_for_remove(table_name, column_name, options)
-          if unique_constraints(table_name).any? { |uc| uc.name == index_name }
+          index_name = index_name_for_remove(table_name, column_name, options).to_s
+          ucs = unique_constraints(table_name)
+
+          divergent = ucs.detect { |uc| uc.using_index == index_name }
+          if divergent
+            raise ArgumentError, "Index '#{index_name}' on table '#{table_name}' is used by unique constraint '#{divergent.name}' (USING INDEX #{index_name}). Call remove_unique_constraint(:#{table_name}, name: \"#{divergent.name}\") first, then remove_index."
+          end
+
+          if ucs.any? { |uc| uc.name == index_name }
             execute "ALTER TABLE #{quote_table_name(table_name)} DROP CONSTRAINT #{quote_column_name(index_name)}"
           end
           execute "DROP INDEX #{quote_column_name(index_name)}"

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -739,6 +739,51 @@ end
       expect(drop_index).not_to be_nil
       expect(@conn.index_exists?(:test_employees, :first_name)).to be(false)
     end
+
+    it "drops a unique index and its implicit constraint when name is given as a Symbol" do
+      schema_define do
+        add_index :test_employees, :first_name, unique: true, name: :uniq_sym_name
+      end
+
+      schema_define do
+        remove_index :test_employees, name: :uniq_sym_name
+      end
+
+      expect(@conn.index_exists?(:test_employees, :first_name)).to be(false)
+      expect(@conn.unique_constraints(:test_employees).map(&:name)).not_to include("uniq_sym_name")
+    end
+
+    it "raises ArgumentError when a divergent unique constraint references the index" do
+      schema_define do
+        add_index :test_employees, :first_name, name: :idx_divergent
+        add_unique_constraint :test_employees, name: "uniq_divergent", using_index: :idx_divergent
+      end
+
+      expect {
+        schema_define do
+          remove_index :test_employees, name: :idx_divergent
+        end
+      }.to raise_error(ArgumentError, /idx_divergent.*used by unique constraint 'uniq_divergent'.*remove_unique_constraint/)
+
+      # Ensure neither the index nor the constraint were touched.
+      expect(@conn.index_exists?(:test_employees, :first_name)).to be(true)
+      expect(@conn.unique_constraints(:test_employees).map(&:name)).to include("uniq_divergent")
+    end
+
+    it "succeeds when the divergent constraint is dropped before the index" do
+      schema_define do
+        add_index :test_employees, :first_name, name: :idx_divergent_ok
+        add_unique_constraint :test_employees, name: "uniq_divergent_ok", using_index: :idx_divergent_ok
+      end
+
+      schema_define do
+        remove_unique_constraint :test_employees, name: "uniq_divergent_ok"
+        remove_index :test_employees, name: :idx_divergent_ok
+      end
+
+      expect(@conn.index_exists?(:test_employees, :first_name)).to be(false)
+      expect(@conn.unique_constraints(:test_employees).map(&:name)).not_to include("uniq_divergent_ok")
+    end
   end
 
   describe "add_index with if_not_exists" do


### PR DESCRIPTION
## Summary

Closes #2704.

After #2701 introduced `add_unique_constraint`, users can attach a UNIQUE constraint whose name diverges from its backing index:

```ruby
add_index :t, :col, name: :idx_n
add_unique_constraint :t, name: :uniq_n, using_index: :idx_n
```

State: index `idx_n` (non-unique) + constraint `uniq_n UNIQUE (col) USING INDEX idx_n`.

Calling `remove_index :t, :col` (or `remove_index name: :idx_n`) used to surface as `ORA-02429: cannot drop index used for enforcement of unique/primary key` with no hint at the recovery path. The error message is opaque to a Rails user who doesn't know which constraint is holding the index.

## Changes

`remove_index` now pre-scans `unique_constraints(table_name)` for any constraint whose `using_index` matches the target index name. When found, raises a Rails-level `ArgumentError` that names the constraint and tells the user how to clear it:

```
Index 'idx_n' on table 't' is used by unique constraint 'uniq_n' (USING INDEX idx_n).
Call remove_unique_constraint(:t, name: "uniq_n") first, then remove_index.
```

Same-name and non-unique paths are untouched — only the divergent case (`uc.using_index` populated and matching) raises.

### Drive-by: Symbol vs String comparison normalization

While writing the new spec I noticed that `index_name_for_remove` returns whatever was passed via `:name` — Symbol when the caller wrote `remove_index :t, name: :idx_n`. The post-#2703 `uc.name == index_name` and the new `uc.using_index == index_name` comparisons therefore missed for Symbol callers. Normalizing `index_name` to a `String` at the top of `remove_index` fixes both.

## Specs

Added in the existing `describe "remove index"` block:

- `raises ArgumentError when a divergent unique constraint references the index` — verifies the message names the constraint and points at `remove_unique_constraint`, and that the index/constraint state is unchanged after the raise.
- `drops a unique index and its implicit constraint when name is given as a Symbol` — direct regression test for the `index_name.to_s` normalization.
- `succeeds when the divergent constraint is dropped before the index` — sanity check for the recovery path.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb -e "remove index"` (8 examples)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb` — 175 examples, 0 failures (1 pre-existing pending unrelated)
- [x] `bundle exec rubocop` — clean
- [ ] CI on full matrix (3.3 / 3.4 / 4.0 / jruby)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

