### PR TITLE
Remove unused remove_column_for_alter override

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -997,10 +997,6 @@ module ActiveRecord
             schema_creation.accept(cd)
           end
 
-          def remove_column_for_alter(table_name, column_name, type = nil, **options)
-            quote_column_name(column_name)
-          end
-
           # Returns true when the op needs the full `add_column` /
           # `change_column` path (not the bulk fragment) because those
           # methods issue extra SQL after the ALTER TABLE that the


### PR DESCRIPTION
## Summary

The oracle-enhanced override of `remove_column_for_alter` was kept when `bulk_change_table` (#2737) was first drafted, in case the bulk dispatcher needed it. The final dispatcher routes column drops through `remove_columns(table_name, *col_names)` and never calls `remove_column_for_alter`, leaving the override with no in-tree callers.

```ruby
# lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
def remove_column_for_alter(table_name, column_name, type = nil, **options)
  quote_column_name(column_name)
end
```

`remove_column_for_alter` is `private` in both [Active Record core](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb) and oracle-enhanced — not a public API. Removing the override means any subsequent caller gets AR core's default (`"DROP COLUMN <quoted_name>"`), which is the expected Rails contract.

The two sibling helpers (`add_column_for_alter`, `change_column_for_alter`) are still in active use by the bulk dispatcher's add and modify buckets, so this PR removes only the unused one.

## Test plan

- [x] `bundle exec rubocop` — clean
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb` — 187 examples, 1 pending unrelated, 0 failures
- [x] `bundle exec ruby -Ilib ci/check_method_signatures.rb` — `OK: every overridden method matches the Rails counterpart's signature.`
- [ ] CI on full matrix
