### PR TITLE
Opt query and describe paths into AR-level retry

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -62,7 +62,7 @@ module ActiveRecord
           log(intent) do
             cached = false
             cursor = nil
-            with_raw_connection do |raw_connection|
+            with_raw_connection(allow_retry: true) do |raw_connection|
               with_retry do
                 if binds.nil? || binds.empty?
                   cursor = raw_connection.prepare(sql)
@@ -260,7 +260,7 @@ module ActiveRecord
                 raise ActiveRecord::RecordNotFound, "statement #{sql} returned no rows"
               end
               lob = lob_record[col.name]
-              with_raw_connection do |conn|
+              with_raw_connection(allow_retry: false) do |conn|
                 conn.write_lob(lob, value.to_s, col.type == :binary)
               end
             end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -1529,7 +1529,7 @@ module ActiveRecord
               name: "SCHEMA",
               connection: self,
             ) do
-              with_raw_connection do |conn|
+              with_raw_connection(allow_retry: true) do |conn|
                 conn.name_resolve(real_name)
               end
             end

--- a/spec/active_record/connection_adapters/oracle_enhanced/adapter_leasing_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/adapter_leasing_spec.rb
@@ -108,3 +108,75 @@ RSpec.describe "OracleEnhancedAdapter transaction state changes" do
     end
   end
 end
+
+RSpec.describe "OracleEnhancedAdapter#_exec_insert" do
+  before(:each) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @adapter = ActiveRecord::Base.lease_connection
+    @adapter.create_table(:test_allow_retry_inserts, force: true) do |t|
+      t.string :name
+    end
+    @model_class = Class.new(ActiveRecord::Base) do
+      self.table_name = "test_allow_retry_inserts"
+    end
+  end
+
+  after(:each) do
+    @adapter.drop_table(:test_allow_retry_inserts, if_exists: true)
+  end
+
+  it "routes the INSERT cursor through with_raw_connection with allow_retry: true" do
+    allow(@adapter).to receive(:with_raw_connection).and_call_original
+    @model_class.create!(name: "x")
+    expect(@adapter).to have_received(:with_raw_connection).with(allow_retry: true).at_least(:once)
+  end
+end
+
+RSpec.describe "OracleEnhancedAdapter#resolve_data_source_name" do
+  before(:each) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @adapter = ActiveRecord::Base.lease_connection
+    @adapter.create_table(:test_allow_retry_describe, force: true) { |t| t.string :name }
+  end
+
+  after(:each) do
+    @adapter.drop_table(:test_allow_retry_describe, if_exists: true)
+  end
+
+  it "routes DBMS_UTILITY.NAME_RESOLVE through with_raw_connection with allow_retry: true" do
+    allow(@adapter).to receive(:with_raw_connection).and_call_original
+    @adapter.data_source_exists?(:test_allow_retry_describe)
+    expect(@adapter).to have_received(:with_raw_connection).with(allow_retry: true).at_least(:once)
+  end
+end
+
+RSpec.describe "OracleEnhancedAdapter#write_lobs" do
+  before(:each) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @adapter = ActiveRecord::Base.lease_connection
+    @adapter.create_table(:test_allow_retry_lobs, force: true) do |t|
+      t.text :body
+    end
+    @old_prepared_statements = @adapter.prepared_statements
+    @adapter.instance_variable_set(:@prepared_statements, false)
+    @model_class = Class.new(ActiveRecord::Base) do
+      self.table_name = "test_allow_retry_lobs"
+    end
+    @model_class.create!(body: "x" * 5000)
+  end
+
+  after(:each) do
+    @adapter.instance_variable_set(:@prepared_statements, @old_prepared_statements)
+    @adapter.drop_table(:test_allow_retry_lobs, if_exists: true)
+  end
+
+  # The LOB locator from the preceding SELECT ... FOR UPDATE is tied to the
+  # OCI session, so a reconnect-and-retry would either be a no-op (the
+  # surrounding transaction is already dirty) or fail with ORA-22275 /
+  # ORA-22920 on the new session. Pin the flag explicitly to false.
+  it "routes the LOB write through with_raw_connection with allow_retry: false" do
+    allow(@adapter).to receive(:with_raw_connection).and_call_original
+    @model_class.last.update!(body: "y" * 5000)
+    expect(@adapter).to have_received(:with_raw_connection).with(allow_retry: false).at_least(:once)
+  end
+end


