### PR TITLE
Rename clear_table_columns_cache to clear_table_caches with deprecation

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -242,9 +242,8 @@ module ActiveRecord
           execute "RENAME #{quote_table_name(table_name)} TO #{quote_table_name(new_name)}"
           execute "RENAME #{default_sequence_name(table_name, nil)} TO #{default_sequence_name(new_name, nil)}" rescue nil
           rename_pk_trigger(table_name, new_name)
-          @prefetch_primary_key_cache.delete(table_name.to_s)
-          clear_table_columns_cache(table_name)
-          clear_table_columns_cache(new_name)
+          clear_table_caches(table_name)
+          clear_table_caches(new_name)
 
           rename_table_indexes(table_name, new_name, **options)
         end
@@ -263,8 +262,7 @@ module ActiveRecord
             drop_if_exists("TABLE", table_name, cascade_constraints: cascade, if_exists: if_exists)
             drop_if_exists("SEQUENCE", seq_name, if_exists: true)
           ensure
-            clear_table_columns_cache(table_name)
-            @prefetch_primary_key_cache.delete(table_name.to_s)
+            clear_table_caches(table_name)
           end
         end
 
@@ -453,7 +451,7 @@ module ActiveRecord
           end
           change_column_comment(table_name, column_name, options[:comment]) if options.key?(:comment)
         ensure
-          clear_table_columns_cache(table_name)
+          clear_table_caches(table_name)
         end
 
         def aliased_types(name, fallback)
@@ -464,7 +462,7 @@ module ActiveRecord
           default = extract_new_default_value(default_or_changes)
           execute "ALTER TABLE #{quote_table_name(table_name)} MODIFY #{quote_column_name(column_name)} DEFAULT #{quote(default)}"
         ensure
-          clear_table_columns_cache(table_name)
+          clear_table_caches(table_name)
         end
 
         def change_column_null(table_name, column_name, null, default = nil) # :nodoc:
@@ -498,20 +496,20 @@ module ActiveRecord
 
           change_column_comment(table_name, column_name, options[:comment]) if options.key?(:comment)
         ensure
-          clear_table_columns_cache(table_name)
+          clear_table_caches(table_name)
         end
 
         def rename_column(table_name, column_name, new_column_name) # :nodoc:
           execute "ALTER TABLE #{quote_table_name(table_name)} RENAME COLUMN #{quote_column_name(column_name)} to #{quote_column_name(new_column_name)}"
           rename_column_indexes(table_name, column_name, new_column_name)
         ensure
-          clear_table_columns_cache(table_name)
+          clear_table_caches(table_name)
         end
 
         def remove_column(table_name, column_name, type = nil, **options) # :nodoc:
           execute "ALTER TABLE #{quote_table_name(table_name)} DROP COLUMN #{quote_column_name(column_name)} CASCADE CONSTRAINTS"
         ensure
-          clear_table_columns_cache(table_name)
+          clear_table_caches(table_name)
         end
 
         def remove_columns(table_name, *column_names, type: nil, **options) # :nodoc:
@@ -519,7 +517,7 @@ module ActiveRecord
 
           execute "ALTER TABLE #{quote_table_name(table_name)} DROP (#{quoted_column_names}) CASCADE CONSTRAINTS"
         ensure
-          clear_table_columns_cache(table_name)
+          clear_table_caches(table_name)
         end
 
         def change_table_comment(table_name, comment_or_changes)

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -901,11 +901,20 @@ module ActiveRecord
         SQL
       end
 
-      def clear_table_columns_cache(table_name)
+      def clear_table_caches(table_name) # :nodoc:
         table_name = table_name.to_s
         @columns_cache[table_name] = nil
         @trigger_assigned_pk_cache.delete(table_name)
+        @prefetch_primary_key_cache.delete(table_name)
         evict_prepared_statements_for(table_name)
+      end
+
+      def clear_table_columns_cache(table_name)
+        OracleEnhanced.deprecator.deprecation_warning(
+          "ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter#clear_table_columns_cache",
+          "use clear_table_caches instead"
+        )
+        clear_table_caches(table_name)
       end
 
       def evict_prepared_statements_for(table_name) # :nodoc:

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "OracleEnhancedAdapter" do
       end
 
       it "should get columns from database at first time" do
-        @conn.clear_table_columns_cache(:test_employees)
+        @conn.clear_table_caches(:test_employees)
         expect(TestEmployee.lease_connection.columns("test_employees").map(&:name)).to eq(@column_names)
         expect(@logger.logged(:debug).join("\n")).to match(/select .* from all_tab_cols/im)
       end
@@ -104,6 +104,19 @@ RSpec.describe "OracleEnhancedAdapter" do
         TestEmployee.create!
         expect(@logger.logged(:debug).first).to match(/SELECT "TEST_EMPLOYEES_SEQ".NEXTVAL FROM dual/im)
       end
+    end
+  end
+
+  describe "deprecated clear_table_columns_cache" do
+    before(:all) do
+      @conn = ActiveRecord::Base.lease_connection
+    end
+
+    it "warns and forwards to clear_table_caches" do
+      expect(@conn).to receive(:clear_table_caches).with(:test_employees)
+      expect {
+        @conn.clear_table_columns_cache(:test_employees)
+      }.to output(/clear_table_columns_cache is deprecated.*activerecord-oracle_enhanced-adapter.*a future version/m).to_stderr
     end
   end
 


### PR DESCRIPTION
Closes #2722.

## Summary

`clear_table_columns_cache` has been misleading for a while: it clears `@trigger_assigned_pk_cache` (a non-columns cache) and, since #2719, also evicts the per-table entries from the prepared-statement pool. Rename the method body to `clear_table_caches` and mark it `:nodoc:`; keep the old name as a deprecation wrapper that forwards via `OracleEnhanced.deprecator`.

## Changes

- `OracleEnhancedAdapter#clear_table_caches(table_name)` (`:nodoc:`) — new canonical method.
- `OracleEnhancedAdapter#clear_table_columns_cache(table_name)` — deprecation wrapper. Emits `OracleEnhanced.deprecator.deprecation_warning` and forwards to the new method.
- All 9 internal callers in `schema_statements.rb` (rename_table x2, drop_table, add_column, remove_column, 4 change_column variants) and the 1 caller in `spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb` are migrated to `clear_table_caches`.

## Drive-by cleanup (in scope per #2722)

- `@prefetch_primary_key_cache.delete(table_name.to_s)` was previously sprinkled at the `rename_table` / `drop_table` call sites. Consolidated into `clear_table_caches` so every per-table DDL invalidation hits the same cache set. The 7 column-level DDL paths now also drop the prefetch entry — a minor cost (forces a re-fetch on next sequence/trigger lookup) but strictly safer when a DDL touches the primary key.

## Verification

- New regression spec in `oracle_enhanced_adapter_spec.rb` (`describe "deprecated clear_table_columns_cache"`) verifies the warning fires and the call forwards to `clear_table_caches`.
- Existing column-cache and DDL specs continue to pass under the new name.
- `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb` → 192 examples, 0 failures, 2 pending (pre-existing).
- `bundle exec rubocop` clean on touched files.

## Migration

Out-of-tree callers that invoke `clear_table_columns_cache` directly will see a deprecation warning but continue to function. No removal in this release.
