### PR TITLE
Deprecate the implicit UNIQUE CONSTRAINT in add_index :col, unique: true

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -287,7 +287,8 @@ module ActiveRecord
           execute schema_creation.accept(create_index)
 
           index = create_index.index
-          if needs_unique_constraint?(index.unique, index.columns)
+          if needs_unique_constraint?(index.unique, index.columns) && OracleEnhancedAdapter.add_index_unique_creates_constraint
+            warn_implicit_unique_constraint_deprecation
             execute add_unique_constraint_sql(index.table, index.columns, index.name)
           end
         end
@@ -825,9 +826,36 @@ module ActiveRecord
           def add_inline_unique_constraints(table_name, td)
             td.indexes.each do |column_name, index_options|
               next unless needs_unique_constraint?(index_options[:unique], column_name)
+              next unless OracleEnhancedAdapter.add_index_unique_creates_constraint
+              warn_implicit_unique_constraint_deprecation
               inline_index_name = index_options[:name]&.to_s || index_name(table_name, column: index_column_names(column_name))
               execute add_unique_constraint_sql(table_name, column_name, inline_index_name)
             end
+          end
+
+          def warn_implicit_unique_constraint_deprecation
+            OracleEnhanced.deprecator.warn(<<~MSG)
+              add_index :col, unique: true creates an implicit named UNIQUE constraint on Oracle,
+              in addition to the unique index. This implicit-constraint behavior will be removed
+              in a future oracle-enhanced release.
+
+              To silence this warning, set the flag in an initializer:
+
+                ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.add_index_unique_creates_constraint = false
+
+              After setting the flag, choose the path that matches your intent:
+
+              * Unique INDEX only (typical when foreign keys reference primary keys):
+                no migration changes needed — add_index :col, unique: true keeps creating
+                the unique index, just without the extra UNIQUE CONSTRAINT.
+
+              * Unique INDEX + UNIQUE CONSTRAINT (needed when this column is a non-PK
+                foreign-key target, which Oracle only allows against named constraints):
+                use add_unique_constraint instead — it creates both the constraint and
+                its backing unique index in one call, e.g.
+
+                  add_unique_constraint :sections, :position, name: :uniq_position
+            MSG
           end
 
           def validate_identity_options!(identity, id, primary_key)

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -239,6 +239,23 @@ module ActiveRecord
 
       ##
       # :singleton-method:
+      # Controls whether <tt>add_index :col, unique: true</tt> implicitly creates
+      # a same-named UNIQUE CONSTRAINT in addition to the unique index. This
+      # behavior was introduced so that Oracle-specific FK targetability worked
+      # with Rails-standard <tt>add_index unique: true</tt> migrations, but the
+      # explicit <tt>add_unique_constraint</tt> DSL is now the recommended path
+      # for callers who actually need a constraint. Defaults to +true+ for
+      # backward compatibility; will flip to +false+ in a future release.
+      #
+      # Set to +false+ in an initializer to opt out of the implicit-constraint
+      # behavior (and silence the deprecation warning) immediately:
+      #
+      #   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.add_index_unique_creates_constraint = false
+      cattr_accessor :add_index_unique_creates_constraint
+      self.add_index_unique_creates_constraint = true
+
+      ##
+      # :singleton-method:
       # Selects the Arel visitor used to compile SQL for the connection.
       #
       # * +:auto+ — pick based on the connected database version:

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -786,6 +786,99 @@ end
     end
   end
 
