### PR TITLE
Wire up CHECK constraint DSL: add_check_constraint, t.check_constraint, dump round-trip

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -33,6 +33,10 @@ module ActiveRecord
               statements.concat(o.unique_constraints.map { |uc| accept uc })
             end
 
+            if supports_check_constraints? && o.respond_to?(:check_constraints)
+              statements.concat(o.check_constraints.map { |chk| accept chk })
+            end
+
             create_sql << "(#{statements.join(', ')})" if statements.present?
 
             unless o.temporary

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -213,9 +213,15 @@ module ActiveRecord # :nodoc:
 
               indexes_in_create(table, tbl)
               unique_constraints_in_create(table, tbl)
+              remaining = check_constraints_in_create(table, tbl) if @connection.supports_check_constraints?
 
               tbl.puts "  end"
               tbl.puts
+
+              if remaining
+                tbl.print remaining.string
+                tbl.puts
+              end
 
               _indexes(table, tbl)
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -619,6 +619,28 @@ module ActiveRecord
           end
         end
 
+        # `generated = 'USER NAME'` skips implicit NOT NULL checks (system-named, type 'C').
+        def check_constraints(table_name) # :nodoc:
+          (_owner, desc_table_name) = resolve_data_source_name(table_name)
+
+          # `search_condition` is LONG; cannot appear in WHERE (ORA-00997).
+          rows = select_all(<<~SQL.squish, "SCHEMA", [bind_string("desc_table_name", desc_table_name)])
+            SELECT constraint_name AS name, search_condition
+              FROM all_constraints
+             WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
+               AND table_name = :desc_table_name
+               AND constraint_type = 'C'
+               AND generated = 'USER NAME'
+             ORDER BY constraint_name
+          SQL
+
+          rows.filter_map do |row|
+            next if row["search_condition"].nil?
+            options = { name: oracle_downcase(row["name"]) }
+            CheckConstraintDefinition.new(oracle_downcase(table_name), row["search_condition"], options)
+          end
+        end
+
         # Returns an array of unique constraints for the given table.
         # The unique constraints are represented as UniqueConstraintDefinition objects.
         def unique_constraints(table_name) # :nodoc:

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -503,6 +503,10 @@ module ActiveRecord
         true
       end
 
+      def supports_check_constraints?
+        true
+      end
+
       def supports_optimizer_hints?
         true
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -324,6 +324,47 @@ RSpec.describe "OracleEnhancedAdapter schema dump" do
     end
   end
 
+  describe "check constraints" do
+    before(:each) do
+      schema_define do
+        create_table :test_products, force: true do |t|
+          t.integer :price
+        end
+      end
+    end
+
+    after(:each) do
+      schema_define do
+        drop_table :test_products, if_exists: true
+      end
+    end
+
+    it "dumps a check constraint as t.check_constraint inside create_table" do
+      schema_define do
+        add_check_constraint :test_products, "price > 0", name: "price_dump_check"
+      end
+      output = dump_table_schema "test_products"
+      expect(output).to match(/t\.check_constraint .*name: "price_dump_check"/)
+    end
+
+    it "round-trips a check constraint through dump and load" do
+      schema_define do
+        add_check_constraint :test_products, "price > 0", name: "price_rt_check"
+      end
+
+      dumped = dump_table_schema "test_products"
+      schema_define do
+        drop_table :test_products, if_exists: true
+      end
+
+      body = dumped[/ActiveRecord::Schema\[.+?\]\.define\(version: \d+\) do\n(.+)\nend\s*\z/m, 1]
+      schema_define { instance_eval(body) }
+
+      cc = @conn.check_constraints(:test_products).detect { |c| c.name == "price_rt_check" }
+      expect(cc).not_to be_nil
+    end
+  end
+
   describe "unique constraints" do
     before(:each) do
       schema_define do

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -1166,6 +1166,100 @@ end
     end
   end
 
