### PR TITLE
Remove driver-level retry and the auto_retry API (#2760 Steps 4-6)

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -57,10 +57,6 @@ module ActiveRecord
         attr_accessor :active
         alias :active? :active
 
-        attr_accessor :auto_retry
-        alias :auto_retry? :auto_retry
-        @auto_retry = false
-
         attr_reader :session_time_zone
 
         def initialize(config)
@@ -243,29 +239,12 @@ module ActiveRecord
           end
         end
 
-        # mark connection as dead if connection lost
-        def with_retry(allow_retry: false, &block)
-          should_retry = (allow_retry || auto_retry?) && autocommit?
-          begin
-            yield if block_given?
-          rescue Java::JavaSql::SQLException => e
-            raise unless lost_connection?(e)
-            @active = false
-            raise unless should_retry
-            should_retry = false
-            reset! rescue nil
-            retry
-          end
-        end
-
-        def exec(sql, *bindvars, allow_retry: false)
+        def exec(sql, *bindvars)
           # The signature mirrors the OCI implementation for polymorphic
           # callers, but the JDBC path here has no bindvar handling. Fail
           # loudly rather than silently dropping values on the floor.
           raise ArgumentError, "JDBC exec does not support bindvars" unless bindvars.empty?
-          with_retry(allow_retry: allow_retry) do
-            exec_no_retry(sql)
-          end
+          exec_no_retry(sql)
         end
 
         def exec_no_retry(sql)
@@ -330,22 +309,20 @@ module ActiveRecord
         # public synonyms are chased server-side, and Oracle raises ORA-00980
         # ("synonym translation is no longer valid") natively on a looping chain.
         def name_resolve(name)
-          with_retry do
-            # Parameters 4-7 are required by NAME_RESOLVE's signature but unused here.
-            cs = @raw_connection.prepareCall("BEGIN DBMS_UTILITY.NAME_RESOLVE(?, 0, ?, ?, ?, ?, ?, ?); END;")
-            begin
-              cs.setString(1, name)
-              cs.registerOutParameter(2, java.sql.Types::VARCHAR) # schema
-              cs.registerOutParameter(3, java.sql.Types::VARCHAR) # part1 (object name)
-              cs.registerOutParameter(4, java.sql.Types::VARCHAR) # part2
-              cs.registerOutParameter(5, java.sql.Types::VARCHAR) # dblink
-              cs.registerOutParameter(6, java.sql.Types::NUMERIC) # part1_type
-              cs.registerOutParameter(7, java.sql.Types::NUMERIC) # object_number
-              cs.execute
-              [cs.getString(2), cs.getString(3)]
-            ensure
-              cs&.close
-            end
+          # Parameters 4-7 are required by NAME_RESOLVE's signature but unused here.
+          cs = @raw_connection.prepareCall("BEGIN DBMS_UTILITY.NAME_RESOLVE(?, 0, ?, ?, ?, ?, ?, ?); END;")
+          begin
+            cs.setString(1, name)
+            cs.registerOutParameter(2, java.sql.Types::VARCHAR) # schema
+            cs.registerOutParameter(3, java.sql.Types::VARCHAR) # part1 (object name)
+            cs.registerOutParameter(4, java.sql.Types::VARCHAR) # part2
+            cs.registerOutParameter(5, java.sql.Types::VARCHAR) # dblink
+            cs.registerOutParameter(6, java.sql.Types::NUMERIC) # part1_type
+            cs.registerOutParameter(7, java.sql.Types::NUMERIC) # object_number
+            cs.execute
+            [cs.getString(2), cs.getString(3)]
+          ensure
+            cs&.close
           end
         end
 
@@ -488,9 +465,9 @@ module ActiveRecord
             @raw_statement.close
           rescue Java::JavaSql::SQLException => e
             # Tolerate closing a statement whose underlying connection or
-            # statement has already been torn down (typical after with_retry
-            # has reset the connection). Re-raise anything else so genuine
-            # driver/resource bugs surface.
+            # statement has already been torn down (typical after AR's
+            # with_raw_connection(allow_retry: true) reset the connection).
+            # Re-raise anything else so genuine driver/resource bugs surface.
             #
             #   ORA-17002 / ORA-17008 — connection already gone
             #     (see JDBC_LOST_CONNECTION_ERROR_CODES).
@@ -504,10 +481,8 @@ module ActiveRecord
           end
         end
 
-        def select(sql, name = nil, return_column_names = false)
-          with_retry do
-            select_no_retry(sql, name, return_column_names)
-          end
+        def select(sql, name = nil, return_column_names = false) # :nodoc:
+          select_no_retry(sql, name, return_column_names)
         end
 
         def select_no_retry(sql, name = nil, return_column_names = false)

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -45,14 +45,6 @@ module ActiveRecord
           end
         end
 
-        def auto_retry
-          @raw_connection.auto_retry if @raw_connection
-        end
-
-        def auto_retry=(value)
-          @raw_connection.auto_retry = value if @raw_connection
-        end
-
         def logoff
           @raw_connection.logoff
           @raw_connection.active = false
@@ -97,12 +89,8 @@ module ActiveRecord
           raise OracleEnhanced::ConnectionException, e.message
         end
 
-        def exec(sql, *bindvars, allow_retry: false, &block)
-          with_retry(allow_retry: allow_retry) { @raw_connection.exec(sql, *bindvars, &block) }
-        end
-
-        def with_retry(allow_retry: false, &block)
-          @raw_connection.with_retry(allow_retry: allow_retry, &block)
+        def exec(sql, *bindvars, &block)
+          @raw_connection.exec(sql, *bindvars, &block)
         end
 
         def prepare(sql)
@@ -114,28 +102,26 @@ module ActiveRecord
         # public synonyms are chased server-side, and Oracle raises ORA-00980
         # ("synonym translation is no longer valid") natively on a looping chain.
         def name_resolve(name)
-          with_retry do
-            # l_part2 / l_dblink / l_type / l_obj_num are required by NAME_RESOLVE's signature but unused here.
-            cursor = @raw_connection.parse(<<~PLSQL)
-              DECLARE
-                l_part2   VARCHAR2(128);
-                l_dblink  VARCHAR2(128);
-                l_type    NUMBER;
-                l_obj_num NUMBER;
-              BEGIN
-                DBMS_UTILITY.NAME_RESOLVE(:name, 0, :out_schema, :out_name,
-                                          l_part2, l_dblink, l_type, l_obj_num);
-              END;
-            PLSQL
-            begin
-              cursor.bind_param(":name", name)
-              cursor.bind_param(":out_schema", nil, String, 128)
-              cursor.bind_param(":out_name", nil, String, 128)
-              cursor.exec
-              [cursor[":out_schema"], cursor[":out_name"]]
-            ensure
-              cursor&.close
-            end
+          # l_part2 / l_dblink / l_type / l_obj_num are required by NAME_RESOLVE's signature but unused here.
+          cursor = @raw_connection.parse(<<~PLSQL)
+            DECLARE
+              l_part2   VARCHAR2(128);
+              l_dblink  VARCHAR2(128);
+              l_type    NUMBER;
+              l_obj_num NUMBER;
+            BEGIN
+              DBMS_UTILITY.NAME_RESOLVE(:name, 0, :out_schema, :out_name,
+                                        l_part2, l_dblink, l_type, l_obj_num);
+            END;
+          PLSQL
+          begin
+            cursor.bind_param(":name", name)
+            cursor.bind_param(":out_schema", nil, String, 128)
+            cursor.bind_param(":out_name", nil, String, 128)
+            cursor.exec
+            [cursor[":out_schema"], cursor[":out_name"]]
+          ensure
+            cursor&.close
           end
         end
 
@@ -225,7 +211,7 @@ module ActiveRecord
           end
         end
 
-        def select(sql, name = nil, return_column_names = false)
+        def select(sql, name = nil, return_column_names = false) # :nodoc:
           cursor = @raw_connection.exec(sql)
           cols = []
           # Ignore raw_rnum_ which is used to simulate LIMIT and OFFSET
@@ -405,23 +391,14 @@ module ActiveRecord
   end
 end
 
-# The OCI8AutoRecover class enhances the OCI8 driver with auto-recover and
-# reset functionality. If a call to #exec fails, and autocommit is turned on
-# (ie., we're not in the middle of a longer transaction), it will
-# automatically reconnect and try again. If autocommit is turned off,
-# this would be dangerous (as the earlier part of the implied transaction
-# may have failed silently if the connection died) -- so instead the
-# connection is marked as dead, to be reconnected on it's next use.
+# OCI8EnhancedAutoRecover wraps the bare OCI8 connection to track its
+# liveness (`@active` / `ping`) and to recreate it on `reset!`. AR core's
+# `with_raw_connection(allow_retry: true)` drives the reconnect-and-retry
+# loop on top of those primitives.
 # :stopdoc:
 class OCI8EnhancedAutoRecover < DelegateClass(OCI8) # :nodoc:
   attr_accessor :active # :nodoc:
   alias :active? :active # :nodoc:
-
-  cattr_accessor :auto_retry
-  class << self
-    alias :auto_retry? :auto_retry # :nodoc:
-  end
-  @@auto_retry = false
 
   def initialize(config, factory) # :nodoc:
     @active = true
@@ -458,26 +435,6 @@ class OCI8EnhancedAutoRecover < DelegateClass(OCI8) # :nodoc:
       @active = false
       raise
     end
-  end
-
-  # Adds auto-recovery functionality.
-  def with_retry(allow_retry: false) # :nodoc:
-    should_retry = (allow_retry || self.class.auto_retry?) && autocommit?
-
-    begin
-      yield
-    rescue OCIException => e
-      raise unless e.is_a?(OCIError) && ActiveRecord::ConnectionAdapters::OracleEnhanced::LOST_CONNECTION_ERROR_CODES.include?(e.code)
-      @active = false
-      raise unless should_retry
-      should_retry = false
-      reset! rescue nil
-      retry
-    end
-  end
-
-  def exec(sql, *bindvars, &block) # :nodoc:
-    with_retry { @raw_connection.exec(sql, *bindvars, &block) }
   end
 end
 # :startdoc:

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -720,15 +720,24 @@ module ActiveRecord
       # CONNECTION MANAGEMENT ====================================
       #
 
-      # If SQL statement fails due to lost connection then reconnect
-      # and retry SQL statement if autocommit mode is enabled.
-      # By default this functionality is disabled.
-      attr_reader :auto_retry # :nodoc:
-      @auto_retry = false
+      # The oracle-enhanced-specific `auto_retry` toggle has been removed
+      # in favor of AR core's standard `connection_retries:` setting; the
+      # accessors are kept only to surface a clear migration path. Both
+      # raise to tell callers exactly what to change.
+      def auto_retry # :nodoc:
+        raise NotImplementedError,
+              "OracleEnhancedAdapter#auto_retry has been removed. " \
+              "Set `connection_retries:` in database.yml (or your connection " \
+              "configuration) to use AR core's retry instead. " \
+              "See https://github.com/rsim/oracle-enhanced/issues/2760."
+      end
 
-      def auto_retry=(value) # :nodoc:
-        @auto_retry = value
-        _connection.auto_retry = value if _connection
+      def auto_retry=(_value) # :nodoc:
+        raise NotImplementedError,
+              "OracleEnhancedAdapter#auto_retry= has been removed. " \
+              "Set `connection_retries:` in database.yml (or your connection " \
+              "configuration) to use AR core's retry instead. " \
+              "See https://github.com/rsim/oracle-enhanced/issues/2760."
       end
 
       # return raw OCI8 or JDBC connection

--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -123,8 +123,7 @@ RSpec.describe "OracleEnhancedAdapter establish connection" do
     skip "Oracle 11g XE does not support native network encryption" if ENV["DATABASE_VERSION"] == "11.2.0.2"
     if ORACLE_ENHANCED_CONNECTION == :jdbc
       ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS.merge(jdbc_connect_properties: { "oracle.net.encryption_client" => "REJECTED" }))
