### PR TITLE
Mirror AbstractAdapter PK inference fallback in sql_for_insert

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -275,15 +275,20 @@ module ActiveRecord
           end
 
           def sql_for_insert(sql, pk, binds, returning) # :nodoc:
+            table_ref = extract_table_ref_from_insert_sql(sql)
+            # Mirror AbstractAdapter#sql_for_insert: when caller passes pk: nil,
+            # infer the primary key from the SQL via the schema cache so that
+            # generic `connection.exec_insert(sql, name, binds)` callers also
+            # benefit from RETURNING auto-fetch.
+            pk = schema_cache.primary_keys(table_ref) if pk.nil? && table_ref
             cols = columns_for_returning_clause(sql, pk, binds, returning)
             unless cols.empty?
-              table_name = extract_table_ref_from_insert_sql(sql)
               quoted_cols = cols.map { |c| quote_column_name(c) }.join(", ")
               placeholders = cols.map { |c| ":returning_#{c}" }.join(", ")
               sql = "#{sql} RETURNING #{quoted_cols} INTO #{placeholders}"
               binds = binds.dup
               cols.each do |col|
-                column = table_name ? columns(table_name).find { |c| c.name == col } : nil
+                column = table_ref ? columns(table_ref).find { |c| c.name == col } : nil
                 type = column&.cast_type || Type::OracleEnhanced::Integer.new
                 binds << ActiveRecord::Relation::QueryAttribute.new("returning_#{col}", nil, type)
               end

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -165,6 +165,19 @@ RSpec.describe "OracleEnhancedAdapter" do
         expect(insert_log).to match(/RETURNING\s+"ID"\s+INTO\s+:returning_id/i)
         expect(insert_log).not_to match(/RETURNING\s+"ID"\s*\)?\s*\z/i)
       end
+
+      # AbstractAdapter#sql_for_insert infers the primary key from the SQL when
+      # the caller passes pk: nil. Generic callers that go through this path
+      # without an explicit `pk` used to miss out on RETURNING auto-fetch on
+      # Oracle because the fallback was not mirrored locally; this spec locks
+      # in the parity introduced for issue #2732.
+      it "infers the primary key from the SQL when pk: nil (parity with AbstractAdapter)" do
+        conn = ActiveRecord::Base.lease_connection
+        insert_sql = "INSERT INTO #{conn.quote_table_name('test_returning_identity_items')} (#{conn.quote_column_name('name')}) VALUES ('direct-call')"
+        out_sql, out_binds = conn.send(:sql_for_insert, insert_sql, nil, [], nil)
+        expect(out_sql).to match(/RETURNING\s+"ID"\s+INTO\s+:returning_id/i)
+        expect(out_binds.last.name).to eq("returning_id")
+      end
     end
 
     # Sequence-prefetched path: oracle-enhanced's default for `create_table` (no


### PR DESCRIPTION
Closes #2732.

## Summary

`ActiveRecord::ConnectionAdapters::AbstractAdapter#sql_for_insert` (Rails 8.x) infers the primary key from the INSERT SQL via the schema cache when the caller passes `pk: nil`:

```ruby
if pk.nil?
  table_ref = extract_table_ref_from_insert_sql(sql)
  pk = schema_cache.primary_keys(table_ref) if table_ref
end
```

`OracleEnhanced::DatabaseStatements#sql_for_insert` did not mirror this fallback. As a result, generic callers that route through it without an explicit `pk` (3rd-party gems, custom code reaching past `Model.create!`) skipped the `RETURNING ... INTO :bind` clause and lost the auto-fetched ID even though oracle-enhanced has the machinery to provide it. This is pre-existing behavior — not a regression from #2715.

## Fix

Apply the same fallback at the top of the override, and reuse the extracted `table_ref` for the column-type lookup that already happens later in the method, so the SQL is parsed only once:

```ruby
def sql_for_insert(sql, pk, binds, returning) # :nodoc:
  table_ref = extract_table_ref_from_insert_sql(sql)
  pk = schema_cache.primary_keys(table_ref) if pk.nil? && table_ref
  cols = columns_for_returning_clause(sql, pk, binds, returning)
  unless cols.empty?
    quoted_cols = cols.map { |c| quote_column_name(c) }.join(", ")
    placeholders = cols.map { |c| ":returning_#{c}" }.join(", ")
    sql = "#{sql} RETURNING #{quoted_cols} INTO #{placeholders}"
    binds = binds.dup
    cols.each do |col|
      column = table_ref ? columns(table_ref).find { |c| c.name == col } : nil
      type = column&.cast_type || Type::OracleEnhanced::Integer.new
      binds << ActiveRecord::Relation::QueryAttribute.new("returning_#{col}", nil, type)
    end
  end
  [sql, binds]
end
```

`Model.create!` style paths are unchanged because Active Record always passes `pk` explicitly there; only the previously-missed generic path gains the auto-fetch.

## Risk

Low. The fallback only triggers when `pk` is currently `nil`, which is exactly the case where `RETURNING ... INTO :bind` is currently not applied. Worst case is "an ID that previously was not auto-fetched is now auto-fetched" — a strictly additive behavior change.

## Specs

New spec under `describe "supports_insert_returning?"`'s IDENTITY context (oracle_enhanced_adapter_spec.rb): calls `sql_for_insert(insert_sql, nil, [], nil)` directly (avoiding the deprecated public `exec_insert` path) and asserts that:

- the returned SQL contains `RETURNING "ID" INTO :returning_id`
- the returned binds gain a `returning_id` placeholder

All 6 specs in the `supports_insert_returning?` block pass; the full `oracle_enhanced_adapter_spec.rb` (69 examples) is also green.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb -e "supports_insert_returning?"` (6 examples, 0 failures)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb` (69 examples, 0 failures, 1 pending unrelated)
- [x] `bundle exec rubocop` — clean
- [ ] CI on full matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
