### PR TITLE
Override supports_materialized_views? = true

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -551,6 +551,10 @@ module ActiveRecord
         true
       end
 
+      def supports_materialized_views?
+        true
+      end
+
       def supports_fetch_first_n_rows_and_offset?
         return false unless @raw_connection
         database_version >= "12"

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -2902,6 +2902,10 @@ end
       end
     end
 
+    it "reports supports_materialized_views? as true" do
+      expect(@conn.supports_materialized_views?).to be(true)
+    end
+
     it "tables should not return materialized views" do
       expect(@conn.tables).not_to include("sum_test_employees")
     end


### PR DESCRIPTION
## Summary

Override `supports_materialized_views?` to `true` on `OracleEnhancedAdapter`. Oracle has had `CREATE MATERIALIZED VIEW` since 8i, and oracle-enhanced has had the supporting plumbing for years:

- Reader: `OracleEnhanced::SchemaStatements#materialized_views` (`lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:71`) — queries `all_mviews` filtered by the current schema.
- Schema dumper: excludes materialized views from the dumped table list (`lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb:19`).
- Existing spec coverage: `materialized_views should return materialized views` (`spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb:2909`).

The capability flag had simply not been flipped on the adapter, so AR core was reading the `AbstractAdapter` default of `false` and downstream code that asks `connection.supports_materialized_views?` was getting the wrong answer.

This is the same "the work was done years ago, the flag never caught up" pattern called out in #2728 (Tier 2 audit).

## Behaviour

Advertising-only on AR core's side: the Rails core `MaterializedViewTest` gate at `activerecord/test/cases/view_test.rb:212` is wrapped in a `PostgreSQLTestCase` class, so no AR core test starts running against Oracle from this flip. The visible change is that multi-DB Rails apps targeting Oracle as a secondary backend can drop `connection.adapter_name == "OracleEnhanced"` branches in favour of the capability check.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb -e "materialized views"` — 3 examples, 0 failures (new `reports supports_materialized_views? as true` spec + existing two)
- [x] `bundle exec rubocop lib/... spec/...` — clean
- [ ] CI on full matrix

## Refs

- #2728 — Tier 2 of the `supports_*?` capability audit