-      conn = ActiveRecord::Base.lease_connection.send(:_connection)
-      expect(conn.select("SELECT COUNT(*) Records FROM v$Session_Connect_Info WHERE SID=SYS_CONTEXT('USERENV', 'SID') AND Network_Service_Banner LIKE '%Encryption service adapter%'")).to eq([{ "records" => 0 }])
+      expect(ActiveRecord::Base.lease_connection.select_all("SELECT COUNT(*) Records FROM v$Session_Connect_Info WHERE SID=SYS_CONTEXT('USERENV', 'SID') AND Network_Service_Banner LIKE '%Encryption service adapter%'").to_a).to eq([{ "records" => 0 }])
     end
   end
 
@@ -132,8 +131,7 @@ RSpec.describe "OracleEnhancedAdapter establish connection" do
     skip "Oracle 11g XE does not support native network encryption" if ENV["DATABASE_VERSION"] == "11.2.0.2"
     if ORACLE_ENHANCED_CONNECTION == :jdbc
       ActiveRecord::Base.establish_connection(SYSTEM_CONNECTION_PARAMS.merge(jdbc_connect_properties: { "oracle.net.encryption_client" => "REQUESTED" }))
-      conn = ActiveRecord::Base.lease_connection.send(:_connection)
-      expect(conn.select("SELECT COUNT(*) Records FROM v$Session_Connect_Info WHERE SID=SYS_CONTEXT('USERENV', 'SID') AND Network_Service_Banner LIKE '%Encryption service adapter%'")).to eq([{ "records" => 1 }])
+      expect(ActiveRecord::Base.lease_connection.select_all("SELECT COUNT(*) Records FROM v$Session_Connect_Info WHERE SID=SYS_CONTEXT('USERENV', 'SID') AND Network_Service_Banner LIKE '%Encryption service adapter%'").to_a).to eq([{ "records" => 1 }])
     end
   end
 
