### PR TITLE
Migrate spec syntax to forms compatible with both RSpec 3 and 4

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,4 @@
---color
+--force-color
 --backtrace
 --require spec_helper
 --warnings

--- a/spec/active_record/connection_adapters/emulation/oracle_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/emulation/oracle_adapter_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter emulate OracleAdapter" do
+RSpec.describe "OracleEnhancedAdapter emulate OracleAdapter" do
   after(:all) do
     # Restore the default connection in case the example below replaced it.
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle12_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle12_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Arel::Visitors::Oracle12" do
+RSpec.describe "Arel::Visitors::Oracle12" do
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
   end

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Arel::Visitors::Oracle" do
+RSpec.describe "Arel::Visitors::Oracle" do
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
   end

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel_visitor_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel_visitor_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter arel_visitor configuration" do
+RSpec.describe "OracleEnhancedAdapter arel_visitor configuration" do
   let(:adapter_class) { ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter }
 
   before(:each) do

--- a/spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter#columns_for_distinct" do
+RSpec.describe "OracleEnhancedAdapter#columns_for_distinct" do
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
     @conn = ActiveRecord::Base.lease_connection

--- a/spec/active_record/connection_adapters/oracle_enhanced/compatibility_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/compatibility_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "compatibility migrations" do
+RSpec.describe "compatibility migrations" do
   include SchemaSpecHelper
 
   before(:all) do

--- a/spec/active_record/connection_adapters/oracle_enhanced/composite_primary_key_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/composite_primary_key_spec.rb
@@ -9,7 +9,7 @@
 # Association-level coverage (HABTM joins, `has_many :through`) lives in
 # the sibling `composite_spec.rb` and is intentionally not duplicated here.
 
-describe "OracleEnhancedAdapter composite primary key" do
+RSpec.describe "OracleEnhancedAdapter composite primary key" do
   include SchemaSpecHelper
   include SchemaDumpingHelper
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/composite_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/composite_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter should support composite primary" do
+RSpec.describe "OracleEnhancedAdapter should support composite primary" do
   include SchemaSpecHelper
 
   before(:all) do

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter establish connection" do
+RSpec.describe "OracleEnhancedAdapter establish connection" do
   it "should connect to database" do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
     expect(ActiveRecord::Base.lease_connection).not_to be_nil
@@ -146,7 +146,7 @@ describe "OracleEnhancedAdapter establish connection" do
   end
 end
 
-describe "OracleEnhancedConnection" do
+RSpec.describe "OracleEnhancedConnection" do
   describe "create connection" do
     before(:all) do
       @conn = ActiveRecord::ConnectionAdapters::OracleEnhanced::Connection.create(CONNECTION_PARAMS)

--- a/spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter context index" do
+RSpec.describe "OracleEnhancedAdapter context index" do
   include SchemaSpecHelper
   include LoggerSpecHelper
   include SchemaDumpingHelper

--- a/spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb
@@ -5,7 +5,7 @@ require "active_support/testing/stream"
 require "stringio"
 require "tempfile"
 
-describe "Oracle Enhanced adapter database tasks" do
+RSpec.describe "Oracle Enhanced adapter database tasks" do
   include SchemaSpecHelper
 
   let(:config) { CONNECTION_PARAMS.with_indifferent_access }

--- a/spec/active_record/connection_adapters/oracle_enhanced/database_version_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/database_version_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter::Version" do
+RSpec.describe "OracleEnhancedAdapter::Version" do
   let(:adapter_class) { ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter }
   let(:version_class) { adapter_class::Version }
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/dbconsole_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/dbconsole_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Oracle Enhanced adapter dbconsole" do
+RSpec.describe "Oracle Enhanced adapter dbconsole" do
   subject { ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter }
 
   it "uses sqlplus with user@db when password is not requested" do

--- a/spec/active_record/connection_adapters/oracle_enhanced/dbms_metadata_structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/dbms_metadata_structure_dump_spec.rb
@@ -13,7 +13,7 @@
 # This mirrors how `pg_dump` and `mysqldump` are tested upstream: the
 # implementation's exact byte output is not part of the contract;
 # round-trip-loadability is.
-describe "OracleEnhancedAdapter DBMS_METADATA structure dump" do
+RSpec.describe "OracleEnhancedAdapter DBMS_METADATA structure dump" do
   include SchemaSpecHelper
 
   before(:all) do

--- a/spec/active_record/connection_adapters/oracle_enhanced/dbms_output_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/dbms_output_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter logging dbms_output from plsql" do
+RSpec.describe "OracleEnhancedAdapter logging dbms_output from plsql" do
   include LoggerSpecHelper
 
   before(:all) do

--- a/spec/active_record/connection_adapters/oracle_enhanced/deprecator_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/deprecator_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe ActiveRecord::ConnectionAdapters::OracleEnhanced do
+RSpec.describe ActiveRecord::ConnectionAdapters::OracleEnhanced do
   describe ".deprecator" do
     subject(:deprecator) { described_class.deprecator }
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/identifier_length_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/identifier_length_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter identifier length configuration" do
+RSpec.describe "OracleEnhancedAdapter identifier length configuration" do
   let(:adapter_class) { ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter }
 
   before(:each) do

