### PR TITLE
Apply :comment to add_timestamps columns

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -492,7 +492,7 @@ module ActiveRecord
             create_pk_sequence(table_name, options)
             create_pk_trigger(table_name, column_name, options) if options[:primary_key_trigger]
           end
-          change_column_comment(table_name, column_name, options[:comment]) if options.key?(:comment)
+          apply_column_comments(table_name, column_name, comment: options[:comment]) if options.key?(:comment)
         ensure
           clear_table_caches(table_name)
         end
@@ -537,7 +537,7 @@ module ActiveRecord
           change_column_sql = "ALTER TABLE #{quote_table_name(table_name)} MODIFY #{change_column_stmt}"
           execute(change_column_sql)
 
-          change_column_comment(table_name, column_name, options[:comment]) if options.key?(:comment)
+          apply_column_comments(table_name, column_name, comment: options[:comment]) if options.key?(:comment)
         ensure
           clear_table_caches(table_name)
         end
@@ -827,6 +827,7 @@ module ActiveRecord
           fragments.each do |fragment|
             execute "ALTER TABLE #{quote_table_name(table_name)} #{fragment}"
           end
+          apply_column_comments(table_name, :created_at, :updated_at, comment: options[:comment]) if options.key?(:comment)
         end
 
         def update_table_definition(table_name, base) # :nodoc:
@@ -870,6 +871,23 @@ module ActiveRecord
         end
 
         private
+          # Oracle does not allow inline `COMMENT '...'` in `ALTER TABLE
+          # ADD` / `MODIFY`, so column comments are issued as separate
+          # `COMMENT ON COLUMN` statements after the column DDL is in
+          # place. Centralising the post-ALTER call here keeps
+          # `add_column`, `change_column` and `add_timestamps` in lockstep.
+          # The helper does not short-circuit on `comment.nil?` because
+          # passing `comment: nil` is the canonical way for callers to
+          # clear an existing column comment (`change_column_comment_sql`
+          # turns a nil comment into `COMMENT ON COLUMN ... IS ''`); the
+          # `options.key?(:comment)` guard at each call site is what
+          # decides whether the helper runs at all.
+          def apply_column_comments(table_name, *column_names, comment:)
+            column_names.each do |column_name|
+              change_column_comment(table_name, column_name, comment)
+            end
+          end
+
           # Per-object-kind "does not exist" ORA codes used by `drop_if_exists`.
           MISSING_OBJECT_ORA_CODES = {
             "TABLE"             => "ORA-00942",

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -1132,6 +1132,44 @@ end
       expect(TestEmployee.columns_hash["created_at"]).not_to be_nil
       expect(TestEmployee.columns_hash["updated_at"]).not_to be_nil
     end
+
+    it "applies :comment to created_at and updated_at" do
+      @conn.add_timestamps("test_employees", comment: "audit")
+
+      expect(@conn.column_comment("test_employees", "created_at")).to eq("audit")
+      expect(@conn.column_comment("test_employees", "updated_at")).to eq("audit")
+    end
+  end
+
+  describe "add_column / change_column comment handling" do
+    before(:each) do
+      schema_define do
+        create_table :test_employees, force: true
+      end
+    end
+
+    after(:each) do
+      schema_define do
+        drop_table :test_employees, if_exists: true
+      end
+    end
+
+    it "applies :comment to a newly added column" do
+      @conn.add_column :test_employees, :note, :string, comment: "audit"
+
+      expect(@conn.column_comment("test_employees", "note")).to eq("audit")
+    end
+
+    # Passing `comment: nil` is the canonical way to clear an existing
+    # column comment (`change_column_comment_sql` emits
+    # `COMMENT ON COLUMN ... IS ''` when the value is nil).
+    it "clears the existing comment when add_column is called with comment: nil" do
+      @conn.add_column :test_employees, :note, :string, comment: "audit"
+      expect(@conn.column_comment("test_employees", "note")).to eq("audit")
+
+      @conn.change_column :test_employees, :note, :string, comment: nil
+      expect(@conn.column_comment("test_employees", "note")).to be_nil
+    end
   end
 
   describe "ignore options for LOB columns" do


### PR DESCRIPTION
Closes #2738.

## Summary

`add_timestamps(table, comment: "...")` silently dropped the column comment on Oracle. Active Record's `add_timestamps_for_alter` builds column-level fragments via `add_column_for_alter`, which on Oracle omits the inline `COMMENT '...'` syntax — `OracleEnhanced::SchemaCreation#add_column_options!` only emits `DEFAULT`, `NULL`, `AS`, `PRIMARY KEY`. Oracle SQL itself does not support inline `COMMENT` in `ALTER TABLE ADD`/`MODIFY`; column comments must be issued as separate `COMMENT ON COLUMN` statements. With no follow-up call, the comment never reached the database.

## Fix

`add_column ..., comment: "..."` already worked because the existing override calls `change_column_comment` after the ALTER. Mirror that fix-up for `add_timestamps`, and at the same time pull the three post-ALTER comment-application call sites (`add_column`, `change_column`, `add_timestamps`) into a shared private helper so they stay in lockstep:

```ruby
private
  def apply_column_comments(table_name, *column_names, comment:)
    column_names.each do |column_name|
      change_column_comment(table_name, column_name, comment)
    end
  end
```

Each caller still gates the helper with `if options.key?(:comment)`, so:

| Call form | Behavior (unchanged from before refactor) |
|---|---|
| `add_column :t, :c, :string` (no `:comment` key) | helper not called — column comment untouched |
| `add_column :t, :c, :string, comment: "x"` | `COMMENT ON COLUMN t.c IS 'x'` |
| `add_column :t, :c, :string, comment: nil` | `COMMENT ON COLUMN t.c IS ''` (clears any existing comment, since `change_column_comment_sql` turns a nil value into `IS ''`) |

The helper deliberately does **not** short-circuit on `comment.nil?`. Passing `comment: nil` is the canonical way to clear an existing column comment, and the `options.key?(:comment)` guard at each call site is what decides whether the helper runs at all. Mishandling this was caught during deep review and a regression spec is included.

## Specs

`schema_statements_spec.rb`:

- `describe "add timestamps"` — `add_timestamps :t, comment: "audit"` populates both `created_at` and `updated_at` comments.
- `describe "add_column / change_column comment handling"`:
  - `add_column :t, :col, :string, comment: "audit"` populates the column comment.
  - `change_column :t, :col, :string, comment: nil` clears a previously-set comment (regression-locks the nil-clearing path through the new helper).

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb` — green
- [x] `bundle exec ruby -Ilib ci/check_method_signatures.rb` — green
- [x] `bundle exec ruby -Ilib ci/check_method_visibility.rb` — green
- [x] `bundle exec rubocop` — clean
- [ ] CI on full matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
