### PR TITLE
Reassign IGNORE_PAYLOAD_NAMES via remove_const + const_set

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -114,8 +114,19 @@ module LoggerSpecHelper
   end
 end
 
-ActiveRecord::LogSubscriber::IGNORE_PAYLOAD_NAMES.replace(["EXPLAIN"])
-ActiveRecord::StructuredEventSubscriber::IGNORE_PAYLOAD_NAMES.replace(["EXPLAIN"]) if defined?(ActiveRecord::StructuredEventSubscriber)
+# `IGNORE_PAYLOAD_NAMES` was made frozen on Rails main (the constant ships
+# as `["SCHEMA", "EXPLAIN"].freeze`), so `replace` raises `FrozenError` on
+# recent Rails. Drop "SCHEMA" by reassigning the constant via
+# `remove_const` + `const_set` so the override works on both old (mutable)
+# and new (frozen) Rails versions. Without "SCHEMA" in the ignore list,
+# specs can assert on schema-tagged catalog SQL emitted by the adapter.
+%w[ActiveRecord::LogSubscriber ActiveRecord::StructuredEventSubscriber].each do |const_name|
+  next unless Object.const_defined?(const_name)
+  klass = Object.const_get(const_name)
+  next unless klass.const_defined?(:IGNORE_PAYLOAD_NAMES, false)
+  klass.send(:remove_const, :IGNORE_PAYLOAD_NAMES)
+  klass.const_set(:IGNORE_PAYLOAD_NAMES, ["EXPLAIN"].freeze)
+end
 
 module SchemaSpecHelper
   def schema_define(&block)


### PR DESCRIPTION
## Summary

Rails main recently froze `ActiveRecord::LogSubscriber::IGNORE_PAYLOAD_NAMES` (and the matching `ActiveRecord::StructuredEventSubscriber::IGNORE_PAYLOAD_NAMES`). `spec/spec_helper.rb` was mutating those arrays in place to drop `"SCHEMA"` from the ignore list:

```ruby
ActiveRecord::LogSubscriber::IGNORE_PAYLOAD_NAMES.replace(["EXPLAIN"])
ActiveRecord::StructuredEventSubscriber::IGNORE_PAYLOAD_NAMES.replace(["EXPLAIN"]) if defined?(ActiveRecord::StructuredEventSubscriber)
```

That now raises `FrozenError` on every CI run against Rails main:

```
Failure/Error: ActiveRecord::LogSubscriber::IGNORE_PAYLOAD_NAMES.replace(["EXPLAIN"])
FrozenError
```

This blocks every PR's RSpec job (#2746 surfaced it).

Replace the in-place mutation with `remove_const` + `const_set` so the override works on both old (mutable) and new (frozen) Rails. The replacement array is frozen too, mirroring upstream's intent. Functionality is unchanged — `"SCHEMA"` is still removed from the ignore list so specs can assert on schema-tagged catalog SQL.

## Test plan

- [x] `bundle exec rubocop` — clean
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb` — 19 examples, 0 failures (sanity check that spec_helper still loads)
- [ ] CI on full matrix
