### PR TITLE
Backport #2767 to release81: ci: Pin Bundler to 4.0.6 in RuboCop workflow

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -10,12 +10,20 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    env:
+      BUNDLER_VERSION: 4.0.6
     steps:
       - uses: actions/checkout@v6
       - name: Set up Ruby 4.0
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 4.0
+      - name: Pin Bundler to 4.0.6 (workaround for ruby/rubygems#9536)
+        run: |
+          gem install bundler -v 4.0.6
+          ruby --version
+          gem --version
+          bundle --version
       - name: Build and run RuboCop
         run: |
           BUNDLE_ONLY=rubocop bundle install --jobs 4 --retry 3


### PR DESCRIPTION
## Summary
- Backports #2767 to `release81`.
- The RuboCop workflow on release81 fails the same way master did before #2767: with Ruby 4.0.4 (Bundler 4.0.10+ bundled), `BUNDLE_ONLY=rubocop bundle install` cannot resolve this Gemfile against the multi-gemspec `rails/rails` git source whose top-level gem sits in a filtered-out group. Bundler 4.0.5 / 4.0.6 succeed; 4.0.7 through 4.0.11 fail. Upstream regression: ruby/rubygems#9536.
- Pin Bundler explicitly in `.github/workflows/rubocop.yml`: keep `ruby-version: 4.0`, set `BUNDLER_VERSION=4.0.6` at job level, and `gem install bundler -v 4.0.6` so the version is actually present in the Ruby image.
- Surfaced because the backport PR #2777 RuboCop job fails identically on release81 — see https://github.com/rsim/oracle-enhanced/actions/runs/25720875342/job/75521502179?pr=2777.

## Test plan
- [x] Cherry-picks cleanly onto release81 (no conflicts).
- [ ] Watch this PR's RuboCop workflow run — should pass with the pin.

Once Bundler ships a fix for ruby/rubygems#9536, drop `BUNDLER_VERSION` and the install step (same revert path as master).