@@ -803,93 +801,52 @@ RSpec.describe "OracleEnhancedConnection" do
           WHERE  audsid = '#{audsid}'").first["sid_serial"]
     end
 
-    it "should reconnect and execute SQL statement if connection is lost and auto retry is enabled" do
-      # @conn.auto_retry = true
-      ActiveRecord::Base.lease_connection.auto_retry = true
-      kill_current_session
-      expect(@conn.exec("SELECT * FROM dual")).not_to be_nil
-    end
-
-    it "should reconnect and execute SQL statement if connection is lost and allow_retry is passed" do
-      kill_current_session
-      expect(@conn.exec("SELECT * FROM dual", allow_retry: true)).not_to be_nil
-    end
-
     # Regression test ported from rails/rails#46273, which only covers
     # Mysql2 and PostgreSQL in the Rails repository.
     it "adapter #execute is retryable when allow_retry: true is passed" do
-      previous_auto_retry = ActiveRecord::Base.lease_connection.auto_retry
-      ActiveRecord::Base.lease_connection.auto_retry = false
-      begin
-        initial_connection_id = connection_id_from_server(@conn)
-        kill_current_session
-        expect { ActiveRecord::Base.lease_connection.execute("SELECT 1 FROM dual", allow_retry: true) }.not_to raise_error
-        expect(connection_id_from_server(@conn)).not_to eq(initial_connection_id)
-      ensure
-        ActiveRecord::Base.lease_connection.auto_retry = previous_auto_retry
-      end
-    end
-
-    it "should not reconnect and execute SQL statement if connection is lost and auto retry is disabled" do
-      # @conn.auto_retry = false
-      ActiveRecord::Base.lease_connection.auto_retry = false
+      initial_connection_id = connection_id_from_server(@conn)
       kill_current_session
