### PR TITLE
ci: Force client TZ data to match server via ORA_TZFILE

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,17 @@ jobs:
       - name: Create database user
         run: |
           ./ci/setup_accounts.sh
+      - name: Force client TZ data to match server (ORA_TZFILE workaround)
+        run: |
+          ORACLE_CONTAINER=$(docker ps --filter "ancestor=gvenzl/oracle-free" -q)
+          SRC=$(docker exec "$ORACLE_CONTAINER" bash -c 'ls $ORACLE_HOME/oracore/zoneinfo/timezlrg_*.dat 2>/dev/null | head -1')
+          echo "Server TZ file: $SRC"
+          DST_DIR="$ORACLE_HOME/oracore/zoneinfo"
+          sudo mkdir -p "$DST_DIR"
+          docker cp "$ORACLE_CONTAINER":"$SRC" /tmp/_server_tzfile.dat
+          sudo mv /tmp/_server_tzfile.dat "$DST_DIR/$(basename "$SRC")"
+          ls -l "$DST_DIR"
+          echo "ORA_TZFILE=$DST_DIR/$(basename "$SRC")" >> $GITHUB_ENV
       - name: Bundle install
         run: |
           bundle install --jobs 4 --retry 3


### PR DESCRIPTION
## Summary

`gvenzl/oracle-free:latest` currently runs **Oracle Database 23.26.1.0.0** (TZ file `timezlrg_43.dat`, version **43**). Oracle has rolled the public Instant Client zip URL forward to **23.26.2.0.0**, which embeds a newer TZ data version. The mismatch raises `ORA-01805: possible error in date/time operation` on every `TIMESTAMP WITH TIME ZONE` operation, taking out the four `spec/active_record/oracle_enhanced/type/timestamp_spec.rb` examples on every CRuby (OCI) build job.

JRuby (JDBC) jobs are unaffected because the JDBC driver ships its own TZ data and does not consult Instant Client's embedded copy.

## Fix

Copy the server's `timezlrg_*.dat` out of the running Oracle container into the client's `oracore/zoneinfo/` directory and point `ORA_TZFILE` at it. Verified that **23.x Instant Client honors `ORA_TZFILE` to override the embedded TZ data** -- this was confirmed empirically on the experiment branch (see Test plan).

```yaml
- name: Force client TZ data to match server (ORA_TZFILE workaround)
  run: |
    ORACLE_CONTAINER=$(docker ps --filter "ancestor=gvenzl/oracle-free" -q)
    SRC=$(docker exec "$ORACLE_CONTAINER" bash -c 'ls $ORACLE_HOME/oracore/zoneinfo/timezlrg_*.dat 2>/dev/null | head -1')
    DST_DIR="$ORACLE_HOME/oracore/zoneinfo"
    sudo mkdir -p "$DST_DIR"
    docker cp "$ORACLE_CONTAINER":"$SRC" /tmp/_server_tzfile.dat
    sudo mv /tmp/_server_tzfile.dat "$DST_DIR/$(basename "$SRC")"
    echo "ORA_TZFILE=$DST_DIR/$(basename "$SRC")" >> $GITHUB_ENV
```

## Why bind from the server (rather than other approaches)

| Considered | Outcome |
|---|---|
| Pin Instant Client to 23.26.1 via versioned URL | Oracle does not publish versioned URLs for 23.x Instant Client (`/2326100/...zip`, `/232610000/...zip`, etc. all 404). Public URL is rolling-latest only. |
| Wait for `gvenzl/oracle-free:latest` to bump to 23.26.2 | Image is currently 3 months old; bump timing not under our control. |
| Disable the failing `timestamp_spec` examples on the broken combination | Hides a real coverage gap and would have to be reverted per release. |
| `ORA_TZFILE` workaround (this PR) | Self-contained, deterministic, no external dependency on Oracle's URL pinning. |

## Lifecycle

The step is unconditional. Once both sides converge on the same release (`gvenzl/oracle-free:latest` bumps to 23.26.2 or later, **or** Oracle ships 23.26.3 with realigned TZ data), the workaround becomes a near-zero-cost no-op (one `docker exec` + one `docker cp`) but stays harmless. It can be removed once the matrix is stable on a single release.

## Test plan

- [x] Verified on `yahonda/oracle-enhanced` experiment branch: [run 25552178217](https://github.com/yahonda/oracle-enhanced/actions/runs/25552178217) -- **4/4 build matrix jobs pass** (Ruby 3.3, 3.4, 4.0, JRuby 10.1.0.0). Without the workaround, the same matrix produces 4 ORA-01805 failures per CRuby job.
- [ ] Same matrix on `rsim/oracle-enhanced` once this PR is opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
