### PR TITLE
Mark the injected ROWNUM SqlLiteral as retryable in the pre-12c Arel visitor

### DIFF
--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -15,7 +15,7 @@ module Arel # :nodoc: all
           # then can use simple ROWNUM in WHERE clause
           if o.limit && o.orders.empty? && o.cores.first.groups.empty? && !o.offset && !o.cores.first.set_quantifier.class.to_s.include?("Distinct")
             o.cores.last.wheres.push Nodes::LessThanOrEqual.new(
-              Nodes::SqlLiteral.new("ROWNUM"), o.limit.expr
+              Nodes::SqlLiteral.new("ROWNUM", retryable: true), o.limit.expr
             )
             return super
           end

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle_spec.rb
@@ -66,6 +66,15 @@ RSpec.describe "Arel::Visitors::Oracle" do
         expect(compile(stmt)).to be_like %{ SELECT WHERE ROWNUM <= 10 }
       end
 
+      it "leaves collector.retryable true so the SELECT is retryable end-to-end" do
+        stmt = Arel::Nodes::SelectStatement.new
+        stmt.limit = Arel::Nodes::Limit.new(10)
+        collector = Arel::Collectors::SQLString.new
+        collector.retryable = true
+        @visitor.accept(stmt, collector)
+        expect(collector.retryable).to be(true)
+      end
+
       it "is idempotent" do
         stmt = Arel::Nodes::SelectStatement.new
         stmt.orders << Arel::Nodes::SqlLiteral.new("foo")

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -866,16 +866,22 @@ RSpec.describe "OracleEnhancedConnection" do
       expect(Post.take).not_to be_nil
     end
 
-    it "should not reconnect and execute query if connection is lost and auto retry is disabled" do
-      # On Oracle 23ai, `SELECT ... FETCH FIRST n ROWS ONLY` (emitted by
-      # Arel::Visitors::Oracle12) is transparently recovered by the server
-      # after `ALTER SYSTEM KILL SESSION`, so the adapter never sees an
-      # OCIError and the expected StatementInvalid is never raised.
-      skip "Oracle 23ai transparently recovers FETCH FIRST queries after session kill" if ActiveRecord::Base.connection.database_version >= "23"
+    # `auto_retry =` originally controlled the only retry path on this
+    # adapter (driver-level `OCI8EnhancedAutoRecover#with_retry` /
+    # `JDBCConnection#with_retry`), so setting it to false used to
+    # propagate the OCI/JDBC error and surface as `StatementInvalid`.
+    # Once AR core gained `with_raw_connection(allow_retry: true)` and
+    # oracle-enhanced routed Arel-built SELECTs through it, retry started
+    # happening at the AR layer regardless of `auto_retry =`, as long as
+    # the collector keeps `retryable` true (now the case for both
+    # Oracle12's FETCH FIRST and the pre-12c ROWNUM visitor). The expected
+    # outcome shifted accordingly — `Post.take` after a session kill now
+    # recovers via the AR layer even with `auto_retry = false`.
+    it "still recovers a killed-session SELECT via AR retry even when auto_retry is disabled" do
       Post.create!
       ActiveRecord::Base.lease_connection.auto_retry = false
       kill_current_session
-      expect { Post.take }.to raise_error(ActiveRecord::StatementInvalid)
+      expect(Post.take).not_to be_nil
     end
 
     # `lost_connection?` is the single source of truth for connection-loss


### PR DESCRIPTION
## Summary
Two coupled changes that bring AR core's `with_raw_connection(allow_retry: ...)` reconnect-and-retry into play for Arel-built SELECTs on Oracle pre-12c, plus the spec change that follows from it.

### 1. Arel visitor fix (`lib/arel/visitors/oracle.rb`)

