### PR TITLE
Conditional updated_at bump on Oracle MERGE upsert

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -477,15 +477,8 @@ module ActiveRecord
             sql = +"MERGE INTO #{target} t\nUSING (#{using_select}) s\nON (#{on_clause})\n"
 
             if insert.update_duplicates?
-              on_set = on_columns.map { |c| c.to_s.downcase }.to_set
-              updatable = keys.reject { |k| on_set.include?(k.to_s.downcase) }
-              unless updatable.empty?
-                update_pairs = updatable.map { |k|
-                  q = quote_column_name(k)
-                  "t.#{q} = s.#{q}"
-                }.join(", ")
-                sql << "WHEN MATCHED THEN UPDATE SET #{update_pairs}\n"
-              end
+              update_pairs = merge_update_pairs(insert, on_columns)
+              sql << "WHEN MATCHED THEN UPDATE SET #{update_pairs}\n" unless update_pairs.empty?
             end
 
             insert_cols_csv = quoted_cols.join(", ")
@@ -497,6 +490,49 @@ module ActiveRecord
           def merge_on_columns(insert_all)
             cols = insert_all.unique_by ? Array(insert_all.unique_by.columns) : Array(insert_all.primary_keys)
             cols.map(&:to_s)
+          end
+
+          # Build the `WHEN MATCHED THEN UPDATE SET` clause. Auto-filled
+          # `updated_at`-style columns get a no-change CASE guard so idempotent
+          # upserts don't bump them — mirrors AR core's
+          # Builder#touch_model_timestamps_unless.
+          def merge_update_pairs(insert, on_columns)
+            on_set = on_columns.map { |c| c.to_s.downcase }.to_set
+            updatable = insert.keys_including_timestamps.reject { |k| on_set.include?(k.to_s.downcase) }
+            return "" if updatable.empty?
+
+            # `insert_all.updatable_columns` is `keys - readonly - unique_by` —
+            # user-supplied columns only, so auto-filled timestamps don't poison
+            # the no-change comparison.
+            user_updatable = insert.send(:insert_all).updatable_columns.map(&:to_s).reject { |k| on_set.include?(k.downcase) }
+            auto_filled_ts = auto_filled_update_timestamps(insert, updatable)
+            guard = no_change_predicate(user_updatable) unless user_updatable.empty?
+
+            updatable.map { |column|
+              q = quote_column_name(column)
+              if guard && auto_filled_ts.include?(column.to_s)
+                "t.#{q} = CASE WHEN #{guard} THEN t.#{q} ELSE s.#{q} END"
+              else
+                "t.#{q} = s.#{q}"
+              end
+            }.join(", ")
+          end
+
+          # AND-joined per-column NULL-safe equality between target (`t`) and
+          # source (`s`); drives the no-change CASE guard in merge_update_pairs.
+          def no_change_predicate(columns)
+            columns.map { |column|
+              q = quote_column_name(column)
+              "(t.#{q} = s.#{q} OR (t.#{q} IS NULL AND s.#{q} IS NULL))"
+            }.join(" AND ")
+          end
+
+          def auto_filled_update_timestamps(insert, updatable)
+            return [] unless insert.record_timestamps?
+
+            user_supplied = insert.keys.map(&:to_s).to_set
+            ts_cols = insert.model.timestamp_attributes_for_update_in_model.map(&:to_s).to_set
+            updatable.map(&:to_s).select { |k| ts_cols.include?(k) && !user_supplied.include?(k) }
           end
       end
     end

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -537,6 +537,58 @@ RSpec.describe "OracleEnhancedAdapter" do
       end
     end
 
+    # Mirrors AR core PG/MySQL's `Builder#touch_model_timestamps_unless`:
+    # `updated_at` is only bumped when a user-supplied column actually changes.
+    # See #2755 for the implementation rationale.
+    describe "on_duplicate via Oracle MERGE with timestamps" do
+      before(:all) do
+        schema_define do
+          create_table :test_merge_ts_items, force: true do |t|
+            t.string :name
+            t.integer :qty
+            t.timestamps
+          end
+        end
+        class ::TestMergeTsItem < ActiveRecord::Base
+        end
+      end
+
+      after(:all) do
+        schema_define do
+          drop_table :test_merge_ts_items, if_exists: true
+        end
+        Object.send(:remove_const, "TestMergeTsItem") if defined?(TestMergeTsItem)
+        ActiveRecord::Base.clear_cache!
+      end
+
+      after(:each) { TestMergeTsItem.delete_all }
+
+      it "keeps updated_at stable on an idempotent upsert_all" do
+        TestMergeTsItem.upsert_all([{ id: 1, name: "alpha", qty: 1 }], unique_by: :id)
+        before_ts = TestMergeTsItem.find(1).updated_at
+        sleep 0.1  # advance wall clock past TIMESTAMP precision
+        TestMergeTsItem.upsert_all([{ id: 1, name: "alpha", qty: 1 }], unique_by: :id)
+        expect(TestMergeTsItem.find(1).updated_at).to eq(before_ts)
+      end
+
+      it "bumps updated_at when a non-key column changes" do
+        TestMergeTsItem.upsert_all([{ id: 2, name: "alpha", qty: 1 }], unique_by: :id)
+        before_ts = TestMergeTsItem.find(2).updated_at
+        sleep 0.1
+        TestMergeTsItem.upsert_all([{ id: 2, name: "beta", qty: 2 }], unique_by: :id)
+        expect(TestMergeTsItem.find(2).updated_at).to be > before_ts
+      end
+
+      it "respects an explicit updated_at value supplied by the caller" do
+        explicit = Time.utc(2020, 1, 1, 12, 0, 0)
+        TestMergeTsItem.upsert_all(
+          [{ id: 3, name: "alpha", qty: 1, updated_at: explicit }],
+          unique_by: :id,
+        )
+        expect(TestMergeTsItem.find(3).updated_at.utc).to eq(explicit)
+      end
+    end
+
     # Unit-level coverage of the helper that bridges AR core's bundled
     # values_list to Oracle's per-row INSERT ALL form. Locks in the per-row
     # split shape and the value-quoting behavior so a regression in either


