### PR TITLE
Wire up validate_constraint / validate_check_constraint with NOVALIDATE support

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -94,6 +94,15 @@ module ActiveRecord
           def visit_AlterTable(o)
             sql = super
             sql << o.unique_constraint_adds.map { |c| visit_AddUniqueConstraint(c) }.join(" ")
+            sql << o.constraint_validations.map { |name| visit_ValidateConstraint(name) }.join(" ")
+          end
+
+          def visit_CheckConstraintDefinition(o)
+            super.dup.tap { |sql| sql << " NOVALIDATE" unless o.validate? }
+          end
+
+          def visit_ValidateConstraint(name)
+            "MODIFY CONSTRAINT #{quote_column_name(name)} VALIDATE"
           end
 
           def visit_UniqueConstraintDefinition(o)

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -127,15 +127,20 @@ module ActiveRecord
       end
 
       class AlterTable < ActiveRecord::ConnectionAdapters::AlterTable
-        attr_reader :unique_constraint_adds
+        attr_reader :unique_constraint_adds, :constraint_validations
 
         def initialize(td)
           super
           @unique_constraint_adds = []
+          @constraint_validations = []
         end
 
         def add_unique_constraint(column_name, options)
           @unique_constraint_adds << @td.new_unique_constraint_definition(column_name, options)
+        end
+
+        def validate_constraint(name)
+          @constraint_validations << name
         end
       end
 
@@ -148,6 +153,14 @@ module ActiveRecord
 
         def remove_unique_constraint(...)
           @base.remove_unique_constraint(name, ...)
+        end
+
+        def validate_constraint(...)
+          @base.validate_constraint(name, ...)
+        end
+
+        def validate_check_constraint(...)
+          @base.validate_check_constraint(name, ...)
         end
       end
     end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -625,7 +625,7 @@ module ActiveRecord
 
           # `search_condition` is LONG; cannot appear in WHERE (ORA-00997).
           rows = select_all(<<~SQL.squish, "SCHEMA", [bind_string("desc_table_name", desc_table_name)])
-            SELECT constraint_name AS name, search_condition
+            SELECT constraint_name AS name, search_condition, validated
               FROM all_constraints
              WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
                AND table_name = :desc_table_name
@@ -637,8 +637,21 @@ module ActiveRecord
           rows.filter_map do |row|
             next if row["search_condition"].nil?
             options = { name: oracle_downcase(row["name"]) }
+            options[:validate] = false if row["validated"] == "NOT VALIDATED"
             CheckConstraintDefinition.new(oracle_downcase(table_name), row["search_condition"], options)
           end
+        end
+
+        def validate_constraint(table_name, constraint_name) # :nodoc:
+          at = create_alter_table(table_name)
+          at.validate_constraint(constraint_name)
+
+          execute schema_creation.accept(at)
+        end
+
+        def validate_check_constraint(table_name, **options) # :nodoc:
+          chk_name_to_validate = check_constraint_for!(table_name, **options).name
+          validate_constraint(table_name, chk_name_to_validate)
         end
 
         # Returns an array of unique constraints for the given table.

--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -194,19 +194,11 @@ module ActiveRecord # :nodoc:
           join_with_statement_token(fks)
         end
 
-        # Only user-named CHECK constraints are preserved. Anonymous
-        # constraints created via `ALTER TABLE ... ADD CHECK (...)` receive
-        # Oracle-generated names (e.g. SYS_C00123) and are skipped to avoid
-        # also emitting the implicit NOT NULL check constraints that Oracle
-        # stores with constraint_type = 'C'.
+        # `generated = 'USER NAME'` skips implicit NOT NULL checks (system-named, type 'C').
         def structure_dump_check_constraints(table_name) # :nodoc:
-          # `search_condition` is a LONG column, so it cannot appear in a
-          # WHERE clause (ORA-00997). The driver reads it as a String on
-          # SELECT. Implicit NOT NULL constraints Oracle stores with
-          # constraint_type = 'C' are excluded by `generated = 'USER NAME'`
-          # since they receive system-generated names.
+          # `search_condition` is LONG; cannot appear in WHERE (ORA-00997).
           check_constraints = select_all(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name.upcase)])
-            SELECT constraint_name, search_condition
+            SELECT constraint_name, search_condition, validated
             FROM all_constraints
             WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
               AND table_name = :table_name
@@ -217,7 +209,9 @@ module ActiveRecord # :nodoc:
           check_constraints.filter_map do |row|
             condition = row["search_condition"]
             next if condition.nil?
