### PR TITLE
bulk_change_table Phase 2: t.timestamps / t.remove_timestamps

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -568,11 +568,13 @@ module ActiveRecord
         # half-applies a migration.
         SUPPORTED_BULK_COMMANDS = %i[
           add_column
+          add_timestamps
           change_column
           change_column_default
           change_column_null
           remove_column
           remove_columns
+          remove_timestamps
         ].freeze
         private_constant :SUPPORTED_BULK_COMMANDS
 
@@ -587,6 +589,14 @@ module ActiveRecord
               "bulk_change_table only supports #{SUPPORTED_BULK_COMMANDS.inspect} " \
               "(got #{unsupported.first.inspect}); use change_table(bulk: false)"
           end
+
+          # Collect comments from `:add_timestamps` ops *before* expansion so
+          # the synthesised `:add_column` ops can drop `:comment` and stay on
+          # the bulk fragment path. The comments fire after the bulk ALTER
+          # via `apply_column_comments`, matching the non-bulk
+          # `add_timestamps` flow (1 combined ADD + N COMMENT ON COLUMN).
+          pending_timestamps_comments = collect_timestamps_comments(operations)
+          operations = expand_bulk_timestamps(operations)
 
           add_buf = []
           modify_buf = []
@@ -606,7 +616,7 @@ module ActiveRecord
                 add_column(table_name, column_name, type, **options)
               else
                 flush_bulk_drops(table_name, drop_buf)
-                add_buf << add_column_for_alter(table_name, *args)
+                add_buf << add_column_for_alter(table_name, column_name, type, **options)
                 add_pending << quote_column_name(column_name)
               end
             when :change_column
@@ -621,7 +631,7 @@ module ActiveRecord
                   flush_bulk_add_modify(table_name, add_buf, modify_buf)
                   add_pending.clear
                 end
-                modify_buf << change_column_for_alter(table_name, *args)
+                modify_buf << change_column_for_alter(table_name, column_name, type, **options)
               end
             when :change_column_default
               column_name = args[0]
@@ -662,6 +672,10 @@ module ActiveRecord
           end
 
           flush_bulk_buffers(table_name, add_buf, modify_buf, drop_buf)
+
+          pending_timestamps_comments.each do |comment|
+            apply_column_comments(table_name, :created_at, :updated_at, comment: comment)
+          end
         ensure
           clear_table_caches(table_name)
         end
@@ -1112,6 +1126,49 @@ module ActiveRecord
             return true if column_in_modify_buf?(modify_buf, column_name)
             return true if add_buf.any? && modify_buf.any?
             false
+          end
+
+          # Pre-expand `:add_timestamps` / `:remove_timestamps` into the
+          # underlying `:add_column` / `:remove_column` operations so the
+          # streaming dispatcher folds them into the same `ADD (...)` /
+          # `DROP (...)` buckets as ordinary column changes. Mirrors the
+          # defaults `AbstractAdapter#add_timestamps` would have applied
+          # (`null: false`, `precision: 6` when supported).
+          def expand_bulk_timestamps(operations)
+            operations.flat_map do |operation|
+              command, args, block = operation
+              case command
+              when :add_timestamps
+                table_name = args[0]
+                # Strip `:comment` here — it is applied after the bulk
+                # flush via `apply_column_comments` (Oracle has no inline
+                # `COMMENT` in ADD); see #2739 for the non-bulk equivalent.
+                options = args[1].is_a?(Hash) ? args[1].except(:comment) : {}
+                options[:null] = false if options[:null].nil?
+                options[:precision] = 6 if !options.key?(:precision) && supports_datetime_with_precision?
+                [
+                  [:add_column, [table_name, :created_at, :datetime, options], block],
+                  [:add_column, [table_name, :updated_at, :datetime, options], block],
+                ]
+              when :remove_timestamps
+                table_name = args[0]
+                [
+                  [:remove_column, [table_name, :updated_at], block],
+                  [:remove_column, [table_name, :created_at], block],
+                ]
+              else
+                [operation]
+              end
+            end
+          end
+
+          def collect_timestamps_comments(operations)
+            operations.each_with_object([]) do |(command, args, _block), acc|
+              next unless command == :add_timestamps
+              options = args[1]
+              next unless options.is_a?(Hash) && options.key?(:comment)
+              acc << options[:comment]
+            end
           end
 
           def flush_bulk_add_modify(table_name, add_buf, modify_buf)

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -1200,6 +1200,122 @@ RSpec.describe "OracleEnhancedAdapter schema definition" do
         schema_define { drop_table :test_bulk_clear, if_exists: true }
       end
     end