-      if defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
-        expect { @conn.exec("SELECT * FROM dual") }.to raise_error(Java::JavaSql::SQLRecoverableException)
-      else
-        expect { @conn.exec("SELECT * FROM dual") }.to raise_error(OCIError)
-      end
+      expect { ActiveRecord::Base.lease_connection.execute("SELECT 1 FROM dual", allow_retry: true) }.not_to raise_error
+      expect(connection_id_from_server(@conn)).not_to eq(initial_connection_id)
     end
 
-    it "should reconnect and execute SQL select if connection is lost and auto retry is enabled" do
-      # @conn.auto_retry = true
-      ActiveRecord::Base.lease_connection.auto_retry = true
-      kill_current_session
-      expect(@conn.select("SELECT * FROM dual")).to eq([{ "dummy" => "X" }])
-    end
-
-    it "should not reconnect and execute SQL select if connection is lost and auto retry is disabled" do
-      # @conn.auto_retry = false
-      ActiveRecord::Base.lease_connection.auto_retry = false
-      kill_current_session
-      if defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
-        expect { @conn.select("SELECT * FROM dual") }.to raise_error(Java::JavaSql::SQLRecoverableException)
-      else
-        expect { @conn.select("SELECT * FROM dual") }.to raise_error(OCIError)
-      end
-    end
-
-    it "should reconnect and execute query if connection is lost and auto retry is enabled" do
+    # Arel-built SELECTs route through `with_raw_connection(allow_retry: true)`
+    # in `database_statements.rb` and the collector keeps `retryable` true on
+    # both Oracle12 (FETCH FIRST) and the pre-12c ROWNUM visitor, so a session
+    # kill is transparently recovered at the AR layer.
+    it "recovers a killed-session SELECT via AR retry" do
       Post.create!
-      ActiveRecord::Base.lease_connection.auto_retry = true
       kill_current_session
       expect(Post.take).not_to be_nil
     end
 
