### PR TITLE
Wire up insert_all / upsert_all via Oracle MERGE

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -222,11 +222,7 @@ module ActiveRecord
         end
 
         def build_insert_sql(insert) # :nodoc:
-          if insert.skip_duplicates? || insert.update_duplicates?
-            raise NotImplementedError,
-                  "Oracle insert_all does not yet support :on_duplicate (skip/update). " \
-                  "Use a MERGE statement directly until upsert_all support lands (tracked in #2733)."
-          end
+          return build_merge_sql(insert) if insert.skip_duplicates? || insert.update_duplicates?
 
           # INSERT ALL cannot carry RETURNING; `insert.returning` is dropped and `result.rows` is empty.
           rows_sql = compile_per_row_values(insert).map do |row_values|
@@ -404,15 +400,27 @@ module ActiveRecord
           # ActiveRecord::InsertAll::Builder#values_list applies before bundling
           # rows into a single `VALUES (...), (...)` fragment.
           def compile_per_row_values(insert)
+            rows = compile_per_row_coerced_values(insert)
+            rows.map { |row| visitor.compile(Arel::Nodes::ValuesList.new([row])) }
+          end
+
+          # Shared coercion used by both INSERT ALL (compile_per_row_values) and
+          # MERGE (compile_per_row_select_aliases). Returns Array<Array> where each
+          # inner array is a row of pre-quoting coerced values aligned with
+          # `keys_including_timestamps`.
+          def compile_per_row_coerced_values(insert)
             insert_all = insert.send(:insert_all)
-            keys = insert.send(:keys_including_timestamps)
-            # Delegate to AR core's check so unknown attributes raise
-            # `ActiveModel::UnknownAttributeError` locally rather than slipping
-            # through to Oracle as ORA-00904.
-            types = insert.send(:extract_types_for, keys)
+            keys = insert.keys_including_timestamps
+            # Raise early on unknown columns so callers get
+            # ActiveModel::UnknownAttributeError instead of ORA-00904. Mirrors
+            # the guard inside AR core's private Builder#extract_types_for.
+            unknown_column = (keys - insert.model.columns_hash.keys).first
+            raise ActiveModel::UnknownAttributeError.new(insert.model.new, unknown_column) if unknown_column
+
+            types = keys.index_with { |key| insert.model.type_for_attribute(key) }
             primary_keys = insert_all.primary_keys.to_set
 
-            rows = insert_all.send(:map_key_with_value) do |key, value|
+            insert_all.map_key_with_value do |key, value|
               if Arel::Nodes::SqlLiteral === value
                 value
               elsif primary_keys.include?(key) && value.nil?
@@ -422,8 +430,73 @@ module ActiveRecord
                 ActiveModel::Type::SerializeCastValue.serialize(type, type.cast(value))
               end
             end
+          end
 