+  describe "check constraints" do
+    before(:each) do
+      schema_define do
+        create_table :test_products, force: true do |t|
+          t.integer :price
+        end
+      end
+    end
+
+    after(:each) do
+      schema_define do
+        drop_table :test_products, if_exists: true
+      end
+      ActiveRecord::Base.clear_cache!
+    end
+
+    it "adds a check constraint with an explicit name" do
+      schema_define do
+        add_check_constraint :test_products, "price > 0", name: "price_check"
+      end
+      ccs = @conn.check_constraints(:test_products)
+      expect(ccs.size).to eq(1)
+      expect(ccs.first.name).to eq("price_check")
+      expect(ccs.first.expression).to match(/price\s*>\s*0/i)
+    end
+
+    it "auto-generates a name when none is supplied" do
+      schema_define do
+        add_check_constraint :test_products, "price > 0"
+      end
+      cc = @conn.check_constraints(:test_products).first
+      expect(cc).not_to be_nil
+      expect(cc.name).to match(/\Achk_rails_[0-9a-f]{10}\z/)
+    end
+
+    it "drains t.check_constraint declared inline in create_table" do
+      schema_define do
+        drop_table :test_products, if_exists: true
+        create_table :test_products, force: true do |t|
+          t.integer :price
+          t.check_constraint "price > 100", name: "inline_check"
+        end
+      end
+      cc = @conn.check_constraints(:test_products).detect { |c| c.name == "inline_check" }
+      expect(cc).not_to be_nil
+    end
+
+    it "removes a check constraint by name" do
+      schema_define do
+        add_check_constraint :test_products, "price > 0", name: "rm_check"
+        remove_check_constraint :test_products, name: "rm_check"
+      end
+      expect(@conn.check_constraints(:test_products).map(&:name)).not_to include("rm_check")
+    end
+
+    it "honors if_not_exists: true on add_check_constraint" do
+      schema_define do
+        add_check_constraint :test_products, "price > 0", name: "ifne_check"
+        add_check_constraint :test_products, "price > 0", name: "ifne_check", if_not_exists: true
+      end
+      expect(@conn.check_constraints(:test_products).map(&:name).count("ifne_check")).to eq(1)
+    end
+
+    it "honors if_exists: true on remove_check_constraint" do
+      expect {
+        schema_define do
+          remove_check_constraint :test_products, name: "nonexistent_check", if_exists: true
+        end
+      }.not_to raise_error
+    end
+
+    it "raises ArgumentError on remove_check_constraint for a missing constraint without if_exists" do
+      expect {
+        schema_define do
+          remove_check_constraint :test_products, name: "nonexistent_check"
+        end
+      }.to raise_error(ArgumentError, /no check constraint/)
+    end
+
+    it "supports a multi-column CHECK expression" do
+      schema_define do
+        drop_table :test_products, if_exists: true
+        create_table :test_products, force: true do |t|
+          t.integer :price
+          t.integer :quantity
+        end
+        add_check_constraint :test_products, "price > 0 AND quantity >= 0", name: "multi_col_check"
+      end
+      cc = @conn.check_constraints(:test_products).detect { |c| c.name == "multi_col_check" }
+      expect(cc).not_to be_nil
+      expect(cc.expression).to match(/price\s*>\s*0\s+and\s+quantity\s*>=\s*0/i)
+    end
+  end
+
   describe "unique constraints" do
     before(:each) do
       schema_define do

--- a/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
@@ -235,6 +235,12 @@ RSpec.describe "OracleEnhancedAdapter structure dump" do
       expect(dump).to match(/ALTER TABLE "TEST_POSTS" ADD CONSTRAINT "TEST_POSTS_TITLE_CHECK" CHECK/)
     end
 
+    it "should dump check constraints added via add_check_constraint DSL" do
+      ActiveRecord::Base.lease_connection.add_check_constraint(:test_posts, "LENGTH(title) > 0", name: "test_posts_dsl_title_check")
+      dump = ActiveRecord::Base.lease_connection.structure_dump
+      expect(dump).to match(/ALTER TABLE "TEST_POSTS" ADD CONSTRAINT "TEST_POSTS_DSL_TITLE_CHECK" CHECK/)
+    end
+
     it "should dump table comments" do
       comment_sql = %Q(COMMENT ON TABLE "TEST_POSTS" IS 'Test posts with ''some'' "quotes"')
       @conn.execute comment_sql


