### PR TITLE
Treat ORA-00031 (session marked for kill) as a lost connection

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -28,11 +28,12 @@ module ActiveRecord
       end
 
       # ORA-00028 your session has been killed
+      # ORA-00031 your session is marked for kill (kill in progress; the session is dead-on-arrival to its next op)
       # ORA-01012 not logged on
       # ORA-03113 end-of-file on communication channel
       # ORA-03114 not connected to ORACLE
       # ORA-03135 connection lost contact
-      LOST_CONNECTION_ERROR_CODES = [28, 1012, 3113, 3114, 3135] # :nodoc:
+      LOST_CONNECTION_ERROR_CODES = [28, 31, 1012, 3113, 3114, 3135] # :nodoc:
 
       class ConnectionException < StandardError # :nodoc:
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -878,6 +878,22 @@ describe "OracleEnhancedConnection" do
       expect { Post.take }.to raise_error(ActiveRecord::StatementInvalid)
     end
 
+    # ORA-00031 ("session is marked for kill") arrives during the brief
+    # window after `ALTER SYSTEM KILL SESSION` is issued but before the
+    # target session has actually been torn down. Treating it as a lost
+    # connection lets `with_retry` reset and reconnect transparently —
+    # parallel to ORA-00028 (kill complete). Regression test for the
+    # auto-reconnection flake observed in CI under tight kill-then-query
+    # timing.
+    it "recognises ORA-00031 (session marked for kill) as a lost connection" do
+      exception = if RUBY_ENGINE == "jruby"
+        Java::JavaSql::SQLException.new("ORA-00031: session marked for kill", nil, 31)
+      else
+        OCIError.new("ORA-00031: session marked for kill", 31)
+      end
+      expect(@conn.lost_connection?(exception)).to be true
+    end
+
     if RUBY_ENGINE == "jruby"
       # ojdbc17 surfaces dropped-connection errors with both a proper
       # SQLException#getErrorCode and an "ORA-17NNN:" prefix in the message.


### PR DESCRIPTION
## Summary

Closes #2705.

`ALTER SYSTEM KILL SESSION` is asynchronous on Oracle: the command marks the target session as `PENDING_KILL` and returns immediately, while the actual teardown happens at the next safe checkpoint. Queries that land in this window get `ORA-00031: session marked for kill` rather than the post-kill `ORA-00028: your session has been killed`.

`LOST_CONNECTION_ERROR_CODES` already lists ORA-00028 but not ORA-00031, so `with_retry` (`OCI8EnhancedAutoRecover#with_retry`) did not recognise the mid-kill state as retryable, and let the raw `OCIError` (or the JDBC equivalent) propagate. Same behaviour for production code racing against an admin kill, and the auto-reconnection spec at `connection_spec.rb#L862-L879` surfaced this as a CI flake even though the spec helper already uses `KILL SESSION ... IMMEDIATE`.

## Changes

Add `31` to `LOST_CONNECTION_ERROR_CODES` alongside `28`. The kill-in-progress state is now treated as a lost connection: `with_retry` calls `reset!` (drop the dying session, open a fresh one) and retries the operation once.

```ruby
# ORA-00028 your session has been killed
# ORA-00031 your session is marked for kill (kill in progress; the session is dead-on-arrival to its next op)
# ORA-01012 not logged on
# ORA-03113 end-of-file on communication channel
# ORA-03114 not connected to ORACLE
# ORA-03135 connection lost contact
LOST_CONNECTION_ERROR_CODES = [28, 31, 1012, 3113, 3114, 3135]
```

The shared constant is consulted by `lost_connection?` on both the OCI and JDBC paths, so the fix applies to both adapters.

### Why not just stabilise the spec?

The kill helper already uses `IMMEDIATE` to shrink the race window — that wasn't enough. A polling approach (wait for `V$SESSION` row to disappear) would have papered over the underlying issue without fixing it for production callers. Treating ORA-00031 as a transient lost connection is the principled fix; the spec stabilisation falls out of it.

## Specs

New regression test in `connection_spec.rb` (single shared spec across MRI/JRuby that constructs the adapter-appropriate exception):

```ruby
it "recognises ORA-00031 (session marked for kill) as a lost connection" do
  exception = if RUBY_ENGINE == "jruby"
    Java::JavaSql::SQLException.new("ORA-00031: session marked for kill", nil, 31)
  else
    OCIError.new("ORA-00031: session marked for kill", 31)
  end
  expect(@conn.lost_connection?(exception)).to be true
end
```

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb -e "ORA-00031"` (1 example)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb` — 110 examples, 0 failures (4 pre-existing pending unrelated)
- [x] `bundle exec rubocop` — clean
- [ ] CI on full matrix (3.3 / 3.4 / 4.0 / jruby)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