### PR DESCRIPTION
Closes #2755 — follow-up to #2754 that closes the `updated_at` divergence noted in the "Behaviour differences from PG/MySQL" section of that PR.

## Summary

On the `WHEN MATCHED THEN UPDATE SET` clause of the MERGE statement, AR-auto-filled `timestamp_attributes_for_update_in_model` columns (typically `updated_at`) are now wrapped in a `CASE WHEN no-real-change THEN keep ELSE bump END` guard. Idempotent `upsert_all` calls therefore leave `updated_at` stable on Oracle, matching AR core PG/MySQL behaviour driven by `Builder#touch_model_timestamps_unless` (`activerecord/lib/active_record/insert_all.rb:282-290`).

## How it works

`build_merge_sql` now routes the matched-update assignments through a new private helper `merge_update_pairs`. For each updatable column:

- **Auto-filled timestamps** (`updated_at`-style columns AR injected when the user did not pass them) get the guarded form:
  ```sql
  t.updated_at = CASE
    WHEN (t.name = s.name OR (t.name IS NULL AND s.name IS NULL))
     AND (t.qty  = s.qty  OR (t.qty  IS NULL AND s.qty  IS NULL))
    THEN t.updated_at      -- no real change → keep
    ELSE s.updated_at      -- non-key column changed → bump
  END
  ```
- **Everything else** stays as the simple `t.col = s.col` form, unchanged from #2754.

Key implementation choices:

- **NULL-safe equality written explicitly** as `(t.col = s.col OR (t.col IS NULL AND s.col IS NULL))`. Oracle 23ai added `IS NOT DISTINCT FROM` but `:skip` already targets the 10gR1+ floor established in #2754, so the SQL stays portable across the supported range.
- **The no-change comparison uses `insert_all.updatable_columns`** (user-supplied columns only), not `keys_including_timestamps`. `created_at` / `updated_at` always carry a fresh quoted timestamp literal in the per-row `SELECT ... FROM DUAL` source, so including them in the comparison would defeat the guard.
- **The "bump" branch reads from `s.col`** rather than emitting a duplicate timestamp literal in the matched-update clause. `compile_per_row_select_aliases` already carries the quoted timestamp literal AR core produced once during statement build; reusing it keeps the matched-update value bit-identical to what `WHEN NOT MATCHED THEN INSERT` writes.
- **Caller-supplied `updated_at` is respected**: the guard fires only when the column is in `keys_including_timestamps` but NOT in `keys` (i.e., AR auto-filled, user did not pass it). Explicit `updated_at:` values flow through the regular `t.updated_at = s.updated_at` assignment.
- **`user_updatable.empty?` falls through to always-bump**. If there is nothing to compare, the guard would have no inputs — AR core PG's `touch_model_timestamps_unless` emits a broken `CASE WHEN () THEN … ELSE … END` in the same edge case; this PR's fallback is intentionally a small improvement.

## Specs

New `on_duplicate via Oracle MERGE with timestamps` describe block in `spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb`:

- `keeps updated_at stable on an idempotent upsert_all` — sensitivity guard. Reverting `merge_update_pairs` to the unconditional form makes this spec fail (and only this spec).
- `bumps updated_at when a non-key column changes` — scope anchor; confirms the guard doesn't over-fire.
- `respects an explicit updated_at value supplied by the caller` — scope anchor; the explicit value flows through the regular `t.col = s.col` path.

## Test plan

- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb -e "on_duplicate via Oracle MERGE"` — 9 examples, 0 failures (6 from #2754 + 3 new)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb` — 77 examples, 0 failures, 1 unrelated pending
- [x] Sensitivity: reverting `merge_update_pairs` to unconditional form fails only `keeps updated_at stable`
- [x] `bundle exec rubocop` — clean
- [ ] CI on full matrix

## Out of scope (already documented in #2754)

- `returning:` round-trip on bulk insert.
- Auto-PK substitution for sequence-via-trigger / IDENTITY tables.
- `created_at` overwrite on MATCHED rows — matches AR core PG/MySQL behaviour where `created_at` is in `keys_including_timestamps` and gets `excluded.created_at` (the source row's quoted timestamp literal). This PR keeps that behaviour; only the update-timestamp column is gated.

## Refs

- #2754 — Tier 3 MERGE PR; disclosed the divergence this PR closes
- #2755 — this issue
- AR core: `activerecord/lib/active_record/insert_all.rb` `Builder#touch_model_timestamps_unless` (lines 282-290 at the bundled SHA)
