### PR TITLE
Wire up validate_foreign_key with NOVALIDATE support

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -88,6 +88,7 @@ module ActiveRecord
           def visit_ForeignKeyDefinition(o)
             super.dup.tap do |sql|
               sql << " DEFERRABLE INITIALLY #{o.deferrable.to_s.upcase}" if o.deferrable
+              sql << " NOVALIDATE" unless o.validate?
             end
           end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_definitions.rb
@@ -162,6 +162,10 @@ module ActiveRecord
         def validate_check_constraint(...)
           @base.validate_check_constraint(name, ...)
         end
+
+        def validate_foreign_key(...)
+          @base.validate_foreign_key(name, ...)
+        end
       end
     end
   end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -592,6 +592,7 @@ module ActiveRecord
                   ,c.delete_rule
                   ,c.deferrable
                   ,c.deferred
+                  ,c.validated
               FROM all_constraints c, all_cons_columns cc,
                    all_constraints r, all_cons_columns rc
              WHERE c.owner = SYS_CONTEXT('userenv', 'current_schema')
@@ -615,6 +616,7 @@ module ActiveRecord
             }
             options[:on_delete] = extract_foreign_key_action(row["delete_rule"])
             options[:deferrable] = extract_foreign_key_deferrable(row["deferrable"], row["deferred"])
+            options[:validate] = false if row["validated"] == "NOT VALIDATED"
             ActiveRecord::ConnectionAdapters::ForeignKeyDefinition.new(oracle_downcase(table_name), oracle_downcase(row["to_table"]), options)
           end
         end
@@ -652,6 +654,11 @@ module ActiveRecord
         def validate_check_constraint(table_name, **options) # :nodoc:
           chk_name_to_validate = check_constraint_for!(table_name, **options).name
           validate_constraint(table_name, chk_name_to_validate)
+        end
+
+        def validate_foreign_key(from_table, to_table = nil, **options) # :nodoc:
+          fk_name_to_validate = foreign_key_for!(from_table, to_table: to_table, **options).name
+          validate_constraint(from_table, fk_name_to_validate)
         end
 
         # Returns an array of unique constraints for the given table.

--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -258,6 +258,7 @@ module ActiveRecord # :nodoc:
             sql << " ON DELETE CASCADE"
           end
           sql << " DEFERRABLE INITIALLY #{options[:deferrable].to_s.upcase}" if options[:deferrable]
+          sql << " NOVALIDATE" if options[:validate] == false
           sql
         end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/dbms_metadata_structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/dbms_metadata_structure_dump_spec.rb
@@ -145,6 +145,22 @@ RSpec.describe "OracleEnhancedAdapter DBMS_METADATA structure dump" do
       expect(dump).to match(/CONSTRAINT\s+"DBMS_META_NOVALIDATE_CHK"\s+CHECK\s*\(.+\)\s+.*\bNOVALIDATE\b/im)
     end
 
+    it "emits NOVALIDATE for foreign keys added with validate: false" do
+      schema_define do
+        create_table :test_dbms_metadata_posts, force: true do |t|
+          t.string :title
+        end
+        create_table :test_dbms_metadata_children, force: true do |t|
+          t.references :test_dbms_metadata_post
+        end
+      end
+      @conn.add_foreign_key :test_dbms_metadata_children, :test_dbms_metadata_posts,
+                            column: :test_dbms_metadata_post_id,
+                            name: "dbms_meta_novalidate_fk", validate: false
+      dump = @conn.structure_dump
+      expect(dump).to match(/CONSTRAINT\s+"DBMS_META_NOVALIDATE_FK"\s+FOREIGN\s+KEY.+REFERENCES\s+"TEST_DBMS_METADATA_POSTS".+\bNOVALIDATE\b/im)
+    end
+
     it "emits COMMENT ON TABLE / COMMENT ON COLUMN for documented tables" do
       schema_define do
         create_table :test_dbms_metadata_comments, force: true, comment: "table-level comment" do |t|

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -197,6 +197,32 @@ RSpec.describe "OracleEnhancedAdapter schema dump" do
       expect(standard_dump(ignore_tables: %w(test_comments))).not_to match(/add_foreign_key "test_comments"/)
     end
 
