### PR TITLE
Route query and transaction paths through with_raw_connection

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -62,46 +62,50 @@ module ActiveRecord
           log(intent) do
             cached = false
             cursor = nil
-            with_retry do
-              if binds.nil? || binds.empty?
-                cursor = _connection.prepare(sql)
-              else
-                if prepared_statements?
-                  @statements[sql] ||= _connection.prepare(sql)
-                  cursor = @statements[sql]
-                  cached = true
+            with_raw_connection do |raw_connection|
+              with_retry do
+                if binds.nil? || binds.empty?
+                  cursor = raw_connection.prepare(sql)
                 else
-                  cursor = _connection.prepare(sql)
+                  if prepared_statements?
+                    @statements[sql] ||= raw_connection.prepare(sql)
+                    cursor = @statements[sql]
+                    cached = true
+                  else
+                    cursor = raw_connection.prepare(sql)
+                  end
+
+                  cursor.bind_params(type_casted_binds)
+
+                  bind_specs.each do |position, klass|
+                    cursor.bind_returning_param(position, klass)
+                  end
                 end
 
-                cursor.bind_params(type_casted_binds)
+                cursor.exec_update
+              rescue
+                (cursor.close rescue nil) if cursor && !cached
+                raise
+              end
 
-                bind_specs.each do |position, klass|
-                  cursor.bind_returning_param(position, klass)
+              rows = []
+              unless bind_specs.empty?
+                values = bind_specs.map do |position, klass|
+                  value = cursor.get_returning_param(position, klass)
+                  klass == Integer ? value.to_i : value
                 end
+                rows << values
               end
-
-              cursor.exec_update
-            rescue
-              (cursor.close rescue nil) if cursor && !cached
-              raise
+              cursor.close unless cached
+              build_result(columns: [], rows: rows)
             end
-
-            rows = []
-            unless bind_specs.empty?
-              values = bind_specs.map do |position, klass|
-                value = cursor.get_returning_param(position, klass)
-                klass == Integer ? value.to_i : value
-              end
-              rows << values
-            end
-            cursor.close unless cached
-            build_result(columns: [], rows: rows)
           end
         end
 
         def begin_db_transaction # :nodoc:
-          _connection.autocommit = false
+          with_raw_connection(allow_retry: true, materialize_transactions: false) do |conn|
+            conn.autocommit = false
+          end
         end
 
         def transaction_isolation_levels
@@ -120,15 +124,19 @@ module ActiveRecord
         end
 
         def commit_db_transaction # :nodoc:
-          _connection.commit
-        ensure
-          _connection.autocommit = true
+          with_raw_connection(allow_retry: false, materialize_transactions: true) do |conn|
+            conn.commit
+          ensure
+            conn.autocommit = true
+          end
         end
 
         def exec_rollback_db_transaction # :nodoc:
-          _connection.rollback
-        ensure
-          _connection.autocommit = true
+          with_raw_connection(allow_retry: false, materialize_transactions: true) do |conn|
+            conn.rollback
+          ensure
+            conn.autocommit = true
+          end
         end
 
         def create_savepoint(name = current_savepoint_name) # :nodoc:
@@ -252,7 +260,9 @@ module ActiveRecord
                 raise ActiveRecord::RecordNotFound, "statement #{sql} returned no rows"
               end
               lob = lob_record[col.name]
-              _connection.write_lob(lob, value.to_s, col.type == :binary)
+              with_raw_connection do |conn|
+                conn.write_lob(lob, value.to_s, col.type == :binary)
+              end
             end
           end
         end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -1529,7 +1529,9 @@ module ActiveRecord
               name: "SCHEMA",
               connection: self,
             ) do
-              _connection.name_resolve(real_name)
+              with_raw_connection do |conn|
+                conn.name_resolve(real_name)
+              end
             end
           rescue OracleEnhanced::ConnectionException, ArgumentError
             raise

--- a/spec/active_record/connection_adapters/oracle_enhanced/adapter_leasing_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/adapter_leasing_spec.rb
@@ -62,3 +62,49 @@ RSpec.describe "OracleEnhancedAdapter#discard!" do
     expect(@adapter.connected?).to be(false)
   end
 end
