### PR TITLE
Remove unreachable tablespace_for call from change_column

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -533,7 +533,6 @@ module ActiveRecord
           td = create_table_definition(table_name)
           cd = td.new_column_definition(column.name, type, **options)
           change_column_stmt = schema_creation.accept cd
-          change_column_stmt << tablespace_for((type_to_sql(type).downcase.to_sym), nil, options[:table_name], options[:column_name]) if type
           change_column_sql = "ALTER TABLE #{quote_table_name(table_name)} MODIFY #{change_column_stmt}"
           execute(change_column_sql)
 


### PR DESCRIPTION
## Summary

`change_column` appends `tablespace_for(...)` after the column definition:

```ruby
change_column_stmt = schema_creation.accept cd
change_column_stmt << tablespace_for((type_to_sql(type).downcase.to_sym), nil, options[:table_name], options[:column_name]) if type
change_column_sql = "ALTER TABLE #{quote_table_name(table_name)} MODIFY #{change_column_stmt}"
```

This produces SQL like `ALTER TABLE t MODIFY col TYPE [TABLESPACE ts | LOB (col) STORE AS … (TABLESPACE ts)]`. Oracle does not accept any of those forms via `ALTER TABLE … MODIFY`:

- Non-LOB tablespace cannot be changed via `MODIFY` (segment storage attributes are fixed at column creation; moving requires segment-level operations).
- LOB tablespace cannot be changed via `MODIFY` either. The supported syntax is `ALTER TABLE t MOVE LOB (col) STORE AS (TABLESPACE ts)` — separate DDL, separate code path.
- Converting a non-LOB column to a LOB type fails with `ORA-22858: invalid alteration of datatype` before the appended clause is even relevant.

The call has been there since 2014 ([2e65e1df](https://github.com/rsim/oracle-enhanced/commit/2e65e1df)), and even when it did fire it passed nil identifiers via `options[:table_name]` / `options[:column_name]` (Active Record does not populate those keys), which would have produced malformed SQL. In practice the line never produces valid Oracle SQL, so remove it.

This is also a small cleanup that makes #2737 (`bulk_alter` Phase 1) easier to reason about: the bulk dispatcher routes LOB column changes through `change_column`'s full path for tablespace correctness, but with this line gone the routing is no longer trying to attach LOB clauses Oracle would reject anyway.

## Test plan

- [x] `bundle exec rubocop` — clean
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb` — 173 examples, 1 pending unrelated, 0 failures
- [ ] CI on full matrix

## Risk

Zero observable behavior change. The `if type` guard meant the line only fired when a type was given, and any path that exercised it produced SQL Oracle would reject. Removing it lets `change_column` emit cleaner errors (e.g. ORA-22858 directly, instead of an even more malformed statement).