+    it "dumps validate: false for NOVALIDATE foreign keys" do
+      schema_define do
+        add_foreign_key :test_comments, :test_posts, validate: false
+      end
+      output = dump_table_schema "test_comments"
+      expect(output).to match(/add_foreign_key "test_comments", "test_posts".*validate: false/)
+    end
+
+    it "round-trips validate: false on a foreign key through dump and load" do
+      schema_define do
+        add_foreign_key :test_comments, :test_posts, validate: false
+      end
+
+      dumped = dump_table_schema "test_comments"
+      schema_define do
+        remove_foreign_key :test_comments, :test_posts, if_exists: true
+      end
+
+      body = dumped[/ActiveRecord::Schema\[.+?\]\.define\(version: \d+\) do\n(.+)\nend\s*\z/m, 1]
+      schema_define { instance_eval(body) }
+
+      fk = ActiveRecord::Base.lease_connection.foreign_keys(:test_comments).first
+      expect(fk).not_to be_nil
+      expect(fk.options[:validate]).to be(false)
+    end
+
     it "should not include foreign keys on ignored table regexes in schema dump" do
       schema_define do
         add_foreign_key :test_comments, :test_posts

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -1166,6 +1166,58 @@ end
         end
       }.to raise_error(ArgumentError, /deferrable must be `:immediate` or `:deferred`/)
     end
+
+    it "creates a NOVALIDATE foreign key when validate: false is given" do
+      schema_define do
+        add_foreign_key :test_comments, :test_posts, validate: false
+      end
+      fk = ActiveRecord::Base.lease_connection.foreign_keys(:test_comments).first
+      expect(fk.options[:validate]).to be(false)
+    end
+
+    it "validates a NOVALIDATE foreign key via validate_foreign_key" do
+      schema_define do
+        add_foreign_key :test_comments, :test_posts, name: "fk_to_validate", validate: false
+      end
+      fk_before = ActiveRecord::Base.lease_connection.foreign_keys(:test_comments).first
+      expect(fk_before.options[:validate]).to be(false)
+
+      schema_define do
+        validate_foreign_key :test_comments, :test_posts
+      end
+      fk_after = ActiveRecord::Base.lease_connection.foreign_keys(:test_comments).first
+      expect(fk_after.options.key?(:validate)).to be(false)
+    end
+
+    it "supports change_table { |t| t.validate_foreign_key }" do
+      schema_define do
+        add_foreign_key :test_comments, :test_posts, name: "fk_ct_validate", validate: false
+        change_table :test_comments do |t|
+          t.validate_foreign_key :test_posts
+        end
+      end
+      fk = ActiveRecord::Base.lease_connection.foreign_keys(:test_comments).first
+      expect(fk.options.key?(:validate)).to be(false)
+    end
+
+    it "validates a foreign key by name" do
+      schema_define do
+        add_foreign_key :test_comments, :test_posts, name: "fk_by_name", validate: false
+        validate_foreign_key :test_comments, name: "fk_by_name"
+      end
+      fk = ActiveRecord::Base.lease_connection.foreign_keys(:test_comments).first
+      expect(fk.options.key?(:validate)).to be(false)
+    end
+
+    it "validates a foreign key by column" do
+      schema_define do
+        add_foreign_key :test_comments, :test_posts, column: :post_id, name: "fk_by_col", validate: false
+        validate_foreign_key :test_comments, column: :post_id
+      end
+      fk = ActiveRecord::Base.lease_connection.foreign_keys(:test_comments).detect { |f| f.options[:name] == "fk_by_col" }
+      expect(fk).not_to be_nil
+      expect(fk.options.key?(:validate)).to be(false)
+    end
   end
 
   describe "check constraints" do

--- a/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe "OracleEnhancedAdapter structure dump" do
   include LoggerSpecHelper
