### PR TITLE
Tidy _connection helper and align with upstream patterns

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -568,7 +568,7 @@ module ActiveRecord
       end
 
       def supports_fetch_first_n_rows_and_offset?
-        return false unless @raw_connection
+        return false unless _connection
         database_version >= "12"
       end
 
@@ -1092,7 +1092,7 @@ module ActiveRecord
       end
 
       def get_database_version # :nodoc:
-        _connection.database_version
+        with_raw_connection { |conn| conn.database_version }
       end
 
       def check_version # :nodoc:
@@ -1103,7 +1103,7 @@ module ActiveRecord
       end
 
       private def _connection
-        @unconfigured_connection || @raw_connection
+        @raw_connection
       end
 
       private def connect
@@ -1381,7 +1381,7 @@ module ActiveRecord
         end
 
         def resolved_arel_visitor_mode
-          return :rownum unless @raw_connection
+          return :rownum unless _connection
 
           mode = configured_arel_visitor_mode
 


### PR DESCRIPTION
## Summary
- Route `get_database_version` through `with_raw_connection` so it picks up `verify!`/materialize_transactions like the upstream PostgreSQL and MySQL adapters do, instead of bare ivar access.
- Use the existing `_connection` helper for the last two `@raw_connection` nil-guards in `supports_fetch_first_n_rows_and_offset?` and `resolved_arel_visitor_mode`, so every read of the underlying connection goes through one method.
- Drop the `@unconfigured_connection ||` short-circuit from `_connection`. The ivar is only ever set by `AbstractAdapter#initialize` on its deprecated constructor path (existing connection object as the first argument). `OracleEnhancedAdapter`'s registered factory and every spec construct the adapter with a config hash, and `connect` runs inside `initialize` so `@raw_connection` is always set on return. The left side of the `||` was dead.

Single-file refactor; no behavior change for any path exercised by the test suite.

## Out of scope (follow-up)
- `discard!` has `_connection = nil`, which creates a local variable instead of clearing `@raw_connection` (since `_connection` is a method). Latent bug, fix it separately.
- The remaining `_connection.<...>` call sites in query/transaction paths (`do_exec_returning`, `commit_db_transaction`, etc.) could also move to `with_raw_connection`, but that touches retry/transaction-materialization behavior and deserves its own change.

## Test plan
- [x] `bundle exec rubocop`
- [x] `bundle exec rspec ./spec/active_record/connection_adapters/emulation/oracle_adapter_spec.rb`
- [x] `bundle exec rspec ./spec/active_record/connection_adapters/oracle_enhanced/adapter_leasing_spec.rb`
- [x] `bundle exec rspec` (987 examples, 0 failures, 12 version-conditional pending)
