### PR TITLE
bulk_change_table Phase 2: change_column_default / change_column_null

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -569,6 +569,8 @@ module ActiveRecord
         SUPPORTED_BULK_COMMANDS = %i[
           add_column
           change_column
+          change_column_default
+          change_column_null
           remove_column
           remove_columns
         ].freeze
@@ -605,7 +607,7 @@ module ActiveRecord
               else
                 flush_bulk_drops(table_name, drop_buf)
                 add_buf << add_column_for_alter(table_name, *args)
-                add_pending << column_name.to_s
+                add_pending << quote_column_name(column_name)
               end
             when :change_column
               column_name, type, options = args[0], args[1], (args[2] || {})
@@ -615,13 +617,36 @@ module ActiveRecord
                 change_column(table_name, column_name, type, **options)
               else
                 flush_bulk_drops(table_name, drop_buf)
-                # `change_column_for_alter` -> `column_for` reads the live
-                # catalog, so a same-block ADD must commit first.
-                if add_pending.any? { |c| c.casecmp?(column_name.to_s) }
+                if needs_pre_modify_flush?(add_buf, modify_buf, add_pending, column_name)
                   flush_bulk_add_modify(table_name, add_buf, modify_buf)
                   add_pending.clear
                 end
                 modify_buf << change_column_for_alter(table_name, *args)
+              end
+            when :change_column_default
+              column_name = args[0]
+              flush_bulk_drops(table_name, drop_buf)
+              if needs_pre_modify_flush?(add_buf, modify_buf, add_pending, column_name)
+                flush_bulk_add_modify(table_name, add_buf, modify_buf)
+                add_pending.clear
+              end
+              modify_buf << change_column_default_for_alter(table_name, *args)
+            when :change_column_null
+              column_name, null, default = args[0], args[1], args[2]
+              if !null && !default.nil?
+                # change_column_null with a default value runs an UPDATE before
+                # the MODIFY to backfill NULLs, which can't combine into ALTER.
+                flush_bulk_buffers(table_name, add_buf, modify_buf, drop_buf)
+                add_pending.clear
+                change_column_null(table_name, column_name, null, default)
+              else
+                flush_bulk_drops(table_name, drop_buf)
+                if needs_pre_modify_flush?(add_buf, modify_buf, add_pending, column_name)
+                  flush_bulk_add_modify(table_name, add_buf, modify_buf)
+                  add_pending.clear
+                end
+                fragment = change_column_null_for_alter(table_name, *args)
+                modify_buf << fragment if fragment
               end
             when :remove_column
               flush_bulk_add_modify(table_name, add_buf, modify_buf)
@@ -997,6 +1022,37 @@ module ActiveRecord
             schema_creation.accept(cd)
           end
 
+          # Bare-fragment helpers used only by `bulk_change_table`. AR core
+          # defines methods of the same name with different return shapes
+          # (a SchemaCreation node for default; a Proc-or-string sentinel
+          # for null). These overrides intentionally diverge — keep them
+          # private so AR core's contract is unaffected.
+          # Both fragments include the column's SQL type to match the
+          # non-bulk `change_column` shape (`MODIFY col TYPE …`); see the
+          # ORA-02264 / Oracle 11g caveat documented on
+          # `change_column_null_for_alter` below.
+          def change_column_default_for_alter(table_name, column_name, default_or_changes) # :nodoc:
+            column = column_for(table_name, column_name)
+            default = extract_new_default_value(default_or_changes)
+            "#{quote_column_name(column_name)} #{column.sql_type} DEFAULT #{quote(default)}"
+          end
+
+          # Returns nil when the requested nullability already matches the
+          # column read from the data dictionary, so the dispatcher can
+          # skip the MODIFY entirely.
+          # Mirrors the redundancy guard `change_column` uses to avoid
+          # ORA-01451 (already nullable) / ORA-01442 (already NOT NULL).
+          # Includes the column's SQL type in the fragment to match the
+          # non-bulk `change_column` path (`MODIFY col TYPE NOT NULL`);
+          # the bare-column form `MODIFY col NOT NULL` triggers ORA-02264
+          # on Oracle 11g (constraint-name auto-generation reuses an
+          # existing implicit constraint name when the type is omitted).
+          def change_column_null_for_alter(table_name, column_name, null, default = nil) # :nodoc:
+            column = column_for(table_name, column_name)
+            return nil if column.null == null
+            "#{quote_column_name(column_name)} #{column.sql_type} #{null ? 'NULL' : 'NOT NULL'}"
+          end
+
           # Returns true when the op needs the full `add_column` /
           # `change_column` path (not the bulk fragment) because those
           # methods issue extra SQL after the ALTER TABLE that the
