### PR TITLE
Phase 2: flip add_index unique: true default in Migration[8.2]+ [DRAFT — depends on Rails per-adapter-migration-compatibility]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development do
   gem "rspec"
   gem "rdoc"
   gem "rake"
-  gem "activerecord",   github: "rails/rails", branch: "main"
+  gem "activerecord",   github: "yahonda/rails", branch: "per-adapter-migration-compatibility"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do

--- a/lib/active_record/connection_adapters/oracle_enhanced/migration_compatibility.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/migration_compatibility.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module OracleEnhanced
+      module MigrationCompatibility # :nodoc: all
+        extend ActiveRecord::Migration::Compatibility::Versioned
+
+        # Thread-local key used by V8_1 to opt back into the legacy implicit-
+        # constraint behavior. Encapsulated here so that the entire
+        # MigrationCompatibility module — key included — can be removed in
+        # one piece in Phase 3 of the deprecation (#2702) without leaving
+        # observable state behind in `Thread.current`.
+        IMPLICIT_UNIQUE_CONSTRAINT_KEY = :__oracle_enhanced_implicit_unique_constraint
+        private_constant :IMPLICIT_UNIQUE_CONSTRAINT_KEY
+
+        def self.implicit_unique_constraint_enabled?
+          Thread.current[IMPLICIT_UNIQUE_CONSTRAINT_KEY] == true
+        end
+
+        def self.with_implicit_unique_constraint_enabled
+          prev = Thread.current[IMPLICIT_UNIQUE_CONSTRAINT_KEY]
+          Thread.current[IMPLICIT_UNIQUE_CONSTRAINT_KEY] = true
+          yield
+        ensure
+          Thread.current[IMPLICIT_UNIQUE_CONSTRAINT_KEY] = prev
+        end
+
+        # Phase 2 of the implicit-UNIQUE-CONSTRAINT deprecation (#2702):
+        # `Migration[8.2]+` (the current default) treats `add_index unique:
+        # true` as "create only the unique index" — matching the Rails-core
+        # PostgreSQL/MySQL/SQLite adapters. `Migration[8.1]` and earlier
+        # opt back into the pre-Phase-2 behavior of also creating a
+        # same-named UNIQUE CONSTRAINT, so existing migrations keep
+        # working unchanged. Callers that need a constraint should call
+        # `add_unique_constraint :t, :col, name: :n` directly.
+        module V8_1
+          def add_index(table_name, column_name, **options)
+            MigrationCompatibility.with_implicit_unique_constraint_enabled { super }
+          end
+
+          def create_table(table_name, **options, &block)
+            MigrationCompatibility.with_implicit_unique_constraint_enabled { super }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -309,7 +309,7 @@ module ActiveRecord
           execute schema_creation.accept(create_index)
 
           index = create_index.index
-          if needs_unique_constraint?(index.unique, index.columns) && OracleEnhancedAdapter.add_index_unique_creates_constraint
+          if needs_unique_constraint?(index.unique, index.columns) && implicit_unique_constraint_active?
             warn_implicit_unique_constraint_deprecation
             execute add_unique_constraint_sql(index.table, index.columns, index.name)
           end
@@ -1248,11 +1248,28 @@ module ActiveRecord
           def add_inline_unique_constraints(table_name, td)
             td.indexes.each do |column_name, index_options|
               next unless needs_unique_constraint?(index_options[:unique], column_name)
-              next unless OracleEnhancedAdapter.add_index_unique_creates_constraint
+              next unless implicit_unique_constraint_active?
               warn_implicit_unique_constraint_deprecation
               inline_index_name = index_options[:name]&.to_s || index_name(table_name, column: index_column_names(column_name))
               execute add_unique_constraint_sql(table_name, column_name, inline_index_name)
             end