-            rows.map { |row| visitor.compile(Arel::Nodes::ValuesList.new([row])) }
+          # Compile each insert row to `SELECT v1 AS col1, v2 AS col2 FROM DUAL`,
+          # the per-row shape Oracle MERGE's `USING (...) s` source needs. Combined
+          # with `UNION ALL` between rows in build_merge_sql.
+          def compile_per_row_select_aliases(insert)
+            aliases = insert.keys_including_timestamps.map { |k| quote_column_name(k) }
+            compile_per_row_coerced_values(insert).map do |row|
+              pairs = row.zip(aliases).map do |value, col_alias|
+                sql_value = Arel::Nodes::SqlLiteral === value ? visitor.compile(value) : quote(value)
+                "#{sql_value} AS #{col_alias}"
+              end
+              "SELECT #{pairs.join(", ")} FROM DUAL"
+            end
+          end
+
+          # Bridge AR's :skip / :update on_duplicate semantics to Oracle MERGE.
+          # `unique_by:` drives the ON clause; if omitted, falls back to the
+          # table's primary key (matches AR core's Builder#conflict_target for
+          # :update, and extends the same fallback to :skip — Oracle has no
+          # equivalent to PG's bare `ON CONFLICT DO NOTHING`). ON-clause columns
+          # are excluded from `WHEN MATCHED THEN UPDATE SET` (ORA-38104).
+          # RETURNING is not emitted (Oracle MERGE does not carry it in standard
+          # SQL); `result.rows` is empty, mirroring the existing INSERT ALL path.
+          def build_merge_sql(insert)
+            insert_all = insert.send(:insert_all)
+            on_columns = merge_on_columns(insert_all)
+
+            if on_columns.empty?
+              raise ArgumentError,
+                    "Oracle MERGE-based insert_all/upsert_all requires :unique_by or " \
+                    "a primary key to drive the ON clause; neither is available on " \
+                    "#{insert_all.model.name}."
+            end
+
+            target = insert_all.model.quoted_table_name
+            keys = insert.keys_including_timestamps
+            quoted_cols = keys.map { |k| quote_column_name(k) }
+            using_select = compile_per_row_select_aliases(insert).join(" UNION ALL ")
+            on_clause = on_columns.map { |c|
+              q = quote_column_name(c)
+              "t.#{q} = s.#{q}"
+            }.join(" AND ")
+
+            sql = +"MERGE INTO #{target} t\nUSING (#{using_select}) s\nON (#{on_clause})\n"
+
+            if insert.update_duplicates?
+              on_set = on_columns.map { |c| c.to_s.downcase }.to_set
+              updatable = keys.reject { |k| on_set.include?(k.to_s.downcase) }
+              unless updatable.empty?
+                update_pairs = updatable.map { |k|
+                  q = quote_column_name(k)
+                  "t.#{q} = s.#{q}"
+                }.join(", ")
+                sql << "WHEN MATCHED THEN UPDATE SET #{update_pairs}\n"
+              end
+            end
+
+            insert_cols_csv = quoted_cols.join(", ")
+            insert_vals_csv = quoted_cols.map { |c| "s.#{c}" }.join(", ")
+            sql << "WHEN NOT MATCHED THEN INSERT (#{insert_cols_csv}) VALUES (#{insert_vals_csv})"
+            sql
+          end
+
+          def merge_on_columns(insert_all)
+            cols = insert_all.unique_by ? Array(insert_all.unique_by.columns) : Array(insert_all.primary_keys)
+            cols.map(&:to_s)
           end
       end
     end

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -539,6 +539,18 @@ module ActiveRecord
         true
       end
 
+      def supports_insert_on_duplicate_skip?
+        true
+      end
+
+      def supports_insert_on_duplicate_update?
+        true
+      end
+
+      def supports_insert_conflict_target?
+        true
+      end
+
       def supports_optimizer_hints?
         true
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -453,11 +453,88 @@ RSpec.describe "OracleEnhancedAdapter" do
       include_examples "insert_all! basics"
     end
 
