### PR TITLE
PoC: insert_all extras (on_duplicate skip/update via MERGE + auto-PK injection)

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -222,18 +222,30 @@ module ActiveRecord
         end
 
         def build_insert_sql(insert) # :nodoc:
-          if insert.skip_duplicates? || insert.update_duplicates?
-            raise NotImplementedError,
-                  "Oracle insert_all does not yet support :on_duplicate (skip/update). " \
-                  "Use a MERGE statement directly until upsert_all support lands (tracked separately)."
+          if insert.update_duplicates?
+            return build_merge_sql(insert, on_duplicate: :update)
+          elsif insert.skip_duplicates?
+            return build_merge_sql(insert, on_duplicate: :skip)
           end
 
           rows = split_values_list(insert.values_list)
-          rows_sql = rows.map { |row| "  #{insert.into} VALUES #{row}" }.join("\n")
-          # `INSERT ALL ... SELECT 1 FROM DUAL` is Oracle's bulk-insert idiom.
-          # Active Record's RETURNING expectations don't apply here -- INSERT ALL
-          # cannot carry a RETURNING clause -- so `insert.returning` is dropped.
-          "INSERT ALL\n#{rows_sql}\nSELECT 1 FROM DUAL"
+          model = insert.send(:model)
+          pk = model.primary_key
+          pk_in_keys = pk.is_a?(String) || pk.is_a?(Symbol) ?
+            insert.send(:keys_including_timestamps).include?(pk.to_s) : true
+
+          if pk_in_keys
+            # Standard INSERT ALL path. AR's `returning:` does NOT round-trip --
+            # INSERT ALL cannot carry a RETURNING clause per Oracle SQL Reference.
+            rows_sql = rows.map { |row| "  #{insert.into} VALUES #{row}" }.join("\n")
+            "INSERT ALL\n#{rows_sql}\nSELECT 1 FROM DUAL"
+          else
+            # Auto-PK injection path. INSERT ALL evaluates `seq.NEXTVAL` only
+            # once per statement (causing ORA-00001), so we route through
+            # `INSERT INTO t (...) SELECT seq.NEXTVAL, ... FROM dual UNION ALL ...`
+            # where NEXTVAL is evaluated per row of the SELECT.
+            build_insert_select_with_nextval(insert, rows)
+          end
         end
 
         # Writes LOB values from attributes for specified columns
@@ -392,6 +404,142 @@ module ActiveRecord
               warning.sql = sql
               ActiveRecord.db_warnings_action.call(warning)
             end