+          end
+
+          # Implicit UNIQUE CONSTRAINT creation for `add_index unique: true`
+          # is gated by:
+          #
+          # * the global flag `add_index_unique_creates_constraint` (explicit
+          #   user opt-in), OR
+          # * `MigrationCompatibility.implicit_unique_constraint_enabled?`,
+          #   set to true while an `Migration[8.1]` or earlier migration is
+          #   running (legacy default preserved for old migrations).
+          #
+          # In Phase 2, the global flag defaults to `false`, so callers
+          # outside the V8_1 path (Migration[8.2]+, Schema.define, direct
+          # adapter calls) skip the implicit constraint by default.
+          def implicit_unique_constraint_active?
+            return true if OracleEnhancedAdapter.add_index_unique_creates_constraint
+            OracleEnhanced::MigrationCompatibility.implicit_unique_constraint_enabled?
           end
 
           def warn_implicit_unique_constraint_deprecation

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -50,6 +50,7 @@ require "active_record/connection_adapters/oracle_enhanced/database_limits"
 require "active_record/connection_adapters/oracle_enhanced/dbms_output"
 require "active_record/connection_adapters/oracle_enhanced/type_metadata"
 require "active_record/connection_adapters/oracle_enhanced/structure_dump"
+require "active_record/connection_adapters/oracle_enhanced/migration_compatibility"
 require "active_record/connection_adapters/oracle_enhanced/structure_dump/dbms_metadata"
 require "active_record/connection_adapters/oracle_enhanced/structure_dump/dispatcher"
 require "active_record/connection_adapters/oracle_enhanced/lob"
@@ -244,15 +245,22 @@ module ActiveRecord
       # behavior was introduced so that Oracle-specific FK targetability worked
       # with Rails-standard <tt>add_index unique: true</tt> migrations, but the
       # explicit <tt>add_unique_constraint</tt> DSL is now the recommended path
-      # for callers who actually need a constraint. Defaults to +true+ for
-      # backward compatibility; will flip to +false+ in a future release.
+      # for callers who actually need a constraint.
       #
-      # Set to +false+ in an initializer to opt out of the implicit-constraint
-      # behavior (and silence the deprecation warning) immediately:
+      # Phase 2 default: +false+. <tt>Migration[8.2]+</tt> migrations,
+      # <tt>Schema.define</tt> blocks, and direct adapter calls all default
+      # to "create the unique index only". <tt>Migration[8.1]</tt> and earlier
+      # migrations opt back into the legacy implicit-constraint behavior via
+      # the +MigrationCompatibility+ module so existing migrations keep
+      # working unchanged.
       #
-      #   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.add_index_unique_creates_constraint = false
+      # Set to +true+ explicitly to force the legacy implicit-constraint
+      # behavior project-wide (e.g. when migrating a long-running multi-DB
+      # application that depends on it):
+      #
+      #   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.add_index_unique_creates_constraint = true
       cattr_accessor :add_index_unique_creates_constraint
-      self.add_index_unique_creates_constraint = true
+      self.add_index_unique_creates_constraint = false
 
       ##
       # :singleton-method:
@@ -569,6 +577,10 @@ module ActiveRecord
 
       def supports_materialized_views?
         true
+      end
+
+      def migration_compatibility_module_for(migration_class) # :nodoc:
+        OracleEnhanced::MigrationCompatibility.module_for(migration_class)
       end
 
       def supports_fetch_first_n_rows_and_offset?

--- a/spec/active_record/connection_adapters/oracle_enhanced/dbms_metadata_structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/dbms_metadata_structure_dump_spec.rb
@@ -144,19 +144,21 @@ RSpec.describe "OracleEnhancedAdapter DBMS_METADATA structure dump" do
     # as VISIBLE.
     it "emits ALTER INDEX ... INVISIBLE for an INVISIBLE constraint-backed index" do
       skip "Not supported in this database version" unless @conn.supports_disabling_indexes?
-      schema_define do
-        create_table :test_dbms_meta_inv_uniq, force: true do |t|
-          t.string :email
+      with_implicit_unique_constraint_enabled do
+        schema_define do
+          create_table :test_dbms_meta_inv_uniq, force: true do |t|
+            t.string :email
+          end
+          add_index :test_dbms_meta_inv_uniq, :email,
+                    unique: true, name: "ix_dbms_meta_inv_uniq", enabled: false
         end
-        add_index :test_dbms_meta_inv_uniq, :email,
-                  unique: true, name: "ix_dbms_meta_inv_uniq", enabled: false
-      end
 
-      dump = @conn.structure_dump
-      alter_stmt = dump.split("\n\n/\n\n").find do |stmt|
-        stmt.match?(/\AALTER\s+INDEX\s+"?IX_DBMS_META_INV_UNIQ"?\s+INVISIBLE\s*\z/i)
+        dump = @conn.structure_dump
+        alter_stmt = dump.split("\n\n/\n\n").find do |stmt|
+          stmt.match?(/\AALTER\s+INDEX\s+"?IX_DBMS_META_INV_UNIQ"?\s+INVISIBLE\s*\z/i)
+        end
+        expect(alter_stmt).not_to be_nil
       end
