### PR TITLE
Override supports_lazy_transactions? = true

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
@@ -187,6 +187,10 @@ module ActiveRecord # :nodoc:
 
       def log_custom_method(sql, name, &block)
         connection = self.class.lease_connection
+        # Custom create/update/delete blocks call ruby-plsql directly, bypassing
+        # AR's exec path. Flush any buffered BEGIN here so the PL/SQL call lands
+        # inside the materialized transaction.
+        connection.materialize_transactions
         intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(
           adapter: connection, raw_sql: sql, name: name, binds: []
         )

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -497,6 +497,10 @@ module ActiveRecord
         true
       end
 
+      def supports_lazy_transactions? # :nodoc:
+        true
+      end
+
       def supports_transaction_isolation? # :nodoc:
         true
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced/lazy_transactions_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/lazy_transactions_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Ported from `activerecord/test/cases/transactions_test.rb` (Rails PR #32647).
+# Verifies the `supports_lazy_transactions?` contract on Oracle:
+#
+# - An empty transaction is not materialized (no `autocommit = false` toggle
+#   nor any `BEGIN`-equivalent fired).
+# - A DML statement inside the transaction triggers materialization.
+# - Savepoints / raising do not materialize on their own.
+# - Accessing `raw_connection` materializes and disables lazy transactions
+#   until the connection is checked back into the pool.
+# - `materialize_transactions` can be called manually.
+#
+# Unlike MySQL/PG, Oracle does not emit a literal `BEGIN` statement —
+# `begin_db_transaction` toggles the connection's autocommit flag. We
+# therefore assert against `current_transaction.materialized?` directly
+# rather than scanning SQL logs for `/BEGIN|COMMIT/i`.
+
+RSpec.describe "OracleEnhancedAdapter lazy transactions" do
+  include SchemaSpecHelper
+
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @conn = ActiveRecord::Base.lease_connection
+    schema_define do
+      drop_table :test_lazy_txn, if_exists: true
+      create_table :test_lazy_txn, force: true do |t|
+        t.string :name
+      end
+    end
+
+    class ::TestLazyTxnRecord < ActiveRecord::Base
+      self.table_name = "test_lazy_txn"
+    end
+  end
+
+  after(:all) do
+    Object.send(:remove_const, "TestLazyTxnRecord") if defined?(::TestLazyTxnRecord)
+    schema_define do
+      drop_table :test_lazy_txn, if_exists: true
+    end
+  end
+
+  before(:each) do
+    # `raw_connection` / `disable_lazy_transactions!` mutate per-checkout
+    # state that the pool only resets on checkin. Specs in this file may
+    # toggle that flag — return the connection to the pool and re-lease
+    # so each example starts with lazy transactions enabled.
+    ActiveRecord::Base.connection_pool.checkin(@conn)
+    @conn = ActiveRecord::Base.lease_connection
+    @conn.enable_lazy_transactions!
+  end
+
+  it "reports supports_lazy_transactions? as true" do
+    expect(@conn.supports_lazy_transactions?).to be(true)
+  end
+
+  # Rails core: test_empty_transaction_is_not_materialized
+  it "does not materialize an empty transaction" do
+    ActiveRecord::Base.transaction do
+      expect(@conn.current_transaction).not_to be_materialized
+    end
+  end
+
+  # Rails core: test_unprepared_statement_materializes_transaction
+  it "materializes the transaction when a query runs inside it" do
+    ActiveRecord::Base.transaction do
+      expect(@conn.current_transaction).not_to be_materialized
+      TestLazyTxnRecord.where("1 = 1").to_a
+      expect(@conn.current_transaction).to be_materialized
+    end
+  end
+
+  # Rails core: test_savepoint_does_not_materialize_transaction
+  it "does not materialize when only a nested savepoint runs" do
+    ActiveRecord::Base.transaction do
+      ActiveRecord::Base.transaction(requires_new: true) { }
+      expect(@conn.current_transaction).not_to be_materialized
+    end
+  end
+
+  # Rails core: test_raising_does_not_materialize_transaction
+  it "does not materialize when the block raises before any query" do
+    expect {
+      ActiveRecord::Base.transaction do
+        expect(@conn.current_transaction).not_to be_materialized
+        raise "expected"
+      end
+    }.to raise_error("expected")
+  end
+
+  # Rails core: test_accessing_raw_connection_materializes_transaction
+  it "materializes when raw_connection is accessed" do
+    ActiveRecord::Base.transaction do
+      expect(@conn.current_transaction).not_to be_materialized
+      @conn.raw_connection
+      expect(@conn.current_transaction).to be_materialized
+    end
+  end
+
+  # Rails core: test_accessing_raw_connection_disables_lazy_transactions
+  it "disables lazy transactions for the rest of the checkout after raw_connection access" do
+    @conn.raw_connection
+    ActiveRecord::Base.transaction do
+      expect(@conn.current_transaction).to be_materialized
+    end
+  end
+
+  # Rails core: test_checking_in_connection_reenables_lazy_transactions
+  it "re-enables lazy transactions when the connection is checked in to the pool" do
+    connection = ActiveRecord::Base.connection_pool.checkout
+    connection.raw_connection # disables lazy on this checkout
+    ActiveRecord::Base.connection_pool.checkin(connection)
+
+    ActiveRecord::Base.transaction do
+      expect(@conn.current_transaction).not_to be_materialized
+    end
+  end
+
+  # Rails core: test_transactions_can_be_manually_materialized
+  it "can be manually materialized via materialize_transactions" do
+    ActiveRecord::Base.transaction do
+      expect(@conn.current_transaction).not_to be_materialized
+      @conn.materialize_transactions
+      expect(@conn.current_transaction).to be_materialized
+    end
+  end
+
+  # Oracle-specific addenda: the pre-DML `not_to be_materialized` is the
+  # discriminator that fails when the flag flip is reverted; the post-DML
+  # `materialized?` + `autocommit?` pair sanity-checks the OCI/JDBC
+  # autocommit toggle in both directions.
+  it "rolls back DML inside a lazy transaction" do
+    before_count = TestLazyTxnRecord.count
+    expect {
+      ActiveRecord::Base.transaction do
+        expect(@conn.current_transaction).not_to be_materialized
+        TestLazyTxnRecord.create!(name: "rolled back")
+        expect(@conn.current_transaction).to be_materialized
+        expect(@conn.send(:_connection).autocommit?).to be(false)
+        raise "abort"
+      end
+    }.to raise_error("abort")
+    expect(TestLazyTxnRecord.count).to eq(before_count)
+  end
+
+  it "commits DML inside a lazy transaction" do
+    before_count = TestLazyTxnRecord.count
+    ActiveRecord::Base.transaction do
+      expect(@conn.current_transaction).not_to be_materialized
+      TestLazyTxnRecord.create!(name: "committed")
+      expect(@conn.current_transaction).to be_materialized
+      expect(@conn.send(:_connection).autocommit?).to be(false)
+    end
+    expect(TestLazyTxnRecord.count).to eq(before_count + 1)
+  ensure
+    TestLazyTxnRecord.delete_all
+  end
+end


### PR DESCRIPTION
Refs #2728 Tier 2. Prerequisite #2751 (route `raw_connection` through `with_raw_connection` + add the `disable_lazy_transactions!` / `@raw_connection_dirty = true` bookkeeping) is merged; this PR rebased onto master so the diff is now just the flag flip plus the `procedures.rb` fix-up and specs.

## Summary

Active Record's `Transaction#materialize` delays issuing `BEGIN` until the first DML when the adapter advertises `supports_lazy_transactions?` (PR rails/rails#32647). Oracle is compatible with that contract:

- `OracleEnhanced::DatabaseStatements#begin_db_transaction` flips `_connection.autocommit = false` without sending an explicit `BEGIN` keyword.
- Both connection backends expose the toggle: `OCIConnection#autocommit=` forwards to `@raw_connection.autocommit = value`, and `JDBCConnection#autocommit=` calls `@raw_connection.setAutoCommit(value)`.

Delaying the `autocommit = false` flip until the first DML therefore preserves the same transaction semantics on both backends — the connection is in autocommit mode while the transaction is lazy (no DML yet), and flips to non-autocommit just before AR's first DML runs.

## Adapter-side fix-up

`procedures.rb` (custom create / update / destroy methods) calls ruby-plsql blocks that talk to OCI8 / JDBC directly, bypassing AR's exec path and the buffered `materialize_transactions` call site. With lazy transactions on, the PL/SQL call lands on an autocommit connection and rollbacks become no-ops. The shared `log_custom_method` wrapper now calls `connection.materialize_transactions` before the PL/SQL block runs, so the buffered `begin_db_transaction` fires in time.

This regression is caught on the Oracle 11g (11.2.0.2 XE) CI row by the existing `procedures_spec.rb` after_create / after_update / after_destroy rollback tests. On 23ai (local FREEPDB1) the same tests happen to pass without the fix — the autocommit-toggle interaction with PL/SQL differs between 11.x and 12c+ — so the fix is also defensive against a 11g-only regression rather than something every backend reproduces.

The matching `raw_connection` change (route through `with_raw_connection`, add the AR core bookkeeping) shipped in #2751 and is now on master; nothing further to do in this PR for that path.

## Specs

A new `lazy_transactions_spec.rb` ports the relevant assertions from Rails core's `activerecord/test/cases/transactions_test.rb` (the rails/rails#32647 test additions) to the rspec / Oracle setup:

- `supports_lazy_transactions?` reports `true`.
- Empty transactions do not materialize.
- A query inside a transaction materializes it.
- A nested savepoint without queries does not materialize.
- A `raise` before any query does not materialize.
- Accessing `raw_connection` materializes and disables lazy for the rest of the checkout.
- Checking the connection back in re-enables lazy.
- `materialize_transactions` can be called manually.
- DML committed / rolled back inside a lazy transaction — the pre-DML `not_to be_materialized` assertion is the discriminator that fails when the flag flip is reverted; the post-DML `materialized?` + `autocommit?` pair sanity-checks the OCI/JDBC toggle in both directions.

Rails' SQL-log scans (`/BEGIN|COMMIT/i`) don't translate to Oracle because `begin_db_transaction` toggles autocommit rather than issuing a literal `BEGIN`; the specs assert against `current_transaction.materialized?` directly, which is the same predicate AR core uses for the underlying logic.

Verified sensitivity: reverting the `supports_lazy_transactions?` override fails 10 of 11 specs locally (the `disables lazy transactions for the rest of the checkout` spec at line 104 passes regardless — it exercises the #2751 short-circuit and is intentionally version-independent).

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/lazy_transactions_spec.rb` — 11 examples, 0 failures
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb spec/active_record/connection_adapters/oracle_enhanced/adapter_leasing_spec.rb` — green
- [x] Sensitivity: removing the override fails 10/11 lazy-transactions specs (addenda included)
- [x] `bundle exec rubocop` — clean (95 files inspected)
- [x] CI on full matrix — 12/12 pass (incl. 11g + 23ai rows × Ruby 3.3/3.4/4.0 + jruby-10.1.0.0)
