### PR TITLE
Override supports_bulk_alter? = true (Phase 1: add / change / remove column)

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -562,6 +562,85 @@ module ActiveRecord
           clear_table_caches(table_name)
         end
 
+        # Commands the bulk dispatcher knows how to combine into Oracle's
+        # ADD/MODIFY/DROP buckets. Anything else raises `NotImplementedError`
+        # *before* any DDL fires, so `change_table(bulk: true)` never
+        # half-applies a migration.
+        SUPPORTED_BULK_COMMANDS = %i[
+          add_column
+          change_column
+          remove_column
+          remove_columns
+        ].freeze
+        private_constant :SUPPORTED_BULK_COMMANDS
+
+        def bulk_change_table(table_name, operations) # :nodoc:
+          # Two ALTER buckets (ORA-12987 forbids mixing ADD/MODIFY with DROP).
+          # Invariant: never let a DROP sit pending while we queue an ADD/MODIFY,
+          # and vice versa — flushing the *other* bucket at every kind switch
+          # preserves the user's operation order across the two ALTER statements.
+          unsupported = operations.map(&:first).reject { |c| SUPPORTED_BULK_COMMANDS.include?(c) }
+          if unsupported.any?
+            raise NotImplementedError,
+              "bulk_change_table only supports #{SUPPORTED_BULK_COMMANDS.inspect} " \
+              "(got #{unsupported.first.inspect}); use change_table(bulk: false)"
+          end
+
+          add_buf = []
+          modify_buf = []
+          drop_buf = []
+          add_pending = [] # column names queued in add_buf — see :change_column branch
+
+          operations.each do |command, args|
+            args = args.dup
+            args.shift # remove table_name
+
+            case command
+            when :add_column
+              column_name, type, options = args[0], args[1], (args[2] || {})
+              if requires_full_command?(:add_column, type, options)
+                flush_bulk_buffers(table_name, add_buf, modify_buf, drop_buf)
+                add_pending.clear
+                add_column(table_name, column_name, type, **options)
+              else
+                flush_bulk_drops(table_name, drop_buf)
+                add_buf << add_column_for_alter(table_name, *args)
+                add_pending << column_name.to_s
+              end
+            when :change_column
+              column_name, type, options = args[0], args[1], (args[2] || {})
+              if requires_full_command?(:change_column, type, options)
+                flush_bulk_buffers(table_name, add_buf, modify_buf, drop_buf)
+                add_pending.clear
+                change_column(table_name, column_name, type, **options)
+              else
+                flush_bulk_drops(table_name, drop_buf)
+                # `change_column_for_alter` -> `column_for` reads the live
+                # catalog, so a same-block ADD must commit first.
+                if add_pending.any? { |c| c.casecmp?(column_name.to_s) }
+                  flush_bulk_add_modify(table_name, add_buf, modify_buf)
+                  add_pending.clear
+                end
+                modify_buf << change_column_for_alter(table_name, *args)
+              end
+            when :remove_column
+              flush_bulk_add_modify(table_name, add_buf, modify_buf)
+              add_pending.clear
+              drop_buf << args[0] # column_name
+            when :remove_columns
+              flush_bulk_add_modify(table_name, add_buf, modify_buf)
+              add_pending.clear
+              drop_buf.concat(args.reject { |a| a.is_a?(Hash) })
+            else
+              raise "missing dispatch branch for #{command.inspect}; update both SUPPORTED_BULK_COMMANDS and the case statement"
+            end
+          end
+
+          flush_bulk_buffers(table_name, add_buf, modify_buf, drop_buf)
+        ensure
+          clear_table_caches(table_name)
+        end
+
         def change_table_comment(table_name, comment_or_changes)
           clear_cache!
           execute change_table_comment_sql(table_name, comment_or_changes)
@@ -822,9 +901,12 @@ module ActiveRecord
         end
 
         def add_timestamps(table_name, **options)