-      expect(alter_stmt).not_to be_nil
     ensure
       schema_define { drop_table :test_dbms_meta_inv_uniq, if_exists: true }
     end
@@ -230,7 +232,14 @@ RSpec.describe "OracleEnhancedAdapter DBMS_METADATA structure dump" do
         create_table :test_dbms_metadata_posts, force: true do |t|
           t.string :email
         end
-        add_index :test_dbms_metadata_posts, :email, unique: true, name: "ix_test_dbms_metadata_email"
+      end
+      # Use the legacy implicit-constraint path so this Oracle 12.1+
+      # DBMS_METADATA path test exercises the "unique index backed by a
+      # same-name UNIQUE constraint" scenario it was written for.
+      with_implicit_unique_constraint_enabled do
+        schema_define do
+          add_index :test_dbms_metadata_posts, :email, unique: true, name: "ix_test_dbms_metadata_email"
+        end
       end
       dump = @conn.structure_dump
       stmts = dump.split("\n\n/\n\n")

--- a/spec/active_record/connection_adapters/oracle_enhanced/migration_compatibility_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/migration_compatibility_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+RSpec.describe "OracleEnhanced::MigrationCompatibility for add_index unique: true" do
+  include SchemaSpecHelper
+
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @conn = ActiveRecord::Base.lease_connection
+  end
+
+  before(:each) do
+    schema_define do
+      create_table :test_compat_warn, force: true do |t|
+        t.string :first_name
+      end
+    end
+  end
+
+  after(:each) do
+    schema_define do
+      drop_table :test_compat_warn, if_exists: true
+    end
+  end
+
+  def run_migration(migration_class, &body)
+    klass = Class.new(migration_class) do
+      define_method(:change, &body)
+    end
+    klass.migrate(:up)
+  end
+
+  describe "Migration[8.2] (current default — Phase 2)" do
+    it "does not create an implicit UNIQUE constraint and does not warn" do
+      expect {
+        run_migration(ActiveRecord::Migration[8.2]) do
+          add_index :test_compat_warn, :first_name, unique: true, name: :uniq_v82
+        end
+      }.not_to output(/implicit named UNIQUE constraint/).to_stderr
+
+      expect(@conn.indexes(:test_compat_warn).map(&:name)).to include("uniq_v82")
+      expect(@conn.unique_constraints(:test_compat_warn).map(&:name)).not_to include("uniq_v82")
+    end
+
+    it "does not create the implicit constraint for inline t.index :col, unique: true" do
+      run_migration(ActiveRecord::Migration[8.2]) do
+        create_table :test_v82_inline, force: true do |t|
+          t.string :name
+          t.index :name, unique: true, name: :uniq_v82_inline
+        end
+      end
+
+      expect(@conn.indexes(:test_v82_inline).map(&:name)).to include("uniq_v82_inline")
+      expect(@conn.unique_constraints(:test_v82_inline).map(&:name)).not_to include("uniq_v82_inline")
+    ensure
+      schema_define { drop_table :test_v82_inline, if_exists: true }
+    end
+  end
+
+  describe "Migration[8.1] (legacy — V8_1 module preserves implicit-constraint default)" do
+    it "creates the implicit UNIQUE constraint and emits the deprecation warning" do
+      expect {
+        run_migration(ActiveRecord::Migration[8.1]) do
+          add_index :test_compat_warn, :first_name, unique: true, name: :uniq_v81
+        end
+      }.to output(/implicit named UNIQUE constraint/).to_stderr
+
+      expect(@conn.indexes(:test_compat_warn).map(&:name)).to include("uniq_v81")
+      expect(@conn.unique_constraints(:test_compat_warn).map(&:name)).to include("uniq_v81")
+    end
+
+    it "creates the implicit constraint for inline t.index :col, unique: true" do
+      expect {
+        run_migration(ActiveRecord::Migration[8.1]) do
+          create_table :test_v81_inline, force: true do |t|
+            t.string :name
+            t.index :name, unique: true, name: :uniq_v81_inline
+          end
+        end
+      }.to output(/implicit named UNIQUE constraint/).to_stderr
+
+      expect(@conn.indexes(:test_v81_inline).map(&:name)).to include("uniq_v81_inline")
+      expect(@conn.unique_constraints(:test_v81_inline).map(&:name)).to include("uniq_v81_inline")
+    ensure
+      schema_define { drop_table :test_v81_inline, if_exists: true }
+    end
+  end
+
+  describe "explicit global flag overrides Migration[8.2] default" do
+    around(:each) do |example|
+      adapter = ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter
+      previous = adapter.add_index_unique_creates_constraint
+      example.run
+    ensure
+      adapter.add_index_unique_creates_constraint = previous
+    end
+
+    it "creates the implicit constraint when the flag is true even under Migration[8.2]" do
+      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.add_index_unique_creates_constraint = true
+
+      expect {
+        run_migration(ActiveRecord::Migration[8.2]) do
+          add_index :test_compat_warn, :first_name, unique: true, name: :uniq_flag_override
+        end
+      }.to output(/implicit named UNIQUE constraint/).to_stderr
+
+      expect(@conn.unique_constraints(:test_compat_warn).map(&:name)).to include("uniq_flag_override")
+    end
+  end
+end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -775,7 +775,7 @@ RSpec.describe "OracleEnhancedAdapter schema dump" do
 
     it "does not double-emit t.index unique: true for an index that backs a unique constraint" do
       schema_define do
