### PR TITLE
Split multi-statement TABLE DDL CLOBs in the DBMS_METADATA dump path

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump/dbms_metadata.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump/dbms_metadata.rb
@@ -26,7 +26,7 @@ module ActiveRecord # :nodoc:
 
           private
             def dbms_metadata_structure_dump
-              dbms_metadata_with_transforms do
+              dbms_metadata_with_transforms(sql_terminator: true) do
                 structure = []
                 table_names = list_schema_objects("TABLE", non_mview_only: true)
                 skip_indexes = constraint_backed_index_names
@@ -41,10 +41,12 @@ module ActiveRecord # :nodoc:
                   names.each do |name|
                     next if object_type == "INDEX" && skip_indexes.include?(name.upcase)
                     ddl = dbms_metadata_get_ddl(object_type.tr(" ", "_"), name)
-                    if ddl && object_type == "INDEX" && invisible_indexes.include?(name.upcase)
-                      ddl = ensure_invisible_keyword(ddl)
+                    next unless ddl
+                    statements = split_dbms_metadata_sql_ddl(ddl)
+                    if object_type == "INDEX" && invisible_indexes.include?(name.upcase)
+                      statements = statements.map { |stmt| ensure_invisible_keyword(stmt) }
                     end
-                    structure << ddl if ddl
+                    structure.concat(statements)
                   end
                 end
 
@@ -66,7 +68,7 @@ module ActiveRecord # :nodoc:
 
                 fk_statements = table_names.flat_map do |table_name|
                   fk_ddl = dbms_metadata_get_dependent_ddl("REF_CONSTRAINT", table_name)
-                  fk_ddl ? split_dbms_metadata_ddl(fk_ddl) : []
+                  fk_ddl ? split_dbms_metadata_sql_ddl(fk_ddl) : []
                 end
 
                 join_with_statement_token(structure) << join_with_statement_token(fk_statements)
@@ -94,8 +96,8 @@ module ActiveRecord # :nodoc:
               end
             end
 
-            def dbms_metadata_with_transforms
-              configure_dbms_metadata_transforms
+            def dbms_metadata_with_transforms(sql_terminator: false)
+              configure_dbms_metadata_transforms(sql_terminator: sql_terminator)
               yield
             ensure
               reset_dbms_metadata_transforms
@@ -179,7 +181,14 @@ module ActiveRecord # :nodoc:
 
             # Suppress installation-specific output, in spirit of
             # `pg_dump --schema-only --no-owner --no-tablespaces`.
-            def configure_dbms_metadata_transforms
+            # When `sql_terminator: true` is requested, also tell Oracle
+            # to append a SQL terminator (`;`) to each statement so the
+            # caller can split a multi-statement TABLE DDL CLOB on the
+            # boundary; this is only safe for the SQL DDL path (TABLE /
+            # SEQUENCE / VIEW / INDEX). The PL/SQL DDL path leaves
+            # SQLTERMINATOR at the default FALSE because PL/SQL bodies
+            # contain `;` characters internally (`END;`).
+            def configure_dbms_metadata_transforms(sql_terminator: false)
               execute(<<~SQL)
                 BEGIN
                   DBMS_METADATA.SET_TRANSFORM_PARAM(DBMS_METADATA.SESSION_TRANSFORM, 'STORAGE', FALSE);
@@ -187,6 +196,7 @@ module ActiveRecord # :nodoc:
                   DBMS_METADATA.SET_TRANSFORM_PARAM(DBMS_METADATA.SESSION_TRANSFORM, 'SEGMENT_ATTRIBUTES', FALSE);
                   DBMS_METADATA.SET_TRANSFORM_PARAM(DBMS_METADATA.SESSION_TRANSFORM, 'EMIT_SCHEMA', FALSE);
                   DBMS_METADATA.SET_TRANSFORM_PARAM(DBMS_METADATA.SESSION_TRANSFORM, 'REF_CONSTRAINTS', FALSE);
