### PR TITLE
Override supports_index_sort_order? to true

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -96,7 +96,7 @@ module ActiveRecord
             SELECT LOWER(i.table_name) AS table_name, LOWER(i.index_name) AS index_name, i.uniqueness,
               i.index_type, i.ityp_owner, i.ityp_name, i.parameters,
               LOWER(i.tablespace_name) AS tablespace_name,
-              LOWER(c.column_name) AS column_name, e.column_expression,
+              LOWER(c.column_name) AS column_name, c.descend, e.column_expression,
               atc.virtual_column
             FROM all_indexes i
               JOIN all_ind_columns c ON c.index_name = i.index_name AND c.index_owner = i.owner
@@ -146,14 +146,33 @@ module ActiveRecord
               current_index = row["index_name"]
             end
 
-            # Functional index columns and virtual columns both get stored as column expressions,
-            # but re-creating a virtual column index as an expression (instead of using the virtual column's name)
-            # results in a ORA-54018 error.  Thus, we only want the column expression value returned
-            # when the column is not virtual.
-            if row["column_expression"] && row["virtual_column"] != "YES"
-              all_schema_indexes.last.columns << row["column_expression"]
+            expression = row["column_expression"]
+            user_defined_virtual_column = row["virtual_column"] == "YES"
+            column = if user_defined_virtual_column || expression.nil?
+              # Plain column or user-defined virtual column. Re-creating a
+              # virtual-column index as an expression (instead of using the
+              # virtual column's name) results in ORA-54018, so use the
+              # column name in both cases.
+              row["column_name"].downcase
+            elsif row["descend"] == "DESC" && expression =~ /\A"([^"]+)"\z/ # quoted-bare-identifier ("LAST_NAME"); function expressions like LOWER("NAME") fail to match
+              # Oracle implements `(col DESC)` via a system-generated virtual
+              # column whose column_expression is the quoted user column
+              # name. Peel that off so the orders hash keys off the bare name.
+              # Example: column_name = SYS_NC00003$, column_expression = "LAST_NAME"
+              # -> column = "last_name", orders["last_name"] = :desc.
+              $1.downcase
             else
-              all_schema_indexes.last.columns << row["column_name"].downcase
+              # Function-based expression (e.g. `LOWER("NAME")`).
+              expression
+            end
+            all_schema_indexes.last.columns << column
+            # Track DESC only for plain column names. A function-based DESC index
+            # (column = expression) would dump as `order: { LOWER("NAME"): :desc }`,
+            # which AR core's hash formatter emits in symbol-shorthand form and
+            # produces invalid Ruby. Plain columns / DESC-marker virtuals are safe
+            # because `column` is downcased and identifier-like.
+            if row["descend"] == "DESC" && column != expression
+              all_schema_indexes.last.orders[column] = :desc
             end
           end
 
@@ -315,7 +334,7 @@ module ActiveRecord
             index_name,
             options[:unique] || false,
             column_names,
-            {},
+            options[:order] || {},
             nil,
             nil,
             options[:options],

--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -162,7 +162,12 @@ module ActiveRecord # :nodoc:
 
         def structure_dump_indexes(table_name) # :nodoc:
           indexes(table_name).map do |index|
-            quoted_column_names = index.columns.map { |c| quote_column_name_or_expression(c) }.join(", ")
+            orders = index.orders || {}
+            quoted_column_names = index.columns.map do |c|
+              sql = quote_column_name_or_expression(c)
+              sql = "#{sql} DESC" if orders[c] == :desc
+              sql
+            end.join(", ")
             "CREATE#{' UNIQUE' if index.unique} INDEX #{quote_column_name(index.name)} ON #{quote_table_name(table_name)} (#{quoted_column_names})"
           end
         end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -515,6 +515,10 @@ module ActiveRecord
         true
       end
 
+      def supports_index_sort_order?
+        true
+      end
+
       def supports_optimizer_hints?
         true
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -148,6 +148,75 @@ RSpec.describe "OracleEnhancedAdapter schema dump" do
     end
   end
 
