### PR TITLE
Enable Style/MutableConstant cop with literals style

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -139,6 +139,10 @@ Style/FrozenStringLiteralComment:
   Enabled: true
   EnforcedStyle: always
 
+Style/MutableConstant:
+  Enabled: true
+  EnforcedStyle: literals
+
 Style/MapToHash:
   Enabled: true
 

--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -36,7 +36,7 @@ CONNECTION_PARAMS = {
   port: DATABASE_PORT,
   username: DATABASE_USER,
   password: DATABASE_PASSWORD
-}
+}.freeze
 
 ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
 

--- a/guides/bug_report_templates/active_record_gem_spec.rb
+++ b/guides/bug_report_templates/active_record_gem_spec.rb
@@ -35,7 +35,7 @@ CONNECTION_PARAMS = {
   port: DATABASE_PORT,
   username: DATABASE_USER,
   password: DATABASE_PASSWORD
-}
+}.freeze
 
 ActiveRecord::Base.logger = Logger.new(STDOUT)
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/connection.rb
@@ -33,7 +33,7 @@ module ActiveRecord
       # ORA-03113 end-of-file on communication channel
       # ORA-03114 not connected to ORACLE
       # ORA-03135 connection lost contact
-      LOST_CONNECTION_ERROR_CODES = [28, 31, 1012, 3113, 3114, 3135] # :nodoc:
+      LOST_CONNECTION_ERROR_CODES = [28, 31, 1012, 3113, 3114, 3135].freeze # :nodoc:
 
       class ConnectionException < StandardError # :nodoc:
       end

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -578,7 +578,7 @@ module ActiveRecord
         # not return true for it (doing so would discard a live session).
         # Cursor#close tolerates 17009 separately as a cursor-local
         # concern.
-        JDBC_LOST_CONNECTION_ERROR_CODES = [17002, 17008]
+        JDBC_LOST_CONNECTION_ERROR_CODES = [17002, 17008].freeze
 
         # Fallback for older ojdbc that surfaces disconnects with
         # SQLException#getErrorCode == 0 and no ORA-NNNNN prefix in the

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -656,13 +656,13 @@ module ActiveRecord
         nls_timestamp_tz_format: nil,
         nls_time_format: nil,
         nls_time_tz_format: nil
-      }
+      }.freeze
 
       # :stopdoc:
       FIXED_NLS_PARAMETERS = {
         nls_date_format: "YYYY-MM-DD HH24:MI:SS",
         nls_timestamp_format: "YYYY-MM-DD HH24:MI:SS:FF6"
-      }
+      }.freeze
 
       # :stopdoc:
       NATIVE_DATABASE_TYPES = {
@@ -684,11 +684,11 @@ module ActiveRecord
         boolean: { name: "NUMBER", limit: 1 },
         raw: { name: "RAW", limit: 2000 },
         bigint: { name: "NUMBER", limit: 19 }
-      }
+      }.freeze
       # if emulate_booleans_from_strings then store booleans in VARCHAR2
       NATIVE_DATABASE_TYPES_BOOLEAN_STRINGS = NATIVE_DATABASE_TYPES.dup.merge(
         boolean: { name: "VARCHAR2", limit: 1 }
-      )
+      ).freeze
       # :startdoc:
 
       def native_database_types # :nodoc:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -63,7 +63,7 @@ module LoggerSpecHelper
   end
 
   class MockLogger
-    LEVELS = %i[debug info warn error fatal unknown]
+    LEVELS = %i[debug info warn error fatal unknown].freeze
 
     attr_reader :flush_count
 