-          fragments = add_timestamps_for_alter(table_name, **options)
-          fragments.each do |fragment|
-            execute "ALTER TABLE #{quote_table_name(table_name)} #{fragment}"
+          options[:null] = false if options[:null].nil?
+          options[:precision] = 6 if !options.key?(:precision) && supports_datetime_with_precision?
+          column_options = options.except(:comment)
+          change_table(table_name, bulk: true) do |t|
+            t.column :created_at, :datetime, **column_options
+            t.column :updated_at, :datetime, **column_options
           end
           apply_column_comments(table_name, :created_at, :updated_at, comment: options[:comment]) if options.key?(:comment)
         end
@@ -885,6 +967,91 @@ module ActiveRecord
             column_names.each do |column_name|
               change_column_comment(table_name, column_name, comment)
             end
+          end
+
+          def add_column_for_alter(table_name, column_name, type, **options)
+            if options[:identity]
+              raise ArgumentError,
+                "`identity: true` is not supported on `add_column`. Recreate the table with `create_table ..., identity: true` instead."
+            end
+            if options[:primary_key_trigger] && type.to_s.to_sym != :primary_key
+              raise ArgumentError,
+                "`primary_key_trigger: true` on `add_column` requires the column type to be `:primary_key`; got type: #{type.inspect}."
+            end
+            type = aliased_types(type.to_s, type)
+            td = create_table_definition(table_name)
+            cd = td.new_column_definition(column_name, type, **options)
+            schema_creation.accept(cd)
+          end
+
+          def change_column_for_alter(table_name, column_name, type, **options)
+            column = column_for(table_name, column_name)
+            if options.has_key?(:null) && options[:null] == column.null
+              options[:null] = nil
+            end
+            if type.to_sym == :virtual
+              type = options[:type]
+            end
+            td = create_table_definition(table_name)
+            cd = td.new_column_definition(column.name, type, **options)
+            schema_creation.accept(cd)
+          end
+
+          def remove_column_for_alter(table_name, column_name, type = nil, **options)
+            quote_column_name(column_name)
+          end
+
+          # Returns true when the op needs the full `add_column` /
+          # `change_column` path (not the bulk fragment) because those
+          # methods issue extra SQL after the ALTER TABLE that the
+          # column-only `*_for_alter` fragments do not reproduce:
+          # - `comment:` -> a follow-up `COMMENT ON COLUMN`
+          # - `:primary_key` type -> the `<table>_seq` sequence and, when
+          #   `primary_key_trigger:` is true, the BEFORE INSERT trigger
+          # - LOB types (text/ntext/binary/clob/nclob/blob) and any type
+          #   with an explicit `tablespace:` option or a configured
+          #   `default_tablespaces[type]` — `tablespace_for(...)` appends
+          #   a TABLESPACE / LOB STORE clause that the bare column-fragment
+          #   does not carry.
+          def requires_full_command?(command, type, options)
+            return true if options.key?(:comment)
+            return true if command == :add_column && type.to_s.to_sym == :primary_key
+            return true if needs_tablespace_clause?(type, options)
+            false
+          end
+
+          LOB_TYPE_SYMBOLS = %i[text ntext binary clob nclob blob].freeze
+          private_constant :LOB_TYPE_SYMBOLS
+
+          def needs_tablespace_clause?(type, options)
+            return true if options.key?(:tablespace)
+            return false if type.nil?
+            type_sym = type.to_s.to_sym
+            return true if LOB_TYPE_SYMBOLS.include?(type_sym)
+            return true if default_tablespaces.key?(type_sym)
+            sql_type_sym = (type_to_sql(type).downcase.to_sym rescue nil)
+            sql_type_sym && default_tablespaces.key?(sql_type_sym)
+          end
+
+          def flush_bulk_add_modify(table_name, add_buf, modify_buf)
+            return if add_buf.empty? && modify_buf.empty?
+            clauses = []
+            clauses << "ADD (#{add_buf.join(', ')})" if add_buf.any?
+            clauses << "MODIFY (#{modify_buf.join(', ')})" if modify_buf.any?
+            execute "ALTER TABLE #{quote_table_name(table_name)} #{clauses.join(' ')}"
+            add_buf.clear
+            modify_buf.clear
+          end
+
+          def flush_bulk_drops(table_name, drop_buf)
+            return if drop_buf.empty?
+            remove_columns(table_name, *drop_buf)
+            drop_buf.clear
+          end
+
+          def flush_bulk_buffers(table_name, add_buf, modify_buf, drop_buf)
+            flush_bulk_add_modify(table_name, add_buf, modify_buf)
+            flush_bulk_drops(table_name, drop_buf)
           end
 
           # Per-object-kind "does not exist" ORA codes used by `drop_if_exists`.

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -485,6 +485,18 @@ module ActiveRecord
         true
       end
 
