### PR TITLE
Fix discard! so it actually clears @raw_connection

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -776,7 +776,7 @@ module ActiveRecord
 
       def discard!
         super
-        _connection = nil
+        @raw_connection = nil
       end
 
       # use in set_sequence_name to avoid fetching primary key value from sequence

--- a/spec/active_record/connection_adapters/oracle_enhanced/adapter_leasing_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/adapter_leasing_spec.rb
@@ -49,3 +49,16 @@ RSpec.describe "OracleEnhancedAdapter#raw_connection" do
     expect(@adapter.transaction_manager.lazy_transactions_enabled?).to be(false)
   end
 end
+
+RSpec.describe "OracleEnhancedAdapter#discard!" do
+  before(:each) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @adapter = ActiveRecord::Base.lease_connection
+  end
+
+  it "clears @raw_connection so the adapter reports as disconnected" do
+    expect(@adapter.connected?).to be(true)
+    @adapter.discard!
+    expect(@adapter.connected?).to be(false)
+  end
+end


### PR DESCRIPTION
## Summary
`OracleEnhancedAdapter#discard!` (`lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:777-780`) read:

```ruby
def discard!
  super
  _connection = nil
end
```

`_connection` is a private method, so Ruby parsed `_connection = nil` as a local-variable assignment and silently dropped it on the floor. `@raw_connection` stayed set, `connected?` kept returning true, and the OCI8 / JDBC handle was held until garbage collection.

Assign the ivar directly, matching the upstream PostgreSQL (`postgresql_adapter.rb:433-437`) and MySQL (`mysql2_adapter.rb:130-134`) shape.

## Test plan
- [x] New spec asserts `connected?` flips from true to false after `discard!` (`spec/active_record/connection_adapters/oracle_enhanced/adapter_leasing_spec.rb`).
- [x] `bundle exec rubocop`
- [x] `bundle exec rspec` (full suite, local oracle-container / FREEPDB1)
