### PR TITLE
Add direct visitor spec for Arel::Visitors::OracleCommon helpers (#2663 task F)

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle_common_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle_common_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+RSpec.describe "Arel::Visitors::OracleCommon" do
+  include SchemaSpecHelper
+
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    schema_define do
+      create_table :test_oracle_common_lobs, force: true do |t|
+        t.text   :body
+        t.binary :payload
+        t.string :name
+      end
+    end
+    # Warm the schema cache so `cached_column_for` (which uses cached
+    # lookups only) can resolve attribute types in the assertions below.
+    ActiveRecord::Base.connection.schema_cache.columns_hash("test_oracle_common_lobs")
+  end
+
+  after(:all) do
+    schema_define do
+      drop_table :test_oracle_common_lobs, if_exists: true
+    end
+  end
+
+  before(:each) do
+    @visitor = Arel::Visitors::Oracle12.new(ActiveRecord::Base.connection)
+    @table = Arel::Table.new(:test_oracle_common_lobs)
+  end
+
+  def compile(node)
+    @visitor.accept(node, Arel::Collectors::SQLString.new).value
+  end
+
+  describe "visit_Arel_Nodes_Equality" do
+    it "rewrites equality on a :text column to DBMS_LOB.COMPARE = 0" do
+      node = Arel::Nodes::Equality.new(@table[:body], Arel::Nodes::Casted.new("hello", @table[:body]))
+      expect(compile(node)).to match(/DBMS_LOB\.COMPARE\(.*"BODY".*'hello'.*\)\s*=\s*0/)
+    end
+
+    it "rewrites equality on a :binary column to DBMS_LOB.COMPARE = 0" do
+      node = Arel::Nodes::Equality.new(@table[:payload], Arel::Nodes::Casted.new("x", @table[:payload]))
+      expect(compile(node)).to match(/DBMS_LOB\.COMPARE\(.*"PAYLOAD".*\)\s*=\s*0/)
+    end
+
+    it "leaves equality on a :string column as plain `=`" do
+      node = Arel::Nodes::Equality.new(@table[:name], Arel::Nodes::Casted.new("foo", @table[:name]))
+      sql = compile(node)
+      expect(sql).not_to match(/DBMS_LOB/)
+      expect(sql).to match(/"NAME"\s*=\s*'foo'/)
+    end
+
+    it "falls through to plain `=` when the table is not in the schema cache" do
+      unknown_table = Arel::Table.new(:test_oracle_common_no_such_table)
+      node = Arel::Nodes::Equality.new(unknown_table[:any], Arel::Nodes::Casted.new("x", unknown_table[:any]))
+      expect(compile(node)).not_to match(/DBMS_LOB/)
+    end
+
+    it "falls through to plain `=` when the left side is not an Arel::Attributes::Attribute" do
+      literal = Arel::Nodes::SqlLiteral.new("dummy_fn()")
+      node = Arel::Nodes::Equality.new(literal, Arel.sql("'x'"))
+      expect(compile(node)).not_to match(/DBMS_LOB/)
+    end
+
+    it "does not rewrite NotEqual on a :text column" do
+      node = Arel::Nodes::NotEqual.new(@table[:body], Arel::Nodes::Casted.new("hello", @table[:body]))
+      expect(compile(node)).not_to match(/DBMS_LOB/)
+    end
+
+    it "does not rewrite GreaterThan on a :text column" do
+      node = Arel::Nodes::GreaterThan.new(@table[:body], Arel::Nodes::Casted.new("hello", @table[:body]))
+      expect(compile(node)).not_to match(/DBMS_LOB/)
+    end
+
+    it "rewrites equality the same way via Arel::Visitors::Oracle" do
+      oracle = Arel::Visitors::Oracle.new(ActiveRecord::Base.connection)
+      node = Arel::Nodes::Equality.new(@table[:body], Arel::Nodes::Casted.new("hello", @table[:body]))
+      sql = oracle.accept(node, Arel::Collectors::SQLString.new).value
+      expect(sql).to match(/DBMS_LOB\.COMPARE\(.*"BODY".*'hello'.*\)\s*=\s*0/)
+    end
+  end
+
+  describe "visit_Arel_Nodes_Matches" do
+    it "wraps both sides in UPPER() when case_sensitive is false (default)" do
+      node = Arel::Nodes::Matches.new(@table[:name], Arel.sql("'foo'"), nil, false)
+      sql = compile(node)
+      expect(sql).to match(/UPPER\(\s*"TEST_ORACLE_COMMON_LOBS"\."NAME"\s*\)\s+LIKE\s+UPPER\(\s*'foo'\s*\)/)
+    end
+
+    it "leaves the SQL as-is when case_sensitive is true" do
+      node = Arel::Nodes::Matches.new(@table[:name], Arel.sql("'foo'"), nil, true)
+      sql = compile(node)
+      expect(sql).not_to match(/UPPER/)
+      expect(sql).to match(/"NAME"\s+LIKE\s+'foo'/)
+    end
+
+    it "wraps both sides in UPPER() the same way via Arel::Visitors::Oracle" do
+      oracle = Arel::Visitors::Oracle.new(ActiveRecord::Base.connection)
+      node = Arel::Nodes::Matches.new(@table[:name], Arel.sql("'foo'"), nil, false)
+      sql = oracle.accept(node, Arel::Collectors::SQLString.new).value
+      expect(sql).to match(/UPPER\(\s*"TEST_ORACLE_COMMON_LOBS"\."NAME"\s*\)\s+LIKE\s+UPPER\(\s*'foo'\s*\)/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- First slice of #2663 — tightens visitor-level coverage for `Arel::Visitors::OracleCommon`. Spec-only; no `lib/` change.
- Adds a new file `spec/active_record/connection_adapters/oracle_enhanced/arel/oracle_common_spec.rb` covering the three helpers in `lib/arel/visitors/oracle_common.rb` (lines 12-48) that were previously only exercised via integration:
  - `visit_Arel_Nodes_Equality` rewrites equality on `:text` / `:binary` columns to `DBMS_LOB.COMPARE(...) = 0`. Equality on a `:string` column stays as plain `=`, and so does equality when `cached_column_for` falls through — either because the table is not in the schema cache, or because the left side is not an `Arel::Attributes::Attribute`.
  - `visit_Arel_Nodes_Matches` with `case_sensitive: false` wraps both sides in `UPPER()`; with `case_sensitive: true` the SQL stays as-is.
- Pins the boundary of the equality override: `NotEqual` and `GreaterThan` on a `:text` column are **not** rewritten to `DBMS_LOB.COMPARE`. This prevents a future override extension from silently masking `ORA-00932: inconsistent datatypes` on non-`=` comparisons against CLOB/BLOB columns.
- Covers both visitors: `Arel::Visitors::Oracle` (legacy ROWNUM) and `Arel::Visitors::Oracle12`. `OracleCommon` is mixed into both, so the override behaviour for `Equality` and `Matches` is asserted against each visitor instance rather than relying on the implementations staying identical by inspection.
- Schema cache is warmed in `before(:all)` via `connection.schema_cache.columns_hash("test_oracle_common_lobs")` because `cached_column_for` only consults the *cached* lookup (`schema_cache.columns_hash?` returns false until populated).
- Tasks A (`HomogeneousIn` branches), B (`UpdateStatement` order stripping), C (`order_hacks` NULLS handling), D (`build_subselect` orders=[]), E (literal limit/offset `value_before_type_cast`) from #2663 are left for follow-up PRs.

## Test plan
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/arel/oracle_common_spec.rb` — 11 examples, 0 failures (Oracle Free 23.26 / FREEPDB1)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/arel/` — 48 examples, 0 failures (no regressions in the surrounding `arel/` specs)
- [x] `bundle exec rubocop spec/active_record/connection_adapters/oracle_enhanced/arel/oracle_common_spec.rb` — no offenses
