### PR TITLE
Silence DatabaseTasks Created/Dropped output in specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,12 @@ end
 
 require "active_record"
 
+# Suppress "Created database 'X'" / "Dropped database 'X'" announcements
+# from `ActiveRecord::Tasks::DatabaseTasks` during specs that exercise
+# the create/drop flows. Allow callers to opt back in by passing
+# `VERBOSE=true` on the command line.
+ENV["VERBOSE"] ||= "false"
+
 require "active_support/core_ext/module/attribute_accessors"
 require "active_support/core_ext/class/attribute_accessors"
 


### PR DESCRIPTION
## Summary

Specs that exercise `ActiveRecord::Tasks::DatabaseTasks.create` and `.drop` (`database_tasks_spec.rb`, `dbms_metadata_structure_dump_spec.rb`) emit `Created database 'FREEPDB1'` / `Dropped database 'FREEPDB1'` lines into rspec output via `$stdout.puts ... if verbose?` in Rails' DatabaseTasks. The CI logs end up with these lines interleaved with the dot progress, for example from a recent run:

```
......................*.....Dropped database 'FREEPDB1'
....Dropped database 'FREEPDB1'
```

`DatabaseTasks.verbose?` reads `ENV["VERBOSE"]`, defaulting to true. Default it to `"false"` once in `spec_helper.rb` so the announcement is suppressed during specs. Use `||=` so a `VERBOSE=true bundle exec rspec ...` run still gets the announcements when someone is debugging.

## Before / after

Before:
```
......................*.....Dropped database 'FREEPDB1'
....Dropped database 'FREEPDB1'
```

After:
```
.................................*.........
```

## Test plan

- [x] `bundle exec rubocop` — clean
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb spec/active_record/connection_adapters/oracle_enhanced/dbms_metadata_structure_dump_spec.rb` — 38 examples, 1 pending unrelated, 0 failures, no "Dropped/Created database" leaks
- [ ] CI on full matrix
