### PR TITLE
Correct `be_data_source_exist` matcher to `be_data_source_exists`

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -587,7 +587,7 @@ RSpec.describe "OracleEnhancedAdapter" do
 
     it "includes synonyms in data_source" do
       conn = ActiveRecord::Base.lease_connection
-      expect(conn).to be_data_source_exist("synonym_comments")
+      expect(conn).to be_data_source_exists("synonym_comments")
       expect(conn.data_sources).to include("synonym_comments")
     end
   end


### PR DESCRIPTION
## Summary

The synonym_names spec at `spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:588` calls:

```ruby
expect(conn).to be_data_source_exist("synonym_comments")
```

That dispatches to `conn.data_source_exist?` (no `s`). Neither ActiveRecord's `AbstractAdapter` nor oracle-enhanced defines such a method — the actual method is `data_source_exists?` (with `s`, defined at `activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb`).

The spec only passes today because RSpec 3's `Has` matcher has a "present-tense dynamic predicate" fallback that silently retries with an `s` appended when the literal predicate does not respond. RSpec 4 removes this fallback, so the spec fails there with:

```
expected #<...OracleEnhancedAdapter...> to respond to `data_source_exist?`
```

Rename to `be_data_source_exists`, which calls the actual `data_source_exists?` method directly. This works under both RSpec 3 and RSpec 4 without relying on any matcher fallback, so this fix can land independently of the eventual RSpec 4 upgrade.

## References

- rspec/rspec-expectations#1286 — Remove support for present-tense dynamic predicate

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb:588` passes under RSpec 3.13.x (Oracle Database 23 Free / FREEPDB1, Rails main)
- [x] Same spec passes under RSpec 4.0.0.beta1 (verified locally in a separate worktree)
- [x] `BUNDLE_ONLY=rubocop bundle exec rubocop spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
