### PR TITLE
Refactor structure_dump_indexes: drop dead Hash/String branch + variable shadowing

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -161,20 +161,9 @@ module ActiveRecord # :nodoc:
         end
 
         def structure_dump_indexes(table_name) # :nodoc:
-          indexes(table_name).map do |options|
-            column_names = options.columns
-            options = { name: options.name, unique: options.unique }
-            index_name = index_name(table_name, column: column_names)
-            if Hash === options # legacy support, since this param was a string
-              unique = options[:unique]
-              index_name = options[:name] || index_name
-            else
-              # Legacy String form only ever carried "UNIQUE" / ""; BITMAP and
-              # other index_types were never supported via this helper.
-              unique = (options == "UNIQUE")
-            end
-            quoted_column_names = column_names.map { |e| quote_column_name_or_expression(e) }.join(", ")
-            "CREATE#{' UNIQUE' if unique} INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} (#{quoted_column_names})"
+          indexes(table_name).map do |index|
+            quoted_column_names = index.columns.map { |c| quote_column_name_or_expression(c) }.join(", ")
+            "CREATE#{' UNIQUE' if index.unique} INDEX #{quote_column_name(index.name)} ON #{quote_table_name(table_name)} (#{quoted_column_names})"
           end
         end
 


### PR DESCRIPTION
## Summary

`OracleEnhanced::StructureDump#structure_dump_indexes` had three pieces of code that no longer matched the actual contract of the helper:

1. **Variable shadowing** — the loop variable was an `IndexDefinition`, but the first line inside the block overwrote it with a Hash:
   ```ruby
   indexes(table_name).map do |options|
     column_names = options.columns
     options = { name: options.name, unique: options.unique }   # <- shadow
     ...
   ```
   After this assignment, `options.orders` and the rest of the IndexDefinition are no longer reachable.

2. **Unreachable `else` branch** — the next block was `if Hash === options ... else (options == "UNIQUE") end`, where the `if` branch is always true because we just assigned a Hash one line above. The comment on the else clause says:
   ```
   # Legacy String form only ever carried "UNIQUE" / ""; BITMAP and
   # other index_types were never supported via this helper.
   ```
   The String shape hasn't been a contract of this helper since `indexes(table_name)` started returning `IndexDefinition` objects, so the else branch is unreachable.

3. **Always-overridden default `index_name`** — `index_name = index_name(table_name, column: column_names)` computed a default that was always overridden by `options[:name] || index_name`, because `options[:name]` was just set non-nil on the same Hash.

After the refactor, the helper reads straight off the IndexDefinition — half the lines, no shadowing, no unreachable branches:

```ruby
def structure_dump_indexes(table_name) # :nodoc:
  indexes(table_name).map do |index|
    quoted_column_names = index.columns.map { |c| quote_column_name_or_expression(c) }.join(", ")
    "CREATE#{' UNIQUE' if index.unique} INDEX #{quote_column_name(index.name)} ON #{quote_table_name(table_name)} (#{quoted_column_names})"
  end
end
```

## Why now

The upcoming #2726 (`supports_index_sort_order?`) needs to read `index.orders` from the IndexDefinition to emit `... col DESC` clauses. With the overwrite in place, that field is unreachable without re-capturing it before the shadow assignment. Splitting the cleanup out keeps #2726's diff focused on the new feature.

## Behavior

No change. The dumped DDL is byte-identical for every index shape the helper has handled (plain B*Tree, UNIQUE, function-based via `quote_column_name_or_expression`).

## Note: archaeology

The unreachable `else` branch has been so since the day the method was introduced. `git log` traces it to commit [a9a814b4](https://github.com/rsim/oracle-enhanced/commit/a9a814b4) by Billy Reisinger (2009-12-30, "Add index support to structure dumper") — the very commit that introduced `structure_dump_indexes`:

```ruby
def structure_dump_indexes(table_name)
  statements = indexes(table_name).map do |options|
    column_names = options[:columns]
    options = {:name => options[:name], :unique => options[:unique]}    # always Hash
    index_name   = index_name(table_name, :column => column_names)
    if Hash === options # legacy support, since this param was a string  # always true
      ...
    else
      index_type = options                                                # never runs
    end
    ...
```

The comment "_legacy support, since this param was a string_" suggests the author was being defensive against a String-shaped caller — but the same commit unconditionally assigns a Hash one line above, which makes the legacy String path unreachable on day one. No caller anywhere in the history passes a String to this helper.

So the else branch has been **unreachable for ~16 years** (2009-12-30 → 2026-05-08), preserved through several refactors (`81444d1c` 2010 module split; `26646c94` recent identifier-quoting tightening). The pattern survived because:

- The comment looked load-bearing ("legacy support" implies a real caller).
- Ruby's `Hash === options` reads as a real type guard at a glance, hiding the fact that the LHS was just assigned a Hash literal a line above.
- Tests only exercised the live branch, so it never regressed.

Removing this branch as part of #2726's prep makes the helper compose cleanly with the upcoming `index.orders` access.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb` — 45 examples, 0 failures, 1 pre-existing pending
- [x] `bundle exec rubocop` — clean
- [ ] CI on full matrix