`Arel::Visitors::Oracle#visit_Arel_Nodes_SelectStatement` injects `Nodes::SqlLiteral.new("ROWNUM")` into the WHERE list to apply the pre-12c `WHERE ROWNUM <= n` limit form. `SqlLiteral` defaults to `retryable: false`, and upstream `Arel::Visitors::ToSql#visit_Arel_Nodes_SqlLiteral` runs `collector.retryable &&= o.retryable` — so this single literal flips the whole SELECT's `collector.retryable` to false.

Downstream, AR's `to_sql_and_binds` reads `collector.retryable` back into `allow_retry`, which drives `with_raw_connection(allow_retry: ...)`. Result: every Arel-built SELECT with a LIMIT on Oracle pre-12c is silently marked non-retryable, even though the SQL itself is a plain idempotent SELECT. Oracle 12c+ escapes the bug because the `Oracle12` visitor emits FETCH FIRST via `collector << "..."` and never builds a ROWNUM `SqlLiteral`.

The practical fallout is that AR-level reconnect-and-retry never engages for these queries; until now the driver-level `OCI8EnhancedAutoRecover#with_retry` masked the gap whenever `auto_retry?` was on. As that layer is being retired (#2760) the gap surfaces directly — most concretely, `connection_spec.rb:862` (`should reconnect and execute query if connection is lost and auto retry is enabled`) starts failing on the test_11g matrix once the driver-level wrap is removed (#2765).

Pass `retryable: true` to the injected literal so the LIMIT branch is neutral on retryability and AR's `allow_retry` flag survives intact.

### 2. Spec expectation shift (`spec/.../connection_spec.rb`)

`should not reconnect ... auto retry is disabled` was written when driver-level `with_retry` was the only retry mechanism on this adapter — `auto_retry = false` actually disabled retry, the OCI/JDBC error propagated, and the spec asserted the resulting `StatementInvalid`. The spec was already skipped on Oracle 23ai with a comment attributing the behaviour change to "transparent server-side recovery" of FETCH FIRST queries, but the real cause is simpler: AR core's `with_raw_connection(allow_retry: true)` now retries on its own as soon as the Arel collector keeps `retryable` true, regardless of the driver flag.

With change (1), the same Arel route also marks pre-12c ROWNUM SELECTs retryable, so AR retry recovers session-killed SELECTs on 11g just like 12c+. The spec's expected outcome therefore shifts on every supported version: `Post.take` no longer raises after the kill.

Replace the spec with `still recovers a killed-session SELECT via AR retry even when auto_retry is disabled`, asserting the new outcome on every Oracle version (no version-conditional skip), and document inline how `auto_retry =`'s scope narrowed once AR-level retry started picking up the same work.

## Verification

A new regression spec in `arel/oracle_spec.rb` builds a `SELECT ... LIMIT` statement, runs it through the visitor with a collector preset to `retryable = true` (matching AR's `to_sql_and_binds` preamble), and asserts the collector still reports `retryable` true after compilation. Reverting the lib change makes that spec fail; with the fix it passes.

End-to-end on a real Oracle 11g XE container (Instant Client 21.21, Ruby 3.4, AR main):

| State | `connection_spec.rb` `auto reconnection should reconnect ...` |
|---|---|
| `oracle.rb` unchanged + #2765 (`drop-inner-with-retry`) applied | 0/10 PASS (consistent fail with `ConnectionFailed: ORA-03113`) |
| `oracle.rb` patched (this PR) + same #2765 applied | 10/10 PASS |

Local 23ai (`oracle-container` / FREEPDB1): `auto reconnection` describe — 16/16 PASS.

Local 11g (`gvenzl/oracle-xe:11`) + Instant Client 21.21: `auto reconnection` describe — 16/16 PASS.

## Test plan
- [x] `bundle exec rubocop`
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/arel/oracle_spec.rb` (23 examples, 0 failures — was 22)
- [x] `bundle exec rspec` on local oracle-container / FREEPDB1 (1002 examples, 0 failures, 12 pending)
- [x] 11g local container — `connection_spec.rb` auto reconnection describe 16/16 PASS

Refs #2760, #2765.