+
+    it "expands t.timestamps inside a bulk block into a single ALTER TABLE ADD (...)" do
+      sqls = []
+      ActiveSupport::Notifications.subscribed(->(_n, _s, _f, _id, payload) { sqls << payload[:sql] if payload[:sql]&.include?("ALTER TABLE") }, "sql.active_record") do
+        @conn.change_table :test_bulk, bulk: true do |t|
+          t.timestamps
+        end
+      end
+      expect(sqls.size).to eq(1)
+      expect(sqls.first).to match(/ADD \(.*created_at.*updated_at.*\)/i)
+      expect(sqls.first).to match(/NOT NULL/i)
+
+      cols = @conn.columns(:test_bulk).index_by(&:name)
+      expect(cols).to include("created_at", "updated_at")
+      expect(cols["created_at"].null).to be(false)
+      expect(cols["updated_at"].null).to be(false)
+    end
+
+    it "propagates t.timestamps options (null:, precision:) through the expansion" do
+      sqls = []
+      ActiveSupport::Notifications.subscribed(->(_n, _s, _f, _id, payload) { sqls << payload[:sql] if payload[:sql]&.include?("ALTER TABLE") }, "sql.active_record") do
+        @conn.change_table :test_bulk, bulk: true do |t|
+          t.timestamps null: true, precision: 3
+        end
+      end
+      expect(sqls.size).to eq(1)
+      expect(sqls.first).to match(/TIMESTAMP\(3\)/i)
+      expect(sqls.first).not_to match(/NOT NULL/i)
+
+      cols = @conn.columns(:test_bulk).index_by(&:name)
+      expect(cols["created_at"].null).to be(true)
+      expect(cols["updated_at"].null).to be(true)
+    end
+
+    it "fuses t.timestamps with t.string into a single ADD (...)" do
+      sqls = []
+      ActiveSupport::Notifications.subscribed(->(_n, _s, _f, _id, payload) { sqls << payload[:sql] if payload[:sql]&.include?("ALTER TABLE") }, "sql.active_record") do
+        @conn.change_table :test_bulk, bulk: true do |t|
+          t.string :note
+          t.timestamps
+        end
+      end
+      expect(sqls.size).to eq(1)
+      expect(sqls.first).to match(/ADD \(.*note.*created_at.*updated_at.*\)/i)
+
+      cols = @conn.columns(:test_bulk).map(&:name)
+      expect(cols).to include("note", "created_at", "updated_at")
+    end
+
+    it "applies t.timestamps comment as separate COMMENT ON COLUMN after the bulk ADD" do
+      sqls = []
+      ActiveSupport::Notifications.subscribed(->(_n, _s, _f, _id, payload) { sqls << payload[:sql] if payload[:sql] }, "sql.active_record") do
+        @conn.change_table :test_bulk, bulk: true do |t|
+          t.timestamps comment: "audit"
+        end
+      end
+
+      add_alters = sqls.grep(/ALTER TABLE.*\bADD\b/i)
+      comment_stmts = sqls.grep(/^COMMENT ON COLUMN/i)
+      # `:comment` is stripped before expansion so the ADD stays combined;
+      # the comment fires as separate COMMENT ON COLUMN statements (mirrors
+      # the non-bulk `add_timestamps` flow added in #2739).
+      expect(add_alters.size).to eq(1)
+      expect(add_alters.first).to match(/ADD \(.*created_at.*updated_at.*\)/i)
+      expect(comment_stmts.size).to eq(2)
+      expect(@conn.column_comment("test_bulk", "created_at")).to eq("audit")
+      expect(@conn.column_comment("test_bulk", "updated_at")).to eq("audit")
+    end
+
+    it "fires COMMENT ON COLUMN ... IS '' when t.timestamps comment: nil is passed in a bulk block" do
+      sqls = []
+      ActiveSupport::Notifications.subscribed(->(_n, _s, _f, _id, payload) { sqls << payload[:sql] if payload[:sql] }, "sql.active_record") do
+        @conn.change_table :test_bulk, bulk: true do |t|
+          t.timestamps comment: nil
+        end
+      end
+
+      add_alters = sqls.grep(/ALTER TABLE.*\bADD\b/i)
+      comment_stmts = sqls.grep(/^COMMENT ON COLUMN/i)
+      # `comment: nil` is the explicit-clear form that #2739's non-bulk
+      # `add_timestamps` translates into `COMMENT ON COLUMN ... IS ''`.
+      # The bulk path must keep the same parity — collect_timestamps_comments
+      # must not silently drop the nil sentinel.
+      expect(add_alters.size).to eq(1)
+      expect(comment_stmts.size).to eq(2)
+      expect(comment_stmts).to all(match(/IS\s+''/))
+      expect(@conn.column_comment("test_bulk", "created_at")).to be_nil
+      expect(@conn.column_comment("test_bulk", "updated_at")).to be_nil
+    end
+
+    it "expands t.remove_timestamps inside a bulk block into a single DROP (...)" do
+      schema_define do
+        drop_table :test_bulk_rm_ts, if_exists: true
+        create_table :test_bulk_rm_ts, force: true do |t|
+          t.string :name
+          t.timestamps
+        end
+      end
+
+      begin
+        sqls = []
+        ActiveSupport::Notifications.subscribed(->(_n, _s, _f, _id, payload) { sqls << payload[:sql] if payload[:sql]&.include?("ALTER TABLE") }, "sql.active_record") do
+          @conn.change_table :test_bulk_rm_ts, bulk: true do |t|
+            t.remove_timestamps
+          end
+        end
+        drops = sqls.grep(/ALTER TABLE.*\bDROP\b/i)
+        expect(drops.size).to eq(1)
+        expect(drops.first).to match(/DROP \(.*updated_at.*created_at.*\)/i)
+
+        cols = @conn.columns(:test_bulk_rm_ts).map(&:name)
+        expect(cols).not_to include("created_at", "updated_at")
+      ensure
+        schema_define { drop_table :test_bulk_rm_ts, if_exists: true }
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Refs #2728. Phase 2 follow-up — `:change_column_default` / `:change_column_null` shipped in #2746; this PR completes the Phase 2 promise from that PR's "Out of scope" section by adding `t.timestamps` / `t.remove_timestamps` support inside `change_table(bulk: true)`.