-    it "raises NotImplementedError when build_insert_sql is reached with on_duplicate" do
-      insert = double(skip_duplicates?: true, update_duplicates?: false)
-      expect {
-        ActiveRecord::Base.lease_connection.build_insert_sql(insert)
-      }.to raise_error(NotImplementedError, /on_duplicate/)
+    describe "on_duplicate via Oracle MERGE" do
+      before(:all) do
+        schema_define do
+          create_table :test_merge_items, force: true do |t|
+            t.string :name
+            t.integer :qty
+          end
+        end
+        class ::TestMergeItem < ActiveRecord::Base
+        end
+      end
+
+      after(:all) do
+        schema_define do
+          drop_table :test_merge_items, if_exists: true
+        end
+        Object.send(:remove_const, "TestMergeItem") if defined?(TestMergeItem)
+        ActiveRecord::Base.clear_cache!
+      end
+
+      after(:each) { TestMergeItem.delete_all }
+
+      it "reports the three on_duplicate capability flags as true" do
+        conn = ActiveRecord::Base.lease_connection
+        expect(conn.supports_insert_on_duplicate_skip?).to be(true)
+        expect(conn.supports_insert_on_duplicate_update?).to be(true)
+        expect(conn.supports_insert_conflict_target?).to be(true)
+      end
+
+      it "skips rows whose unique_by conflicts with existing ones (insert_all default)" do
+        TestMergeItem.insert_all!([{ id: 100, name: "anchor", qty: 5 }])
+        TestMergeItem.insert_all(
+          [{ id: 100, name: "skip-this", qty: 99 }, { id: 101, name: "new", qty: 1 }],
+          unique_by: :id,
+        )
+        expect(TestMergeItem.find(100).name).to eq("anchor")
+        expect(TestMergeItem.find(100).qty).to eq(5)
+        expect(TestMergeItem.find(101).name).to eq("new")
+      end
+
+      it "updates matched rows and inserts the rest (upsert_all)" do
+        TestMergeItem.insert_all!([{ id: 200, name: "anchor", qty: 5 }])
+        TestMergeItem.upsert_all(
+          [{ id: 200, name: "updated", qty: 99 }, { id: 201, name: "fresh", qty: 1 }],
+          unique_by: :id,
+        )
+        expect(TestMergeItem.find(200).name).to eq("updated")
+        expect(TestMergeItem.find(200).qty).to eq(99)
+        expect(TestMergeItem.find(201).name).to eq("fresh")
+      end
+
+      # ORA-38104: a MERGE that lists an ON-clause column in WHEN MATCHED UPDATE
+      # SET is rejected by Oracle. Confirm the builder strips the unique_by
+      # column(s) from the UPDATE SET clause.
+      it "excludes the unique_by column from WHEN MATCHED THEN UPDATE SET" do
+        TestMergeItem.insert_all!([{ id: 300, name: "anchor", qty: 5 }])
+        expect {
+          TestMergeItem.upsert_all(
+            [{ id: 300, name: "renamed", qty: 50 }],
+            unique_by: :id,
+          )
+        }.not_to raise_error
+        expect(TestMergeItem.find(300).name).to eq("renamed")
+      end
+
+      it "falls back to the primary key when unique_by is omitted" do
+        TestMergeItem.insert_all!([{ id: 400, name: "anchor", qty: 5 }])
+        TestMergeItem.upsert_all([{ id: 400, name: "updated", qty: 50 }])
+        expect(TestMergeItem.find(400).name).to eq("updated")
+      end
+
+      it "preserves values containing parens and embedded single quotes" do
+        TestMergeItem.upsert_all(
+          [
+            { id: 500, name: "Hello (world)", qty: 10 },
+            { id: 501, name: "O'Reilly's", qty: 20 },
+          ],
+          unique_by: :id,
+        )
+        names = TestMergeItem.where(id: [500, 501]).order(:id).pluck(:name)
+        expect(names).to eq(["Hello (world)", "O'Reilly's"])
+      end
     end
 
     # Unit-level coverage of the helper that bridges AR core's bundled


### PR DESCRIPTION
Closes #2733 (Tier 3 of the supports_*? capability audit tracked in #2728).

## Summary

Wires up `Model.insert_all([...], unique_by: ...)` (default `:skip`) and `Model.upsert_all([...], unique_by: ...)` for Oracle by routing the `:skip` / `:update` `on_duplicate` paths through a new `build_merge_sql` builder. The placeholder `NotImplementedError` left behind by #2730 (the base `insert_all!` PR) is gone.

Flips three capability flags on the adapter:

- `supports_insert_on_duplicate_skip?` — `true`
- `supports_insert_on_duplicate_update?` — `true`
- `supports_insert_conflict_target?` — `true`

## How it works