+      # Oracle's ALTER TABLE accepts combined `ADD (...)` and `MODIFY (...)`
+      # clauses in a single statement, which `bulk_change_table` uses to
+      # collapse contiguous `add_column` / `change_column` operations.
+      # `DROP (...)` cannot be combined with any other ALTER clause
+      # (ORA-12987: cannot combine drop column with other operations) so
+      # it is issued as its own statement.
+      # See the Oracle 19c SQL Language Reference, ALTER TABLE:
+      # https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/ALTER-TABLE.html
+      def supports_bulk_alter? # :nodoc:
+        true
+      end
+
       def supports_transaction_isolation? # :nodoc:
         true
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -779,6 +779,247 @@ RSpec.describe "OracleEnhancedAdapter schema definition" do
       @conn.rename_index("test_employees", original_name, "new_index_name")
     end.not_to raise_error
   end
+
+  describe "bulk_change_table (Phase 1: add / change / remove column)" do
+    before(:each) do
+      schema_define do
+        drop_table :test_bulk, if_exists: true
+        create_table :test_bulk, force: true do |t|
+          t.string :name
+          t.integer :qty
+          t.string :doomed
+        end
+      end
+    end
+
+    after(:each) do
+      schema_define { drop_table :test_bulk, if_exists: true }
+    end
+
+    it "reports supports_bulk_alter? as true" do
+      expect(@conn.supports_bulk_alter?).to be(true)
+    end
+
+    it "combines multiple add_column ops into a single ALTER TABLE ADD (...)" do
+      sqls = []
+      ActiveSupport::Notifications.subscribed(->(_n, _s, _f, _id, payload) { sqls << payload[:sql] if payload[:sql]&.include?("ALTER TABLE") }, "sql.active_record") do
+        @conn.change_table :test_bulk, bulk: true do |t|
+          t.string :added1
+          t.integer :added2
+          t.string :added3
+        end
+      end
+      add_alters = sqls.grep(/ALTER TABLE.*\bADD\b/i)
+      expect(add_alters.size).to eq(1)
+      expect(add_alters.first).to match(/ADD \(.*ADDED1.*ADDED2.*ADDED3.*\)/im)
+
+      cols = @conn.columns(:test_bulk).map(&:name)
+      expect(cols).to include("added1", "added2", "added3")
+    end
+
+    it "combines add + change into ADD (...) MODIFY (...) in one ALTER" do
+      sqls = []
+      ActiveSupport::Notifications.subscribed(->(_n, _s, _f, _id, payload) { sqls << payload[:sql] if payload[:sql]&.include?("ALTER TABLE") }, "sql.active_record") do
+        @conn.change_table :test_bulk, bulk: true do |t|
+          t.string :added_col
+          t.change :qty, :decimal, precision: 10, scale: 2
+        end
+      end
+      expect(sqls.size).to eq(1)
+      # Lock in the exact clause shape: one ALTER TABLE that opens with
+      # `ADD (...)` and is immediately followed by `MODIFY (...)` (no
+      # trailing/leading clauses), so a regression that breaks the clauses
+      # apart or reorders them shows up here rather than as a runtime ORA error.
+      expect(sqls.first).to match(/\AALTER TABLE "?TEST_BULK"? ADD \(.+"?ADDED_COL"?.+\) MODIFY \(.+"?QTY"?.+\)\z/i)
+    end
+
+    it "preserves NOT NULL when bulk-changing a column" do
+      sqls = []
+      ActiveSupport::Notifications.subscribed(->(_n, _s, _f, _id, payload) { sqls << payload[:sql] if payload[:sql]&.include?("ALTER TABLE") }, "sql.active_record") do
+        @conn.change_table :test_bulk, bulk: true do |t|
+          t.change :qty, :integer, null: false
+        end
+      end
+      expect(sqls.size).to eq(1)
+      expect(sqls.first).to match(/MODIFY \(.*"?QTY"?.*NOT NULL.*\)/i)
+
+      qty = @conn.columns(:test_bulk).detect { |c| c.name == "qty" }
+      expect(qty.null).to be(false)
+    end
+
+    it "issues DROP COLUMN as a separate ALTER TABLE (Oracle ORA-12987)" do
+      sqls = []
+      ActiveSupport::Notifications.subscribed(->(_n, _s, _f, _id, payload) { sqls << payload[:sql] if payload[:sql]&.include?("ALTER TABLE") }, "sql.active_record") do
+        @conn.change_table :test_bulk, bulk: true do |t|
+          t.string :added_after_drop
+          t.remove :doomed
+        end
+      end
+      add_alters = sqls.grep(/ALTER TABLE.*\bADD\b/i)
+      drop_alters = sqls.grep(/ALTER TABLE.*\bDROP\b/i)
+      expect(add_alters.size).to eq(1)
+      expect(drop_alters.size).to eq(1)
+      # The two clauses must NOT appear together; that would raise ORA-12987.
+      expect(sqls).to all(satisfy { |s| !(s.match?(/\bADD\b/i) && s.match?(/\bDROP\b/i)) })
+
+      cols = @conn.columns(:test_bulk).map(&:name)
+      expect(cols).to include("added_after_drop")
+      expect(cols).not_to include("doomed")
+    end
+
+    it "applies all three operations on the live table" do
+      @conn.change_table :test_bulk, bulk: true do |t|
+        t.string :note
+        t.change :qty, :decimal, precision: 8, scale: 2
+        t.remove :doomed
+      end
+
+      cols = @conn.columns(:test_bulk).index_by(&:name)
+      expect(cols.keys).to include("note")
+      expect(cols.keys).not_to include("doomed")
+      expect(cols["qty"].sql_type).to match(/NUMBER\(8,\s*2\)/i)
+    end
+
+    # `t.remove :foo` followed by `t.string :foo` re-uses the same column
+    # name. Oracle requires the DROP to land before the ADD or the second
+    # ALTER fails because `foo` is still defined on the table.
+    it "preserves migration order when remove precedes add of the same column" do
+      sqls = []
+      ActiveSupport::Notifications.subscribed(->(_n, _s, _f, _id, payload) { sqls << payload[:sql] if payload[:sql]&.include?("ALTER TABLE") }, "sql.active_record") do
+        @conn.change_table :test_bulk, bulk: true do |t|
+          t.remove :doomed
+          t.string :doomed, limit: 50
+        end
+      end
+
+      expect(sqls.size).to eq(2)
+      expect(sqls.first).to match(/\bDROP\b/i)
+      expect(sqls.last).to match(/\bADD\b/i)
+
+      doomed = @conn.columns(:test_bulk).detect { |c| c.name == "doomed" }
+      expect(doomed).not_to be_nil
+      expect(doomed.sql_type).to match(/VARCHAR2\(50\)/i)
+    end
+
+    it "issues an interleaved drop+add+drop block as three separate ALTERs in order" do
+      sqls = []
+      ActiveSupport::Notifications.subscribed(->(_n, _s, _f, _id, payload) { sqls << payload[:sql] if payload[:sql]&.include?("ALTER TABLE") }, "sql.active_record") do
+        @conn.change_table :test_bulk, bulk: true do |t|
+          t.remove :doomed
+          t.string :note
+          t.remove :qty
+        end
+      end
+
+      expect(sqls.size).to eq(3)
+      expect(sqls[0]).to match(/\bDROP\b.*"?DOOMED"?/i)
+      expect(sqls[1]).to match(/\bADD\b.*"?NOTE"?/i)
+      expect(sqls[2]).to match(/\bDROP\b.*"?QTY"?/i)
+    end
+
+    # `comment:` requires a follow-up `COMMENT ON COLUMN` statement that
+    # the column-only `add_column_for_alter` fragment does not include.
+    # Falls back to `add_column` so the comment is applied.
+    it "falls back to add_column when the column carries a comment" do
+      sqls = []
+      ActiveSupport::Notifications.subscribed(->(_n, _s, _f, _id, payload) { sqls << payload[:sql] if payload[:sql] }, "sql.active_record") do
+        @conn.change_table :test_bulk, bulk: true do |t|
+          t.string :commented, comment: "audit"
+        end
+      end
+
+      expect(sqls.any? { |s| s.match?(/COMMENT ON COLUMN.*COMMENTED/i) }).to be(true)
+      expect(@conn.column_comment("test_bulk", "commented")).to eq("audit")
+    end
+
+    # `:primary_key` columns trigger sequence + trigger setup that the
+    # column-only fragment does not reproduce; fall back to the full
+    # `add_column` path which performs those statements.
+    it "falls back to add_column for a :primary_key column type" do
+      schema_define do
+        drop_table :test_bulk_pk, if_exists: true
+        create_table :test_bulk_pk, force: true, id: false do |t|
+          t.string :name
+        end
+      end
+
+      begin
+        @conn.change_table :test_bulk_pk, bulk: true do |t|
+          t.column :id, :primary_key
+        end
+
+        seq_exists = @conn.select_value(<<~SQL.squish) == 1
+          SELECT COUNT(*) FROM all_sequences
+          WHERE sequence_owner = SYS_CONTEXT('userenv', 'current_schema')
+            AND sequence_name = 'TEST_BULK_PK_SEQ'
+        SQL
+        expect(seq_exists).to be(true)
+      ensure
+        schema_define { drop_table :test_bulk_pk, if_exists: true }
+      end
+    end
+
+    it "raises NotImplementedError for ops outside Phase 1 scope (e.g. t.rename)" do
+      expect {
+        @conn.change_table :test_bulk, bulk: true do |t|
+          t.rename :doomed, :renamed
+        end
+      }.to raise_error(NotImplementedError, /bulk_change_table.*:rename_column.*bulk: false/)
+    end
+
+    # Pre-scan guard: an unsupported op must raise BEFORE any ALTER fires,
+    # otherwise an early `t.string` would commit and leave the schema in a
+    # half-applied state when the rename later raised.
+    it "rejects unsupported ops up front so no DDL is issued" do
+      sqls = []
+      expect {
+        ActiveSupport::Notifications.subscribed(->(_n, _s, _f, _id, payload) { sqls << payload[:sql] if payload[:sql]&.include?("ALTER TABLE") }, "sql.active_record") do
+          @conn.change_table :test_bulk, bulk: true do |t|
+            t.string :added_first
+            t.rename :doomed, :renamed
+          end
+        end
+      }.to raise_error(NotImplementedError)
+
+      cols = @conn.columns(:test_bulk).map(&:name)
+      expect(cols).not_to include("added_first")
+      expect(sqls).to be_empty
+    end
+
+    it "batches multiple t.remove calls into a single DROP (...) clause" do
+      sqls = []
+      ActiveSupport::Notifications.subscribed(->(_n, _s, _f, _id, payload) { sqls << payload[:sql] if payload[:sql]&.include?("ALTER TABLE") }, "sql.active_record") do
+        @conn.change_table :test_bulk, bulk: true do |t|
+          t.remove :doomed
+          t.remove :qty
+        end
+      end
+      drops = sqls.grep(/ALTER TABLE.*\bDROP\b/i)
+      expect(drops.size).to eq(1)
+      expect(drops.first).to match(/DROP \(.*doomed.*qty.*\)/i)
+
+      cols = @conn.columns(:test_bulk).map(&:name)
+      expect(cols).not_to include("doomed", "qty")
+    end
+
+    it "flushes the queued ADD when a bulk block changes the column it just added" do
+      sqls = []
+      ActiveSupport::Notifications.subscribed(->(_n, _s, _f, _id, payload) { sqls << payload[:sql] if payload[:sql]&.include?("ALTER TABLE") }, "sql.active_record") do
+        @conn.change_table :test_bulk, bulk: true do |t|
+          t.string :late_arrival
+          t.change :late_arrival, :string, limit: 8, null: false
+        end
+      end
+      add_alters = sqls.grep(/ALTER TABLE.*\bADD\b/i)
+      modify_alters = sqls.grep(/ALTER TABLE.*\bMODIFY\b/i)
+      expect(add_alters.size).to eq(1)
+      expect(modify_alters.size).to eq(1)
+
+      col = @conn.columns(:test_bulk).find { |c| c.name == "late_arrival" }
+      expect(col.sql_type).to match(/VARCHAR2\(8\)/i)
+      expect(col.null).to be(false)
+    end
+  end
 end
 
   describe "remove index" do