## Summary

Add `:add_timestamps` and `:remove_timestamps` to `SUPPORTED_BULK_COMMANDS` and pre-expand them into the underlying `:add_column` / `:remove_column` operations before the streaming dispatcher runs. With the expansion in place, `t.timestamps` and `t.remove_timestamps` fold into the same `ADD (…)` / `DROP (…)` buckets as ordinary column moves and combine cleanly with other column ops in the same `ALTER TABLE`.

| Migration call | Bulk SQL |
|---|---|
| `t.timestamps` | `ALTER TABLE t ADD ("created_at" TIMESTAMP(6) NOT NULL, "updated_at" TIMESTAMP(6) NOT NULL)` |
| `t.timestamps null: true, precision: 3` | `ALTER TABLE t ADD ("created_at" TIMESTAMP(3), "updated_at" TIMESTAMP(3))` |
| `t.timestamps comment: "audit"` | `ALTER TABLE t ADD (…created_at, updated_at…)` followed by two `COMMENT ON COLUMN … IS 'audit'` (mirrors the non-bulk `add_timestamps` flow from #2739) |
| `t.timestamps comment: nil` | Same shape; the two `COMMENT ON COLUMN … IS ''` statements clear any prior comment |
| `t.string :note; t.timestamps` | one `ALTER TABLE t ADD ("note" VARCHAR2(255), "created_at" …, "updated_at" …)` |
| `t.remove_timestamps` | `ALTER TABLE t DROP ("updated_at", "created_at") CASCADE CONSTRAINTS` |

Expansion details:

- `t.timestamps` → two synthesised `:add_column` ops (`created_at` then `updated_at`, both `:datetime`). Defaults mirror `AbstractAdapter#add_timestamps` (`null: false`, `precision: 6` when supported); explicit `null:` / `precision:` from the migration call are propagated.
- `:comment` is **stripped during expansion** and replayed *after* the bulk flush via `apply_column_comments(table_name, :created_at, :updated_at, comment: ...)` — that keeps the ADD combined (1 ALTER TABLE) and matches the non-bulk `add_timestamps` flow added in #2739. `comment: nil` is honored (clears existing comments via `COMMENT ON COLUMN … IS ''`).
- `t.remove_timestamps` → two `:remove_column` ops (`updated_at` then `created_at`), matching the non-bulk `remove_timestamps` ordering.

While here, the four column-fragment dispatch sites (`:add_column` / `:change_column`) switched from positional `*args` to explicit `column_name, type, **options`. Synthesised operations weren't necessarily `ruby2_keywords`-flagged, and the explicit `**` form removes the dependency on that quirk. Real AR-recorded operations round-trip cleanly through both call shapes.

## Specs

`schema_statements_spec.rb` `bulk_change_table (Phase 1: add / change / remove column)` — 6 new tests bring the file total to 203:

- `t.timestamps` inside a bulk block emits a single `ALTER TABLE ADD (created_at …, updated_at …)`.
- `t.timestamps null: true, precision: 3` propagates the options (column `null = true` and `TIMESTAMP(3)` are observable on the live columns).
- `t.timestamps` combined with `t.string` fuses into one `ADD (…)` carrying all three columns.
- `t.timestamps comment: "audit"` keeps the ADD combined and fires two `COMMENT ON COLUMN … IS 'audit'` after the bulk flush.
- `t.timestamps comment: nil` fires two `COMMENT ON COLUMN … IS ''` (clear-comment parity with the non-bulk `add_timestamps` path).
- `t.remove_timestamps` inside a bulk block emits a single `ALTER TABLE DROP (updated_at, created_at) CASCADE CONSTRAINTS` and clears both columns from the table.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb` — 203 examples, 1 pending unrelated, 0 failures
- [x] `bundle exec ruby -Ilib ci/check_method_signatures.rb` — green
- [x] `bundle exec rubocop` — clean
- [ ] CI on full matrix

## Known caveat

`t.timestamps comment: "x"` followed by `t.remove_timestamps` (or any subsequent op that drops `created_at` / `updated_at`) inside the same bulk block currently fires the `COMMENT ON COLUMN` statements *after* the drop, which targets non-existent columns and errors. This is a pathological sequence (adding timestamps with a comment then dropping them in the same block), but worth knowing. Tracked as a follow-up.

## Out of scope (still Phase 3+)

- `rename_column`, `add_index` / `remove_index`, FK / check constraints, `COMMENT ON …` — these cannot combine into a single `ALTER TABLE` on Oracle and continue to raise `NotImplementedError` from the pre-scan check.
- Per `project_bulk_alter_silent_fallback_review.md`, the raise-vs-silent-fallback question for the pre-scan is up for re-evaluation now that Phase 2's combinable surface is filled in. Tracked separately.
