### PR TITLE
Drop test_dbms_meta_inv_uniq after the INVISIBLE-constraint spec

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/dbms_metadata_structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/dbms_metadata_structure_dump_spec.rb
@@ -164,6 +164,8 @@ RSpec.describe "OracleEnhancedAdapter DBMS_METADATA structure dump" do
         stmt.match?(/\ACREATE\s+(?:UNIQUE\s+)?INDEX\s+"?IX_DBMS_META_INV_UNIQ"?/i)
       end
       expect(standalone).to be_empty
+    ensure
+      schema_define { drop_table :test_dbms_meta_inv_uniq, if_exists: true }
     end
 
     it "emits referential constraints as ALTER TABLE … ADD CONSTRAINT after the tables" do


### PR DESCRIPTION
## Summary

The `dbms_metadata_structure_dump_spec.rb` spec **"emits `ALTER INDEX ... INVISIBLE` for an INVISIBLE constraint-backed index"** (added in #2736) creates `test_dbms_meta_inv_uniq` — a table with a UNIQUE constraint backed by a named, INVISIBLE index — but never drops it. The outer `after(:each)` only cleans `test_dbms_metadata_*` tables, so this new table leaks into later specs.

When `database_tasks_spec.rb`'s `structure_load loads the database structure from a file` example runs while `test_dbms_meta_inv_uniq` still exists, `DBMS_METADATA.GET_DDL('TABLE', ...)` emits **three SQL statements** glued together without `/` separators inside a single CLOB chunk:

```sql
CREATE TABLE "TEST_DBMS_META_INV_UNIQ" 
   (	"ID" NUMBER(38,0) NOT NULL ENABLE, 
	"EMAIL" VARCHAR2(255 CHAR), 
	 PRIMARY KEY ("ID")
  USING INDEX  ENABLE
   ) 
  CREATE UNIQUE INDEX "IX_DBMS_META_INV_UNIQ" ON "TEST_DBMS_META_INV_UNIQ" ("EMAIL") 
  
ALTER TABLE "TEST_DBMS_META_INV_UNIQ" ADD CONSTRAINT "IX_DBMS_META_INV_UNIQ" UNIQUE ("EMAIL")
  USING INDEX "IX_DBMS_META_INV_UNIQ"  ENABLE
```

`structure_load` feeds this whole chunk to Oracle as one statement and gets back **`ORA-00922: missing or invalid option`**. Reproducible deterministically with `bundle exec rspec --seed 27` on the full suite.

## Fix

Add an `ensure` block to the spec so the table is dropped in the example's own scope. The fix is two lines:

```ruby
ensure
  schema_define { drop_table :test_dbms_meta_inv_uniq, if_exists: true }
```

## Why this is a separate PR

Surfaced during CI of #2739 but unrelated to that change — the leaking spec landed with #2736 and the failure is deterministic under `--seed 27` regardless of #2739's diff.

## Out of scope (follow-up)

The underlying `dbms_metadata_get_ddl` does not split a multi-statement TABLE DDL CLOB when Oracle emits one (the named-backing-index case). With the cleanup in this PR no test exercises that input shape, but the gap should be tracked in its own issue and fixed independently — for example by setting `SQLTERMINATOR=TRUE` on the DBMS_METADATA session and splitting the CLOB on the terminator.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/dbms_metadata_structure_dump_spec.rb:145 spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb:286 --seed 27` — green
- [x] `bundle exec rspec --seed 27` — green (926 examples, 0 failures, 12 pending unrelated)
- [x] `bundle exec rubocop` — clean
- [ ] CI on full matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