-        add_index :test_sections, :position, unique: true, name: :uniq_via_idx
+        add_unique_constraint :test_sections, :position, name: :uniq_via_idx
       end
       output = dump_table_schema "test_sections"
       expect(output).not_to match(/t\.index .*"uniq_via_idx".*unique: true/)

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -1366,9 +1366,11 @@ end
       expect(@conn.index_exists?(:test_employees, :first_name)).to be(false)
     end
 
-    it "drops a unique index together with its implicit constraint" do
-      schema_define do
-        add_index :test_employees, :first_name, unique: true, name: :uniq_test_employees_first_name
+    it "drops both the index and the same-name implicit constraint when add_index unique: true created them (legacy implicit-constraint path)" do
+      with_implicit_unique_constraint_enabled do
+        schema_define do
+          add_index :test_employees, :first_name, unique: true, name: :uniq_test_employees_first_name
+        end
       end
 
       sqls = capture_sql do
@@ -1414,15 +1416,14 @@ end
       expect(drop_index).not_to be_nil
     end
 
-    it "skips DROP CONSTRAINT after the implicit constraint was manually dropped" do
+    it "skips DROP CONSTRAINT for a unique index without a backing constraint" do
       schema_define do
-        add_index :test_employees, :first_name, unique: true, name: :uniq_manual_drop
+        add_index :test_employees, :first_name, unique: true, name: :uniq_no_constraint
       end
-      @conn.execute "ALTER TABLE test_employees DROP CONSTRAINT uniq_manual_drop"
 
       sqls = capture_sql do
         schema_define do
-          remove_index :test_employees, name: :uniq_manual_drop
+          remove_index :test_employees, name: :uniq_no_constraint
         end
       end
 
@@ -2272,11 +2273,6 @@ end
     it "allows attaching a unique constraint to an existing index via :using_index" do
       schema_define do
         add_index :test_sections, :position, unique: true, name: :idx_existing_unique
-      end
-      # The trailing constraint added by add_index already shares the index name; drop it
-      # so we can re-attach a constraint with a different name pointing at the same index.
-      @conn.execute "ALTER TABLE test_sections DROP CONSTRAINT idx_existing_unique"
-      schema_define do
         add_unique_constraint :test_sections, name: "uniq_via_idx", using_index: :idx_existing_unique
       end
       uc = @conn.unique_constraints(:test_sections).detect { |u| u.name == "uniq_via_idx" }
@@ -2413,9 +2409,6 @@ end
     it "preserves divergent constraint and index names on round-trip" do
       schema_define do
         add_index :test_sections, :position, unique: true, name: :idx_div
-      end
-      @conn.execute "ALTER TABLE test_sections DROP CONSTRAINT idx_div"
-      schema_define do
         add_unique_constraint :test_sections, name: "uniq_div", using_index: :idx_div
       end
       uc = @conn.unique_constraints(:test_sections).detect { |u| u.name == "uniq_div" }