-            "ALTER TABLE #{quote_table_name(table_name)} ADD CONSTRAINT #{quote_column_name(row["constraint_name"])} CHECK (#{condition})"
+            sql = "ALTER TABLE #{quote_table_name(table_name)} ADD CONSTRAINT #{quote_column_name(row["constraint_name"])} CHECK (#{condition})"
+            sql << " NOVALIDATE" if row["validated"] == "NOT VALIDATED"
+            sql
           end
         end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -507,6 +507,10 @@ module ActiveRecord
         true
       end
 
+      def supports_validate_constraints?
+        true
+      end
+
       def supports_optimizer_hints?
         true
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced/dbms_metadata_structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/dbms_metadata_structure_dump_spec.rb
@@ -134,6 +134,17 @@ RSpec.describe "OracleEnhancedAdapter DBMS_METADATA structure dump" do
       expect(dump).to match(/REFERENCES\s+"?TEST_DBMS_METADATA_POSTS"?/i)
     end
 
+    it "emits NOVALIDATE for check constraints added with validate: false" do
+      schema_define do
+        create_table :test_dbms_metadata_posts, force: true do |t|
+          t.integer :price
+        end
+      end
+      @conn.add_check_constraint(:test_dbms_metadata_posts, "price > 0", name: "dbms_meta_novalidate_chk", validate: false)
+      dump = @conn.structure_dump
+      expect(dump).to match(/CONSTRAINT\s+"DBMS_META_NOVALIDATE_CHK"\s+CHECK\s*\(.+\)\s+.*\bNOVALIDATE\b/im)
+    end
+
     it "emits COMMENT ON TABLE / COMMENT ON COLUMN for documented tables" do
       schema_define do
         create_table :test_dbms_metadata_comments, force: true, comment: "table-level comment" do |t|

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -363,6 +363,32 @@ RSpec.describe "OracleEnhancedAdapter schema dump" do
       cc = @conn.check_constraints(:test_products).detect { |c| c.name == "price_rt_check" }
       expect(cc).not_to be_nil
     end
+
+    it "dumps validate: false for NOVALIDATE check constraints" do
+      schema_define do
+        add_check_constraint :test_products, "price > 0", name: "novalidate_dump", validate: false
+      end
+      output = dump_table_schema "test_products"
+      expect(output).to match(/add_check_constraint "test_products".*name: "novalidate_dump".*validate: false/)
+    end
+
+    it "round-trips validate: false through dump and load" do
+      schema_define do
+        add_check_constraint :test_products, "price > 0", name: "novalidate_rt", validate: false
+      end
+
+      dumped = dump_table_schema "test_products"
+      schema_define do
+        drop_table :test_products, if_exists: true
+      end
+
+      body = dumped[/ActiveRecord::Schema\[.+?\]\.define\(version: \d+\) do\n(.+)\nend\s*\z/m, 1]
+      schema_define { instance_eval(body) }
+
+      cc = @conn.check_constraints(:test_products).detect { |c| c.name == "novalidate_rt" }
+      expect(cc).not_to be_nil
+      expect(cc.validate?).to be(false)
+    end
   end
 
   describe "unique constraints" do

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -842,9 +842,11 @@ end
         # which would suppress the very warning we want to capture.
         expect {
           ActiveRecord::Schema.define do
-            create_table :test_dep_inline, force: true do |t|
-              t.string :first_name
-              t.index :first_name, unique: true, name: :uniq_dep_inline
+            suppress_messages do
+              create_table :test_dep_inline, force: true do |t|
+                t.string :first_name
+                t.index :first_name, unique: true, name: :uniq_dep_inline
+              end
             end
           end
         }.to output(/add_index :col, unique: true creates an implicit named UNIQUE constraint/).to_stderr
@@ -1257,6 +1259,70 @@ end
       cc = @conn.check_constraints(:test_products).detect { |c| c.name == "multi_col_check" }
       expect(cc).not_to be_nil
       expect(cc.expression).to match(/price\s*>\s*0\s+and\s+quantity\s*>=\s*0/i)