@@ -1027,6 +1083,35 @@ module ActiveRecord
             return true if default_tablespaces.key?(type_sym)
             sql_type_sym = (type_to_sql(type).downcase.to_sym rescue nil)
             sql_type_sym && default_tablespaces.key?(sql_type_sym)
+          end
+
+          # True if a fragment targeting *this same* `column_name` is already
+          # queued in `modify_buf`. Each fragment built by the `*_for_alter`
+          # helpers starts with the quoted column name followed by a space,
+          # so a prefix scan is enough. Used to avoid emitting
+          # `MODIFY ("X" DEFAULT 1, "X" NOT NULL)` (ORA-00957).
+          def column_in_modify_buf?(modify_buf, column_name)
+            prefix = "#{quote_column_name(column_name)} "
+            modify_buf.any? { |frag| frag.start_with?(prefix) }
+          end
+
+          # Returns true if pushing another fragment to `modify_buf` should
+          # be preceded by a flush. Three triggers:
+          # 1. `column_name` is queued in `add_buf` — `column_for` would not
+          #    yet see the column, and the `MODIFY` would not be valid until
+          #    the ADD commits.
+          # 2. `column_name` is already in `modify_buf` — duplicate column
+          #    references inside `MODIFY (...)` raise ORA-00957.
+          # 3. Both `add_buf` and `modify_buf` are non-empty — Oracle 11g
+          #    rejects `ALTER TABLE ADD (...) MODIFY (col1 ..., col2 ...)`
+          #    (combined ADD with multi-column MODIFY) with ORA-02264, even
+          #    though 12c+ accept it. Splitting forces single-column MODIFY
+          #    when an ADD is in flight, which 11g handles cleanly.
+          def needs_pre_modify_flush?(add_buf, modify_buf, add_pending, column_name)
+            return true if add_pending.include?(quote_column_name(column_name))
+            return true if column_in_modify_buf?(modify_buf, column_name)
+            return true if add_buf.any? && modify_buf.any?
+            false
           end
 
           def flush_bulk_add_modify(table_name, add_buf, modify_buf)

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -1019,6 +1019,187 @@ RSpec.describe "OracleEnhancedAdapter schema definition" do
       expect(col.sql_type).to match(/VARCHAR2\(8\)/i)
       expect(col.null).to be(false)
     end
