### PR TITLE
Skip prepared-statement cache eviction specs when prepared_statements is false

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -2574,6 +2574,7 @@ end
 
   describe "prepared statement cache eviction on DDL" do
     before(:each) do
+      skip "requires prepared_statements: true" unless @conn.prepared_statements
       schema_define do
         create_table :test_evict, force: true do |t|
           t.string :name


### PR DESCRIPTION
## Summary
The two examples in `describe "prepared statement cache eviction on DDL"` (`schema_statements_spec.rb:2598, 2610`) assert that the `@statements` cache holds an entry for the test table after `klass.create!`, then verify the entry is gone after DDL. With prepared_statements disabled the cache is never populated, so the pre-DDL `expect(cached_prepared_sqls_for(...)).not_to be_empty` assertion fails before the eviction behaviour is exercised.

Skip when the connection runs with `prepared_statements: false`, matching how other prepared-statement-dependent specs are guarded.

Spotted in a recent run of the manually-dispatched `test_prepared_statements_false` workflow:
- https://github.com/rsim/oracle-enhanced/actions/runs/25679254486/job/75385903909

## Test plan
- [x] `bundle exec rubocop`
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb -e "prepared statement cache eviction"` (2 examples, 0 failures, default `prepared_statements: true`)
- [x] `ORACLE_ENHANCED_PREPARED_STATEMENTS_FALSE=1 bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb -e "prepared statement cache eviction"` (2 examples, 0 failures, 2 pending — both skipped)
