### PR TITLE
Collapse OCI8EnhancedAutoRecover into OracleEnhanced::OCIConnection

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -224,10 +224,6 @@ module ActiveRecord
         end
 
         # Resets connection, by logging off and creating a new connection.
-        def reset
-          reset!
-        end
-
         def reset!
           logoff rescue nil
           begin

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -75,10 +75,6 @@ module ActiveRecord
           raise OracleEnhanced::ConnectionException, e.message
         end
 
-        def reset
-          reset!
-        end
-
         # Resets connection, by logging off and creating a new connection.
         def reset!
           logoff rescue nil

--- a/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "delegate"
-
 begin
   require "oci8"
 rescue LoadError => e
@@ -27,8 +25,14 @@ module ActiveRecord
     # OCI database interface for MRI
     module OracleEnhanced
       class OCIConnection < OracleEnhanced::Connection # :nodoc:
+        attr_accessor :active
+        alias :active? :active
+
         def initialize(config)
-          @raw_connection = OCI8EnhancedAutoRecover.new(config, OracleEnhancedOCIFactory)
+          @config = config
+          @factory = OracleEnhancedOCIFactory
+          @raw_connection = @factory.new_connection(@config)
+          @active = true
           # default schema owner
           @owner = config[:schema]
           @owner ||= config[:username]
@@ -36,18 +40,12 @@ module ActiveRecord
         end
 
         def raw_oci_connection
-          if @raw_connection.is_a? OCI8
-            @raw_connection
-          # ActiveRecord Oracle enhanced adapter puts OCI8EnhancedAutoRecover wrapper around OCI8
-          # in this case we need to pass original OCI8 connection
-          else
-            @raw_connection.instance_variable_get(:@raw_connection)
-          end
+          @raw_connection
         end
 
         def logoff
           @raw_connection.logoff
-          @raw_connection.active = false
+          @active = false
         end
 
         def commit
@@ -70,22 +68,24 @@ module ActiveRecord
         # checks the connection, while #active? simply returns the last
         # known state.
         def ping
-          @raw_connection.ping
+          @raw_connection.exec("select 1 from dual") { |r| nil }
+          @active = true
         rescue OCIException => e
+          @active = false
           raise OracleEnhanced::ConnectionException, e.message
         end
 
-        def active?
-          @raw_connection.active?
-        end
-
         def reset
-          @raw_connection.reset
+          reset!
         end
 
+        # Resets connection, by logging off and creating a new connection.
         def reset!
-          @raw_connection.reset!
+          logoff rescue nil
+          @raw_connection = @factory.new_connection(@config)
+          @active = true
         rescue OCIException => e
+          @active = false
           raise OracleEnhanced::ConnectionException, e.message
         end
 
@@ -390,51 +390,3 @@ module ActiveRecord
     end
   end
 end
-
-# OCI8EnhancedAutoRecover wraps the bare OCI8 connection to track its
-# liveness (`@active` / `ping`) and to recreate it on `reset!`. AR core's
-# `with_raw_connection(allow_retry: true)` drives the reconnect-and-retry
-# loop on top of those primitives.
-# :stopdoc:
-class OCI8EnhancedAutoRecover < DelegateClass(OCI8) # :nodoc:
-  attr_accessor :active # :nodoc:
-  alias :active? :active # :nodoc:
-
-  def initialize(config, factory) # :nodoc:
-    @active = true
-    @config = config
-    @factory = factory
-    @raw_connection = @factory.new_connection @config
-    super @raw_connection
-  end
-
-  # Checks connection, returns true if active. Note that ping actively
-  # checks the connection, while #active? simply returns the last
-  # known state.
-  def ping # :nodoc:
-    @raw_connection.exec("select 1 from dual") { |r| nil }
-    @active = true
-  rescue
-    @active = false
-    raise
-  end
-
-  def reset
-    # tentative
-    reset!
-  end
-
-  # Resets connection, by logging off and creating a new connection.
-  def reset! # :nodoc:
-    logoff rescue nil
-    begin
-      @raw_connection = @factory.new_connection @config
-      __setobj__ @raw_connection
-      @active = true
-    rescue
-      @active = false
-      raise
-    end
-  end
-end
-# :startdoc:

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1120,7 +1120,7 @@ module ActiveRecord
       end
 
       private def reconnect
-        _connection.reset
+        _connection.reset!
       rescue OracleEnhanced::ConnectionException
         connect
       end


### PR DESCRIPTION
## Summary

Closes #2774.

`OCI8EnhancedAutoRecover` originally existed to layer driver-level auto-retry on top of OCI8. The retry mechanism moved entirely to AR core's `with_raw_connection(allow_retry: true)` in #2768, leaving this class as a thin `DelegateClass(OCI8)` wrapper whose only remaining job was to let `OCIConnection` swap its underlying OCI8 in place via `__setobj__` during reconnect.

That swap can be done with a plain ivar reassignment now that the outer `OCIConnection` instance is what AR holds on to (the adapter's `@raw_connection`). The JDBC side already takes that approach — `JDBCConnection` holds the raw JDBC connection directly and recreates it inside its own `reset!`, without any intermediate wrapper class. The OCI side now matches.

Before / after:

```
OCI side, before                        OCI side, after        JDBC side
─────────────────                       ─────────────────      ─────────────────
OracleEnhanced::OCIConnection           OracleEnhanced::       OracleEnhanced::
  @raw_connection                       OCIConnection          JDBCConnection
    = OCI8EnhancedAutoRecover             @raw_connection        @raw_connection
        @raw_connection                     = OCI8               = raw JDBC conn
          = OCI8 (via DelegateClass)
```

### Removed
- Top-level `OCI8EnhancedAutoRecover < DelegateClass(OCI8)` class
- `require "delegate"` (no other code in this file used it)

### Moved into `OracleEnhanced::OCIConnection`
- `attr_accessor :active` / `alias :active? :active`
- `@config` / `@factory` ivars
- `ping` body — exec a probe SELECT, update `@active`, translate `OCIException` to `OracleEnhanced::ConnectionException` (the outer ping previously delegated to the inner ping and only translated; now both responsibilities live in one method)
- `reset!` body — logoff (best-effort), recreate the OCI8 via `@factory.new_connection(@config)`, reset `@active`

### Simplified
- `OCIConnection#raw_oci_connection` is now just `@raw_connection` — the `@raw_connection.is_a? OCI8` case branch that unwrapped the DelegateClass via `instance_variable_get(:@raw_connection)` is no longer needed.
- `OCIConnection#logoff` sets `@active = false` on itself instead of reaching through the wrapper's accessor.

Net: -48 lines in `oci_connection.rb`.

### Compatibility

The constant `OCI8EnhancedAutoRecover` is `:nodoc:`-marked (originally between `:stopdoc:` / `:startdoc:`), so it was never part of the documented surface. External code that referenced it via `lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb`'s top-level constant will now get `NameError`. No deprecated alias is kept — the class is fully internal and the only known callers were inside this file.

## Test plan

- [x] `BUNDLE_ONLY=rubocop bundle exec rubocop` — clean (95 files, 0 offenses)
- [x] `ruby -c` syntax check on the modified file
- [ ] CI `test` (Oracle 23ai) — exercise the new direct-OCI8 lifecycle on the connection / ping / reset! paths
- [ ] CI `test_11g` — same on Oracle 11g
