### PR TITLE
Backport #2664 to release81: Restore Arel In and NotIn support

### DIFF
--- a/lib/arel/visitors/oracle_common.rb
+++ b/lib/arel/visitors/oracle_common.rb
@@ -46,6 +46,35 @@ module Arel # :nodoc: all
         def schema_cache
           @connection.schema_cache
         end
+
+        def visit_Arel_Nodes_In(o, collector)
+          attr, values = o.left, o.right
+          return super unless values.is_a?(Array)
+
+          in_clause_length = @connection.in_clause_length
+          return super if values.length <= in_clause_length
+
+          # Split into multiple IN nodes and combine with OR
+          in_nodes = values.each_slice(in_clause_length).map do |slice|
+            Arel::Nodes::In.new(attr, slice)
+          end
+          or_node = Arel::Nodes::Or.new(in_nodes)
+          visit(Arel::Nodes::Grouping.new(or_node), collector)
+        end
+
+        def visit_Arel_Nodes_NotIn(o, collector)
+          attr, values = o.left, o.right
+          return super unless values.is_a?(Array)
+
+          in_clause_length = @connection.in_clause_length
+          return super if values.length <= in_clause_length
+
+          # Split into multiple NOT IN nodes and combine with AND
+          not_in_nodes = values.each_slice(in_clause_length).map do |slice|
+            Arel::Nodes::NotIn.new(attr, slice)
+          end
+          visit(Arel::Nodes::And.new(not_in_nodes), collector)
+        end
     end
   end
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -244,7 +244,7 @@ describe "OracleEnhancedAdapter" do
       class ::TestPost < ActiveRecord::Base
         has_many :test_comments
       end
-      @ids = (1..1010).to_a
+      @ids = (1..2010).to_a
       TestPost.transaction do
         @ids.each do |id|
           TestPost.create!(id: id, title: "Title #{id}")
@@ -271,6 +271,38 @@ describe "OracleEnhancedAdapter" do
     it "should allow more than 1000 items in a list where the list is non-homogenous" do
       posts = TestPost.where(id: [*@ids, nil]).to_a
       expect(posts.size).to eq(@ids.size)
+    end
+
+    # some frameworks like baby_squeel construct Arel objects directly
+    it "should allow more than 1000 items using Arel::Nodes::In" do
+      table = TestPost.arel_table
+      in_node = Arel::Nodes::In.new(table[:id], @ids)
+      query = table.where(in_node).project(Arel.star)
+
+      sql = query.to_sql
+      posts = TestPost.connection.select_all(sql).to_a
+      expect(posts.size).to eq(@ids.size)
+
+      # SQL contains multiple IN clauses (split due to 1000 limit)
+      expect(sql.scan(/IN \(/).size).to be > 1
+    end
+
+    it "should allow more than 1000 items using Arel::Nodes::NotIn" do
+      ids = @ids.dup
+      non_not_in = ids.pop
+
+      table = TestPost.arel_table
+      not_in_node = Arel::Nodes::NotIn.new(table[:id], ids)
+      query = table.where(not_in_node).project(Arel.star)
+
+      sql = query.to_sql
+      posts = TestPost.connection.select_all(sql).to_a
+
+      expect(posts.size).to eq(1)
+      expect(posts.first["id"]).to eq(non_not_in)
+
+      # SQL contains multiple NOT IN clauses (split due to 1000 limit)
+      expect(sql.scan(/NOT IN \(/).size).to be > 1
     end
   end
 
@@ -806,10 +838,54 @@ describe "OracleEnhancedAdapter" do
       ActiveRecord::Base.clear_cache!
     end
 
+    before(:each) do
+      TestPost.delete_all
+      TestComment.delete_all
+    end
+
     it "should not raise undefined method length" do
       post = TestPost.create!
       post.test_comments << TestComment.create!
       expect(TestComment.where(test_post_id: TestPost.select(:id)).size).to eq(1)
+    end
+
+    it "should handle IN with subquery using Arel::Nodes::In" do
+      post = TestPost.create!
+      post.test_comments << TestComment.create!
+
+      table = TestComment.arel_table
+      subquery = TestPost.select(:id).arel
+      in_node = Arel::Nodes::In.new(table[:test_post_id], subquery)
+      query = table.where(in_node).project(Arel.star)
+
+      sql = query.to_sql
+      comments = TestComment.connection.select_all(sql).to_a
+      expect(comments.size).to eq(1)
+
+      # SQL should contain IN with subquery, not split into multiple IN clauses
+      expect(sql).to match(/IN \(+SELECT/)
+      expect(sql.scan(/IN \(/).size).to eq(1)
+    end
+
+    it "should handle NOT IN with subquery using Arel::Nodes::NotIn" do
+      post = TestPost.create!
+      TestComment.create!(test_post_id: post.id)
+      orphan_comment = TestComment.create!(test_post_id: post.id + 1)
+
+      table = TestComment.arel_table
+      subquery = TestPost.select(:id).arel
+      not_in_node = Arel::Nodes::NotIn.new(table[:test_post_id], subquery)
+      query = table.where(not_in_node).project(Arel.star)
+
+      sql = query.to_sql
+      comments = TestComment.connection.select_all(sql).to_a
+
+      expect(comments.size).to eq(1)
+      expect(comments.first["id"]).to eq(orphan_comment.id)
+
+      # SQL should contain NOT IN with subquery, not split into multiple NOT IN clauses
+      expect(sql).to match(/NOT IN \(+SELECT/)
+      expect(sql.scan(/NOT IN \(/).size).to eq(1)
     end
   end
 end


### PR DESCRIPTION
## Summary
- Backports #2664 to `release81`.
- Restores `visit_Arel_Nodes_In` / `visit_Arel_Nodes_NotIn` in `Arel::Visitors::OracleCommon`. They were removed in `94057806b` (2020) when AR core switched to `visit_Arel_Nodes_HomogeneousIn`, but direct Arel use (e.g. `baby_squeel`, hand-built Arel queries) still produces `Arel::Nodes::In` / `Arel::Nodes::NotIn` and was hitting ORA-01795 ("maximum number of expressions in a list is 1000") for arrays larger than `in_clause_length`.
- Implementation deconstructs the original node into smaller `In` / `NotIn` chunks and combines them with `Or` / `And`, then delegates back through `visit`, so the upstream `Arel::Visitors::ToSql` handling (including `collector.preparable = false` and `unboundable?` removal) is reused unchanged. Subqueries (non-Array values) and arrays at or under `in_clause_length` short-circuit to `super`.
- Cherry-pick had a context conflict in `lib/arel/visitors/oracle_common.rb` because release81 does not have `573aaa1c` ("Hoist order_hacks/split_order_string into OracleCommon"). Resolved by keeping only the two new `visit_Arel_Nodes_In{,NotIn}` methods; `order_hacks` is unrelated and stays out of release81.

## Test plan
- [x] `bundle exec rubocop lib/arel/visitors/oracle_common.rb spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb` — no offenses
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb -e "more than 1000 items using Arel" -e "subquery using Arel" -e "should not raise undefined method length" -e "should load included association with more than 1000 records"` — 6 examples, 0 failures (Oracle Free 23.26 / FREEPDB1, Rails 8.1-stable)