+    end
+
+    it "creates a NOVALIDATE check constraint when validate: false is given" do
+      schema_define do
+        add_check_constraint :test_products, "price > 0", name: "novalidate_check", validate: false
+      end
+      cc = @conn.check_constraints(:test_products).detect { |c| c.name == "novalidate_check" }
+      expect(cc).not_to be_nil
+      expect(cc.validate?).to be(false)
+    end
+
+    it "drains inline t.check_constraint with validate: false" do
+      schema_define do
+        drop_table :test_products, if_exists: true
+        create_table :test_products, force: true do |t|
+          t.integer :price
+          t.check_constraint "price > 0", name: "inline_novalidate", validate: false
+        end
+      end
+      cc = @conn.check_constraints(:test_products).detect { |c| c.name == "inline_novalidate" }
+      expect(cc).not_to be_nil
+      expect(cc.validate?).to be(false)
+    end
+
+    it "validates a NOVALIDATE constraint via validate_check_constraint" do
+      schema_define do
+        add_check_constraint :test_products, "price > 0", name: "to_validate", validate: false
+      end
+      expect(@conn.check_constraints(:test_products).detect { |c| c.name == "to_validate" }.validate?).to be(false)
+
+      schema_define do
+        validate_check_constraint :test_products, name: "to_validate"
+      end
+      expect(@conn.check_constraints(:test_products).detect { |c| c.name == "to_validate" }.validate?).to be(true)
+    end
+
+    it "validates a constraint by name via validate_constraint" do
+      schema_define do
+        add_check_constraint :test_products, "price > 0", name: "to_validate2", validate: false
+      end
+      schema_define do
+        validate_constraint :test_products, "to_validate2"
+      end
+      expect(@conn.check_constraints(:test_products).detect { |c| c.name == "to_validate2" }.validate?).to be(true)
+    end
+
+    it "supports change_table { |t| t.validate_check_constraint name: ... }" do
+      schema_define do
+        add_check_constraint :test_products, "price > 0", name: "ct_validate_chk", validate: false
+        change_table :test_products do |t|
+          t.validate_check_constraint name: "ct_validate_chk"
+        end
+      end
+      expect(@conn.check_constraints(:test_products).detect { |c| c.name == "ct_validate_chk" }.validate?).to be(true)
+    end
+
+    it "supports change_table { |t| t.validate_constraint(name) }" do
+      schema_define do
+        add_check_constraint :test_products, "price > 0", name: "ct_validate_bare", validate: false
+        change_table :test_products do |t|
+          t.validate_constraint "ct_validate_bare"
+        end
+      end
+      expect(@conn.check_constraints(:test_products).detect { |c| c.name == "ct_validate_bare" }.validate?).to be(true)
     end
   end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
@@ -241,6 +241,24 @@ RSpec.describe "OracleEnhancedAdapter structure dump" do
       expect(dump).to match(/ALTER TABLE "TEST_POSTS" ADD CONSTRAINT "TEST_POSTS_DSL_TITLE_CHECK" CHECK/)
     end
 
+    it "appends NOVALIDATE for check constraints added with validate: false" do
+      ActiveRecord::Base.lease_connection.add_check_constraint(:test_posts, "LENGTH(title) > 0", name: "test_posts_novalidate_check", validate: false)
+      dump = ActiveRecord::Base.lease_connection.structure_dump_check_constraints("test_posts")
+      novalidate_row = dump.find { |line| line.include?("TEST_POSTS_NOVALIDATE_CHECK") }
+      expect(novalidate_row).to match(/ NOVALIDATE\z/)
+    end
+
+    it "round-trips a NOVALIDATE check constraint via structure_dump and execute_structure_dump" do
+      conn = ActiveRecord::Base.lease_connection
+      conn.add_check_constraint(:test_posts, "LENGTH(title) > 0", name: "test_posts_rt_novalidate", validate: false)
+      dumped_alter = conn.structure_dump_check_constraints("test_posts").find { |line| line.include?("TEST_POSTS_RT_NOVALIDATE") }
+      conn.remove_check_constraint(:test_posts, name: "test_posts_rt_novalidate")
+      conn.execute_structure_dump(dumped_alter)
+      cc = conn.check_constraints(:test_posts).detect { |c| c.name == "test_posts_rt_novalidate" }
+      expect(cc).not_to be_nil
+      expect(cc.validate?).to be(false)
+    end
+
     it "should dump table comments" do
       comment_sql = %Q(COMMENT ON TABLE "TEST_POSTS" IS 'Test posts with ''some'' "quotes"')
       @conn.execute comment_sql


### PR DESCRIPTION
Follow-up to #2717.

## Summary