### PR DESCRIPTION
## Summary
Step 1 of #2760. Two of the three `with_raw_connection` wraps added in #2759 are flagged `allow_retry: true` so AR core's reconnect-and-retry kicks in on connection-loss errors, matching the semantics the driver-level `with_retry` already provides. `write_lob` is intentionally left at `allow_retry: false` (now stated explicitly) because its semantics make retry unsafe.

- **`_exec_insert`** (INSERT...RETURNING via the custom cursor path) — `allow_retry: true`. AR's `reconnect_can_restore_state?` gates the rest: outside any transaction or inside a clean transaction, retry runs on a fresh connection; inside a dirty transaction, the gate rejects so the failure surfaces. Matches the driver-level `autocommit?` gate.

- **`name_resolve`** (`DBMS_UTILITY.NAME_RESOLVE` inside `resolve_data_source_name`) — `allow_retry: true`. Schema lookups typically run outside any transaction, so retry actually engages.

- **`write_lob`** — explicitly `allow_retry: false`. The LOB locator returned by the preceding `SELECT ... FOR UPDATE` is tied to that OCI/JDBC session, so retrying on a reconnected session would either:
  1. Be a no-op (AR's dirty-transaction gate blocks the reconnect since the prior INSERT/UPDATE that triggered `write_lobs` already dirtied the transaction), or
  2. If somehow reachable, fail with ORA-22275 / ORA-22920 ("invalid LOB locator" / "row containing the LOB value is not locked") on the new session.

  Pin the flag to `false` to make the intent explicit rather than relying on the default, and document the locator-session coupling.

The transaction state methods (`begin_db_transaction` / `commit_db_transaction` / `exec_rollback_db_transaction`) keep their existing flag pairs from #2759 (`true/false` on begin, `false/true` on commit and rollback — matching PG).

## On `retryable_query_error?` for Oracle

AR core's `retryable_query_error?` (`abstract_adapter.rb:1151-1156`) matches `ActiveRecord::Deadlocked || ActiveRecord::LockWaitTimeout`. oracle-enhanced's `translate_exception` (`oracle_enhanced_adapter.rb:1424-1444`) maps **ORA-00060 → `Deadlocked`** but does **not** map any Oracle code to `LockWaitTimeout` today (ORA-30006 / ORA-04020 fall through as raw OCIError). So the query-error retry path on Oracle is effectively triggered only by ORA-00060 deadlocks. Connection-loss retries go through `retryable_connection_error?` via `translate_exception`'s `ConnectionFailed` branch, which leans on the `lost_connection?` contract pinned in #2761.

## Specs

Three new routing specs in `oracle_enhanced/adapter_leasing_spec.rb`, following the spy pattern used for #2759's transaction routing specs:

- `OracleEnhancedAdapter#_exec_insert` — `create!` invokes `with_raw_connection(allow_retry: true)`
- `OracleEnhancedAdapter#resolve_data_source_name` — `data_source_exists?` invokes `with_raw_connection(allow_retry: true)`
- `OracleEnhancedAdapter#write_lobs` — `update!` of a LOB column invokes `with_raw_connection(allow_retry: false)`

Each assertion uses `have_received(...).with(...).at_least(:once)` because the operations also exercise the new `(allow_retry: true)` / `(allow_retry: false)` signatures from other adjacent call sites (e.g., schema-cache `name_resolve` during `create!` matches `(allow_retry: true)` six times via column / sequence / table lookups). The flag matcher is the precise contract; the call count is incidental.

## Test plan
- [x] `bundle exec rubocop`
- [x] `bundle exec rspec` (full suite on local oracle-container / FREEPDB1, all green)

The driver-level `with_retry` stays in place as belt-and-braces. Step 2 of #2760 will retire the inner wrap once this layer's behaviour has settled.

Refs #2760.
