### PR TITLE
Wire up insert_all! via Oracle INSERT ALL multi-table form

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -221,6 +221,20 @@ module ActiveRecord
           "(#{quoted_cols}) VALUES (#{defaults})"
         end
 
+        def build_insert_sql(insert) # :nodoc:
+          if insert.skip_duplicates? || insert.update_duplicates?
+            raise NotImplementedError,
+                  "Oracle insert_all does not yet support :on_duplicate (skip/update). " \
+                  "Use a MERGE statement directly until upsert_all support lands (tracked in #2733)."
+          end
+
+          # INSERT ALL cannot carry RETURNING; `insert.returning` is dropped and `result.rows` is empty.
+          rows_sql = compile_per_row_values(insert).map do |row_values|
+            "  #{insert.into} #{row_values}"
+          end.join("\n")
+          "INSERT ALL\n#{rows_sql}\nSELECT 1 FROM DUAL"
+        end
+
         # Writes LOB values from attributes for specified columns
         def write_lobs(table_name, klass, attributes, columns) # :nodoc:
           pk_predicate = Array(klass.primary_key).map { |pk|
@@ -377,6 +391,34 @@ module ActiveRecord
               warning.sql = sql
               ActiveRecord.db_warnings_action.call(warning)
             end
+          end
+
+          # Compile each insert row to `VALUES (...)` individually via Arel, so
+          # we can interleave each row between `INTO ... VALUES` for Oracle's
+          # multi-table INSERT ALL form. Mirrors the per-row coercion that
+          # ActiveRecord::InsertAll::Builder#values_list applies before bundling
+          # rows into a single `VALUES (...), (...)` fragment.
+          def compile_per_row_values(insert)
+            insert_all = insert.send(:insert_all)
+            keys = insert.send(:keys_including_timestamps)
+            # Delegate to AR core's check so unknown attributes raise
+            # `ActiveModel::UnknownAttributeError` locally rather than slipping
+            # through to Oracle as ORA-00904.
+            types = insert.send(:extract_types_for, keys)
+            primary_keys = insert_all.primary_keys.to_set
+
+            rows = insert_all.send(:map_key_with_value) do |key, value|
+              if Arel::Nodes::SqlLiteral === value
+                value
+              elsif primary_keys.include?(key) && value.nil?
+                default_insert_value(insert_all.model.columns_hash[key])
+              else
+                type = types[key]
+                ActiveModel::Type::SerializeCastValue.serialize(type, type.cast(value))
+              end
+            end
+
+            rows.map { |row| visitor.compile(Arel::Nodes::ValuesList.new([row])) }
           end
       end
     end

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -342,6 +342,172 @@ RSpec.describe "OracleEnhancedAdapter" do
     end
   end
 
+  describe "insert_all!" do
+    # `insert_all!` with explicit IDs is the minimum-viable surface for Oracle:
+    # `INSERT ALL` cannot consume sequence-via-trigger or IDENTITY auto-fill
+    # (Oracle evaluates the underlying sequence once per statement on INSERT ALL,
+    # causing ORA-00001), so callers must supply IDs in either schema. Auto-PK
+    # injection is tracked as follow-up.
+    shared_examples "insert_all! basics" do
+      it "inserts multiple rows in a single INSERT ALL statement" do
+        model.insert_all!([
+          { id: 1, name: "alpha", qty: 1 },
+          { id: 2, name: "beta", qty: 2 },
+          { id: 3, name: "gamma", qty: 3 },
+        ])
+        rows = model.order(:qty).pluck(:name, :qty)
+        expect(rows).to eq([["alpha", 1], ["beta", 2], ["gamma", 3]])
+      end
+
+      it "handles values containing parens and embedded single quotes" do
+        model.insert_all!([
+          { id: 1, name: "Hello (world)", qty: 10 },
+          { id: 2, name: "O'Reilly's", qty: 20 },
+        ])
+        rows = model.order(:qty).pluck(:name)
+        expect(rows).to eq(["Hello (world)", "O'Reilly's"])
+      end
+
+      it "returns an empty result because INSERT ALL cannot carry RETURNING" do
+        result = model.insert_all!([{ id: 1, name: "alpha", qty: 1 }])
+        expect(result.rows).to eq([])
+      end
+
+      it "returns an empty result even when `returning:` is explicitly requested" do
+        result = model.insert_all!([{ id: 1, name: "alpha", qty: 1 }], returning: [:id])
+        expect(result.rows).to eq([])
+      end
+
+      it "raises ActiveModel::UnknownAttributeError for unknown columns (parity with AR core)" do
+        expect {
+          model.insert_all!([{ id: 1, name: "alpha", qty: 1, bogus: 99 }])
+        }.to raise_error(ActiveModel::UnknownAttributeError, /bogus/)
+      end
+    end
+
+    context "with sequence-based PK" do
+      before(:all) do
+        schema_define do
+          create_table :test_insert_all_items, force: true do |t|
+            t.string :name
+            t.integer :qty
+          end
+        end
+        class ::TestInsertAllItem < ActiveRecord::Base
+        end
+      end
+
+      after(:all) do
+        schema_define do
+          drop_table :test_insert_all_items, if_exists: true
+        end
+        Object.send(:remove_const, "TestInsertAllItem") if defined?(TestInsertAllItem)
+        ActiveRecord::Base.clear_cache!
+      end
+
+      after(:each) { TestInsertAllItem.delete_all }
+
+      let(:model) { TestInsertAllItem }
+
+      include_examples "insert_all! basics"
+    end
+
+    context "with IDENTITY PK (Oracle 12.1+)" do
+      before(:all) do
+        skip "Not supported in this database version" unless ActiveRecord::Base.lease_connection.supports_identity_columns?
+        schema_define do
+          create_table :test_insert_all_identity_items, force: true, identity: true do |t|
+            t.string :name
+            t.integer :qty
+          end
+        end
+        class ::TestInsertAllIdentityItem < ActiveRecord::Base
+        end
+      end
+
+      after(:all) do
+        schema_define do
+          drop_table :test_insert_all_identity_items, if_exists: true
+        end
+        Object.send(:remove_const, "TestInsertAllIdentityItem") if defined?(TestInsertAllIdentityItem)
+        ActiveRecord::Base.clear_cache!
+      end
+
+      after(:each) { TestInsertAllIdentityItem.delete_all }
+
+      let(:model) { TestInsertAllIdentityItem }
+
+      include_examples "insert_all! basics"
+    end
+
+    it "raises NotImplementedError when build_insert_sql is reached with on_duplicate" do
+      insert = double(skip_duplicates?: true, update_duplicates?: false)
+      expect {
+        ActiveRecord::Base.lease_connection.build_insert_sql(insert)
+      }.to raise_error(NotImplementedError, /on_duplicate/)
+    end
+
+    # Unit-level coverage of the helper that bridges AR core's bundled
+    # values_list to Oracle's per-row INSERT ALL form. Locks in the per-row
+    # split shape and the value-quoting behavior so a regression in either
+    # AR core's `Builder#values_list` coercion or Arel's
+    # `ValuesList` visitor surfaces here rather than as a misleading
+    # ORA-9999 from the DB.
+    describe "compile_per_row_values" do
+      before(:all) do
+        schema_define do
+          create_table :test_insert_all_items, force: true do |t|
+            t.string :name
+            t.integer :qty
+          end
+        end
+        class ::TestInsertAllItem < ActiveRecord::Base
+        end unless defined?(TestInsertAllItem)
+      end
+
+      after(:all) do
+        schema_define do
+          drop_table :test_insert_all_items, if_exists: true
+        end
+        Object.send(:remove_const, "TestInsertAllItem") if defined?(TestInsertAllItem)
+        ActiveRecord::Base.clear_cache!
+      end
+
+      let(:conn) { ActiveRecord::Base.lease_connection }
+
+      def builder_for(rows)
+        insert_all = ActiveRecord::InsertAll.new(
+          TestInsertAllItem.all, conn, rows, on_duplicate: :raise,
+        )
+        ActiveRecord::InsertAll::Builder.new(insert_all)
+      end
+
+      it "returns one VALUES (...) fragment per input row" do
+        builder = builder_for([
+          { id: 1, name: "alpha", qty: 10 },
+          { id: 2, name: "beta", qty: 20 },
+        ])
+        rows = conn.send(:compile_per_row_values, builder)
+        expect(rows).to eq([
+          "VALUES (1, 'alpha', 10)",
+          "VALUES (2, 'beta', 20)",
+        ])
+      end
+
+      it "preserves embedded parens and quote-escapes single quotes" do
+        builder = builder_for([
+          { id: 1, name: "Hello (world)", qty: 10 },
+          { id: 2, name: "O'Reilly's",    qty: 20 },
+        ])
+        rows = conn.send(:compile_per_row_values, builder)
+        expect(rows).to eq([
+          "VALUES (1, 'Hello (world)', 10)",
+          "VALUES (2, 'O''Reilly''s', 20)",
+        ])
+      end
+    end
+  end
+
   describe "lists" do
     before(:all) do
       schema_define do


### PR DESCRIPTION
## Summary

Active Record's `insert_all!` calls `connection.build_insert_sql(insert)`. oracle-enhanced did not override this method, so the abstract PG-shaped output

```sql
INSERT INTO "t" (...) VALUES (1, 'a'), (2, 'b')
```

was emitted — which Oracle rejects (multi-row `VALUES` is not legal). This PR overrides `build_insert_sql` to emit Oracle's `INSERT ALL` idiom:

```sql
INSERT ALL
  INTO "T" (...) VALUES (1, 'a')
  INTO "T" (...) VALUES (2, 'b')
SELECT 1 FROM DUAL
```

Oracle has supported the multi-table `INSERT ALL` form since **9i (2001)**. See the [Oracle9i SQL Reference (Release 2, 9.2), INSERT statement](https://docs.oracle.com/cd/B10501_01/server.920/a96540/statements_913a.htm).

A private helper (`compile_per_row_values`) reuses Active Record core's `Builder#values_list` per-row coercion (`map_key_with_value` + `Arel::Nodes::ValuesList`) to produce one `VALUES (...)` fragment per input row, avoiding string-parsing of the abstract multi-row `VALUES (...), (...)` output.

## Scope

### In scope

- `insert_all!` (`on_duplicate: :raise`) with **explicit primary key values** supplied by the caller.

### Out of scope

| Form | Reason | Status |
|------|--------|--------|
| `insert_all` (default `:skip`) | Requires `supports_insert_on_duplicate_skip?` + Oracle MERGE | AR core raises `ArgumentError` before reaching us |
| `upsert_all` (`:update`) | Requires `supports_insert_on_duplicate_update?` + Oracle MERGE | AR core raises `ArgumentError` |
| `returning:` option | Oracle's `INSERT ALL` cannot carry `RETURNING` (per 9i SQL Ref: _"You cannot specify the returning_clause for a multitable insert"_) | Silently dropped; `result.rows` is empty (locked by spec). Tracked in #2733 |
| Auto-supplied primary keys | Oracle's sequence-via-trigger PK assignment does not fire reliably for `INSERT ALL`, and IDENTITY columns hit the same statement-scoped sequence evaluation gotcha | Callers must supply IDs; tracked in #2733 |

## Known limits

- **`returning:` is silently dropped.** Even though `supports_insert_returning? == true` (single-row INSERT path honors `RETURNING ... INTO :bind` since #2715), Oracle's `INSERT ALL` form cannot carry `RETURNING`. `Model.insert_all!([...])` therefore returns an `ActiveRecord::Result` with `result.rows == []`, matching the behavior of adapters where `supports_insert_returning?` is `false` (e.g., MySQL). A spec locks this contract for both sequence-based and IDENTITY tables. Full bulk RETURNING support (or splitting `supports_insert_returning?` into single-row and bulk variants) is tracked in #2733.

- **999-row cap on `INSERT ALL` for Oracle < 11.2.** Well-known parser stack limit; minimum supported Oracle is 11.2, so practical impact is small. Auto-chunking is out of scope here; callers with 1000+ row batches should chunk client-side.

## Specs

`oracle_enhanced_adapter_spec.rb` `describe "insert_all!"`:

- `shared_examples "insert_all! basics"` — exercised against both PK patterns:
  - Inserts multiple rows in a single `INSERT ALL` statement.
  - Handles values containing parens (`Hello (world)`) and embedded single quotes (`O'Reilly's`).
  - **Empty-result contract**: `result.rows == []` whether `returning:` is omitted or explicitly requested (RETURNING not supported in INSERT ALL).
- `context "with sequence-based PK"` — runs shared examples against a sequence+trigger table.
- `context "with IDENTITY PK (Oracle 12.1+)"` — runs shared examples against an `identity: true` table; skipped pre-12.1.
- `build_insert_sql` raises `NotImplementedError` for `:skip` / `:update` `on_duplicate` (references #2733).
- `describe "compile_per_row_values"` — unit tests for the per-row split helper:
  - One `VALUES (...)` fragment per input row.
  - Embedded parens preserved; single quotes escaped via `''`.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb -e "insert_all!"` — 9 examples, 0 failures
- [x] `bundle exec rubocop` — clean
- [x] CI on full matrix (12/12 green after jruby listener-flake rerun)