-    # `auto_retry =` originally controlled the only retry path on this
-    # adapter (driver-level `OCI8EnhancedAutoRecover#with_retry` /
-    # `JDBCConnection#with_retry`), so setting it to false used to
-    # propagate the OCI/JDBC error and surface as `StatementInvalid`.
-    # Once AR core gained `with_raw_connection(allow_retry: true)` and
-    # oracle-enhanced routed Arel-built SELECTs through it, retry started
-    # happening at the AR layer regardless of `auto_retry =`, as long as
-    # the collector keeps `retryable` true (now the case for both
-    # Oracle12's FETCH FIRST and the pre-12c ROWNUM visitor). The expected
-    # outcome shifted accordingly — `Post.take` after a session kill now
-    # recovers via the AR layer even with `auto_retry = false`.
-    it "still recovers a killed-session SELECT via AR retry even when auto_retry is disabled" do
-      Post.create!
-      ActiveRecord::Base.lease_connection.auto_retry = false
+    # Direct `select_all` call exercises the same `perform_query` →
+    # `with_raw_connection(allow_retry: true)` path the Arel-built SELECTs
+    # rely on, without going through Arel / record materialisation.
+    it "adapter #select_all recovers a killed-session SELECT via AR retry" do
       kill_current_session
-      expect(Post.take).not_to be_nil
+      expect(ActiveRecord::Base.lease_connection.select_all("SELECT * FROM dual", allow_retry: true).to_a).to eq([{ "dummy" => "X" }])
+    end
+
+    # Inverse of the rails/rails#46273 port above: `execute` defaults to
+    # `allow_retry: false`, which is the right semantics for DDL/DML that
+    # cannot be safely re-run. A killed session must surface as
+    # `ActiveRecord::ConnectionFailed` rather than retry transparently.
+    it "adapter #execute does not retry when allow_retry is not passed" do
+      kill_current_session
+      expect { ActiveRecord::Base.lease_connection.execute("SELECT * FROM dual") }.to raise_error(ActiveRecord::ConnectionFailed)
+    end
+
+    it "raises NotImplementedError when the removed auto_retry accessor is used" do
+      expect { ActiveRecord::Base.lease_connection.auto_retry = true }.to raise_error(NotImplementedError, /connection_retries:/)
+      expect { ActiveRecord::Base.lease_connection.auto_retry }.to raise_error(NotImplementedError, /connection_retries:/)
     end
 
     # `lost_connection?` is the single source of truth for connection-loss
-    # detection, consumed by both the driver-level `with_retry` and the
-    # adapter-level `translate_exception` (→ `ConnectionFailed` →
-    # `with_raw_connection(allow_retry:)`). Pin every code/message in the
-    # contract so changes to either retry layer can rely on equivalent
-    # classification accuracy.
+    # detection, consumed by the adapter-level `translate_exception` (→
+    # `ConnectionFailed` → `with_raw_connection(allow_retry:)`). Pin every
+    # code/message in the contract so changes to the retry layer can rely
+    # on stable classification accuracy.
     describe "#lost_connection? coverage" do
       ActiveRecord::ConnectionAdapters::OracleEnhanced::LOST_CONNECTION_ERROR_CODES.each do |code|
         # ORA-00028 (session killed) and ORA-00031 (session marked for kill)


### PR DESCRIPTION
## Summary

Closes the bulk of #2760 by deleting the driver-level reconnect-and-retry layer and the `auto_retry` API now that AR core's `with_raw_connection(allow_retry: true)` covers the same surface.

### Step 4 — delete the driver-level retry methods
- `OCI8EnhancedAutoRecover#with_retry` and its `#exec` retry wrap
- `OracleEnhanced::JDBCConnection#with_retry`
- Inline `with_retry { ... }` calls in `OCIConnection` / `JDBCConnection` `exec`, `name_resolve`, and `select` bodies
- `OCIConnection#exec` and `JDBCConnection#exec` lose the now-unused `allow_retry:` kwarg
- `OCI8EnhancedAutoRecover` itself stays for `@active` / `ping` / `reset!`

### Step 5 — drop the `auto_retry` API
- Internal handles (`cattr_accessor :auto_retry`, `auto_retry?` aliases, `attr_accessor :auto_retry`, the `OracleEnhanced::Connection`-level passthrough setters) are removed without deprecation — they were never part of the documented surface.
- `OracleEnhancedAdapter#auto_retry` and `#auto_retry=` now raise `NotImplementedError` with a message pointing users at `connection_retries:` in `database.yml`. `auto_retry` is oracle-enhanced specific (no Rails analog), defaults to `false`, and the migration is mechanical, so a hard fail with a clear pointer is friendlier than a silent no-op setter.