### PR DESCRIPTION
Refs #2728. Phase 1 of [several phases](https://github.com/rsim/oracle-enhanced/issues/2728#issuecomment-4406997269); `:skip` / `:update` `on_duplicate`, `t.timestamps` inside a bulk block, FK / index / comment / rename paths are tracked separately.

## Summary

Active Record's `change_table(t, bulk: true) { |t| ... }` collapses multiple migration commands into a single `ALTER TABLE` statement when the adapter advertises `supports_bulk_alter?`. Oracle has supported the combined-clause form (`ALTER TABLE t ADD (...) MODIFY (...)`) since 9i, but oracle-enhanced reported `false` so every migration block went back to issuing one DDL per operation.

Flip the override to `true` and add an Oracle-aware `bulk_change_table` driver that respects the syntax constraints we verified empirically:

| Combination | Result |
|---|---|
| `ADD` + `MODIFY` | combine into one `ALTER TABLE t ADD (...) MODIFY (...)` |
| `ADD` / `MODIFY` + `DROP COLUMN` | `ORA-12987: cannot combine drop column with other operations` — emitted as two separate `ALTER TABLE` statements |
| Anything else (constraints, indexes, comments, `rename_column`, `t.timestamps`, etc.) | raises `NotImplementedError` |

Reference: [Oracle Database 19c SQL Language Reference, ALTER TABLE](https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/ALTER-TABLE.html).

