### PR TITLE
Remove the database_statements private with_retry helper

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -63,7 +63,7 @@ module ActiveRecord
             cached = false
             cursor = nil
             with_raw_connection(allow_retry: true) do |raw_connection|
-              with_retry do
+              begin
                 if binds.nil? || binds.empty?
                   cursor = raw_connection.prepare(sql)
                 else
@@ -345,7 +345,7 @@ module ActiveRecord
 
             cursor = nil
             cached = false
-            with_retry do
+            begin
               if binds.nil? || binds.empty?
                 cursor = raw_connection.prepare(sql)
               else
@@ -384,15 +384,6 @@ module ActiveRecord
             intent.notification_payload[:row_count] = rows.length
 
             { columns: columns, rows: rows, affected_rows_count: affected_rows_count }
-          end
-
-          def with_retry
-            _connection.with_retry do
-              yield
-            rescue
-              @statements.clear if prepared_statements?
-              raise
-            end
           end
 
           def handle_warnings(raw_result, sql)


### PR DESCRIPTION
## Summary
Step 2 of #2760. With #2762 routing `_exec_insert` and `perform_query` through `with_raw_connection` (`allow_retry: true` for the INSERT path; `perform_query` inherits `intent.allow_retry` from AR core), connection-loss recovery for these paths is fully owned by AR core. The inner driver-level `with_retry` wrap and its private helper become redundant.

- Delete the `with_retry` helper at `database_statements.rb:379-387` and unwrap its two call sites (`_exec_insert` and `perform_query`) into plain `begin/rescue/end` blocks that preserve the original cursor-cleanup semantics on failure.

The driver-level `_connection.with_retry` method itself stays in place for now; Step 3 of #2760 audits its remaining internal callers in `oci_connection.rb` / `jdbc_connection.rb` before removing it.

## On the dropped `@statements.clear if prepared_statements?` defensive behavior

The deleted helper used to wipe the entire prepared-statement cache on **any** exception before re-raising:

```ruby
def with_retry
  _connection.with_retry do
    yield
  rescue
    @statements.clear if prepared_statements?
    raise
  end
end
```

This PR intentionally drops that behavior rather than re-inlining it into the rescue blocks of `_exec_insert` / `perform_query`. Rationale:

1. **Connection-loss already covered.** When AR translates the error to `ConnectionFailed` (via `lost_connection?`) and `with_raw_connection(allow_retry: true)` retries, `reconnect!(restore_transactions: true)` calls `clear_cache!(new_connection: true)`, which calls `@statements.reset`. This is the case the old helper was protecting in the retry workflow.

2. **Adapter-driven DDL already covered.** PR-#... commit 376c7a27 ("Evict stale prepared statements on DDL via `clear_table_columns_cache`") wires column / index / table mutations through cache invalidation. So `add_column`, `drop_table` and friends emitted via the adapter flush the relevant cached cursors on their own.

3. **What is lost: external DDL → stale cursor on a healthy connection.** If another session changes the schema and our cached cursor goes stale, the next query against it raises something like ORA-00904 (`invalid identifier`). `translate_exception` maps it to `StatementInvalid`, which is not a `retryable_connection_error?`, so AR does not reconnect and the cache stays populated. The next attempt with the same SQL hits the same stale cursor.

4. **Acceptability.** PostgreSQL / MySQL adapters do not carry this defensive clear either; the Rails community accepts the resulting "stale cursor → user-visible error → user reconnects or restarts" behavior. The failure is loud (a `StatementInvalid` propagates to the caller), not silent or corrupting. Within the #2760 plan, keeping the helper just for this corner case is the wrong trade — the migration's goal is to unify retry / cache-invalidation semantics on AR core's plumbing, not preserve adapter-specific defensive patches.

If a real-world incident later motivates re-adding the external-DDL defense, treat it as its own enhancement PR with explicit scope.

## Test plan
- [x] `bundle exec rubocop`
- [x] `bundle exec rspec` (1001 examples, 0 failures, 12 pending) on local oracle-container / FREEPDB1

Refs #2760.