### PR DESCRIPTION
## Summary

Closes #2716.

Oracle Database has supported `CHECK` constraints since 8i, and `OracleEnhanced::StructureDump#structure_dump_check_constraints` already reads them out of `all_constraints` for SQL structure dumps. Active Record's standard schema-DSL surface for check constraints (`add_check_constraint` / `remove_check_constraint` / inline `t.check_constraint` / `check_constraints(table_name)` reader) was **not** wired up on oracle-enhanced — `supports_check_constraints?` returned the abstract default `false`, the abstract `add_check_constraint` short-circuited, and `db/schema.rb` round-trips silently dropped check constraints.

Active Record 8.x's abstract layer already provides essentially the entire CHECK constraint surface — `CheckConstraintDefinition` Struct, `visit_CheckConstraintDefinition` / `visit_AddCheckConstraint` / `visit_DropCheckConstraint` visitors, `add_check_constraint` / `remove_check_constraint` / `check_constraint_for!` schema statements, and the dumper's `check_constraints_in_create` helper. The adapter only needs to plug in.

## Changes

### Production

- `OracleEnhancedAdapter#supports_check_constraints?` overridden to `true`.
- `OracleEnhanced::SchemaStatements#check_constraints(table_name)` reader added, modelled on `unique_constraints(table_name)`. SQL is the same shape as the existing `structure_dump_check_constraints`: queries `all_constraints` filtered by `constraint_type = 'C' AND generated = 'USER NAME'` so implicit NOT NULL constraints (Oracle stores them with `constraint_type = 'C'` too, but with system-generated names) are excluded. Returns `ActiveRecord::ConnectionAdapters::CheckConstraintDefinition` instances — no Oracle subclass needed.
- `OracleEnhanced::SchemaCreation#visit_TableDefinition` drains `o.check_constraints` alongside the existing `o.unique_constraints` drain, so inline `t.check_constraint` inside `create_table` flows through to the same `CREATE TABLE` statement.
- `OracleEnhanced::SchemaDumper#table` calls `check_constraints_in_create` next to `unique_constraints_in_create`, and prints any `add_check_constraint` lines the abstract dumper returns for `validate: false` constraints (today this is always empty since `validate` semantics aren't yet supported on Oracle — see Out of scope below).

### Specs

- `schema_statements_spec.rb` `describe "check constraints"` (8 specs): add/remove, auto-name, inline `t.check_constraint`, `if_not_exists`/`if_exists`, missing-constraint-raise, **multi-column CHECK expression**.
- `schema_dumper_spec.rb` `describe "check constraints"` (2 specs): dump emits `t.check_constraint`; dump → drop → reload round-trip preserves the constraint.
- `structure_dump_spec.rb` (1 new spec): structure.sql emission via `add_check_constraint` DSL path verifies the adapter's DSL flows through to the existing `structure_dump_check_constraints` reader.

Total 11 new specs.

## Out of scope

- `validate: false` / `validate_check_constraint` semantics (Oracle's `ENABLE NOVALIDATE`). The dumper already calls into the abstract `check_constraints_in_create`, which would split `validate: false` constraints into a post-`create_table` `add_check_constraint` block — but the connection reader currently returns every constraint with `validate: true` (the default), so the post-table branch is unreachable. Tracked as a follow-up.
- Round-trip of expression text: Oracle's `all_constraints.search_condition` is database-normalised, so the dumped expression may differ from the user's original text (same caveat PostgreSQL has with `pg_get_expr`). The `t.check_constraint` line still loads correctly.
- DEFERRABLE on CHECK constraints: tracked separately as #2718.
- Schema-qualified table names: not specifically exercised; relies on `resolve_data_source_name` which is already used by other readers.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb -e "check constraints"` (8 examples)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb -e "check constraints"` (2 examples)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb -e "check constraint"` (2 examples; 1 pre-existing + 1 new DSL-path)
- [x] `bundle exec rubocop` — clean
- [ ] CI on full matrix (3.3 / 3.4 / 4.0 / jruby)