### `Connection#select`
Both `OCIConnection#select` and `JDBCConnection#select` have no callers inside the library (spec-only, reached via `send(:_connection)`). Marked `:nodoc:` to spell out their internal-only status. No deprecation warning is emitted: the retry behaviour that vanished with the `with_retry` removal only fired under `auto_retry = true`, which already raises `NotImplementedError` through `OracleEnhancedAdapter#auto_retry=`, so there are no real users to warn. Full removal (with spec migration) is tracked at #2769.

### Step 6 — rewrite the `auto_retry` specs
- Drop the auto_retry-driven scenarios in `connection_spec.rb`'s `"auto reconnection"` describe block (those tests modelled the now-removed driver-level retry).
- Keep `"adapter #execute is retryable when allow_retry: true is passed"` (rails/rails#46273 port), stripped of auto_retry setup.
- Keep `"recovers a killed-session SELECT via AR retry"` with the `auto_retry = false` line removed.
- Add `"adapter #select_all recovers a killed-session SELECT via AR retry"` — direct AR-API counterpart for the deleted JDBC `@conn.select` + `auto_retry = true` scenario. AR's `select_all(sql)` defaults to `allow_retry: false` on a raw SQL string, so the spec passes `allow_retry: true` explicitly.
- Add `"adapter #execute does not retry when allow_retry is not passed"` — inverse of the #46273 port; pins `ActiveRecord::ConnectionFailed` propagating from the default `allow_retry: false` path on a killed session.
- Add a spec pinning the `NotImplementedError` surface for the removed `auto_retry` accessors.
- Refresh the comment above `#lost_connection? coverage` (Step 0); driver-level `with_retry` no longer reads the predicate.

### Side cleanup
JDBC encryption probes (`"should not encrypt JDBC network connection"` and `"should encrypt JDBC network connection"`) route through `ActiveRecord::Base.lease_connection.select_all(...).to_a` instead of reaching into `_connection.select(...)`. Same Network_Service_Banner assertion, exercising the public AR adapter surface.

### Breaking changes

1. **`OracleEnhancedAdapter#auto_retry=` raises `NotImplementedError`.** Replace `OracleEnhancedAdapter.auto_retry = true` with the standard `connection_retries: 1` (or larger) entry in `database.yml` / connection configuration. This matches PG / MySQL / SQLite.
2. **`OracleEnhancedAdapter#auto_retry` (reader) also raises `NotImplementedError`.** Apps or external tooling that read the flag for introspection / diagnostics — e.g. `ActiveRecord::Base.connection.auto_retry`, custom monitoring code, gem-provided AR adapter inspectors — will crash with `NotImplementedError` instead of silently returning the old value. AR core itself does not reference `auto_retry` by name (verified with `grep`), so the impact is limited to oracle-enhanced-specific external code. The raise on read is intentional: returning `false` would lie about the underlying mechanism, and returning `nil` would force callers to special-case the response anyway. The clear migration message is preferred to either silent option.
3. **`OracleEnhanced::OCIConnection#exec` / `JDBCConnection#exec` lost the `allow_retry:` kwarg.** Any external code that reached into `lease_connection.send(:_connection).exec(sql, allow_retry: true)` (the kwarg is now removed; calling with it raises `ArgumentError`). `_connection` is fetched via `send` past a private boundary, so this surface is effectively internal — but it is technically observable. Callers should route through the public adapter API (`ActiveRecord::Base.lease_connection.execute(sql, allow_retry: true)`) which still accepts `allow_retry:` and threads it down to `with_raw_connection`.

## Test plan

- [x] `BUNDLE_ONLY=rubocop bundle exec rubocop` — clean (95 files, 0 offenses)
- [x] CI `test` (Oracle 23ai) — green on the squashed final SHA
- [x] CI `test_11g` — green on the squashed final SHA

## Follow-up

- #2769 — remove `Connection#select` after migrating spec call sites off the internal helper (also covers renaming the now-misleading `exec_no_retry` / `select_no_retry` helpers on JDBC).
- #2772 — `Arel::Nodes::NamedFunction` is unconditionally non-retryable, blocking AR retry for several oracle-enhanced predicates (CLOB `=`, case-insensitive LIKE, `Model.contains`, aggregate functions). Tracked separately.
- #2773 — add an explicit killed-session recovery regression spec for `Connection#name_resolve` / `resolve_data_source_name`.
- #2774 — rename `OCI8EnhancedAutoRecover` now that its auto-recovery functionality is gone.