+
+    it "combines change_column_default and change_column_null into a single MODIFY clause" do
+      sqls = []
+      ActiveSupport::Notifications.subscribed(->(_n, _s, _f, _id, payload) { sqls << payload[:sql] if payload[:sql]&.include?("ALTER TABLE") }, "sql.active_record") do
+        @conn.change_table :test_bulk, bulk: true do |t|
+          t.change_default :qty, 42
+          t.change_null :name, false
+        end
+      end
+      modify_alters = sqls.grep(/ALTER TABLE.*\bMODIFY\b/i)
+      expect(modify_alters.size).to eq(1)
+      expect(modify_alters.first).to match(/MODIFY \(.*qty.*DEFAULT.*42.*name.*NOT NULL.*\)/i)
+
+      cols = @conn.columns(:test_bulk).index_by(&:name)
+      expect(cols["qty"].default.to_i).to eq(42)
+      expect(cols["name"].null).to be(false)
+    end
+
+    it "combines add_column with change_column_default in a single ALTER" do
+      sqls = []
+      ActiveSupport::Notifications.subscribed(->(_n, _s, _f, _id, payload) { sqls << payload[:sql] if payload[:sql]&.include?("ALTER TABLE") }, "sql.active_record") do
+        @conn.change_table :test_bulk, bulk: true do |t|
+          t.string :added_col
+          t.change_default :qty, 7
+        end
+      end
+      expect(sqls.size).to eq(1)
+      expect(sqls.first).to match(/\AALTER TABLE.*ADD \(.*added_col.*\) MODIFY \(.*qty.*DEFAULT.*7.*\)\z/im)
+
+      cols = @conn.columns(:test_bulk).index_by(&:name)
+      expect(cols).to include("added_col")
+      expect(cols["qty"].default.to_i).to eq(7)
+    end
+
+    it "routes change_column_null through the full path when a default value is given (backfill UPDATE)" do
+      sqls = []
+      ActiveSupport::Notifications.subscribed(->(_n, _s, _f, _id, payload) { sqls << payload[:sql] if payload[:sql] }, "sql.active_record") do
+        @conn.change_table :test_bulk, bulk: true do |t|
+          t.change_null :qty, false, 0
+        end
+      end
+      # The full change_column_null path issues UPDATE then MODIFY.
+      expect(sqls.any? { |s| s.match?(/UPDATE.*test_bulk.*SET.*qty/i) }).to be(true)
+      expect(sqls.any? { |s| s.match?(/ALTER TABLE.*MODIFY.*qty.*NOT NULL/i) }).to be(true)
+
+      col = @conn.columns(:test_bulk).find { |c| c.name == "qty" }
+      expect(col.null).to be(false)
+    end
+
+    it "flushes the queued ADD when bulk block sets default on a just-added column" do
+      sqls = []
+      ActiveSupport::Notifications.subscribed(->(_n, _s, _f, _id, payload) { sqls << payload[:sql] if payload[:sql]&.include?("ALTER TABLE") }, "sql.active_record") do
+        @conn.change_table :test_bulk, bulk: true do |t|
+          t.integer :counter
+          t.change_default :counter, 5
+        end
+      end
+      add_alters = sqls.grep(/ALTER TABLE.*\bADD\b/i)
+      modify_alters = sqls.grep(/ALTER TABLE.*\bMODIFY\b/i)
+      expect(add_alters.size).to eq(1)
+      expect(modify_alters.size).to eq(1)
+
+      col = @conn.columns(:test_bulk).find { |c| c.name == "counter" }
+      expect(col.default.to_i).to eq(5)
+    end
+
+    it "flushes the queued ADD when bulk block sets NOT NULL on a just-added column" do
+      sqls = []
+      ActiveSupport::Notifications.subscribed(->(_n, _s, _f, _id, payload) { sqls << payload[:sql] if payload[:sql]&.include?("ALTER TABLE") }, "sql.active_record") do
+        @conn.change_table :test_bulk, bulk: true do |t|
+          t.string :late_addition
+          t.change_null :late_addition, false
+        end
+      end
+      # `change_column_null_for_alter` calls `column_for`, which would not
+      # see the just-added column unless the dispatcher flushed the ADD
+      # first. Two ALTERs are expected: ADD then MODIFY NOT NULL.
+      add_alters = sqls.grep(/ALTER TABLE.*\bADD\b/i)
+      modify_alters = sqls.grep(/ALTER TABLE.*\bMODIFY\b/i)
+      expect(add_alters.size).to eq(1)
+      expect(modify_alters.size).to eq(1)
+
+      col = @conn.columns(:test_bulk).find { |c| c.name == "late_addition" }
+      expect(col).not_to be_nil
+      expect(col.null).to be(false)
+    end
+
+    it "skips a redundant change_null whose target matches the existing nullability" do
+      sqls = []
+      # `qty` is already nullable; asking for null: true is a no-op that
+      # the non-bulk path silently skips. The bulk path must do the same
+      # or Oracle raises ORA-01451 from MODIFY (col NULL).
+      ActiveSupport::Notifications.subscribed(->(_n, _s, _f, _id, payload) { sqls << payload[:sql] if payload[:sql]&.include?("ALTER TABLE") }, "sql.active_record") do
+        @conn.change_table :test_bulk, bulk: true do |t|
+          t.change_null :qty, true
+        end
+      end
+      expect(sqls).to be_empty
+    end
+
+    it "splits same-column change_default + change_null into separate ALTERs to avoid duplicate column in MODIFY" do
+      sqls = []
+      ActiveSupport::Notifications.subscribed(->(_n, _s, _f, _id, payload) { sqls << payload[:sql] if payload[:sql]&.include?("ALTER TABLE") }, "sql.active_record") do
+        @conn.change_table :test_bulk, bulk: true do |t|
+          t.change_default :qty, 9
+          t.change_null :qty, false
+        end
+      end
+      modify_alters = sqls.grep(/ALTER TABLE.*\bMODIFY\b/i)
+      expect(modify_alters.size).to eq(2)
+      # Each ALTER must reference qty exactly once — never duplicate it
+      # within a single MODIFY (..., ...) clause (ORA-00957 guard).
+      modify_alters.each do |sql|
+        expect(sql.scan(/"?QTY"?/i).size).to eq(1)
+      end
+      expect(modify_alters.first).to match(/DEFAULT.*9/i)
+      expect(modify_alters.last).to match(/NOT NULL/i)
+
+      col = @conn.columns(:test_bulk).find { |c| c.name == "qty" }
+      expect(col.default.to_i).to eq(9)
+      expect(col.null).to be(false)
+    end
+
+    it "splits duplicate change_default on the same column into separate ALTERs (last value wins on the table)" do
+      sqls = []
+      ActiveSupport::Notifications.subscribed(->(_n, _s, _f, _id, payload) { sqls << payload[:sql] if payload[:sql]&.include?("ALTER TABLE") }, "sql.active_record") do
+        @conn.change_table :test_bulk, bulk: true do |t|
+          t.change_default :qty, 1
+          t.change_default :qty, 2
+        end
+      end
+      modify_alters = sqls.grep(/ALTER TABLE.*\bMODIFY\b/i)
+      expect(modify_alters.size).to eq(2)
+
+      col = @conn.columns(:test_bulk).find { |c| c.name == "qty" }
+      expect(col.default.to_i).to eq(2)
+    end
+
+    it "preserves user order across an interleaved change_default + add_column + change_null block" do
+      sqls = []
+      ActiveSupport::Notifications.subscribed(->(_n, _s, _f, _id, payload) { sqls << payload[:sql] if payload[:sql]&.include?("ALTER TABLE") }, "sql.active_record") do
+        @conn.change_table :test_bulk, bulk: true do |t|
+          t.change_default :qty, 3
+          t.string :extra
+          t.change_null :name, false
+        end
+      end
+      # Oracle 11g rejects `ALTER TABLE ADD (...) MODIFY (col1 ..., col2 ...)`
+      # (ADD combined with multi-column MODIFY) with ORA-02264, even though
+      # 12c+ accept it. The dispatcher therefore flushes the pending ADD +
+      # first MODIFY before queuing the second MODIFY fragment, producing
+      # two ALTERs in user-specified order.
+      expect(sqls.size).to eq(2)
+      expect(sqls[0]).to match(/ADD \(.*extra.*\) MODIFY \(.*qty.*DEFAULT.*3.*\)/i)
+      expect(sqls[1]).to match(/MODIFY \(.*name.*NOT NULL.*\)/i)
+
+      cols = @conn.columns(:test_bulk).index_by(&:name)
+      expect(cols).to include("extra")
+      expect(cols["qty"].default.to_i).to eq(3)
+      expect(cols["name"].null).to be(false)
+    end
+
+    it "clears a default by emitting MODIFY (col DEFAULT NULL)" do
+      schema_define do
+        drop_table :test_bulk_clear, if_exists: true
+        create_table :test_bulk_clear, force: true do |t|
+          t.integer :n, default: 7
+        end
+      end
+
+      begin
+        @conn.change_table :test_bulk_clear, bulk: true do |t|
+          t.change_default :n, nil
+        end
+
+        col = @conn.columns(:test_bulk_clear).find { |c| c.name == "n" }
+        expect(col.default).to be_nil
+      ensure
+        schema_define { drop_table :test_bulk_clear, if_exists: true }
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Refs #2728. Phase 2 of the bulk_alter work; Phase 1 landed in #2737.