## Why raise instead of silently falling back

A user who writes `change_table(:t, bulk: true)` is explicitly opting into bulk semantics. Silently dispatching unsupported ops via `send` would hide the fact that part of the migration is no longer running in the combined statement.

The dispatcher therefore **pre-scans operations** and raises `NotImplementedError` *before* issuing any DDL. Concretely, an op list like `[t.string :a, t.rename :b, :c]` raises immediately — the `ALTER TABLE ADD` for `:a` is **not** executed, so the schema is never half-applied. The error is actionable:

```
bulk_change_table only supports [:add_column, :change_column, :remove_column, :remove_columns] (got :rename_column); use change_table(bulk: false)
```

## Phase 1 surface

- `supports_bulk_alter?` overridden to `true`.
- `bulk_change_table(table_name, operations)` runs a streaming dispatcher with three column buckets:
  - `add_buf` — combined into `ADD (...)`
  - `modify_buf` — combined into `MODIFY (...)`
  - `drop_buf` — column names emitted as a separate `ALTER TABLE t DROP (col1, col2, ...) CASCADE CONSTRAINTS` (Oracle rejects combining `DROP COLUMN` with anything else — ORA-12987)
- The dispatcher flushes the *other* bucket whenever the operation kind switches, preserving the user's migration order across the two ALTER statements (e.g., `t.remove :foo; t.string :foo` emits DROP before ADD).
- Column ops that need extra SQL after the ALTER TABLE — `comment:` (issues `COMMENT ON COLUMN`), `:primary_key` type (creates the sequence and optional trigger), LOB types (`:text`/`:ntext`/`:binary`/`:clob`/`:nclob`/`:blob`) and any column with `tablespace:` / a configured `default_tablespaces[type]` — are routed through the full `add_column` / `change_column` path via `requires_full_command?` so `add_column` can append the `LOB ... STORE AS ... (TABLESPACE ...)` clause that the bare column-fragment cannot carry. The remaining bucketed entries are still combined.
- `change_column_for_alter` reads the live catalog via `column_for`. When a bulk block changes a column it just added in the same block (`t.string :foo; t.change :foo, :integer`), the dispatcher flushes the queued ADD before invoking `column_for`, so the lookup succeeds. Different-column add+change still combine into a single `ALTER TABLE`.
- `add_timestamps` now expresses itself as a `change_table(bulk: true)` block, so `add_timestamps` issues a single `ALTER TABLE t ADD (created_at ..., updated_at ...)` instead of two separate ALTERs. (`t.timestamps` *inside* an existing bulk block raises `NotImplementedError`; explicit support is tracked for Phase 2.)
- A guarded `else` branch in the dispatcher raises a maintenance error if `SUPPORTED_BULK_COMMANDS` lists a command without a matching `when` branch — an internal assertion to keep the allowlist and dispatch in sync.
- Anything in the block that is not `:add_column` / `:change_column` / `:remove_column` / `:remove_columns` raises `NotImplementedError` *before any DDL* (see "Why raise" above).

