### PR TITLE
ci: Add ORA_TZFILE workaround to test_prepared_statements_false

### DIFF
--- a/.github/workflows/test_prepared_statements_false.yml
+++ b/.github/workflows/test_prepared_statements_false.yml
@@ -80,6 +80,17 @@ jobs:
       - name: Create database user
         run: |
           ./ci/setup_accounts.sh
+      - name: Force client TZ data to match server (ORA_TZFILE workaround)
+        run: |
+          ORACLE_CONTAINER=$(docker ps --filter "ancestor=gvenzl/oracle-free" -q)
+          SRC=$(docker exec "$ORACLE_CONTAINER" bash -c 'ls $ORACLE_HOME/oracore/zoneinfo/timezlrg_*.dat 2>/dev/null | head -1')
+          echo "Server TZ file: $SRC"
+          DST_DIR="$ORACLE_HOME/oracore/zoneinfo"
+          sudo mkdir -p "$DST_DIR"
+          docker cp "$ORACLE_CONTAINER":"$SRC" /tmp/_server_tzfile.dat
+          sudo mv /tmp/_server_tzfile.dat "$DST_DIR/$(basename "$SRC")"
+          ls -l "$DST_DIR"
+          echo "ORA_TZFILE=$DST_DIR/$(basename "$SRC")" >> $GITHUB_ENV
       - name: Bundle install
         run: |
           bundle install --jobs 4 --retry 3


### PR DESCRIPTION
## Summary
`test.yml` already copies the server's `timezlrg_*.dat` onto the Instant Client and points `ORA_TZFILE` at it so DATE/TIMESTAMP fetches do not raise `ORA-01805` against Oracle Free 23ai's newer tz data. The manually-dispatched `test_prepared_statements_false` workflow lacked the same step and was hitting the four `TIMESTAMP WITH TIME ZONE values from ActiveRecord model` examples in `timestamp_spec.rb` with `OCIError: ORA-01805: possible error in date/time operation` on the most recent dispatch:

https://github.com/rsim/oracle-enhanced/actions/runs/25679254486/job/75385903909

Inline the same workaround block immediately after the `Create database user` step so both workflows share equivalent client/server TZ alignment.

## Test plan
- [ ] Re-dispatch the `test_prepared_statements_false` workflow after merge and confirm the four `timestamp_spec.rb` examples pass.
