### PR TITLE
Add killed-session recovery regression spec for resolve_data_source_name

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb
@@ -837,6 +837,18 @@ RSpec.describe "OracleEnhancedConnection" do
       expect { ActiveRecord::Base.lease_connection.execute("SELECT * FROM dual") }.to raise_error(ActiveRecord::ConnectionFailed)
     end
 
+    # `resolve_data_source_name` routes the `DBMS_UTILITY.NAME_RESOLVE`
+    # call-out through `with_raw_connection(allow_retry: true)` in
+    # `schema_statements.rb`. Pin that AR-layer retry recovers it after
+    # a session kill — the SELECT-side counterparts above cover the
+    # `perform_query` path, this covers the schema-introspection path.
+    it "resolve_data_source_name recovers from a killed session via AR retry" do
+      # Warm the connection so the killed session is the one we just used.
+      ActiveRecord::Base.lease_connection.send(:resolve_data_source_name, "POSTS")
+      kill_current_session
+      expect(ActiveRecord::Base.lease_connection.send(:resolve_data_source_name, "POSTS")).not_to be_nil
+    end
+
     it "raises NotImplementedError when the removed auto_retry accessor is used" do
       expect { ActiveRecord::Base.lease_connection.auto_retry = true }.to raise_error(NotImplementedError, /connection_retries:/)
       expect { ActiveRecord::Base.lease_connection.auto_retry }.to raise_error(NotImplementedError, /connection_retries:/)


### PR DESCRIPTION
## Summary

Closes #2773.

PR #2768 removed the driver-level `with_retry { ... }` wrap from `OracleEnhanced::OCIConnection#name_resolve` and `OracleEnhanced::JDBCConnection#name_resolve`. Reconnect-and-retry moved to AR core's `with_raw_connection(allow_retry: true)`, applied in `OracleEnhanced::SchemaStatements#resolve_data_source_name`. The Step 3 audit for #2760 confirmed the call always reaches the connection through that wrap, so retry coverage is preserved, but the `connection_spec.rb` `"auto reconnection"` describe block had no explicit spec exercising it — the SELECT-side counterparts in #2768 only covered `perform_query` (Arel SELECTs, raw `select_all`, and the negative `execute(sql)` path).

This PR adds one regression spec:

```ruby
it "resolve_data_source_name recovers from a killed session via AR retry" do
  # Warm the connection so the killed session is the one we just used.
  ActiveRecord::Base.lease_connection.send(:resolve_data_source_name, "POSTS")
  kill_current_session
  expect(ActiveRecord::Base.lease_connection.send(:resolve_data_source_name, "POSTS")).not_to be_nil
end
```

Lives in the existing `"auto reconnection"` block to reuse `kill_current_session` and the `Post` setup from the describe-level `before(:all)`.

## Test plan

- [x] `BUNDLE_ONLY=rubocop bundle exec rubocop spec/active_record/connection_adapters/oracle_enhanced/connection_spec.rb` — clean
- [ ] CI `test` (Oracle 23ai) — exercise the new spec on the OCI path
- [ ] CI `test_11g` — same on Oracle 11g