## Out of scope (separate PRs)

These commands raise `NotImplementedError` in this PR; users must either issue them outside the bulk block or run the whole block with `bulk: false`. Phase 2+ may add direct support where it makes sense for Oracle.

- `t.timestamps` / `t.remove_timestamps` inside a bulk block (Phase 2 will pre-expand to `:add_column` × 2 / `:remove_column` × 2)
- `change_column_default` / `change_column_null`
- Foreign keys / check constraints
- `rename_column` — Oracle's `ALTER TABLE ... RENAME COLUMN` cannot be combined with any other clause (ORA-23290).
- `add_index` / `remove_index` — `CREATE INDEX` / `DROP INDEX` are not `ALTER TABLE` clauses.
- Comments — `COMMENT ON TABLE` / `COMMENT ON COLUMN` are separate statements.

## Specs

`schema_statements_spec.rb` `bulk_change_table (Phase 1: add / change / remove column)`:

- `supports_bulk_alter?` reports `true`.
- Multiple `add_column` ops collapse into a single `ALTER TABLE t ADD (...)`.
- `add` + `change` collapse into one `ALTER TABLE t ADD (...) MODIFY (...)`.
- `NOT NULL` is preserved when bulk-changing a column.
- `add` + `remove` issues two separate ALTERs and never mixes `ADD` and `DROP` in the same statement (ORA-12987 guard).
- `t.remove :foo` followed by `t.string :foo` flushes the DROP first (order preservation).
- An interleaved `drop` + `add` + `drop` block emits three separate ALTERs in the user-specified order.
- Multiple `t.remove` calls batch into a single `DROP (col1, col2)` clause.
- `t.string :foo` followed by `t.change :foo, ...` (changing the just-added column) flushes the ADD before MODIFY so `column_for` succeeds.
- `comment:` on `add_column` falls back to the full `add_column` path so `COMMENT ON COLUMN` still fires.
- `:primary_key` column type falls back to the full path so the sequence (and optional trigger) is created.
- An unsupported op (e.g. `t.rename`) raises `NotImplementedError` mentioning the command and `bulk: false`, *before* any DDL is emitted (the pre-scan check).

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb` — 187 examples, 1 pending unrelated, 0 failures
- [x] `bundle exec rspec spec/` — 945 examples, 12 pending unrelated, 0 failures
- [x] `bundle exec ruby -Ilib ci/check_method_signatures.rb` — green
- [x] `bundle exec rubocop` — clean
- [ ] CI on full matrix (re-running after rebase onto current master)