--- a/spec/active_record/connection_adapters/oracle_enhanced/identity_primary_key_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/identity_primary_key_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "identity primary keys" do
+RSpec.describe "identity primary keys" do
   include SchemaSpecHelper
   include LoggerSpecHelper
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/multiple_databases_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/multiple_databases_spec.rb
@@ -7,7 +7,7 @@
 # Pattern: abstract base class with establish_connection — the programmatic
 # equivalent of connects_to — to connect models to a second Oracle schema.
 
-describe "OracleEnhancedAdapter multiple database support" do
+RSpec.describe "OracleEnhancedAdapter multiple database support" do
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/primary_key_trigger_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/primary_key_trigger_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "primary_key_trigger" do
+RSpec.describe "primary_key_trigger" do
   include SchemaSpecHelper
   include LoggerSpecHelper
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb
@@ -2,7 +2,7 @@
 
 require "ruby-plsql"
 
-describe "OracleEnhancedAdapter custom methods for create, update and destroy" do
+RSpec.describe "OracleEnhancedAdapter custom methods for create, update and destroy" do
   include LoggerSpecHelper
   include SchemaSpecHelper
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/quoting_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/quoting_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter quoting" do
+RSpec.describe "OracleEnhancedAdapter quoting" do
   include LoggerSpecHelper
   include SchemaSpecHelper
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_cache_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_cache_spec.rb
@@ -2,7 +2,7 @@
 
 require "tempfile"
 