@@ -175,7 +175,7 @@ DATABASE_PASSWORD     = config["database"]["password"]     || ENV["DATABASE_PASS
 DATABASE_SCHEMA       = config["database"]["schema"]       || ENV["DATABASE_SCHEMA"]       || "oracle_enhanced_schema"
 DATABASE_SYS_PASSWORD = config["database"]["sys_password"] || ENV["DATABASE_SYS_PASSWORD"] || "admin"
 
-CONNECTION_PARAMS = {
+connection_params = {
   adapter: "oracle_enhanced",
   database: DATABASE_NAME,
   host: DATABASE_HOST,
@@ -185,9 +185,11 @@ CONNECTION_PARAMS = {
 }
 
 if ENV["ORACLE_ENHANCED_PREPARED_STATEMENTS_FALSE"]
-  CONNECTION_PARAMS[:prepared_statements] = false
+  connection_params[:prepared_statements] = false
   puts "==> Forcing prepared_statements: false via ORACLE_ENHANCED_PREPARED_STATEMENTS_FALSE"
 end
+
+CONNECTION_PARAMS = connection_params.freeze
 
 CONNECTION_WITH_SCHEMA_PARAMS = {
   adapter: "oracle_enhanced",
@@ -197,7 +199,7 @@ CONNECTION_WITH_SCHEMA_PARAMS = {
   username: DATABASE_USER,
   password: DATABASE_PASSWORD,
   schema: DATABASE_SCHEMA
-}
+}.freeze
 
 CONNECTION_WITH_TIMEZONE_PARAMS = {
   adapter: "oracle_enhanced",
@@ -207,7 +209,7 @@ CONNECTION_WITH_TIMEZONE_PARAMS = {
   username: DATABASE_USER,
   password: DATABASE_PASSWORD,
   time_zone: "Europe/Riga"
-}
+}.freeze
 
 SYS_CONNECTION_PARAMS = {
   adapter: "oracle_enhanced",
@@ -217,7 +219,7 @@ SYS_CONNECTION_PARAMS = {
   username: "sys",
   password: DATABASE_SYS_PASSWORD,
   privilege: "SYSDBA"
-}
+}.freeze
 
 SYSTEM_CONNECTION_PARAMS = {
   adapter: "oracle_enhanced",
@@ -226,7 +228,7 @@ SYSTEM_CONNECTION_PARAMS = {
   port: DATABASE_PORT,
   username: "system",
   password: DATABASE_SYS_PASSWORD
-}
+}.freeze
 
 SERVICE_NAME_CONNECTION_PARAMS = {
   adapter: "oracle_enhanced",
@@ -235,7 +237,7 @@ SERVICE_NAME_CONNECTION_PARAMS = {
   port: DATABASE_PORT,
   username: DATABASE_USER,
   password: DATABASE_PASSWORD
-}
+}.freeze
 
 DATABASE_REMOTE_USER     = config["database"]["remote_user"]     || ENV["DATABASE_REMOTE_USER"]     || "oracle_enhanced_remote"
 DATABASE_REMOTE_PASSWORD = config["database"]["remote_password"] || ENV["DATABASE_REMOTE_PASSWORD"] || "oracle_enhanced_remote"
@@ -247,7 +249,7 @@ REMOTE_CONNECTION_PARAMS = {
   port: DATABASE_PORT,
   username: DATABASE_REMOTE_USER,
   password: DATABASE_REMOTE_PASSWORD
-}
+}.freeze
 
 DATABASE_NON_DEFAULT_TABLESPACE = config["database"]["non_default_tablespace"] || ENV["DATABASE_NON_DEFAULT_TABLESPACE"] || "SYSTEM"
 


### PR DESCRIPTION
## Summary

Mirror [rails/rails#57323](https://github.com/rails/rails/pull/57323): enable RuboCop's `Style/MutableConstant` cop with `EnforcedStyle: literals` and freeze every literal Array/Hash constant the cop flags. Keeps the gem's RuboCop config aligned with upstream Rails and makes these constants Ractor-shareable.

Related: #2747 (same theme — handling frozen constants).

## Changes

- `.rubocop.yml`: enable `Style/MutableConstant` with `EnforcedStyle: literals`.
- `lib/`: freeze 5 literal constants — `LOST_CONNECTION_ERROR_CODES`, `JDBC_LOST_CONNECTION_ERROR_CODES`, `DEFAULT_NLS_PARAMETERS`, `FIXED_NLS_PARAMETERS`, `NATIVE_DATABASE_TYPES`. Also freeze `NATIVE_DATABASE_TYPES_BOOLEAN_STRINGS` (a `.dup.merge` derivative the cop does not flag) so the adapter class stays Ractor-shareable end-to-end.
- `spec/spec_helper.rb`: freeze 7 connection-params constants and `LEVELS`. `CONNECTION_PARAMS` was previously mutated at load time when `ORACLE_ENHANCED_PREPARED_STATEMENTS_FALSE` is set; build the hash in a local, apply the conditional mutation and the boot-time `puts` inside the `if` block, then freeze it into the constant.
- `guides/bug_report_templates/`: freeze the two `CONNECTION_PARAMS` literals so the templates stay RuboCop-clean.

## Test plan

- [x] `bundle exec rubocop` — clean
- [x] `bundle exec rubocop --only Style/MutableConstant lib spec` — 0 offenses (cop is actually enforcing)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb` — 19 examples, 0 failures
- [x] `ORACLE_ENHANCED_PREPARED_STATEMENTS_FALSE=1 bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/database_tasks_spec.rb` — 19 examples, 0 failures (exercises the conditional branch)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb` — 69 examples, 0 failures, 1 unrelated pending
- [x] CI on full matrix — green (12/12) on squashed commit `da7f6759`