## Summary

Extend the bulk dispatcher to combine `:change_column_default` and `:change_column_null` operations into the existing `modify_buf` bucket. Both translate into Oracle `MODIFY` clauses that combine cleanly with other ADD/MODIFY ops in the same `ALTER TABLE` (with the Oracle 11g caveat noted under "Robustness").

Phase 1 deliberately raised `NotImplementedError` for these two so users had to issue them outside the bulk block. Phase 2 lifts that restriction:

| Migration call | Bulk SQL fragment |
|---|---|
| `t.change_default :col, value` | `MODIFY ("col" TYPE DEFAULT value)` |
| `t.change_null :col, null` | `MODIFY ("col" TYPE NULL\|NOT NULL)` |
| `t.change_null :col, false, default_val` (UPDATE backfill) | Routed through the **non-bulk** `change_column_null` path so the `UPDATE … SET col = default WHERE col IS NULL` fires before the MODIFY |

`SUPPORTED_BULK_COMMANDS` now includes `:change_column_default` and `:change_column_null`. The dispatcher reuses the existing same-block-flush guard so a `change_default` / `change_null` on a column added earlier in the same block flushes the queued ADD before constructing the MODIFY fragment (so `column_for` can see the new column).

## Robustness

- **Idempotency guard**: `change_column_null_for_alter` consults the live column and returns `nil` when the requested nullability already matches. The dispatcher skips the push, so a no-op `change_null :nullable_col, true` silently no-ops (same as the non-bulk path) instead of letting Oracle raise `ORA-01451 / ORA-01442`.
- **Same-column collision flush**: a new `column_in_modify_buf?` check on `:change_column` / `:change_column_default` / `:change_column_null` flushes the pending MODIFY whenever the same column would otherwise appear twice in `MODIFY (col …, col …)` (which Oracle rejects with `ORA-00957`). Same-column same-block operations therefore split into consecutive ALTERs, matching what users would get without `bulk: true`.
- **Oracle 11g `ADD + multi-column MODIFY` split**: Oracle 11g 11.2 raises `ORA-02264` on `ALTER TABLE … ADD (…) MODIFY (col1 …, col2 …)` (combined ADD with multi-column MODIFY), even though both 11g and 23ai SQL References list `MODIFY` clauses as syntactically valid in this form. The dispatcher therefore flushes the pending ADD + first MODIFY fragment before queuing a second MODIFY entry, producing one `ADD (…) MODIFY (col1 …)` ALTER followed by a separate `MODIFY (col2 …)` ALTER. Phase 1's single-column ADD + MODIFY fusion is unaffected. The workaround is unconditional rather than version-gated because the CI matrix has no rows between 11g and 23ai (no 12c/18c/19c/21c) — applying it on 12c+ costs at most one extra ALTER round-trip in the rare ADD + multi-MODIFY path, which is preferable to silent regressions on whichever intermediate release still carries the 11g behavior.