-describe "OracleEnhancedAdapter schema cache" do
+RSpec.describe "OracleEnhancedAdapter schema cache" do
   include SchemaSpecHelper
 
   PERMITTED_YAML_CLASSES = [

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter schema dump" do
+RSpec.describe "OracleEnhancedAdapter schema dump" do
   include SchemaSpecHelper
   include SchemaDumpingHelper
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_isolation_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_isolation_spec.rb
@@ -10,7 +10,7 @@
 # PDBs, or entirely separate databases.
 #
 
-describe "Oracle schema isolation between primary and remote connections" do
+RSpec.describe "Oracle schema isolation between primary and remote connections" do
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter schema definition" do
+RSpec.describe "OracleEnhancedAdapter schema definition" do
   include SchemaSpecHelper
   include LoggerSpecHelper
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter structure dump" do
+RSpec.describe "OracleEnhancedAdapter structure dump" do
   include LoggerSpecHelper
 
   before(:all) do

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter" do
+RSpec.describe "OracleEnhancedAdapter" do
   include LoggerSpecHelper
   include SchemaSpecHelper
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter date and datetime type detection based on attribute settings" do
+RSpec.describe "OracleEnhancedAdapter date and datetime type detection based on attribute settings" do
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
     @conn = ActiveRecord::Base.lease_connection
@@ -83,7 +83,7 @@ describe "OracleEnhancedAdapter date and datetime type detection based on attrib
   end
 end
 
-describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
+RSpec.describe "OracleEnhancedAdapter assign string to :date and :datetime columns" do
   include SchemaSpecHelper
 
   before(:all) do

--- a/spec/active_record/oracle_enhanced/type/binary_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/binary_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter handling of BLOB columns" do
+RSpec.describe "OracleEnhancedAdapter handling of BLOB columns" do
   include SchemaSpecHelper
 
   before(:all) do

--- a/spec/active_record/oracle_enhanced/type/boolean_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/boolean_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter boolean type detection based on string column types and names" do
+RSpec.describe "OracleEnhancedAdapter boolean type detection based on string column types and names" do
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
     @conn = ActiveRecord::Base.lease_connection
@@ -179,7 +179,7 @@ describe "OracleEnhancedAdapter boolean type detection based on string column ty
   end
 end
 
-describe "OracleEnhancedAdapter boolean support when emulate_booleans_from_strings = true" do
+RSpec.describe "OracleEnhancedAdapter boolean support when emulate_booleans_from_strings = true" do
   include SchemaSpecHelper
 
   before(:all) do

--- a/spec/active_record/oracle_enhanced/type/character_string_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/character_string_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter processing CHAR column" do
+RSpec.describe "OracleEnhancedAdapter processing CHAR column" do
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
     @conn = ActiveRecord::Base.lease_connection

--- a/spec/active_record/oracle_enhanced/type/custom_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/custom_spec.rb
@@ -2,7 +2,7 @@
 
 require "base64"
 
-describe "OracleEnhancedAdapter custom types handling" do
+RSpec.describe "OracleEnhancedAdapter custom types handling" do
   include SchemaSpecHelper
 
   before(:all) do

--- a/spec/active_record/oracle_enhanced/type/decimal_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/decimal_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter handling of DECIMAL columns" do
+RSpec.describe "OracleEnhancedAdapter handling of DECIMAL columns" do
   include SchemaSpecHelper
 
   before(:all) do

--- a/spec/active_record/oracle_enhanced/type/dirty_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/dirty_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter dirty object tracking" do
+RSpec.describe "OracleEnhancedAdapter dirty object tracking" do
   include SchemaSpecHelper
 
   before(:all) do

--- a/spec/active_record/oracle_enhanced/type/float_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/float_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter handling of BINARY_FLOAT columns" do
+RSpec.describe "OracleEnhancedAdapter handling of BINARY_FLOAT columns" do
   include SchemaSpecHelper
 
   before(:all) do

--- a/spec/active_record/oracle_enhanced/type/integer_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/integer_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter integer type detection based on attribute settings" do
+RSpec.describe "OracleEnhancedAdapter integer type detection based on attribute settings" do
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
     conn = ActiveRecord::Base.lease_connection

--- a/spec/active_record/oracle_enhanced/type/json_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/json_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter attribute API support for JSON type" do
+RSpec.describe "OracleEnhancedAdapter attribute API support for JSON type" do
   include SchemaSpecHelper
 
   before(:all) do

--- a/spec/active_record/oracle_enhanced/type/national_character_string_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/national_character_string_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter quoting of NCHAR and NVARCHAR2 columns" do
+RSpec.describe "OracleEnhancedAdapter quoting of NCHAR and NVARCHAR2 columns" do
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
     @conn = ActiveRecord::Base.lease_connection

--- a/spec/active_record/oracle_enhanced/type/national_character_text_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/national_character_text_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter handling of NCLOB columns" do
+RSpec.describe "OracleEnhancedAdapter handling of NCLOB columns" do
   include SchemaSpecHelper
 
   before(:all) do

--- a/spec/active_record/oracle_enhanced/type/raw_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/raw_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter handling of RAW columns" do
+RSpec.describe "OracleEnhancedAdapter handling of RAW columns" do
   include SchemaSpecHelper
 
   before(:all) do

--- a/spec/active_record/oracle_enhanced/type/text_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/text_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter handling of CLOB columns" do
+RSpec.describe "OracleEnhancedAdapter handling of CLOB columns" do
   include SchemaSpecHelper
 
   before(:all) do

--- a/spec/active_record/oracle_enhanced/type/timestamp_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/timestamp_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "OracleEnhancedAdapter timestamp with timezone support" do
+RSpec.describe "OracleEnhancedAdapter timestamp with timezone support" do
   include SchemaSpecHelper
 
   before(:all) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -254,6 +254,7 @@ ActiveRecord::Base.logger = ActiveSupport::Logger.new("debug.log", 0, 100 * 1024
 #   bundle exec rspec --seed <value> --bisect
 #
 RSpec.configure do |config|
+  config.disable_monkey_patching!
   config.order = :random
   Kernel.srand config.seed
 


### PR DESCRIPTION
## Summary

RSpec 4.0.0.beta1 dropped two pieces of behavior the suite relies on:

- the bare `--color` flag in `.rspec` (replaced by `--force-color`)
- the monkey-patched top-level `describe` (must use `RSpec.describe` directly — RSpec 4 removed `expose_dsl_globally=`)

Both new forms are already valid in RSpec 3 (`RSpec.describe` since 3.0, `--force-color` since rspec-core 3.6), so this migration lands now while the project is still on RSpec 3.13.x. That keeps the eventual RSpec 4 upgrade to a single Gemfile bump.

Mechanical change: every top-level `describe "..." do` becomes `RSpec.describe "..." do`. No spec bodies are touched.

Also turns on `config.disable_monkey_patching!` in `spec/spec_helper.rb` so RSpec 3 enforces the same no-global-DSL / no-`should`-syntax rules RSpec 4 will enforce by default. A future regression that re-adds a bare top-level `describe` will now fail under the current RSpec 3 CI rather than waiting for the RSpec 4 upgrade. Note: `disable_monkey_patching!` itself is also removed in RSpec 4, so this line will need to come out as part of the RSpec 4 upgrade PR.

## References

- rspec/rspec-core#2803 — "Scrape out monkey patching": removes the globally-exposed DSL and the `disable_monkey_patching!` method
- rspec/rspec-expectations#1245 — removes `should` / `should_not` syntax (including one-liners)
- rspec/rspec-mocks#1365 — removes monkey-patching `should_receive` / `stub` syntax
- rspec/rspec-core#2864 — `--color` / `color` removed (bundled with several other deprecated removals)

## Test plan

- [x] `bundle exec rspec` on RSpec 3.13.x with `disable_monkey_patching!` + new syntax — 849 examples, 0 failures, 12 pending (Oracle Database 23 Free / FREEPDB1, Rails main)
- [x] `bundle exec rspec` on RSpec 4.0.0.beta1 with these edits — 849 examples, 1 unrelated failure (`be_data_source_exist` predicate-matcher behavior change in RSpec 4), 12 pending. Confirms RSpec 3 keeps working with the new syntax.
- [x] `BUNDLE_ONLY=rubocop bundle exec rubocop` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
