### PR TITLE
Evict stale prepared statements on DDL via clear_table_columns_cache

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -902,9 +902,24 @@ module ActiveRecord
       end
 
       def clear_table_columns_cache(table_name)
-        @columns_cache[table_name.to_s] = nil
-        @trigger_assigned_pk_cache.delete(table_name.to_s)
+        table_name = table_name.to_s
+        @columns_cache[table_name] = nil
+        @trigger_assigned_pk_cache.delete(table_name)
+        evict_prepared_statements_for(table_name)
       end
+
+      def evict_prepared_statements_for(table_name) # :nodoc:
+        return unless prepared_statements?
+        return unless @statements
+
+        quoted_table_name = quote_table_name(table_name)
+        keys_to_delete = []
+        @statements.each do |sql, _stmt|
+          keys_to_delete << sql if sql.include?(quoted_table_name)
+        end
+        keys_to_delete.each { |sql| @statements.delete(sql) }
+      end
+      private :evict_prepared_statements_for
 
       # Returns +[pk, sequence]+ for single-column PKs; +nil+ for composite or
       # missing PKs (composite PKs are introspected via +primary_keys+).

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -1628,6 +1628,54 @@ end
     end
   end
 
+  describe "prepared statement cache eviction on DDL" do
+    before(:each) do
+      schema_define do
+        create_table :test_evict, force: true do |t|
+          t.string :name
+          t.integer :extra
+        end
+      end
+    end
+
+    after(:each) do
+      schema_define do
+        drop_table :test_evict, if_exists: true
+      end
+      ActiveRecord::Base.clear_cache!
+    end
+
+    def cached_prepared_sqls_for(table_name)
+      pool = @conn.instance_variable_get(:@statements)
+      return [] unless pool
+      pool.map { |sql, _| sql }.select { |sql| sql.include?(@conn.send(:quote_table_name, table_name)) }
+    end
+
+    it "removes cached prepared statements after a column is dropped" do
+      klass = Class.new(ActiveRecord::Base) { self.table_name = :test_evict }
+      klass.create!(name: "before-ddl", extra: 1)
+      expect(cached_prepared_sqls_for(:test_evict)).not_to be_empty
+
+      schema_define do
+        remove_column :test_evict, :extra
+      end
+
+      expect(cached_prepared_sqls_for(:test_evict)).to be_empty
+    end
+
+    it "removes cached prepared statements after the table is dropped" do
+      klass = Class.new(ActiveRecord::Base) { self.table_name = :test_evict }
+      klass.create!(name: "before-drop", extra: 1)
+      expect(cached_prepared_sqls_for(:test_evict)).not_to be_empty
+
+      schema_define do
+        drop_table :test_evict, if_exists: true
+      end
+
+      expect(cached_prepared_sqls_for(:test_evict)).to be_empty
+    end
+  end
+
   describe "alter columns with column cache" do
     include LoggerSpecHelper
 


### PR DESCRIPTION
## Summary

Addresses the "DDL stale-pool" finding from the audit on #2714.

`clear_table_columns_cache(table_name)` is called by every DDL path that mutates a table's structure (`drop_table`, `rename_table`, `add_column`, `change_column`, `remove_column`, etc.). It cleared the local `@columns_cache` and `@trigger_assigned_pk_cache`, but left cached `@statements` entries that referenced the table in place. The pool is LRU-bounded (default 1000), so entries eventually age out, but until they do they consume slots and — in pathological cases (`remove_column` followed by `add_column` of the same name with a different type, hitting the same cached SQL key) — risk a bind-shape mismatch on the next reuse.

## Changes

- New private `evict_prepared_statements_for(table_name)` in `OracleEnhancedAdapter`. Walks `@statements`, deletes entries whose SQL contains the quoted table name. Bounded by the actual pool size (default 1000 entries max), so cheap.
- `clear_table_columns_cache(table_name)` calls it after the existing column / trigger-cache invalidation. Every DDL caller (drop_table / rename_table / add_column / change_column / remove_column / etc.) automatically benefits.

The choice of "evict per-table" rather than "call `clear_cache!`" is deliberate: `clear_cache!` would discard the entire pool, including statements unrelated to the table being altered, which is wasteful when a typical migration touches only one or two tables at a time.

## Verification

Audit-style probe (the same kind that surfaced the issue in #2714):

```ruby
ProbeDdl.create!(name: "before-ddl", extra: 1)
# pool: ["INSERT INTO \"PROBE_DDL\" ... (\"NAME\", \"EXTRA\", \"ID\") VALUES (:a1, :a2, :a3)"]

remove_column :probe_ddl, :extra
# pool: []   # <-- previously: same single entry, stale
```

Two regression specs in `schema_statements_spec.rb`:

- `remove_column` evicts the cached INSERT for that table.
- `drop_table` evicts the cached INSERT for that table.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb -e "prepared statement cache eviction"` (2 examples)
- [x] `CI=1 bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/` — 688 examples, 0 failures, 11 pre-existing pending
- [x] `bundle exec rubocop` — clean
- [ ] CI on full matrix (3.3 / 3.4 / 4.0 / jruby)

## Related

- #2714 (audit): Closes the DDL portion of that issue. The other three audit scenarios (LOB writes, OCI reset, JDBC reset) came back PASS — see the audit comment on #2714 — so this PR is the only follow-up needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