The two new `*_for_alter` helpers (`change_column_default_for_alter`, `change_column_null_for_alter`) include the column's SQL type in the fragment to match the non-bulk `change_column` shape (`MODIFY col TYPE …`) and carry `# :nodoc:` comments noting they intentionally diverge from AR core's helpers of the same name (which return SchemaCreation nodes / Procs). The bulk dispatcher is the only caller in this gem.

## Specs

`schema_statements_spec.rb` `bulk_change_table (Phase 1: add / change / remove column)` — 10 new tests bring the file total to 197:

- Combined `change_default` + `change_null` collapse into a single `ALTER TABLE … MODIFY (…)` statement.
- `add_column` + `change_default` combine into one ALTER with an `ADD (…)` clause and a `MODIFY (…)` clause.
- `change_column_null` with a default value runs the UPDATE backfill followed by the MODIFY through the full path.
- `change_column_default` on a column added in the same block flushes the queued ADD before the MODIFY so `column_for` lookups succeed.
- `change_column_null` on a column added in the same block flushes the queued ADD (symmetric to the change_default coverage above).
- Redundant `change_null :already_nullable_col, true` is silently skipped (no DDL).
- Same-column `change_default + change_null` splits into two ALTERs and each MODIFY references the column at most once.
- Duplicate `change_default + change_default` on the same column splits into two ALTERs (the second value sticks).
- Interleaved `change_default + add_column + change_null` on three different columns splits into two ALTERs (Oracle 11g ORA-02264 guard); the first ALTER fuses ADD with the first MODIFY, the second ALTER carries the standalone MODIFY for the third column.
- `change_default :col, nil` clears an existing default via `MODIFY (col DEFAULT NULL)`.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb` — 197 examples, 1 pending unrelated, 0 failures
- [x] `bundle exec ruby -Ilib ci/check_method_signatures.rb` — green
- [x] `bundle exec rubocop` — clean
- [x] CI on full matrix — 12/12 jobs pass (including `test_11g`)

## Out of scope (still Phase 2/3+)

- `t.timestamps` / `t.remove_timestamps` inside a bulk block (Phase 2 follow-up — pre-expand to `add_column` × 2 / `remove_column` × 2)
- `rename_column`, `add_index` / `remove_index`, FK / check constraints, `COMMENT ON …` — these cannot combine into a single `ALTER TABLE` on Oracle and continue to raise `NotImplementedError` from the pre-scan check.