+          end
+
+          # PoC: when the PK isn't supplied, wrap the values in a subquery and
+          # SELECT seq.NEXTVAL from the outer query. Oracle disallows NEXTVAL
+          # directly inside `UNION ALL` branches (ORA-02287), so we layer it as:
+          #
+          #   INSERT INTO t (pk, col1, col2)
+          #   SELECT seq.NEXTVAL, col1, col2 FROM (
+          #     SELECT 'a' AS col1, 1 AS col2 FROM dual UNION ALL
+          #     SELECT 'b' AS col1, 2 AS col2 FROM dual
+          #   )
+          def build_insert_select_with_nextval(insert, rows)
+            model = insert.send(:model)
+            pk = model.primary_key
+            seq_name = default_sequence_name(model.table_name, nil)
+            unless seq_name && oracle_sequence_exists?(seq_name)
+              raise NotImplementedError,
+                    "Oracle insert_all without explicit primary key requires a sequence " \
+                    "named #{seq_name.inspect} for the table; none found."
+            end
+
+            quoted_seq = "#{quote_table_name(seq_name)}.NEXTVAL"
+            keys = insert.send(:keys_including_timestamps)
+            new_into = insert.into.sub(/\(([^)]*)\)\z/) { "(#{quote_column_name(pk)}, #{$1})" }
+
+            inner_select = rows.map do |row|
+              tuple = split_tuple(row)
+              aliases = keys.zip(tuple).map { |k, v| "#{v} AS #{quote_column_name(k)}" }
+              "SELECT #{aliases.join(", ")} FROM dual"
+            end.join(" UNION ALL ")
+
+            outer_cols = keys.map { |k| quote_column_name(k) }.join(", ")
+            "INSERT #{new_into} SELECT #{quoted_seq}, #{outer_cols} FROM (#{inner_select})"
+          end
+
+          def oracle_sequence_exists?(seq_name)
+            select_value(<<~SQL.squish, "SCHEMA", [bind_string("seq_name", seq_name.upcase)]).to_i.positive?
+              SELECT COUNT(*) FROM all_sequences
+               WHERE sequence_owner = SYS_CONTEXT('userenv', 'current_schema')
+                 AND sequence_name = :seq_name
+            SQL
+          end
+
+          # PoC: emit a MERGE statement to bridge AR's `:skip` / `:update` semantics.
+          # Requires `unique_by:` to be supplied so we can build the ON clause.
+          # Limitations: no `returning:` (Oracle MERGE does not carry RETURNING in
+          # standard versions); composite/expression unique_by not exercised.
+          def build_merge_sql(insert, on_duplicate:)
+            insert_all = insert.send(:insert_all)
+            unique_by = insert_all.unique_by or
+              raise NotImplementedError, "Oracle MERGE-based insert_all requires :unique_by to identify the conflict target"
+
+            model = insert.send(:model)
+            target = quote_table_name(model.table_name)
+
+            # PoC: MERGE path expects explicit values (including PK) -- auto-PK
+            # injection isn't applied here because the conflict target normally
+            # IS the primary key, so a fresh seq.NEXTVAL would never match.
+            into = insert.into
+            rows = split_values_list(insert.values_list)
+            keys_match = into.match(/\(([^)]*)\)\z/)
+            quoted_keys_csv = keys_match ? keys_match[1] : ""
+            keys = quoted_keys_csv.scan(/"([^"]+)"/).flatten
+
+            using_select = rows.map do |row|
+              tuple = split_tuple(row)
+              pairs = keys.zip(tuple).map { |k, v| "#{v} AS #{quote_column_name(k)}" }
+              "SELECT #{pairs.join(", ")} FROM dual"
+            end.join(" UNION ALL ")
+
+            on_columns = Array(unique_by.columns).map(&:to_s)
+            on_clause = on_columns.map { |c| "t.#{quote_column_name(c)} = s.#{quote_column_name(c)}" }.join(" AND ")
+
+            insert_vals = keys.map { |k| "s.#{quote_column_name(k)}" }.join(", ")
+
+            sql = +"MERGE INTO #{target} t\n"
+            sql << "USING (#{using_select}) s\n"
+            sql << "ON (#{on_clause})\n"
+
+            if on_duplicate == :update
+              on_set = on_columns.map(&:downcase).to_set
+              updatable = keys.reject { |k| on_set.include?(k.downcase) }
+              update_cols = updatable.map { |k| "t.#{quote_column_name(k)} = s.#{quote_column_name(k)}" }.join(", ")
+              sql << "WHEN MATCHED THEN UPDATE SET #{update_cols}\n" unless update_cols.empty?
+            end
+
+            sql << "WHEN NOT MATCHED THEN INSERT (#{quoted_keys_csv}) VALUES (#{insert_vals})"
+            sql
+          end
+
+          # Split a `(...)` row tuple into individual value strings while tracking
+          # nested parens and single-quoted string literals (with `''` escapes).
+          def split_tuple(row)
+            inside = row[1..-2]
+            values = []
+            current = +""
+            depth = 0
+            in_string = false
+            i = 0
+            while i < inside.length
+              c = inside[i]
+              if in_string
+                if c == "'" && inside[i + 1] == "'"
+                  current << "''"
+                  i += 2
+                  next
+                elsif c == "'"
+                  in_string = false
+                end
+                current << c
+              else
+                case c
+                when "'"
+                  in_string = true
+                  current << c
+                when "("
+                  depth += 1
+                  current << c
+                when ")"
+                  depth -= 1
+                  current << c
+                when ","
+                  if depth.zero?
+                    values << current
+                    current = +""
+                  else
+                    current << c
+                  end
+                else
+                  current << c
+                end
+              end
+              i += 1
+            end
+            values << current unless current.empty?
+            values
           end
 
           # Split a `VALUES (...), (...)` SQL fragment into individual `(...)` row

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -274,7 +274,8 @@ module ActiveRecord
                 binds << ActiveRecord::Relation::QueryAttribute.new("returning_#{col}", nil, type)
               end
             end
-            super(sql, pk, binds, returning)
+            # Skip super: AR's abstract appends PG-style `RETURNING col1, col2` which conflicts with Oracle's `RETURNING ... INTO :bind` form (ORA-00925).
+            [sql, binds]
           end
 
           def columns_for_returning_clause(sql, pk, binds, returning)

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -221,6 +221,21 @@ module ActiveRecord
           "(#{quoted_cols}) VALUES (#{defaults})"
         end
 