Oracle's CHECK constraint state has two axes — ENABLED/DISABLED and VALIDATED/NOT VALIDATED — formalised in the `constraint_state` clause since Oracle 8i. See the [Oracle8i SQL Reference (Release 3, 8.1.7), constraint_clause](https://docs.oracle.com/cd/A87860_01/doc/server.817/a85397/state14a.htm). Active Record exposes the second axis via the abstract `validate:` option (default `true`) on `add_check_constraint` and the `validate_check_constraint` migration helper. Until now oracle-enhanced ignored the option: every constraint was created with the default `ENABLE VALIDATE`, and `validate_check_constraint` short-circuited because `supports_validate_constraints?` returned the abstract default `false`.

The two axes are orthogonal. This PR wires up the VALIDATE axis only and assumes constraints are ENABLED — which they always are when created via the Rails DSL today (no DISABLE creation surface). When PG 18-style ENABLED/DISABLED support lands upstream, the second axis can layer on top without revisiting these primitives.

## Changes

### Production

- `OracleEnhancedAdapter#supports_validate_constraints?` returns `true`.
- `OracleEnhanced::SchemaCreation#visit_CheckConstraintDefinition` appends `NOVALIDATE` when the definition's `validate?` is `false` — Oracle's analogue of PostgreSQL's `NOT VALID`. `ENABLE` is omitted because `ADD CONSTRAINT` defaults the unspecified ENABLE/DISABLE axis to `ENABLE` when only `NOVALIDATE` is given.
- `OracleEnhanced::AlterTable` gains `@constraint_validations` and a `validate_constraint(name)` method, drained by an extended `visit_AlterTable` that emits `MODIFY CONSTRAINT n VALIDATE` — Oracle's equivalent of PG's `VALIDATE CONSTRAINT n`. Like PG, this only touches the validate axis (orthogonal to enforce).
- `OracleEnhanced::Table` gains `validate_constraint` / `validate_check_constraint` delegators so `change_table { |t| t.validate_check_constraint name: "n" }` works.
- `OracleEnhanced::SchemaStatements#validate_constraint(table_name, constraint_name)` and `#validate_check_constraint(table_name, **options)` schema-statement wrappers added, modelled on the PostgreSQL pair.
- `check_constraints(table_name)` reader extended to read the `validated` column on `all_constraints`; constraints whose `validated` is `'NOT VALIDATED'` are returned with `validate: false` on their `CheckConstraintDefinition` options, so the schema dumper emits `add_check_constraint ..., validate: false` lines after the `create_table` block.
- `structure_dump_check_constraints` (the dictionary path used by `structure.sql`) extended to read `validated` and append `NOVALIDATE` when the constraint is not validated, so structure.sql round-trips the state too. The `DBMS_METADATA` path produces the `NOVALIDATE` clause natively via `DBMS_METADATA.GET_DDL`.

### Specs

`schema_statements_spec.rb` `describe "check constraints"`:
- `add_check_constraint :t, "expr", validate: false` → reader returns `validate?: false`.
- Inline `t.check_constraint "expr", validate: false` in `create_table` → reader returns `validate?: false`.
- `validate_check_constraint :t, name: "..."` → flips `validate?` from false to true.
- `validate_constraint :t, "name"` (bare form) → same effect.

`schema_dumper_spec.rb` `describe "check constraints"`:
- A NOVALIDATE constraint is dumped as `add_check_constraint "t", "...", name: "...", validate: false` outside the `create_table` block (matches AR core's `check_constraints_in_create` partition logic).

`structure_dump_spec.rb`:
- `structure_dump_check_constraints` appends `NOVALIDATE` for `validate: false` constraints (dictionary path).

`dbms_metadata_structure_dump_spec.rb`:
- The DBMS_METADATA path includes `NOVALIDATE` natively in the dumped DDL when a constraint is created with `validate: false`.

## Out of scope

- DEFERRABLE on CHECK constraints — tracked separately as #2718.
- The ENABLED/DISABLED axis (Oracle's `DISABLE`, equivalent to PG 18's `NOT ENFORCED`) — Rails has no DSL for this yet; will follow PG 18 support upstream.
- `validate_foreign_key` migration helper: currently inherited from PG-only territory; left for a separate PR if needed.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb -e "check constraint"` (12 examples)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb -e "check constraint"` (3 examples)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb -e "check constraint"` (dictionary path)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/dbms_metadata_structure_dump_spec.rb -e "NOVALIDATE"` (DBMS_METADATA path)
- [x] `bundle exec rubocop` — clean
- [ ] CI on full matrix (3.3 / 3.4 / 4.0 / jruby)
