### PR TITLE
Mark the order_hacks-injected ORDER BY SqlLiteral as retryable

### DIFF
--- a/lib/arel/visitors/oracle_common.rb
+++ b/lib/arel/visitors/oracle_common.rb
@@ -76,7 +76,7 @@ module Arel # :nodoc: all
             if (nulls_match = order.match(/\bNULLS\s+(FIRST|LAST)\b/i))
               parts << "NULLS #{nulls_match[1].upcase}"
             end
-            o.orders << Arel::Nodes::SqlLiteral.new(parts.join(" "))
+            o.orders << Arel::Nodes::SqlLiteral.new(parts.join(" "), retryable: true)
           end
           o
         end

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle_spec.rb
@@ -57,6 +57,17 @@ RSpec.describe "Arel::Visitors::Oracle" do
     }
   end
 
+  it "leaves collector.retryable true after the DISTINCT+FIRST_VALUE ORDER BY rewrite" do
+    select = "DISTINCT foo.id, FIRST_VALUE(projects.name) OVER (foo) AS alias_0__"
+    stmt = Arel::Nodes::SelectStatement.new
+    stmt.cores.first.projections << Arel::Nodes::SqlLiteral.new(select, retryable: true)
+    stmt.orders << Arel::Nodes::SqlLiteral.new("foo", retryable: true)
+    collector = Arel::Collectors::SQLString.new
+    collector.retryable = true
+    @visitor.accept(stmt, collector)
+    expect(collector.retryable).to be(true)
+  end
+
   describe "Nodes::SelectStatement" do
     describe "limit" do
       it "adds a rownum clause" do


### PR DESCRIPTION
## Summary

Companion to #2766. `Arel::Visitors::OracleCommon#order_hacks` rewrites the outer `ORDER BY` of `DISTINCT ... FIRST_VALUE(...)` queries by pushing `Nodes::SqlLiteral.new("alias_N__ DESC NULLS ...")` into `o.orders`. `SqlLiteral` defaults to `retryable: false`, and `visit_Arel_Nodes_SqlLiteral` runs `collector.retryable &&= o.retryable`, so this single literal flips the whole SELECT's `collector.retryable` to false.

Both `Arel::Visitors::Oracle` (pre-12c) and `Arel::Visitors::Oracle12` route through the same `order_hacks` helper, so DISTINCT-with-outside-order queries on either visitor are affected. AR core's `with_raw_connection(allow_retry: true)` reads `collector.retryable` back into `allow_retry`, so the practical fallout is that those SELECTs miss the AR-level reconnect-and-retry layer even though they are plain idempotent SELECTs.

Pass `retryable: true` so the rewrite is neutral on retryability. This matches the upstream Rails convention for visitor-injected `SqlLiteral`: `Arel::Visitors::MySQL` line 30 does `o.froms ||= Arel.sql("DUAL", retryable: true)` and line 106 does the same for projection rewrites.

Adds a regression spec in `arel/oracle_spec.rb` that builds the DISTINCT+FIRST_VALUE shape, runs it through the visitor with a collector preset to `retryable = true` (matching AR's `to_sql_and_binds` preamble), and asserts the collector still reports `retryable` true after compilation.

## Test plan

- [x] `BUNDLE_ONLY=rubocop bundle exec rubocop` — clean (95 files, 0 offenses)
- [ ] CI `test` / `test_11g` — `arel/oracle_spec.rb` exercises the visitor in both versions via `OracleCommon`
