### PR TITLE
Route raw_connection through with_raw_connection

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -713,8 +713,11 @@ module ActiveRecord
 
       # return raw OCI8 or JDBC connection
       def raw_connection
-        verify!
-        _connection.raw_connection
+        with_raw_connection do |conn|
+          disable_lazy_transactions!
+          @raw_connection_dirty = true
+          conn.raw_connection
+        end
       end
 
       # Returns true if the connection is active.

--- a/spec/active_record/connection_adapters/oracle_enhanced/adapter_leasing_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/adapter_leasing_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Ported from activerecord/test/cases/connection_adapters/adapter_leasing_test.rb.
+RSpec.describe "OracleEnhancedAdapter leasing" do
+  before(:each) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @adapter = ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.new(CONNECTION_PARAMS)
+  end
+
+  it "starts out not in use and is in use after lease" do
+    expect(@adapter.in_use?).to be_falsey
+    @adapter.lease
+    expect(@adapter).to be_in_use
+  end
+
+  it "raises ActiveRecordError when leased twice without an intervening expire" do
+    @adapter.lease
+    expect { @adapter.lease }.to raise_error(ActiveRecord::ActiveRecordError)
+  end
+
+  it "clears in_use? after expire" do
+    @adapter.lease
+    expect(@adapter).to be_in_use
+    @adapter.expire
+    expect(@adapter.in_use?).to be_falsey
+  end
+end
+
+RSpec.describe "OracleEnhancedAdapter#raw_connection" do
+  before(:each) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @adapter = ActiveRecord::Base.lease_connection
+  end
+
+  it "routes through AR core's with_raw_connection wrapper" do
+    expect(@adapter).to receive(:with_raw_connection).and_call_original
+    @adapter.raw_connection
+  end
+
+  it "returns the bare OCI8 / JDBC driver, not the OracleEnhanced::Connection wrapper" do
+    raw = @adapter.raw_connection
+    expect(raw).not_to be_a(ActiveRecord::ConnectionAdapters::OracleEnhanced::Connection)
+  end
+
+  it "disables lazy transactions for the rest of the checkout" do
+    @adapter.raw_connection
+    expect(@adapter.transaction_manager.lazy_transactions_enabled?).to be(false)
+  end
+end


### PR DESCRIPTION
Prerequisite refactor lifted out of #2750 (`supports_lazy_transactions?` flag flip).

## Summary

`OracleEnhancedAdapter#raw_connection` reaches through the `OracleEnhanced::Connection` wrapper to the bare OCI8 / JDBC driver. The previous implementation called `verify!` directly and skipped the rest of AR core's raw-connection contract:

- the `@lock` synchronize that other adapters take on raw access
- the verify-then-reconnect retry handling
- `materialize_transactions` (the entry point AR core's `Transaction#materialize` depends on for the lazy-transactions flow)
- `disable_lazy_transactions!` + `@raw_connection_dirty = true` bookkeeping that `AbstractAdapter#raw_connection` performs by default (no-op until `supports_lazy_transactions?` flips to `true`, but kept in lockstep with AR core's contract regardless)
- exception translation through `translate_exception_class`

PG and MySQL just inherit AR core's `raw_connection`, which wraps the yield in `with_raw_connection` and performs the same two bookkeeping side effects. Do the same here while preserving the public semantic of returning the bare driver: yield through `with_raw_connection`, fire the bookkeeping (`disable_lazy_transactions!` + `@raw_connection_dirty = true`, matching `AbstractAdapter#raw_connection` line-for-line), and call `conn.raw_connection` on the wrapper that gets passed back.

References for the `with_raw_connection` contract:
- rails/rails#44576 "Defer verification of database connections" — introduces the wrapper.
- rails/rails@542f0951 — the commit that adds `with_raw_connection` and the lock / retry / materialize sequence other adapters depend on.

## Behaviour

- No observable change for existing callers. `verify!` still runs (now conditional, via `with_raw_connection`'s deferred-check path). The returned object is unchanged (bare OCI8 / JDBC instance). `disable_lazy_transactions!` and `materialize_transactions` are no-ops until `supports_lazy_transactions?` is overridden to `true`.
- The new path also holds `@lock` for the wrapped block, matching every other adapter's raw-handle access pattern.
- Lifts a prerequisite for the `supports_lazy_transactions?` flag flip — the AR core lazy-transactions contract requires `raw_connection` access to materialize any buffered transaction and disable further lazy buffering. Doing that here in isolation keeps the diff focused on contract alignment.

## Specs

`spec/active_record/connection_adapters/oracle_enhanced/adapter_leasing_spec.rb` (new):

- Sensitivity test: `disables lazy transactions for the rest of the checkout` — asserts `transaction_manager.lazy_transactions_enabled?` is `false` after `raw_connection`. Verified by reverting the bookkeeping lines: only this spec fails.
- Routing smoke test: `routes through AR core's with_raw_connection wrapper` — uses `expect(@adapter).to receive(:with_raw_connection).and_call_original`. Senses a future refactor that bypasses the wrapper.
- Return-type smoke test: `returns the bare OCI8 / JDBC driver, not the OracleEnhanced::Connection wrapper` — guards against accidentally yielding the wrapper.
- Ports `test_in_use?`, `test_lease_twice`, `test_expire_mutates_in_use` from Rails core's `activerecord/test/cases/connection_adapters/adapter_leasing_test.rb`. These exercise the inherited `lease` / `expire` / `in_use?` lifecycle that `with_raw_connection` depends on for lock acquisition; they pass with or without the refactor, kept as inherited-contract smoke coverage.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/adapter_leasing_spec.rb spec/active_record/connection_adapters/oracle_enhanced/procedures_spec.rb` — 22 examples, 0 failures
- [x] Sensitivity check: removing both bookkeeping lines fails exactly the new `disables lazy transactions for the rest of the checkout` spec
- [x] `bundle exec rubocop` — clean
- [ ] CI on full matrix