+  include SchemaSpecHelper
 
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
@@ -102,6 +103,17 @@ RSpec.describe "OracleEnhancedAdapter structure dump" do
       dump = ActiveRecord::Base.lease_connection.structure_dump_fk_constraints
       expect(dump.split('\n').length).to eq(0)
       expect(dump).to eq("")
+    end
+
+    it "appends NOVALIDATE for foreign keys added with validate: false" do
+      schema_define do
+        add_column :test_posts, :foo_uniq, :integer
+        add_index :test_posts, :foo_uniq, unique: true, name: "ix_test_posts_foo_uniq"
+        add_foreign_key :test_posts, :test_posts, column: :foo_id, primary_key: :foo_uniq, name: "fk_novalidate_baz", validate: false
+      end
+      dump = ActiveRecord::Base.lease_connection.structure_dump
+      fk_alter = dump.split("\n\n/\n\n").find { |stmt| stmt.include?("FK_NOVALIDATE_BAZ") }
+      expect(fk_alter).to match(/ NOVALIDATE\b/)
     end
 
     it "should dump triggers" do


### PR DESCRIPTION
Follow-up to #2724 (now merged). Same ENABLED-default + orthogonal-axis design extended to foreign keys, completing the `supports_validate_constraints?` surface.

## Summary

Active Record exposes the `validate:` option on `add_foreign_key` and a `validate_foreign_key` migration helper. Until now oracle-enhanced ignored both: the option was silently dropped, and the helper was undefined (the abstract layer doesn't provide it — PostgreSQL ships its own).

## Changes

### Production

- `OracleEnhanced::SchemaCreation#visit_ForeignKeyDefinition` appends `NOVALIDATE` when `!o.validate?` — Oracle's analogue of PostgreSQL's `NOT VALID`. Consistent with the CHECK-constraint visitor in #2724.
- `OracleEnhanced::SchemaStatements#validate_foreign_key(from_table, to_table = nil, **options)` mirrors PostgreSQL's helper: resolves the FK by name/columns then calls the existing `validate_constraint`.
- `OracleEnhanced::Table#validate_foreign_key` delegator so `change_table { |t| t.validate_foreign_key :other }` works.
- `foreign_keys(table_name)` reader extended to read the `validated` column on `all_constraints`; FKs with `validated = 'NOT VALIDATED'` come back with `validate: false` in their `ForeignKeyDefinition` options, so the schema dumper round-trips the state.
- `structure_dump`'s `foreign_key_definition` appends `NOVALIDATE` when `options[:validate] == false`, so structure.sql round-trips it too.

### Specs

`schema_statements_spec.rb` `describe "foreign key constraints"`:

- `add_foreign_key validate: false` → reader returns `validate: false` option.
- `validate_foreign_key :t, :other` → flips the FK to validated state.
- `validate_foreign_key :t, name: "..."` resolution by name.
- `validate_foreign_key :t, column: ...` resolution by column.
- `change_table { |t| t.validate_foreign_key }` delegator works.

`schema_dumper_spec.rb` `describe "foreign key constraints"`:

- Dumps `add_foreign_key ..., validate: false` for NOVALIDATE FKs.
- Round-trip: declare with `validate: false`, dump, drop, reload — verify `validate?` is false.

`structure_dump_spec.rb` (dictionary path):

- `structure_dump` appends `NOVALIDATE` for `validate: false` FKs.

`dbms_metadata_structure_dump_spec.rb` (DBMS_METADATA path):

- DBMS_METADATA emits `NOVALIDATE` natively in the dumped FK DDL.

## Out of scope

- DEFERRABLE-on-CHECK is the parallel follow-up tracked in #2718.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb -e "foreign key"` (23 examples)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb -e "foreign key"` (10 examples)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb -e "NOVALIDATE"` (1 example)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/dbms_metadata_structure_dump_spec.rb -e "NOVALIDATE"` (2 examples)
- [x] `bundle exec rubocop` — clean
- [ ] CI on full matrix (3.3 / 3.4 / 4.0 / jruby)
