### PR TITLE
Override supports_expression_index? to true

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -511,6 +511,10 @@ module ActiveRecord
         true
       end
 
+      def supports_expression_index?
+        true
+      end
+
       def supports_optimizer_hints?
         true
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -106,6 +106,48 @@ RSpec.describe "OracleEnhancedAdapter schema dump" do
     end
   end
 
+  describe "expression index" do
+    before(:each) do
+      schema_define do
+        create_table :test_idx_expr_dump, force: true do |t|
+          t.string :name
+        end
+      end
+    end
+
+    after(:each) do
+      schema_define do
+        drop_table :test_idx_expr_dump, if_exists: true
+      end
+    end
+
+    it "dumps a function-based index with the expression preserved" do
+      schema_define do
+        add_index :test_idx_expr_dump, "LOWER(name)", name: "ix_dump_expr"
+      end
+      output = dump_table_schema "test_idx_expr_dump"
+      expect(output).to match(/t\.index \[.*LOWER\(.*NAME.*\).*\], name: "ix_dump_expr"/im)
+    end
+
+    it "round-trips an expression index through dump and load" do
+      schema_define do
+        add_index :test_idx_expr_dump, "LOWER(name)", name: "ix_rt_expr"
+      end
+      dumped = dump_table_schema "test_idx_expr_dump"
+      schema_define do
+        drop_table :test_idx_expr_dump, if_exists: true
+      end
+      body = dumped[/ActiveRecord::Schema\[.+?\]\.define\(version: \d+\) do\n(.+)\nend\s*\z/m, 1]
+      schema_define { instance_eval(body) }
+      expr = ActiveRecord::Base.lease_connection.select_value(<<~SQL.squish)
+        SELECT column_expression FROM all_ind_expressions
+         WHERE index_owner = SYS_CONTEXT('userenv', 'current_schema')
+           AND index_name = 'IX_RT_EXPR'
+      SQL
+      expect(expr).to match(/LOWER\("?NAME"?\)/i)
+    end
+  end
+
   describe "foreign key constraints" do
     # Recreate the canonical tables before each example. One example
     # (`should include primary_key when reference column name is not 'id'`)

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -559,6 +559,33 @@ RSpec.describe "OracleEnhancedAdapter schema definition" do
       end
     end
 
+    it "supports expression indexes (function-based) via add_index" do
+      schema_define do
+        create_table :test_idx_expr, force: true do |t|
+          t.string :name
+        end
+        add_index :test_idx_expr, "LOWER(name)", name: "ix_expr_lower_name"
+      end
+      idx_count = @conn.select_value(<<~SQL.squish)
+        SELECT COUNT(*) FROM all_indexes
+         WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
+           AND index_name = 'IX_EXPR_LOWER_NAME'
+      SQL
+      expect(idx_count).to eq(1)
+      expr = @conn.select_value(<<~SQL.squish)
+        SELECT column_expression FROM all_ind_expressions
+         WHERE index_owner = SYS_CONTEXT('userenv', 'current_schema')
+           AND index_name = 'IX_EXPR_LOWER_NAME'
+      SQL
+      expect(expr).to match(/LOWER\("?NAME"?\)/i)
+    ensure
+      schema_define { drop_table :test_idx_expr, if_exists: true }
+    end
+
+    it "reports supports_expression_index? as true" do
+      expect(@conn.supports_expression_index?).to be(true)
+    end
+
     it "measures default index name length in bytes, not characters" do
       max = @conn.index_name_length
       # "index_t_on_<col>" fits in `max` characters but overflows in bytes

--- a/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
@@ -105,6 +105,14 @@ RSpec.describe "OracleEnhancedAdapter structure dump" do
       expect(dump).to eq("")
     end
 
+    it "dumps a function-based index expression in structure_dump_indexes" do
+      schema_define do
+        add_index :test_posts, "LOWER(title)", name: "ix_struct_expr"
+      end
+      dump = @conn.structure_dump_indexes("test_posts").join("\n")
+      expect(dump).to match(/CREATE INDEX "?IX_STRUCT_EXPR"? ON "?TEST_POSTS"? \(LOWER\("?TITLE"?\)\)/i)
+    end
+
     it "appends NOVALIDATE for foreign keys added with validate: false" do
       schema_define do
         add_column :test_posts, :foo_uniq, :integer


### PR DESCRIPTION
Refs #2711 (sibling of #2726, which handles `supports_index_sort_order?`).

## Summary

Oracle Database has supported function-based indexes (`CREATE INDEX idx ON t (LOWER(col))`) since 8i — see the [Oracle8i SQL Reference (Release 3, 8.1.7), CREATE INDEX](https://docs.oracle.com/cd/A87860_01/doc/server.817/a85397/state10c.htm). oracle-enhanced has wired the expression-form column quoting via `quote_column_name_or_expression` for years, but the `AbstractAdapter` capability flag stayed at the default `false`. Active Record core branched off the flag for expression-aware code paths and AR-level tests skipped Oracle when the flag was `false`, so an honest override unlocks those paths.

The library change is essentially a single capability-flag override; everything else (DSL, dumper, structure_dump) was already wired up.

## Changes

- `OracleEnhancedAdapter#supports_expression_index?` returns `true`.

### Specs

- `add_index :t, "LOWER(name)", name: :ix` creates a real function-based index with the `LOWER(NAME)` expression visible in `all_ind_expressions.column_expression`.
- `schema.rb` dump emits the index back as `t.index [..LOWER(..NAME..)..], name: "..."` and round-trips through dump → drop → reload.
- `structure.sql` (`structure_dump_indexes`) emits `CREATE INDEX ... ON ... (LOWER(TITLE))` for the function-based form.

## Out of scope

- `supports_index_sort_order?` — the sibling PR (#2726).

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb -e "add index"` (7 examples)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb -e "expression index"` (2 examples)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb -e "function-based"` (1 example)
- [x] `bundle exec rubocop` — clean
- [x] CI 12/12 green