+                  DBMS_METADATA.SET_TRANSFORM_PARAM(DBMS_METADATA.SESSION_TRANSFORM, 'SQLTERMINATOR', #{sql_terminator ? "TRUE" : "FALSE"});
                 END;
               SQL
             end
@@ -245,6 +255,19 @@ module ActiveRecord # :nodoc:
             def split_dbms_metadata_ddl(ddl)
               return [] if ddl.nil?
               ddl.split(/\n\s*\n/).map(&:strip).reject(&:empty?)
+            end
+
+            # `GET_DDL('TABLE', t)` can return more than one SQL statement
+            # in a single CLOB when the table has a UNIQUE constraint
+            # backed by a separately-named index (Oracle emits the
+            # `CREATE TABLE`, the `CREATE UNIQUE INDEX`, and the
+            # `ALTER TABLE ... ADD CONSTRAINT ... USING INDEX ...` as a
+            # group). With `SQLTERMINATOR=TRUE` each statement ends in
+            # `;`, so split on the terminator to surface each statement
+            # to the structure-dump output as its own entry.
+            def split_dbms_metadata_sql_ddl(ddl)
+              return [] if ddl.nil?
+              ddl.split(/;\s*(?:\n|\z)/).map(&:strip).reject(&:empty?)
             end
         end
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced/dbms_metadata_structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/dbms_metadata_structure_dump_spec.rb
@@ -157,13 +157,6 @@ RSpec.describe "OracleEnhancedAdapter DBMS_METADATA structure dump" do
         stmt.match?(/\AALTER\s+INDEX\s+"?IX_DBMS_META_INV_UNIQ"?\s+INVISIBLE\s*\z/i)
       end
       expect(alter_stmt).not_to be_nil
-
-      # And the standalone CREATE INDEX should NOT be emitted (the
-      # constraint inline already created the index).
-      standalone = dump.split("\n\n/\n\n").select do |stmt|
-        stmt.match?(/\ACREATE\s+(?:UNIQUE\s+)?INDEX\s+"?IX_DBMS_META_INV_UNIQ"?/i)
-      end
-      expect(standalone).to be_empty
     ensure
       schema_define { drop_table :test_dbms_meta_inv_uniq, if_exists: true }
     end
@@ -232,7 +225,7 @@ RSpec.describe "OracleEnhancedAdapter DBMS_METADATA structure dump" do
       expect(dump).not_to match(/PCTFREE\s+/i)
     end
 
-    it "does not emit a standalone CREATE INDEX for a UNIQUE constraint's backing index" do
+    it "splits a UNIQUE-constraint-with-named-backing-index into separate CREATE INDEX and ADD CONSTRAINT statements" do
       schema_define do
         create_table :test_dbms_metadata_posts, force: true do |t|
           t.string :email
@@ -240,13 +233,81 @@ RSpec.describe "OracleEnhancedAdapter DBMS_METADATA structure dump" do
         add_index :test_dbms_metadata_posts, :email, unique: true, name: "ix_test_dbms_metadata_email"
       end
       dump = @conn.structure_dump
-      # `CONSTRAINTS=TRUE` already inlines the unique constraint (and its
-      # backing index) into the CREATE TABLE DDL. Emitting a separate
-      # `CREATE UNIQUE INDEX` for the same name would duplicate it.
-      standalone_index_stmts = dump.split("\n\n/\n\n").select do |stmt|
+      stmts = dump.split("\n\n/\n\n")
+
+      # `GET_DDL('TABLE', ...)` returns CREATE TABLE, CREATE UNIQUE INDEX,
+      # and ALTER TABLE ... ADD CONSTRAINT ... USING INDEX as one CLOB
+      # when the UNIQUE constraint references a named backing index.
+      # `SQLTERMINATOR=TRUE` plus `split_dbms_metadata_sql_ddl` splits
+      # them so each one is a separate dump entry; `structure_load`
+      # would otherwise feed the whole CLOB as one statement and Oracle
+      # would reject it with ORA-00922.
+      create_index_stmts = stmts.select do |stmt|
         stmt.match?(/\ACREATE\s+UNIQUE\s+INDEX\s+"?IX_TEST_DBMS_METADATA_EMAIL"?/i)
       end
-      expect(standalone_index_stmts).to be_empty
+      expect(create_index_stmts.size).to eq(1)
+
+      add_constraint_stmts = stmts.select do |stmt|
+        stmt.match?(/\AALTER\s+TABLE\s+"?TEST_DBMS_METADATA_POSTS"?\s+ADD\s+CONSTRAINT\s+"?IX_TEST_DBMS_METADATA_EMAIL"?\s+UNIQUE/i)
+      end
+      expect(add_constraint_stmts.size).to eq(1)
+    end
+
+    # Round-trip regression for the same table shape: dump → drop → load
+    # used to fail with ORA-00922 because the multi-statement `GET_DDL`
+    # CLOB was sent to Oracle as a single statement.
+    it "round-trips a UNIQUE-with-named-backing-index table through structure_dump/structure_load" do
+      require "tempfile"
+      schema_define do
+        create_table :test_dbms_metadata_posts, force: true do |t|
+          t.string :email
+        end
+        add_index :test_dbms_metadata_posts, :email, unique: true, name: "ix_test_dbms_metadata_email"
+      end
+
+      temp_file = Tempfile.create(["oracle_enhanced_roundtrip", ".sql"]).path
+      config = ActiveRecord::Base.connection_db_config.configuration_hash
+
+      begin
+        ActiveRecord::Tasks::DatabaseTasks.structure_dump(config, temp_file)
+        ActiveRecord::Tasks::DatabaseTasks.drop(config)
+        ActiveRecord::Tasks::DatabaseTasks.structure_load(config, temp_file)
+        expect(@conn.table_exists?(:test_dbms_metadata_posts)).to be(true)
+      ensure
+        File.unlink(temp_file) if File.exist?(temp_file)
+      end
+    end
+
+    # Round-trip regression for foreign keys: with SQLTERMINATOR=TRUE
+    # the dependent FK DDL also ends with ';', so the dump must run it
+    # through `split_dbms_metadata_sql_ddl` to strip the trailing
+    # terminator. Otherwise the load raises ORA-00911 on the trailing ';'.
+    it "round-trips foreign-key constraints through structure_dump/structure_load" do
+      require "tempfile"
+      schema_define do
+        create_table :test_dbms_metadata_posts, force: true do |t|
+          t.string :title
+        end
+        create_table :test_dbms_metadata_children, force: true do |t|
+          t.integer :test_dbms_metadata_post_id
+        end
+        add_foreign_key :test_dbms_metadata_children, :test_dbms_metadata_posts,
+                        column: :test_dbms_metadata_post_id, name: "fk_dbms_meta_rt"
+      end
+
+      temp_file = Tempfile.create(["oracle_enhanced_fk_rt", ".sql"]).path
+      config = ActiveRecord::Base.connection_db_config.configuration_hash
+
+      begin
+        ActiveRecord::Tasks::DatabaseTasks.structure_dump(config, temp_file)
+        ActiveRecord::Tasks::DatabaseTasks.drop(config)
+        ActiveRecord::Tasks::DatabaseTasks.structure_load(config, temp_file)
+        expect(@conn.table_exists?(:test_dbms_metadata_children)).to be(true)
+        fk = @conn.foreign_keys(:test_dbms_metadata_children).find { |f| f.name == "fk_dbms_meta_rt" }
+        expect(fk).not_to be_nil
+      ensure
+        File.unlink(temp_file) if File.exist?(temp_file)
+      end
     end
   end
 


### PR DESCRIPTION
Follow-up to #2740 (which contained only the spec-side cleanup that was masking this bug).

## Summary

`DBMS_METADATA.GET_DDL('TABLE', t)` returns **more than one SQL statement in a single CLOB** when the table has a UNIQUE constraint backed by a separately-named index. Oracle emits the three statements together with no terminator between them:

```sql
  CREATE TABLE "TMP" 
   (	"ID" NUMBER(38,0) NOT NULL ENABLE, 
	"EMAIL" VARCHAR2(255 CHAR), 
	 PRIMARY KEY ("ID")
  USING INDEX  ENABLE
   ) 
  CREATE UNIQUE INDEX "IX_TMP" ON "TMP" ("EMAIL") 
  
ALTER TABLE "TMP" ADD CONSTRAINT "IX_TMP" UNIQUE ("EMAIL")
  USING INDEX "IX_TMP"  ENABLE
```

The structure dump previously fed that whole CLOB to `structure_load` as a single statement and Oracle rejected the second / third statement with **`ORA-00922: missing or invalid option`**. The same shape would also appear for any other table whose CONSTRAINT clause requires a named USING INDEX reference.

## Fix

Split at the source by configuring DBMS_METADATA itself to terminate each emitted statement, then split on the terminator:

- `dbms_metadata_with_transforms` accepts a new `sql_terminator:` keyword. The structure-dump path (`dbms_metadata_structure_dump`) passes `true`; the PL/SQL stored-code path (`dbms_metadata_structure_dump_db_stored_code`) keeps the default `false` because PL/SQL bodies contain `;` characters internally (`END;`).
- `configure_dbms_metadata_transforms(sql_terminator:)` adds `SET_TRANSFORM_PARAM('SQLTERMINATOR', TRUE)` accordingly, telling Oracle to terminate every emitted SQL statement with `;`.
- A new private helper `split_dbms_metadata_sql_ddl(ddl)` splits the resulting CLOB on `;\s*\n` (and the trailing `;` at end-of-CLOB), so each statement becomes its own entry. The existing post-processing (`ensure_invisible_keyword`) is applied per split statement instead of to the whole CLOB.
- The dependent FK DDL (`GET_DEPENDENT_DDL("REF_CONSTRAINT", ...)`) is also routed through `split_dbms_metadata_sql_ddl`. The trailing `;` that `SQLTERMINATOR=TRUE` adds to each `ALTER TABLE` is stripped before the statement is replayed by `structure_load`. Without this the load raised `ORA-00911: invalid character` (caught during deep review).

Output before fix (one chunk, single `/` after the whole multi-statement CLOB):

```
CREATE TABLE "TMP" (...) 
  CREATE UNIQUE INDEX "IX_TMP" ON "TMP" ("EMAIL") 
  
ALTER TABLE "TMP" ADD CONSTRAINT "IX_TMP" UNIQUE ("EMAIL")
  USING INDEX "IX_TMP"  ENABLE

/
```

Output after fix (three statements separated by `\n\n/\n\n`, no trailing `;`):

```
CREATE TABLE "TMP" (...)

/

CREATE UNIQUE INDEX "IX_TMP" ON "TMP" ("EMAIL")

/

ALTER TABLE "TMP" ADD CONSTRAINT "IX_TMP" UNIQUE ("EMAIL")
  USING INDEX "IX_TMP"  ENABLE

/
```

## Specs

`dbms_metadata_structure_dump_spec.rb`:

- The existing "INVISIBLE constraint-backed index" spec drops the now-incorrect "no standalone CREATE INDEX" assertion (the standalone CREATE INDEX is legitimately part of the dump now); the post-process `ALTER INDEX ... INVISIBLE` assertion still holds.
- The "UNIQUE constraint backing index" spec is rewritten to lock in the new shape: exactly one `CREATE UNIQUE INDEX` and one `ALTER TABLE ... ADD CONSTRAINT ... UNIQUE` statement appear as separate dump entries.
- New regression test: full `structure_dump` → `drop` → `structure_load` round-trips a UNIQUE-with-named-backing-index table without raising ORA-00922.
- New regression test: full `structure_dump` → `drop` → `structure_load` round-trips a table pair carrying a foreign key without raising ORA-00911 on the trailing `;` left by `SQLTERMINATOR=TRUE`.

## Out of scope

- **PL/SQL DDL emission** (`dbms_metadata_structure_dump_db_stored_code`) deliberately keeps `SQLTERMINATOR=FALSE`. PL/SQL bodies contain `;` characters internally (`NULL;`, `END;`); splitting on the SQL terminator would corrupt the procedure / function / package / type / trigger output. Those types continue to flow through the existing `dbms_metadata_get_ddl` path unchanged.
- **String-literal `;\n` edge case**: the splitter is regex-based, not SQL-aware, so a `DEFAULT 'a;\nb'` / a `CHECK ('a;\nb')` / a function-based index expression containing `;\n` inside a quoted literal could in theory be mis-split. This is the same edge case the previous (`SQLTERMINATOR=FALSE`) behaviour also could not reliably round-trip, so it is treated as a documented limitation. If anyone hits it in practice, a follow-up PR can introduce a SQL-aware splitter that skips quoted strings and comments.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/dbms_metadata_structure_dump_spec.rb spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb` — green (86 examples, 0 failures, 2 pending unrelated)
- [x] `bundle exec rubocop` — clean
- [x] `bundle exec ruby -Ilib ci/check_method_signatures.rb` — green
- [x] Empirical structure_dump → drop → structure_load round-trip for both UNIQUE-with-named-backing-index and FK shapes
- [ ] CI on full matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
