### PR TITLE
Mark Model.contains scope's SqlLiterals as retryable

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/context_index.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/context_index.rb
@@ -339,17 +339,17 @@ module ActiveRecord
               contains_node = Arel::Nodes::NamedFunction.new(
                 "CONTAINS",
                 [
-                  Arel::Nodes::SqlLiteral.new(quoted_column),
+                  Arel::Nodes::SqlLiteral.new(quoted_column, retryable: true),
                   Arel::Nodes::BindParam.new(query),
-                  Arel::Nodes::SqlLiteral.new(score_label.to_s)
+                  Arel::Nodes::SqlLiteral.new(score_label.to_s, retryable: true)
                 ]
               )
 
               # Create comparison node: CONTAINS(...) > 0
-              condition = Arel::Nodes::GreaterThan.new(contains_node, Arel::Nodes::SqlLiteral.new("0"))
+              condition = Arel::Nodes::GreaterThan.new(contains_node, Arel::Nodes::SqlLiteral.new("0", retryable: true))
 
               # Create the where clause and order by score
-              where(condition).order(Arel.sql("SCORE(#{score_label}) DESC"))
+              where(condition).order(Arel.sql("SCORE(#{score_label}) DESC", retryable: true))
             end
           end
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb
@@ -181,6 +181,15 @@ RSpec.describe "OracleEnhancedAdapter context index" do
       end
       @conn.remove_context_index :posts, :title
     end
+
+    it "leaves collector.retryable true so AR retry covers Model.contains queries" do
+      relation = Post.contains(:title, "anything")
+      collector = Arel::Collectors::SQLString.new
+      collector.retryable = true
+      visitor = ActiveRecord::Base.lease_connection.send(:arel_visitor)
+      visitor.accept(relation.arel.ast, collector)
+      expect(collector.retryable).to be(true)
+    end
   end
 
   describe "on multiple tables" do


### PR DESCRIPTION
## Summary

Companion to #2766. `ContextIndexClassMethods#contains` builds the `CONTAINS(col, query, label) > 0` predicate plus an `ORDER BY SCORE(label) DESC` clause from four library-controlled `SqlLiteral` / `Arel.sql` nodes:

- the quoted column inside the `CONTAINS` arguments (`SqlLiteral.new(quoted_column)`)
- the score label inside the `CONTAINS` arguments (`SqlLiteral.new(score_label.to_s)`)
- the `"0"` literal on the right of the `>` comparison
- the `SCORE(...) DESC` order (`Arel.sql("SCORE(#{score_label}) DESC")`)

All four default to `retryable: false`, and `visit_Arel_Nodes_SqlLiteral` runs `collector.retryable &&= o.retryable`, so any one of them flips the whole SELECT's `collector.retryable` to false. The CONTAINS/SCORE query is a plain idempotent CONTEXT-index SELECT, so AR core's `with_raw_connection(allow_retry: true)` should cover it.

The arguments are library-controlled — `quote_table_name` output for the column, `.to_i`-coerced score label, fixed `"0"` and `"SCORE(...) DESC"` — so marking them retryable matches the upstream Rails convention for library-generated identifiers and fixed SQL fragments: `query_methods.rb` / `predicate_builder.rb` / `finder_methods.rb` use `Arel.sql(..., retryable: true)` for the same shape, and adapter-level constants like `HIGH_PRECISION_CURRENT_TIMESTAMP` are declared the same way.

Adds a regression spec in `context_index_spec.rb` that builds the relation, walks the Arel AST through the adapter's visitor with a collector preset to `retryable = true` (matching AR's `to_sql_and_binds` preamble), and asserts the collector still reports `retryable` true after compilation.

## Test plan

- [x] `BUNDLE_ONLY=rubocop bundle exec rubocop` — clean (95 files, 0 offenses)
- [ ] CI `test` / `test_11g` — `context_index_spec.rb` exercises both `Post.contains(...).to_a` (existing scenarios) and the new collector-retryable assertion