@@ -3146,9 +3139,11 @@ end
       expect(@would_execute_sql).not_to include("ADD CONSTRAINT")
     end
 
-    it "should add unique constraint only to the index where it was defined" do
-      schema_define do
-        add_index :keyboards, ["name"], unique: true, name: :this_index
+    it "should add unique constraint only to the index where it was defined (legacy implicit-constraint path)" do
+      with_implicit_unique_constraint_enabled do
+        schema_define do
+          add_index :keyboards, ["name"], unique: true, name: :this_index
+        end
       end
       # Match anywhere in the captured SQL rather than asserting on
       # `lines.last`. `schema_define` calls `ActiveRecord::Schema.define`,
@@ -3160,11 +3155,13 @@ end
       expect(@would_execute_sql).to match(/ALTER +TABLE .* ADD CONSTRAINT .* UNIQUE \(.*\) USING INDEX "THIS_INDEX";/)
     end
 
-    it "should emit CREATE UNIQUE INDEX and ADD CONSTRAINT for inline t.index unique: true" do
-      schema_define do
-        create_table :test_inline_index_posts, force: true do |t|
-          t.string :title
-          t.index :title, unique: true, name: :uniq_inline_title
+    it "should emit CREATE UNIQUE INDEX and ADD CONSTRAINT for inline t.index unique: true (legacy implicit-constraint path)" do
+      with_implicit_unique_constraint_enabled do
+        schema_define do
+          create_table :test_inline_index_posts, force: true do |t|
+            t.string :title
+            t.index :title, unique: true, name: :uniq_inline_title
+          end
         end
       end
       expect(@would_execute_sql).to match(/CREATE UNIQUE INDEX "UNIQ_INLINE_TITLE" ON "TEST_INLINE_INDEX_POSTS" \("TITLE"\)/)
@@ -3203,28 +3200,30 @@ end
       expect(@would_execute_sql).to match(/CREATE INDEX "IDX_INLINE_TITLE_TS" ON "TEST_INLINE_INDEX_POSTS" \("TITLE"\) TABLESPACE bogus/)
     end
 
-    it "produces the same SQL whether unique index is defined inline or via explicit add_index" do
-      schema_define do
-        create_table :test_explicit_idx_posts, force: true do |t|
-          t.string :title
+    it "produces the same SQL whether unique index is defined inline or via explicit add_index (legacy implicit-constraint path)" do
+      with_implicit_unique_constraint_enabled do
+        schema_define do
+          create_table :test_explicit_idx_posts, force: true do |t|
+            t.string :title
+          end
+          add_index :test_explicit_idx_posts, :title, unique: true, name: :uniq_title
         end
-        add_index :test_explicit_idx_posts, :title, unique: true, name: :uniq_title
-      end
-      explicit_sql = @would_execute_sql.dup
+        explicit_sql = @would_execute_sql.dup
 
-      @would_execute_sql.replace("")
-      schema_define do
-        drop_table :test_explicit_idx_posts, if_exists: true
-        create_table :test_explicit_idx_posts, force: true do |t|
-          t.string :title
-          t.index :title, unique: true, name: :uniq_title
+        @would_execute_sql.replace("")
+        schema_define do
+          drop_table :test_explicit_idx_posts, if_exists: true
+          create_table :test_explicit_idx_posts, force: true do |t|
+            t.string :title
+            t.index :title, unique: true, name: :uniq_title
+          end
         end
-      end
-      inline_sql = @would_execute_sql
+        inline_sql = @would_execute_sql
 
-      [/CREATE TABLE "TEST_EXPLICIT_IDX_POSTS"/, /CREATE UNIQUE INDEX "UNIQ_TITLE"/, /ALTER +TABLE "TEST_EXPLICIT_IDX_POSTS" ADD CONSTRAINT "UNIQ_TITLE" UNIQUE \("TITLE"\) USING INDEX "UNIQ_TITLE"/].each do |pattern|
-        expect(explicit_sql).to match(pattern)
-        expect(inline_sql).to match(pattern)
+        [/CREATE TABLE "TEST_EXPLICIT_IDX_POSTS"/, /CREATE UNIQUE INDEX "UNIQ_TITLE"/, /ALTER +TABLE "TEST_EXPLICIT_IDX_POSTS" ADD CONSTRAINT "UNIQ_TITLE" UNIQUE \("TITLE"\) USING INDEX "UNIQ_TITLE"/].each do |pattern|
+          expect(explicit_sql).to match(pattern)
+          expect(inline_sql).to match(pattern)
+        end
       end
     end
   end