+        def build_insert_sql(insert) # :nodoc:
+          if insert.skip_duplicates? || insert.update_duplicates?
+            raise NotImplementedError,
+                  "Oracle insert_all does not yet support :on_duplicate (skip/update). " \
+                  "Use a MERGE statement directly until upsert_all support lands (tracked separately)."
+          end
+
+          rows = split_values_list(insert.values_list)
+          rows_sql = rows.map { |row| "  #{insert.into} VALUES #{row}" }.join("\n")
+          # `INSERT ALL ... SELECT 1 FROM DUAL` is Oracle's bulk-insert idiom.
+          # Active Record's RETURNING expectations don't apply here -- INSERT ALL
+          # cannot carry a RETURNING clause -- so `insert.returning` is dropped.
+          "INSERT ALL\n#{rows_sql}\nSELECT 1 FROM DUAL"
+        end
+
         # Writes LOB values from attributes for specified columns
         def write_lobs(table_name, klass, attributes, columns) # :nodoc:
           pk_predicate = Array(klass.primary_key).map { |pk|
@@ -377,6 +392,45 @@ module ActiveRecord
               warning.sql = sql
               ActiveRecord.db_warnings_action.call(warning)
             end
+          end
+
+          # Split a `VALUES (...), (...)` SQL fragment into individual `(...)` row
+          # tuples, tracking nested parens and single-quoted string literals (with
+          # `''` escapes) so values containing those characters parse correctly.
+          def split_values_list(values_list)
+            body = values_list.sub(/\AVALUES\s*/, "")
+            rows = []
+            depth = 0
+            in_string = false
+            start_idx = nil
+            i = 0
+            while i < body.length
+              c = body[i]
+              if in_string
+                if c == "'" && body[i + 1] == "'"
+                  i += 2
+                  next
+                elsif c == "'"
+                  in_string = false
+                end
+              else
+                case c
+                when "'"
+                  in_string = true
+                when "("
+                  start_idx = i if depth.zero?
+                  depth += 1
+                when ")"
+                  depth -= 1
+                  if depth.zero?
+                    rows << body[start_idx..i]
+                    start_idx = nil
+                  end
+                end
+              end
+              i += 1
+            end
+            rows
           end
       end
     end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -523,6 +523,20 @@ module ActiveRecord
         true
       end
 
+      # PoC overrides for insert_all bulk paths (#TBD-poc-insert-all-extras).
+      # Skip/update map to MERGE; conflict_target enables `:unique_by`.
+      def supports_insert_on_duplicate_skip?
+        true
+      end
+
+      def supports_insert_on_duplicate_update?
+        true
+      end
+
+      def supports_insert_conflict_target?
+        true
+      end
+
       def supports_optimizer_hints?
         true
       end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -519,6 +519,10 @@ module ActiveRecord
         true
       end
 
+      def supports_insert_returning?
+        true
+      end
+
       def supports_optimizer_hints?
         true
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -247,6 +247,61 @@ RSpec.describe "OracleEnhancedAdapter" do
     end
   end
 
+  describe "insert_all!" do
+    before(:all) do
+      schema_define do
+        create_table :test_insert_all_items, force: true do |t|
+          t.string :name
+          t.integer :qty
+        end
+      end
+      class ::TestInsertAllItem < ActiveRecord::Base
+      end
+    end
+
+    after(:all) do
+      schema_define do
+        drop_table :test_insert_all_items, if_exists: true
+      end
+      Object.send(:remove_const, "TestInsertAllItem")
+      ActiveRecord::Base.clear_cache!
+    end
+
+    after(:each) do
+      TestInsertAllItem.delete_all
+    end
+
+    # `insert_all!` with explicit IDs is the minimum-viable surface for Oracle:
+    # `INSERT ALL` cannot consume Oracle's sequence-via-trigger primary keys
+    # (the BEFORE INSERT trigger doesn't fire), so callers must supply IDs.
+    # Sequence-injection support is tracked as follow-up.
+    it "inserts multiple rows in a single INSERT ALL statement" do
+      TestInsertAllItem.insert_all!([
+        { id: 1, name: "alpha", qty: 1 },
+        { id: 2, name: "beta", qty: 2 },
+        { id: 3, name: "gamma", qty: 3 },
+      ])
+      rows = TestInsertAllItem.order(:qty).pluck(:name, :qty)
+      expect(rows).to eq([["alpha", 1], ["beta", 2], ["gamma", 3]])
+    end
+
+    it "handles values containing parens and embedded single quotes" do
+      TestInsertAllItem.insert_all!([
+        { id: 1, name: "Hello (world)", qty: 10 },
+        { id: 2, name: "O'Reilly's", qty: 20 },
+      ])
+      rows = TestInsertAllItem.order(:qty).pluck(:name)
+      expect(rows).to eq(["Hello (world)", "O'Reilly's"])
+    end
+
+    it "raises NotImplementedError when build_insert_sql is reached with on_duplicate" do
+      insert = double(skip_duplicates?: true, update_duplicates?: false)
+      expect {
+        ActiveRecord::Base.lease_connection.build_insert_sql(insert)
+      }.to raise_error(NotImplementedError, /on_duplicate/)
+    end
+  end
+
   describe "lists" do
     before(:all) do
       schema_define do

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -294,11 +294,46 @@ RSpec.describe "OracleEnhancedAdapter" do
       expect(rows).to eq(["Hello (world)", "O'Reilly's"])
     end
 
-    it "raises NotImplementedError when build_insert_sql is reached with on_duplicate" do
-      insert = double(skip_duplicates?: true, update_duplicates?: false)
-      expect {
-        ActiveRecord::Base.lease_connection.build_insert_sql(insert)
-      }.to raise_error(NotImplementedError, /on_duplicate/)
+    # PoC: auto-PK injection — `id` need not be supplied; `seq.NEXTVAL` is inlined
+    # into INSERT ALL per row by the adapter. Validates feasibility, not yet
+    # production-ready (see PR description for caveats).
+    it "auto-fills primary keys from the table's sequence (PoC)" do
+      TestInsertAllItem.insert_all!([
+        { name: "auto-alpha", qty: 1 },
+        { name: "auto-beta", qty: 2 },
+      ])
+      rows = TestInsertAllItem.order(:qty).pluck(:id, :name)
+      expect(rows.size).to eq(2)
+      expect(rows.map(&:last)).to eq(["auto-alpha", "auto-beta"])
+      expect(rows.map(&:first)).to all(be > 0)
+    end
+
+    # PoC: skip_duplicates via MERGE (Oracle's upsert primitive). Existing rows
+    # whose `unique_by` matches are left alone; new rows are inserted.
+    it "honors :skip on_duplicate via MERGE (PoC)" do
+      TestInsertAllItem.insert_all!([{ id: 100, name: "skip-anchor", qty: 5 }])
+      TestInsertAllItem.insert_all(
+        [{ id: 100, name: "skip-NEW", qty: 99 }, { id: 101, name: "skip-fresh", qty: 1 }],
+        unique_by: :id,
+      )
+      anchor = TestInsertAllItem.find(100)
+      expect(anchor.name).to eq("skip-anchor")
+      expect(anchor.qty).to eq(5)
+      expect(TestInsertAllItem.find(101).name).to eq("skip-fresh")
+    end
+
+    # PoC: update_duplicates via MERGE WHEN MATCHED. Existing rows have non-key
+    # columns updated; new rows are inserted.
+    it "honors :update on_duplicate via MERGE WHEN MATCHED (PoC)" do
+      TestInsertAllItem.insert_all!([{ id: 200, name: "upsert-anchor", qty: 5 }])
+      TestInsertAllItem.upsert_all(
+        [{ id: 200, name: "upsert-NEW", qty: 99 }, { id: 201, name: "upsert-fresh", qty: 1 }],
+        unique_by: :id,
+      )
+      anchor = TestInsertAllItem.find(200)
+      expect(anchor.name).to eq("upsert-NEW")
+      expect(anchor.qty).to eq(99)
+      expect(TestInsertAllItem.find(201).name).to eq("upsert-fresh")
     end
   end
 


### PR DESCRIPTION
**Stacked on #2730** which is itself stacked on #2715. Marked **draft**; this PR is for **feasibility verification only**, not for direct merge.

## Goal

Demonstrate that the `out-of-scope` items called out in #2730's description are reachable with a relatively small adapter override:

| Out-of-scope item from #2730 | Status here |
|--------------------------------|-------------|
| `:skip` `on_duplicate` | ✅ via Oracle `MERGE` (caller supplies `unique_by:`) |
| `:update` `on_duplicate` | ✅ via Oracle `MERGE` `WHEN MATCHED THEN UPDATE` |
| Auto-PK via sequence injection | ✅ via `INSERT INTO ... SELECT seq.NEXTVAL, ... FROM (...)` (NOT `INSERT ALL`) |
| `returning:` option | ❌ still out of scope (Oracle MERGE / INSERT ALL don't support `RETURNING`) |

## Two Oracle gotchas this PoC documents

1. **`INSERT ALL` + `seq.NEXTVAL` is broken.** Oracle evaluates the sequence once per statement, so all rows in the multi-table insert get the same value → `ORA-00001` (unique violation). Verified empirically; the PoC routes around it by using `INSERT INTO ... SELECT ... FROM (...)`.

2. **`NEXTVAL` is forbidden inside `UNION ALL` branches** (`ORA-02287`: _sequence number not allowed here_). Oracle requires the sequence reference to live in an outer SELECT that *consumes* a UNION ALL subquery, not inside the branches themselves.

The auto-PK code path therefore looks like:

```sql
INSERT INTO "T" ("ID", "NAME", "QTY")
SELECT "T_SEQ".NEXTVAL, "NAME", "QTY"
  FROM ( SELECT 'a' AS "NAME", 1 AS "QTY" FROM dual
         UNION ALL
         SELECT 'b'        , 2          FROM dual )
```

## MERGE shape

For `on_duplicate: :skip`:

```sql
MERGE INTO "T" t
USING ( SELECT 1 AS "ID", 'a' AS "NAME" FROM dual
        UNION ALL
        SELECT 2        , 'b'           FROM dual ) s
ON (t."ID" = s."ID")
WHEN NOT MATCHED THEN INSERT ("ID", "NAME") VALUES (s."ID", s."NAME")
```

For `on_duplicate: :update`, an additional `WHEN MATCHED THEN UPDATE SET ...` is emitted. Columns in the `ON` clause are excluded from the UPDATE list (Oracle raises `ORA-38104` otherwise), with case-insensitive matching since AR's `unique_by:` typically uses lowercase symbols and `keys_including_timestamps` returns Oracle's quoted uppercase identifiers.

## Capability flags overridden

```ruby
def supports_insert_on_duplicate_skip?    = true
def supports_insert_on_duplicate_update?  = true
def supports_insert_conflict_target?      = true
```

These are set true even though the implementation requires the caller to supply `unique_by:`. With the existing AR core check that gates `unique_by:` behind `supports_insert_conflict_target?`, this is the right place to surface the requirement.

## Specs

`describe "insert_all!"` in `oracle_enhanced_adapter_spec.rb` adds three PoC examples on top of #2730's existing trio:

- Auto-fills primary keys from the table's sequence.
- Honors `:skip` `on_duplicate` via MERGE — existing rows are preserved, new rows inserted.
- Honors `:update` `on_duplicate` via MERGE WHEN MATCHED — existing rows have non-key columns updated, new rows inserted.

5/5 specs green locally.

## Known limitations / production-readiness gaps

These need addressing before this PoC could become a real PR:

1. The `split_values_list` / `split_tuple` parsers handle paren-balancing and `''` escapes, but are still string-shape-dependent. A more robust path would access the raw `insert_all.map_key_with_value` rows and re-compile per-row via Arel.
2. `returning:` is still unsupported. Implementing it would require a per-row `INSERT ... RETURNING ... INTO :bind` fallback (slow but correct), plus careful handling for the bulk case where Oracle's MERGE simply cannot return values.
3. The MERGE path requires explicit PKs (the conflict target). Auto-PK injection doesn't apply because the conflict target IS the PK by definition.
4. Composite-column `unique_by` isn't exercised in the PoC specs.
5. Column-quoting normalization between `keys_including_timestamps` (uppercase quoted via Oracle) and `unique_by.columns` (typically lowercase Ruby symbols) is handled ad-hoc with `downcase` — this might miss case-sensitive identifier scenarios.
6. No `validate_index_length!` / sequence-existence cache; sequence lookup hits the data dictionary on every call.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb -e "insert_all"` (5 examples)
- [x] `bundle exec rubocop` — clean
- [ ] CI on full matrix once #2715 and #2730 merge and this rebases

This is a **feasibility check only** — the gaps above show this is not yet ready for a real merge. If the approach is acceptable, follow-up PRs can address each limitation incrementally.