+  describe "add_index unique: true implicit constraint deprecation" do
+    around(:each) do |example|
+      original = ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.add_index_unique_creates_constraint
+      example.run
+    ensure
+      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.add_index_unique_creates_constraint = original
+      schema_define do
+        drop_table :test_dep_warn, if_exists: true
+      end
+    end
+
+    before(:each) do
+      schema_define do
+        create_table :test_dep_warn, force: true do |t|
+          t.string :first_name
+          t.string :last_name
+        end
+      end
+    end
+
+    it "emits a deprecation warning and creates the implicit constraint by default" do
+      expect {
+        ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.add_index_unique_creates_constraint = true
+        @conn.add_index :test_dep_warn, :first_name, unique: true, name: :uniq_dep_default
+      }.to output(/add_index :col, unique: true creates an implicit named UNIQUE constraint/).to_stderr
+
+      expect(@conn.unique_constraints(:test_dep_warn).map(&:name)).to include("uniq_dep_default")
+    end
+
+    it "does not emit a warning and does not create the constraint when the flag is false" do
+      expect {
+        ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.add_index_unique_creates_constraint = false
+        @conn.add_index :test_dep_warn, :first_name, unique: true, name: :uniq_dep_off
+      }.not_to output(/implicit named UNIQUE constraint/).to_stderr
+
+      expect(@conn.unique_constraints(:test_dep_warn).map(&:name)).not_to include("uniq_dep_off")
+      expect(@conn.indexes(:test_dep_warn).map(&:name)).to include("uniq_dep_off")
+    end
+
+    it "skips both the warning and the constraint for functional unique indexes regardless of the flag" do
+      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.add_index_unique_creates_constraint = true
+
+      expect {
+        @conn.add_index :test_dep_warn, "LOWER(first_name)", unique: true, name: :uniq_dep_func
+      }.not_to output(/implicit named UNIQUE constraint/).to_stderr
+
+      expect(@conn.unique_constraints(:test_dep_warn).map(&:name)).not_to include("uniq_dep_func")
+    end
+
+    it "emits the deprecation warning for inline t.index :col, unique: true inside create_table" do
+      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.add_index_unique_creates_constraint = true
+      begin
+        # Bypass `schema_define` here — it wraps in `OracleEnhanced.deprecator.silence`,
+        # which would suppress the very warning we want to capture.
+        expect {
+          ActiveRecord::Schema.define do
+            create_table :test_dep_inline, force: true do |t|
+              t.string :first_name
+              t.index :first_name, unique: true, name: :uniq_dep_inline
+            end
+          end
+        }.to output(/add_index :col, unique: true creates an implicit named UNIQUE constraint/).to_stderr
+
+        expect(@conn.unique_constraints(:test_dep_inline).map(&:name)).to include("uniq_dep_inline")
+      ensure
+        schema_define { drop_table :test_dep_inline, if_exists: true }
+      end
+    end
+
+    it "emits the deprecation warning for composite-column add_index unique: true" do
+      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.add_index_unique_creates_constraint = true
+
+      expect {
+        @conn.add_index :test_dep_warn, [:first_name, :last_name], unique: true, name: :uniq_dep_composite
+      }.to output(/add_index :col, unique: true creates an implicit named UNIQUE constraint/).to_stderr
+
+      uc = @conn.unique_constraints(:test_dep_warn).detect { |u| u.name == "uniq_dep_composite" }
+      expect(uc).not_to be_nil
+    end
+
+    it "includes a 'called from' frame in the deprecation warning so users can locate the call site" do
+      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.add_index_unique_creates_constraint = true
+
+      # Lightweight call-site check: relies on ActiveSupport::Deprecation's
+      # default `[:stderr]` behavior, which emits `(called from <caller>)`
+      # appended to the message. If a future Rails release changes that
+      # format, update the regex here rather than removing the assertion.
+      expect {
+        @conn.add_index :test_dep_warn, :first_name, unique: true, name: :uniq_dep_caller
+      }.to output(/\(called from /).to_stderr
+    end
+  end
+
   describe "add_index with if_not_exists" do
     before(:each) do
       schema_define do

--- a/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
@@ -185,7 +185,9 @@ describe "OracleEnhancedAdapter structure dump" do
 
     it "should dump indexes" do
       ActiveRecord::Base.lease_connection.add_index(:test_posts, :foo, name: :ix_test_posts_foo)
-      ActiveRecord::Base.lease_connection.add_index(:test_posts, :foo_id, name: :ix_test_posts_foo_id, unique: true)
+      ActiveRecord::ConnectionAdapters::OracleEnhanced.deprecator.silence do
+        ActiveRecord::Base.lease_connection.add_index(:test_posts, :foo_id, name: :ix_test_posts_foo_id, unique: true)
+      end
 
       @conn.execute <<~SQL
         ALTER TABLE test_posts

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -113,9 +113,18 @@ ActiveRecord::StructuredEventSubscriber::IGNORE_PAYLOAD_NAMES.replace(["EXPLAIN"
 
 module SchemaSpecHelper
   def schema_define(&block)
-    ActiveRecord::Schema.define do
-      suppress_messages do
-        instance_eval(&block)
+    # `schema_define` is the primary test-infrastructure helper for setting
+    # up tables and indexes inside specs. Silencing deprecation warnings
+    # here keeps the CI's "no leaked DEPRECATION" gate (see RSpec.configure
+    # below) from catching warnings that come from schema setup itself.
+    # Specs that explicitly want to assert on a deprecation should call
+    # `ActiveRecord::Schema.define` (or the adapter API) directly instead
+    # of going through `schema_define`.
+    ActiveRecord::ConnectionAdapters::OracleEnhanced.deprecator.silence do
+      ActiveRecord::Schema.define do
+        suppress_messages do
+          instance_eval(&block)
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

Closes #2702 (Phase 1 — deprecation warning + global opt-out, no Rails core dependency).

`add_index :col, unique: true` has been emitting a same-named UNIQUE CONSTRAINT alongside the unique index since #2610/#2612 to keep Rails-standard `add_index unique: true` migrations FK-targetable on Oracle. Now that #2701 introduced the explicit `add_unique_constraint` DSL, the implicit-constraint behavior is the wrong default: it's misaligned with Rails core (PG / MySQL / SQLite create only the index), surprises users debugging `all_constraints`, and conflates index identity with constraint identity.

This PR delivers Phase 1 of the deprecation: a deprecation warning plus a global opt-out, without changing the default behavior. Phase 2 (default flip via `Migration[N+1]`, depends on Rails core extension `another-33269`) is tracked separately.

## Changes

### Production

- New `cattr_accessor :add_index_unique_creates_constraint` on `OracleEnhancedAdapter`, defaulting to `true` for backward compatibility.

  ```ruby
  # config/initializers/oracle_enhanced.rb
  ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.add_index_unique_creates_constraint = false
  ```

  Set to `false` to opt out immediately — both the implicit constraint and the deprecation warning are skipped.

- When the flag is `true` (the default) and a non-functional unique index is being added, both `add_index` and the inline `t.index unique: true` drain inside `create_table` now emit a deprecation warning before creating the constraint. The warning is keyed at the call site so each migration step sees one message.

  Warning text — front-loads the universal silence path (set the flag), then splits the two intents the user might have:

  > add_index :col, unique: true creates an implicit named UNIQUE constraint on Oracle,
  > in addition to the unique index. This implicit-constraint behavior will be removed
  > in a future oracle-enhanced release.
  >
  > To silence this warning, set the flag in an initializer:
  >
  >   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.add_index_unique_creates_constraint = false
  >
  > After setting the flag, choose the path that matches your intent:
  >
  > * Unique INDEX only (typical when foreign keys reference primary keys):
  >   no migration changes needed — add_index :col, unique: true keeps creating
  >   the unique index, just without the extra UNIQUE CONSTRAINT.
  >
  > * Unique INDEX + UNIQUE CONSTRAINT (needed when this column is a non-PK
  >   foreign-key target, which Oracle only allows against named constraints):
  >   use add_unique_constraint instead — it creates both the constraint and
  >   its backing unique index in one call, e.g.
  >
  >     add_unique_constraint :sections, :position, name: :uniq_position

- Functional unique indexes (e.g. `add_index :t, "LOWER(c)", unique: true`) keep going through the existing `needs_unique_constraint?` skip — no constraint is created, no warning fires.

### Specs

- New `add_index unique: true implicit constraint deprecation` describe block:
  - emits warning + creates constraint when flag is `true` (default)
  - no warning + no constraint when flag is `false`
  - functional unique index emits no warning (no constraint created)
  - inline `t.index :col, unique: true` inside `create_table` also emits the warning
  - composite-column `add_index :t, [:a, :b], unique: true` emits the warning
  - the warning includes a `(called from ...)` frame so users can locate the call site
- `schema_define` (the test-infrastructure helper used by most spec setups) now wraps its body in `OracleEnhanced.deprecator.silence`, so schema setup that incidentally triggers the new warning does not trip the CI's "no leaked DEPRECATION" gate. Specs that explicitly assert on the warning bypass `schema_define` and call the adapter directly.
- One spec in `structure_dump_spec.rb` calls `lease_connection.add_index(unique: true)` directly outside `schema_define` and is wrapped in `OracleEnhanced.deprecator.silence` for the same reason.

## Out of scope

- **Phase 2** (`Migration[N+1]` flips the default to `false` via `MigrationCompatibility::Versioned`) depends on yahonda/rails `another-33269` landing in Rails core. Tracked in #2702.
- **Per-call opt-out** (e.g. `add_index :t, :col, unique: true, constraint: false`). Considered but rejected: the option becomes obsolete once Phase 2 flips the default, and the global flag covers the project-level opt-out cleanly.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb -e "implicit constraint deprecation"` (6 examples)
- [x] `CI=1 bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/` — 683 examples, 0 failures, 11 pending (no DEPRECATION leakage past the `schema_define` silencing layer)
- [x] `bundle exec rubocop` — clean
- [ ] CI on full matrix (3.3 / 3.4 / 4.0 / jruby)

🤖 Generated with [Claude Code](https://claude.com/claude-code)