+
+RSpec.describe "OracleEnhancedAdapter transaction state changes" do
+  before(:each) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @adapter = ActiveRecord::Base.lease_connection
+  end
+
+  describe "#begin_db_transaction" do
+    after(:each) do
+      @adapter.exec_rollback_db_transaction
+    end
+
+    it "routes through with_raw_connection with allow_retry: true, materialize_transactions: false" do
+      allow(@adapter).to receive(:with_raw_connection).and_call_original
+      @adapter.begin_db_transaction
+      expect(@adapter).to have_received(:with_raw_connection)
+        .with(allow_retry: true, materialize_transactions: false)
+    end
+  end
+
+  describe "#commit_db_transaction" do
+    before(:each) do
+      @adapter.begin_db_transaction
+    end
+
+    it "routes through with_raw_connection with allow_retry: false, materialize_transactions: true" do
+      allow(@adapter).to receive(:with_raw_connection).and_call_original
+      @adapter.commit_db_transaction
+      expect(@adapter).to have_received(:with_raw_connection)
+        .with(allow_retry: false, materialize_transactions: true)
+    end
+  end
+
+  describe "#exec_rollback_db_transaction" do
+    before(:each) do
+      @adapter.begin_db_transaction
+    end
+
+    it "routes through with_raw_connection with allow_retry: false, materialize_transactions: true" do
+      allow(@adapter).to receive(:with_raw_connection).and_call_original
+      @adapter.exec_rollback_db_transaction
+      expect(@adapter).to have_received(:with_raw_connection)
+        .with(allow_retry: false, materialize_transactions: true)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Continues the alignment started in #2757. The query/transaction surface still drove the OCI8 / JDBC connection directly off `_connection` (i.e. `@raw_connection`), bypassing the verify!/materialize_transactions/allow_retry plumbing that `with_raw_connection` provides. This PR routes four call sites through `with_raw_connection`, matching the shape upstream PostgreSQL/MySQL adapters use.

- **Transaction state changes** in `oracle_enhanced/database_statements.rb`: `begin_db_transaction` uses `allow_retry: true, materialize_transactions: false`; `commit_db_transaction` and `exec_rollback_db_transaction` use `allow_retry: false, materialize_transactions: true` — the same flag pairing as PG `BEGIN`/`COMMIT`/`ROLLBACK` (`postgresql/database_statements.rb:68-86`).
- **`_exec_insert`** (the custom INSERT...RETURNING path) wraps the cursor prepare/exec/close around a `with_raw_connection` block, mirroring how `perform_query` already takes a yielded `raw_connection`.
- **`write_lob`** (LOB upload during `write_lobs`) routes through `with_raw_connection`.
- **`DBMS_UTILITY.NAME_RESOLVE`** (the PL/SQL describe call inside `resolve_data_source_name`) routes through `with_raw_connection`.

New specs in `oracle_enhanced/adapter_leasing_spec.rb` lock in the transaction routing by asserting the exact `allow_retry` / `materialize_transactions` flag pair for each of the three transaction state methods (the flag pair is unique to each, so the assertion is precise). The `_exec_insert` / `write_lob` / `name_resolve` paths are exercised by the existing 987-example suite — their `with_raw_connection` wrap shares call signatures with unrelated AR-internal `with_raw_connection` invocations during the same operation, so a routing-only spec for them would be too weak to be useful.

The remaining `_connection.<...>` call sites are intentionally untouched — they live in `active?`, `disconnect!`, `reconnect`, the `auto_retry=` config setter, and `translate_exception`, all of which run inside verify/disconnect/exception-translation paths where re-entering `with_raw_connection` would either recurse or paper over a failure mode.

## Test plan
- [x] `bundle exec rubocop`
- [x] New transaction routing specs (`bundle exec rspec ./spec/active_record/connection_adapters/oracle_enhanced/adapter_leasing_spec.rb`, 10 examples, 0 failures)
- [x] `bundle exec rspec` (987 + 3 new examples, 0 failures, 12 version-conditional pending) on local oracle-container / FREEPDB1
