### PR TITLE
Pass real table_name / column_name to tablespace_for in change_column

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -533,7 +533,7 @@ module ActiveRecord
           td = create_table_definition(table_name)
           cd = td.new_column_definition(column.name, type, **options)
           change_column_stmt = schema_creation.accept cd
-          change_column_stmt << tablespace_for((type_to_sql(type).downcase.to_sym), nil, options[:table_name], options[:column_name]) if type
+          change_column_stmt << tablespace_for((type_to_sql(type).downcase.to_sym), nil, table_name, column_name) if type
           change_column_sql = "ALTER TABLE #{quote_table_name(table_name)} MODIFY #{change_column_stmt}"
           execute(change_column_sql)
 


### PR DESCRIPTION
## Summary

`change_column` calls `tablespace_for` with `options[:table_name]` and `options[:column_name]`:

```ruby
change_column_stmt << tablespace_for((type_to_sql(type).downcase.to_sym), nil, options[:table_name], options[:column_name]) if type
```

Active Record never populates those keys on the options hash — the actual identifiers are the positional `table_name` / `column_name` arguments. So when the call landed on the LOB branch of `tablespace_for`:

```ruby
tablespace_sql << " LOB (#{quote_column_name(column_name)}) STORE AS #{column_name.to_s[0..10]}_#{table_name.to_s[0..14]}_ls (TABLESPACE #{tablespace})"
```

`column_name` and `table_name` were `nil`, producing malformed SQL like `LOB ("") STORE AS _®_ls (TABLESPACE ...)`. This fired whenever `change_column` was invoked with a LOB type plus either an explicit `tablespace:` option or a configured `OracleEnhancedAdapter.default_tablespaces[:clob|:nclob|:blob]`.

Use the positional `table_name` / `column_name` so the LOB clause is rendered correctly. The non-LOB branch of `tablespace_for` ignores these two arguments, so non-LOB call sites are unaffected.

The bug surfaced during review of #2737 (bulk_alter Phase 1), which started routing LOB column changes through `change_column`'s full path.

## Test plan

- [x] `bundle exec rubocop` — clean
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb` — green (no regression on non-LOB `change_column`)
- [ ] CI on full matrix