--- a/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe "OracleEnhancedAdapter structure dump" do
     it "appends NOVALIDATE for foreign keys added with validate: false" do
       schema_define do
         add_column :test_posts, :foo_uniq, :integer
-        add_index :test_posts, :foo_uniq, unique: true, name: "ix_test_posts_foo_uniq"
+        add_unique_constraint :test_posts, :foo_uniq, name: "ix_test_posts_foo_uniq"
         add_foreign_key :test_posts, :test_posts, column: :foo_id, primary_key: :foo_uniq, name: "fk_novalidate_baz", validate: false
       end
       dump = ActiveRecord::Base.lease_connection.structure_dump

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -147,6 +147,21 @@ module SchemaSpecHelper
   end
 end
 
+# Wraps a block with the Phase 1 / pre-Phase 2 implicit-constraint
+# behavior of `add_index :col, unique: true`. Use this only in specs that
+# explicitly exercise the legacy implicit-constraint code path (#2702
+# Phase 3 will delete both this helper and the global flag together).
+module ImplicitUniqueConstraintHelper
+  def with_implicit_unique_constraint_enabled
+    adapter = ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter
+    previous = adapter.add_index_unique_creates_constraint
+    adapter.add_index_unique_creates_constraint = true
+    yield
+  ensure
+    adapter.add_index_unique_creates_constraint = previous
+  end
+end
+
 module SchemaDumpingHelper
   def dump_table_schema(table, connection = ActiveRecord::Base.lease_connection)
     old_ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
@@ -276,6 +291,8 @@ RSpec.configure do |config|
   config.disable_monkey_patching!
   config.order = :random
   Kernel.srand config.seed
+
+  config.include ImplicitUniqueConstraintHelper
 
   # In CI, fail any example that lets a DEPRECATION WARNING leak to
   # stderr — i.e. one that triggered a deprecation but did not consume


### PR DESCRIPTION
## Summary

Closes #2702 (Phase 2).

