### PR TITLE
ci: Pin Bundler to 4.0.6 in RuboCop workflow as workaround for ruby/rubygems#9536

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -10,12 +10,20 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    env:
+      BUNDLER_VERSION: 4.0.6
     steps:
       - uses: actions/checkout@v6
       - name: Set up Ruby 4.0
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 4.0
+      - name: Pin Bundler to 4.0.6 (workaround for ruby/rubygems#9536)
+        run: |
+          gem install bundler -v 4.0.6
+          ruby --version
+          gem --version
+          bundle --version
       - name: Build and run RuboCop
         run: |
           BUNDLE_ONLY=rubocop bundle install --jobs 4 --retry 3


### PR DESCRIPTION
## Summary

The `RuboCop` workflow started failing on master at 2026-05-12T00:23 UTC. Bisected the regression to Bundler: with Ruby 4.0.4 (RubyGems / Bundler 4.0.10+ bundled), `BUNDLE_ONLY=rubocop bundle install` fails to resolve this Gemfile against the multi-gemspec git source `rails/rails` whose top-level gem is in a filtered-out group, aborting with:

```
Could not find compatible versions
Because every version of activerecord depends on activesupport = 8.2.0.alpha
and activesupport = 8.2.0.alpha could not be found in rubygems repository
https://rubygems.org/ or installed locally,
  activerecord cannot be used.
```

Bundler 4.0.5 and 4.0.6 succeed; 4.0.7 through 4.0.11 fail. The upstream Bundler regression is tracked in [ruby/rubygems#9536](https://github.com/ruby/rubygems/issues/9536).

The previous attempt at this PR pinned `ruby-version: "4.0.3"` to pull in Bundler 4.0.6 transitively via the ruby-builder tarball. That works but couples the workaround to a specific Ruby patch release and means any future Ruby 4.0.x bump will also have to roll a Bundler version back. Pin Bundler explicitly instead:

- keep `ruby-version: 4.0` so the rolling line stays current
- set `BUNDLER_VERSION=4.0.6` at the job level so every `bundle` invocation in the workflow resolves to that version
- `gem install bundler -v 4.0.6` so the version is actually present in the Ruby image (the ruby-builder tarball ships only one Bundler; newer Ruby tarballs no longer ship 4.0.6)

Once Bundler ships a fix for [ruby/rubygems#9536](https://github.com/ruby/rubygems/issues/9536), drop `BUNDLER_VERSION` and the install step.

## Test plan

- [x] Locally reproduce the failure on Ruby 4.0.4 / Bundler 4.0.11 with the unmodified Gemfile.
- [x] Confirm `BUNDLE_ONLY=rubocop bundle install --jobs 4 --retry 3` and `BUNDLE_ONLY=rubocop bundle exec rubocop` succeed under Bundler 4.0.6.
- [ ] Watch this PR's `RuboCop` workflow run.