`build_insert_sql` now dispatches to `build_merge_sql` whenever `insert.skip_duplicates?` or `insert.update_duplicates?` is true; otherwise the existing INSERT ALL multi-table form (from #2730) handles `:raise`.

`build_merge_sql` emits:

```sql
MERGE INTO t
USING (SELECT v1 AS col1, v2 AS col2 FROM DUAL UNION ALL ...) s
ON (t.unique_col = s.unique_col)
WHEN MATCHED THEN UPDATE SET t.x = s.x, ...   -- only when :update
WHEN NOT MATCHED THEN INSERT (col1, col2) VALUES (s.col1, s.col2)
```

Key design points:

- The MERGE USING source uses `SELECT ... FROM DUAL UNION ALL` (Oracle does not accept `VALUES (...), (...)` as a MERGE source).
- ON-clause columns are excluded from `WHEN MATCHED THEN UPDATE SET` (Oracle raises `ORA-38104` if they appear there), with case-insensitive matching against `keys_including_timestamps`.
- `unique_by:` drives the ON clause; if omitted, the table's primary key is the fallback. AR core's `Builder#conflict_target` falls back to PK only for `:update`; this PR extends the same fallback to `:skip` because Oracle has no equivalent to PG's bare `ON CONFLICT DO NOTHING` (no target).
- `RETURNING` is not emitted — Oracle MERGE does not carry it in standard SQL. `result.rows` is empty, mirroring the existing INSERT ALL path.

The shared coercion previously inlined in `compile_per_row_values` is extracted into `compile_per_row_coerced_values` and reused by a new `compile_per_row_select_aliases` helper, which produces the per-row `SELECT v1 AS col1, ... FROM DUAL` shape MERGE needs.

## Compatibility floor

The MERGE statement itself has been in Oracle since 9i Release 2 (9.2, 2002). The single-WHEN form the `:skip` path relies on (only `WHEN NOT MATCHED THEN INSERT`, no `WHEN MATCHED`) is explicitly documented as allowed in the Oracle 10g Release 1 SQL Reference (10.1, 2003). The CI matrix exercises 11.2.0.2 XE and 23ai, both comfortably above the 10gR1 floor, so no `database_version` gate is needed on the new `supports_*?` overrides.

- Oracle9i SQL Reference Release 2 (9.2), `MERGE`: https://docs.oracle.com/cd/B10501_01/server.920/a96540/statements_915a.htm
- Oracle Database SQL Reference 10g Release 1 (10.1), `MERGE` (*"You can specify this clause by itself or with the `merge_update_clause`"*): https://docs.oracle.com/cd/B14117_01/server.101/b10759/statements_9016.htm

## Behaviour differences from PG/MySQL

- **`updated_at` is bumped on every matched row, even when no non-key column changes.** AR core's `Builder#touch_model_timestamps_unless` (`activerecord/lib/active_record/insert_all.rb:282-290`) guards against this on PG/MySQL via `CASE WHEN no-real-change THEN keep ELSE bump`; this PR doesn't replicate that guard. Idempotent `upsert_all` calls will therefore touch `updated_at` on Oracle but leave it alone on PG/MySQL. Tracked as a follow-up in #2755.
- **`:skip` without `unique_by:` only skips primary-key collisions.** PG's bare `ON CONFLICT DO NOTHING` silently skips conflicts on *any* unique constraint; Oracle MERGE requires an explicit ON target, so this PR falls back to the primary key. Non-PK unique-index violations therefore propagate as `ORA-00001` on Oracle rather than being silently skipped. Pass `unique_by:` explicitly when targeting a non-PK unique index.

## Specs

The `raises NotImplementedError when build_insert_sql is reached with on_duplicate` spec is replaced by a new `on_duplicate via Oracle MERGE` describe block covering:

- The three capability flag overrides.
- `:skip` (default `insert_all`) with explicit `unique_by:`.
- `:update` (`upsert_all`) with explicit `unique_by:`.
- ON-clause column exclusion (the ORA-38104 regression guard).
- PK fallback when `unique_by:` is omitted.
- Value quoting (parens + embedded single quotes).

Sensitivity check: reverting the dispatch in `build_insert_sql` makes 4 of the 6 new specs fail.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb -e "insert_all"` — 18 examples, 0 failures
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb` — 278 examples, 0 failures, 2 unrelated pending
- [x] Sensitivity: reverting `build_merge_sql` dispatch fails 4/6 new specs
- [x] `bundle exec rubocop` — clean (95 files inspected)
- [ ] CI on full matrix

## Out of scope (deferred per #2733)

- `returning:` round-trip on bulk insert. Oracle MERGE / INSERT ALL cannot carry RETURNING in standard SQL. A per-row `INSERT ... RETURNING ... INTO :bind` fallback would be possible but degraded; not bundled here.
- Auto-PK substitution for sequence-via-trigger / IDENTITY tables. Callers must supply explicit IDs on the MERGE path, matching the existing INSERT ALL `insert_all!` scope from #2730.
- Conditional `updated_at` touch (the `Builder#touch_model_timestamps_unless` `CASE WHEN no-real-change` guard) — see "Behaviour differences" above; follow-up #2755.

## Refs

- #2728 — supports_*? capability audit (Tier 3)
- #2733 — issue this PR closes
- #2730 — base `insert_all!` via INSERT ALL (merged)
- #2731 — closed PoC; this PR shares its MERGE-builder shape, trimmed of auto-PK injection per #2733 scope
- #2755 — follow-up for conditional `updated_at` bump (PG/MySQL parity)