**This PR is a draft because it depends on the unmerged Rails extension point** `AbstractAdapter#migration_compatibility_module_for(migration_class)` plus the `Migration::Compatibility::Versioned` convention from [yahonda/rails `per-adapter-migration-compatibility`](https://github.com/yahonda/rails/tree/per-adapter-migration-compatibility) — same dependency as #2596. Once that lands on `rails/rails#main`:

1. Switch `Gemfile` back to `rails/rails#main`
2. Mark this PR ready for review

In Phase 2 of the implicit-UNIQUE-CONSTRAINT deprecation, the global default flips from "implicit constraint + warning" (Phase 1, shipped in #2709) to "create the unique index only", matching Rails-core PostgreSQL / MySQL / SQLite. Existing migrations declared at `Migration[8.1]` or earlier opt back into the legacy implicit-constraint behavior via a `MigrationCompatibility::V8_1` module so they keep working unchanged.

## Behavior matrix

| Caller | Phase 1 (current `master`) | Phase 2 (this PR) |
|---|---|---|
| `Migration[8.2]` (Current) — `add_index unique: true` | implicit constraint + warning | **index only, no warning** |
| `Migration[8.1]` and earlier — `add_index unique: true` | implicit constraint + warning | implicit constraint + warning (preserved by V8_1) |
| `Schema.define { add_index unique: true }` | implicit constraint + warning | **index only, no warning** |
| Direct `connection.add_index unique: true` | implicit constraint + warning | **index only, no warning** |
| `OracleEnhancedAdapter.add_index_unique_creates_constraint = true` (explicit) — any caller | implicit constraint + warning | implicit constraint + warning (explicit opt-in to legacy) |
| Functional unique index — any caller | index only (no warning) | index only (no warning) — unchanged |

## Changes

### Production

- `OracleEnhancedAdapter.add_index_unique_creates_constraint` default flips from `true` to `false`. Documentation updated to reflect the Phase 2 default and the explicit opt-in for legacy behavior.
- New `lib/active_record/connection_adapters/oracle_enhanced/migration_compatibility.rb`:
  - `MigrationCompatibility::V8_1` module wraps `add_index` and `create_table` so `Migration[8.1]` and earlier migrations re-enable the implicit-constraint path.
  - Thread-local key (`:__oracle_enhanced_implicit_unique_constraint`) is encapsulated as a `private_constant` of `MigrationCompatibility`, with `with_implicit_unique_constraint_enabled` / `implicit_unique_constraint_enabled?` accessors. Phase 3 deletes the whole module — key, accessors, and V8_1 — in one piece without leaving observable state behind in `Thread.current`.
- `OracleEnhancedAdapter#migration_compatibility_module_for(migration_class)` returns `MigrationCompatibility.module_for(migration_class)`, mirroring the PG / MySQL / SQLite adapters in `per-adapter-migration-compatibility`.
- `schema_statements.rb` introduces an `implicit_unique_constraint_active?` private helper that ORs the global flag with the migration-version thread-local, used by both `add_index` and `add_inline_unique_constraints`.

### Specs

- New `migration_compatibility_spec.rb` covering:
  - Migration[8.2] (current) — no implicit constraint, no warning, both `add_index` and inline `t.index` paths
  - Migration[8.1] (legacy) — implicit constraint + warning captured via `expect { ... }.to output(...).to_stderr`, both paths
  - Explicit `add_index_unique_creates_constraint = true` — overrides the Migration[8.2] default
- Mixed-strategy update of existing specs:
  - **Legacy SQL emission tests** (`should add unique constraint only to the index where it was defined`, `should emit CREATE UNIQUE INDEX and ADD CONSTRAINT for inline t.index unique: true`, `produces the same SQL whether unique index is defined inline or via explicit add_index`, the DBMS_METADATA path's `does not emit a standalone CREATE INDEX for a UNIQUE constraint's backing index`, and `emits ALTER INDEX ... INVISIBLE for an INVISIBLE constraint-backed index`) → wrapped in a new `with_implicit_unique_constraint_enabled` helper and labeled "(legacy implicit-constraint path)". These specs intentionally exercise the legacy code path; the helper makes that intent explicit.
  - **Orthogonal-feature tests** (remove_index, add_unique_constraint, schema dumper, and `structure_dump`'s `appends NOVALIDATE for foreign keys added with validate: false`) that just needed an index + constraint pair as setup are migrated to `add_unique_constraint`. Forward-compatible: Phase 3 doesn't need to touch them.
  - The `drops both the index and the same-name implicit constraint when add_index unique: true created them` spec for `remove_index` keeps the legacy `add_index unique: true` setup via the helper, because that pairing is precisely what's being tested. (Per "let Oracle handle constraint-managed indexes" — this scenario only happens for the legacy path where the index is created explicitly via `CREATE UNIQUE INDEX`, not auto-created behind a constraint.)
- `spec_helper.rb` adds `ImplicitUniqueConstraintHelper#with_implicit_unique_constraint_enabled`, included globally so any spec can opt-in to legacy.

## Out of scope

- **`remove_index` against an index that was auto-created behind an `add_unique_constraint`** still raises `ORA-01418` because Oracle's automatic cleanup drops the index together with the constraint, then `remove_index` tries to drop the (already-gone) index. Per the design principle "let Oracle handle the index it auto-creates behind a constraint", the recovery path for that case is `remove_unique_constraint :t, name: :n`, not `remove_index`. Worth a friendly error in a follow-up issue if it bites users in practice.
- **Phase 3** (delete the flag, the helper, the V8_1 module, and the implicit-constraint code path) ships one major release after Phase 2 settles. Tracked in #2702.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/migration_compatibility_spec.rb` (5 examples)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb -e "implicit constraint deprecation"` (6 examples) — Phase 1 specs continue to pass; the explicit-flag-true ones still test the legacy path now
- [x] `CI=1 bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb spec/active_record/connection_adapters/oracle_enhanced/migration_compatibility_spec.rb` — 226 examples, 0 failures, 2 pre-existing pending
- [x] `bundle exec rubocop` — clean
- [ ] Switch `Gemfile` back to `rails/rails#main` once `per-adapter-migration-compatibility` lands
- [ ] Mark PR ready for review and run CI on full matrix

## Related

- Phase 1 (deprecation warning + opt-out flag) — #2709 (merged)
- Rails dependency — yahonda/rails `per-adapter-migration-compatibility` (same as #2596)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



