### PR TITLE
Align supports_insert_returning? with the adapter's actual RETURNING usage

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -274,7 +274,8 @@ module ActiveRecord
                 binds << ActiveRecord::Relation::QueryAttribute.new("returning_#{col}", nil, type)
               end
             end
-            super(sql, pk, binds, returning)
+            # Skip super: AR's abstract appends PG-style `RETURNING col1, col2` which conflicts with Oracle's `RETURNING ... INTO :bind` form (ORA-00925).
+            [sql, binds]
           end
 
           def columns_for_returning_clause(sql, pk, binds, returning)

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -519,6 +519,10 @@ module ActiveRecord
         true
       end
 
+      def supports_insert_returning?
+        true
+      end
+
       def supports_optimizer_hints?
         true
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -120,6 +120,101 @@ RSpec.describe "OracleEnhancedAdapter" do
     end
   end
 
+  describe "supports_insert_returning?" do
+    it "is true" do
+      expect(ActiveRecord::Base.lease_connection.supports_insert_returning?).to be(true)
+    end
+
+    # `RETURNING ... INTO :bind` path: triggered when the PK is database-assigned
+    # at INSERT time (IDENTITY column on Oracle 12.1+).
+    context "with an IDENTITY primary key" do
+      before(:all) do
+        skip "Not supported in this database version" unless ActiveRecord::Base.lease_connection.supports_identity_columns?
+        schema_define do
+          create_table :test_returning_identity_items, force: true, identity: true do |t|
+            t.string :name
+          end
+        end
+        class ::TestReturningIdentityItem < ActiveRecord::Base
+        end
+      end
+
+      after(:all) do
+        schema_define { drop_table :test_returning_identity_items, if_exists: true }
+        Object.send(:remove_const, "TestReturningIdentityItem") if defined?(TestReturningIdentityItem)
+        ActiveRecord::Base.clear_cache!
+      end
+
+      before(:each) { set_logger }
+
+      after(:each) do
+        clear_logger
+        TestReturningIdentityItem.delete_all
+      end
+
+      it "returns the database-assigned primary key from Model.create!" do
+        record = TestReturningIdentityItem.create!(name: "alpha")
+        expect(record.id).to be_a(Integer)
+        expect(record.id).to be > 0
+      end
+
+      it "emits Oracle's `RETURNING ... INTO :bind` form (not the PG-style `RETURNING col`)" do
+        TestReturningIdentityItem.create!(name: "alpha")
+        insert_log = @logger.logged(:debug).find { |line| line.include?("INSERT INTO") && line.include?("TEST_RETURNING_IDENTITY_ITEMS") }
+        expect(insert_log).not_to be_nil, "INSERT statement was not logged"
+        expect(insert_log).to match(/RETURNING\s+"ID"\s+INTO\s+:returning_id/i)
+        expect(insert_log).not_to match(/RETURNING\s+"ID"\s*\)?\s*\z/i)
+      end
+    end
+
+    # Sequence-prefetched path: oracle-enhanced's default for `create_table` (no
+    # `identity: true`). The PK is fetched via `seq.NEXTVAL` before the INSERT
+    # and bound into the values list, so RETURNING is NOT used. This spec locks
+    # in that the flag flip + super-skip does not accidentally inject a RETURNING
+    # clause on this path.
+    context "with a sequence-prefetched primary key" do
+      before(:all) do
+        schema_define do
+          create_table :test_returning_seq_items, force: true do |t|
+            t.string :name
+          end
+        end
+        class ::TestReturningSeqItem < ActiveRecord::Base
+        end
+      end
+
+      after(:all) do
+        schema_define { drop_table :test_returning_seq_items, if_exists: true }
+        Object.send(:remove_const, "TestReturningSeqItem") if defined?(TestReturningSeqItem)
+        ActiveRecord::Base.clear_cache!
+      end
+
+      before(:each) { set_logger }
+
+      after(:each) do
+        clear_logger
+        TestReturningSeqItem.delete_all
+      end
+
+      it "returns the sequence-fetched primary key from Model.create!" do
+        record = TestReturningSeqItem.create!(name: "alpha")
+        expect(record.id).to be_a(Integer)
+        expect(record.id).to be > 0
+      end
+
+      it "binds the sequence-fetched id into the INSERT and does NOT emit RETURNING" do
+        TestReturningSeqItem.create!(name: "alpha")
+        insert_log = @logger.logged(:debug).find { |line| line.include?("INSERT INTO") && line.include?("TEST_RETURNING_SEQ_ITEMS") }
+        expect(insert_log).not_to be_nil, "INSERT statement was not logged"
+        expect(insert_log).to match(/INSERT INTO "TEST_RETURNING_SEQ_ITEMS".*"ID"/im)
+        # \bRETURNING\b\s+(?:"|INTO) catches the SQL keyword followed by either
+        # a quoted column or `INTO :bind`; avoids false matches on the table
+        # name (which contains the substring "RETURNING").
+        expect(insert_log).not_to match(/\bRETURNING\b\s+(?:"|INTO\b)/i)
+      end
+    end
+  end
+
   describe "session information" do
     before(:all) do
       @conn = ActiveRecord::Base.lease_connection


### PR DESCRIPTION
## Summary

Surfaced during the survey for #2702 / #2710 (and incidentally connected to #2711 / #2712 / #2713 / #2714 in the same wave).

`OracleEnhancedAdapter` has used Oracle's `INSERT … RETURNING col INTO :bind` form for years (in `OracleEnhanced::DatabaseStatements#sql_for_insert` / `#_exec_insert`) to fetch the auto-generated primary key after `Model.create!`. The `supports_insert_returning?` capability flag, however, was left at the abstract default (`false`). That mismatch hides the adapter's actual RETURNING support from higher-level Active Record code such as `insert_all`, whose default for `@returning` is gated on the flag (`activerecord/lib/active_record/insert_all.rb#L38`).

Flipping the flag alone surfaces a latent bug: the existing `sql_for_insert` override ends with `super(sql, pk, binds, returning)`, which on the abstract path used to be a no-op (because the flag was false). With the flag set to `true`, the abstract `sql_for_insert` now appends a second, PostgreSQL-style `RETURNING col1, col2` clause on top of the Oracle-style `RETURNING … INTO :returning_id` already produced above. The result is SQL containing two `RETURNING` clauses, which Oracle rejects with `ORA-00925: missing INTO keyword` on every `Model.create!`. Splitting these into two commits would leave the test suite failing in between, so they ship as one cohesive change.

## Changes

* `OracleEnhancedAdapter#supports_insert_returning?` overridden to `true`, with rdoc explaining the alignment with the long-standing `RETURNING … INTO` implementation.
* `OracleEnhanced::DatabaseStatements#sql_for_insert` no longer delegates to `super` after appending the Oracle `RETURNING … INTO` clause; the comment in place explains why (the abstract path would append a duplicate PG-style `RETURNING`).

## What this enables

* Active Record machinery that branches on `supports_insert_returning?` no longer treats Oracle as if it lacked the feature. Most visible effect: `insert_all`'s default `@returning` resolves to the model's primary keys (instead of `false`).

## ⚠️ Transitional limitation: `insert_all!` is broken until #2730 lands

Pre-#2715, `Model.insert_all!([...])` produced PG-style multi-row `VALUES (...), (...)` SQL that Oracle rejected, but the failure was already there because of the missing `build_insert_sql` override. Post-#2715, the flag flip changes the **shape** of the failure: AR core's bulk-insert path now branches into the `RETURNING`-aware code, but oracle-enhanced still has no `build_insert_sql` override, so `insert_all!` continues to emit PG-shaped SQL and fails with `ORA-00933` (or similar) — same outcome, slightly different parser error.

The fix is **#2730** (stacked on this PR), which overrides `build_insert_sql` to emit Oracle's `INSERT ALL … SELECT 1 FROM DUAL` form. Until #2730 merges:

| API | Status |
|-----|--------|
| `Model.create!` / `save!` | ✅ Works (uses Oracle `RETURNING … INTO`) |
| `Model.find_or_create_by` | ✅ Works |
| `Relation#insert(attrs)` (single row) | ⚠️ Routes through `build_insert_sql` → broken until #2730 |
| `Model.insert_all` (default `:skip`) | ✅ Pre-empted by AR core: `supports_insert_on_duplicate_skip?` is still `false`, raises `ArgumentError` |
| `Model.insert_all!` | ❌ Reaches abstract `build_insert_sql` → emits PG-shape multi-row VALUES → Oracle rejects |
| `Model.upsert_all` | ✅ Pre-empted by `supports_insert_on_duplicate_update?` `false` → `ArgumentError` |

The CRUD path that the existing test suite exercises is unaffected. Bulk APIs that already failed continue to fail; one mode of failure changes parser-error code but is no worse for users than the prior state.

## Test plan

* [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb` — 140 examples, 0 failures (flag flip alone caused 25 ORA-00925 failures; the matched `super` removal restores green)
* [x] `CI=1 bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/` — 686 examples, 0 failures, 11 pending (pre-existing)
* [x] `bundle exec rubocop` — clean