+  describe "index sort order" do
+    before(:each) do
+      schema_define do
+        create_table :test_idx_sort_dump, force: true do |t|
+          t.string :first_name
+          t.string :last_name
+        end
+      end
+    end
+
+    after(:each) do
+      schema_define do
+        drop_table :test_idx_sort_dump, if_exists: true
+      end
+    end
+
+    it "dumps order: { col: :desc } for descending indexes" do
+      schema_define do
+        add_index :test_idx_sort_dump, [:first_name, :last_name],
+                  name: "ix_dump_sort", order: { last_name: :desc }
+      end
+      output = dump_table_schema "test_idx_sort_dump"
+      expect(output).to match(/t\.index \[.*first_name.*last_name.*\], name: "ix_dump_sort", order: \{ last_name: :desc \}/im)
+    end
+
+    it "round-trips a DESC index through dump and load" do
+      schema_define do
+        add_index :test_idx_sort_dump, [:first_name, :last_name],
+                  name: "ix_rt_sort", order: { last_name: :desc }
+      end
+      dumped = dump_table_schema "test_idx_sort_dump"
+      schema_define do
+        drop_table :test_idx_sort_dump, if_exists: true
+      end
+      body = dumped[/ActiveRecord::Schema\[.+?\]\.define\(version: \d+\) do\n(.+)\nend\s*\z/m, 1]
+      schema_define { instance_eval(body) }
+      desc_count = ActiveRecord::Base.lease_connection.select_value(<<~SQL.squish)
+        SELECT COUNT(*) FROM all_ind_columns
+         WHERE index_owner = SYS_CONTEXT('userenv', 'current_schema')
+           AND index_name = 'IX_RT_SORT'
+           AND descend = 'DESC'
+      SQL
+      expect(desc_count).to eq(1)
+    end
+
+    it "dumps a single-column DESC index" do
+      schema_define do
+        add_index :test_idx_sort_dump, :last_name,
+                  name: "ix_single_desc", order: :desc
+      end
+      output = dump_table_schema "test_idx_sort_dump"
+      expect(output).to match(/t\.index \[.*last_name.*\], name: "ix_single_desc", order: \{ last_name: :desc \}/im)
+    end
+
+    it "dumps a function-based DESC index without invalid order hash" do
+      # Function-based + DESC: AR core's hash formatter cannot emit
+      # `order: { LOWER("NAME"): :desc }` as valid Ruby (the key is not a
+      # bare identifier). The reader skips DESC tracking in that case so
+      # the dump stays parseable; DESC fidelity is lost on round-trip.
+      schema_define do
+        add_index :test_idx_sort_dump, "LOWER(last_name)",
+                  name: "ix_expr_desc", order: :desc
+      end
+      output = dump_table_schema "test_idx_sort_dump"
+      expect(output).to include('name: "ix_expr_desc"')
+      expect(output).not_to match(/order: \{ LOWER/)
+    end
+  end
+
   describe "foreign key constraints" do
     # Recreate the canonical tables before each example. One example
     # (`should include primary_key when reference column name is not 'id'`)

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -586,6 +586,31 @@ RSpec.describe "OracleEnhancedAdapter schema definition" do
       expect(@conn.supports_expression_index?).to be(true)
     end
 
+    it "supports per-column sort order in add_index" do
+      schema_define do
+        create_table :test_idx_sort, force: true do |t|
+          t.string :first_name
+          t.string :last_name
+        end
+        add_index :test_idx_sort, [:first_name, :last_name],
+                  name: "ix_sort_order",
+                  order: { first_name: :asc, last_name: :desc }
+      end
+      desc_count = @conn.select_value(<<~SQL.squish)
+        SELECT COUNT(*) FROM all_ind_columns
+         WHERE index_owner = SYS_CONTEXT('userenv', 'current_schema')
+           AND index_name = 'IX_SORT_ORDER'
+           AND descend = 'DESC'
+      SQL
+      expect(desc_count).to eq(1)
+    ensure
+      schema_define { drop_table :test_idx_sort, if_exists: true }
+    end
+
+    it "reports supports_index_sort_order? as true" do
+      expect(@conn.supports_index_sort_order?).to be(true)
+    end
+
     it "measures default index name length in bytes, not characters" do
       max = @conn.index_name_length
       # "index_t_on_<col>" fits in `max` characters but overflows in bytes

--- a/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
@@ -113,6 +113,14 @@ RSpec.describe "OracleEnhancedAdapter structure dump" do
       expect(dump).to match(/CREATE INDEX "?IX_STRUCT_EXPR"? ON "?TEST_POSTS"? \(LOWER\("?TITLE"?\)\)/i)
     end
 
+    it "dumps DESC index order in structure_dump_indexes" do
+      schema_define do
+        add_index :test_posts, [:title, :foo], name: "ix_struct_sort", order: { foo: :desc }
+      end
+      dump = @conn.structure_dump_indexes("test_posts").join("\n")
+      expect(dump).to match(/CREATE INDEX "?IX_STRUCT_SORT"? ON "?TEST_POSTS"? \(.*"?TITLE"?.*"?FOO"?\s+DESC.*\)/im)
+    end
+
     it "appends NOVALIDATE for foreign keys added with validate: false" do
       schema_define do
         add_column :test_posts, :foo_uniq, :integer


### PR DESCRIPTION
Refs #2711 (this is one half of the issue; the `supports_expression_index?` half is opened separately).

## Summary

Oracle Database has supported per-column index sort direction (`CREATE INDEX idx ON t (col ASC, other DESC)`) since 8i, but oracle-enhanced never overrode the `AbstractAdapter` default of `false`. Active Record core branched off the flag to suppress the feature on Oracle, and the OE override of `add_index_options` was hard-coding `{}` for `orders`, so the `:order` option was silently dropped even when users passed it.

## Changes

- `OracleEnhancedAdapter#supports_index_sort_order?` returns `true`.
- `OracleEnhanced::SchemaStatements#add_index_options` threads `options[:order]` into the `IndexDefinition`'s `orders` slot (previously hard-coded to `{}`). AR core's `quoted_columns_for_index` then emits `ASC` / `DESC` per column.
- Spec verifying that `add_index :t, [:a, :b], order: { a: :asc, b: :desc }` creates a real index with `descend = 'DESC'` on the second column in `all_ind_columns`.

## Out of scope

- `supports_expression_index?` — separate PR (sibling of this one, also under #2711).
- Schema dumper round-trip of `order:` — already handled by AR core's dumper since `IndexDefinition#orders` is now populated.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb -e "add index"` (7 examples)
- [x] `bundle exec rubocop` — clean
- [ ] CI on full matrix
