### PR TITLE
Move visit_Arel_Nodes_HomogeneousIn into Arel::Visitors::OracleCommon (#2663 task A)

### DIFF
--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -107,54 +107,6 @@ module Arel # :nodoc: all
           end
         end
 
-        ##
-        # To avoid ORA-01795: maximum number of expressions in a list is 1000
-        # tell ActiveRecord to limit us to 1000 ids at a time
-        def visit_Arel_Nodes_HomogeneousIn(o, collector)
-          collector.preparable = false
-          in_clause_length = @connection.in_clause_length
-          values = o.casted_values.map { |v| @connection.quote(v) }
-          operator =
-            if o.type == :in
-              " IN ("
-            else
-              " NOT IN ("
-            end
-
-          if !Array === values || values.length <= in_clause_length
-            visit o.left, collector
-            collector << operator
-
-            expr =
-              if values.empty?
-                @connection.quote(nil)
-              else
-                values.join(",")
-              end
-
-            collector << expr
-            collector << ")"
-          else
-            separator =
-              if o.type == :in
-                " OR "
-              else
-                " AND "
-              end
-            collector << "("
-            values.each_slice(in_clause_length).each_with_index do |valuez, i|
-              collector << separator unless i == 0
-              visit o.left, collector
-              collector << operator
-              collector << valuez.join(",")
-              collector << ")"
-            end
-            collector << ")"
-          end
-
-          collector
-        end
-
         def visit_Arel_Nodes_UpdateStatement(o, collector)
           # Oracle does not allow ORDER BY/LIMIT in UPDATEs.
           if o.orders.any? && o.limit.nil?

--- a/lib/arel/visitors/oracle12.rb
+++ b/lib/arel/visitors/oracle12.rb
@@ -55,52 +55,6 @@ module Arel # :nodoc: all
           collector << " )"
         end
 
-        ##
-        # To avoid ORA-01795: maximum number of expressions in a list is 1000
-        # tell ActiveRecord to limit us to 1000 ids at a time
-        def visit_Arel_Nodes_HomogeneousIn(o, collector)
-          collector.preparable = false
-          in_clause_length = @connection.in_clause_length
-          values = o.casted_values.map { |v| @connection.quote(v) }
-          operator =
-            if o.type == :in
-              " IN ("
-            else
-              " NOT IN ("
-            end
-
-          if !Array === values || values.length <= in_clause_length
-            visit o.left, collector
-            collector << operator
-
-            expr =
-              if values.empty?
-                @connection.quote(nil)
-              else
-                values.join(",")
-              end
-
-            collector << expr
-            collector << ")"
-          else
-            separator =
-              if o.type == :in
-                " OR "
-              else
-                " AND "
-              end
-            collector << "("
-            values.each_slice(in_clause_length).each_with_index do |valuez, i|
-              collector << separator unless i == 0
-              visit o.left, collector
-              collector << operator
-              collector << valuez.join(",")
-              collector << ")"
-            end
-            collector << ")"
-          end
-        end
-
         def visit_Arel_Nodes_UpdateStatement(o, collector)
           # Oracle does not allow ORDER BY/LIMIT in UPDATEs.
           if o.orders.any? && o.limit.nil?

--- a/lib/arel/visitors/oracle_common.rb
+++ b/lib/arel/visitors/oracle_common.rb
@@ -98,6 +98,53 @@ module Arel # :nodoc: all
           array
         end
 
+        # To avoid ORA-01795: maximum number of expressions in a list is 1000
+        # tell ActiveRecord to limit us to 1000 ids at a time
+        def visit_Arel_Nodes_HomogeneousIn(o, collector)
+          collector.preparable = false
+          in_clause_length = @connection.in_clause_length
+          values = o.casted_values.map { |v| @connection.quote(v) }
+          operator =
+            if o.type == :in
+              " IN ("
+            else
+              " NOT IN ("
+            end
+
+          if values.length <= in_clause_length
+            visit o.left, collector
+            collector << operator
+
+            expr =
+              if values.empty?
+                @connection.quote(nil)
+              else
+                values.join(",")
+              end
+
+            collector << expr
+            collector << ")"
+          else
+            separator =
+              if o.type == :in
+                " OR "
+              else
+                " AND "
+              end
+            collector << "("
+            values.each_slice(in_clause_length).each_with_index do |valuez, i|
+              collector << separator unless i == 0
+              visit o.left, collector
+              collector << operator
+              collector << valuez.join(",")
+              collector << ")"
+            end
+            collector << ")"
+          end
+
+          collector
+        end
+
         def visit_Arel_Nodes_In(o, collector)
           attr, values = o.left, o.right
           return super unless values.is_a?(Array)

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/homogeneous_in_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/homogeneous_in_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+RSpec.describe "Arel::Visitors::OracleCommon#visit_Arel_Nodes_HomogeneousIn" do
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+  end
+
+  before(:each) do
+    @visitor = Arel::Visitors::Oracle12.new(ActiveRecord::Base.connection)
+    type_caster = Class.new { def type_for_attribute(_name) = ActiveRecord::Type::Value.new }.new
+    @table = Arel::Table.new(:users, type_caster: type_caster)
+  end
+
+  def compile(node, visitor: @visitor)
+    visitor.accept(node, Arel::Collectors::SQLString.new).value
+  end
+
+  it "marks the collector as not preparable" do
+    node = Arel::Nodes::HomogeneousIn.new([1, 2, 3], @table[:id], :in)
+    collector = Arel::Collectors::SQLString.new
+    collector.preparable = true
+    @visitor.accept(node, collector)
+    expect(collector.preparable).to be(false)
+  end
+
+  it "renders :in as a literal IN list" do
+    node = Arel::Nodes::HomogeneousIn.new([1, 2, 3], @table[:id], :in)
+    expect(compile(node)).to match(/"USERS"\."ID"\s+IN\s+\(1,2,3\)/)
+  end
+
+  it "renders :notin as a literal NOT IN list" do
+    node = Arel::Nodes::HomogeneousIn.new([1, 2, 3], @table[:id], :notin)
+    expect(compile(node)).to match(/"USERS"\."ID"\s+NOT IN\s+\(1,2,3\)/)
+  end
+
+  it "falls back to NULL when :in has an empty values array" do
+    node = Arel::Nodes::HomogeneousIn.new([], @table[:id], :in)
+    expect(compile(node)).to match(/"USERS"\."ID"\s+IN\s+\(NULL\)/)
+  end
+
+  it "falls back to NULL when :notin has an empty values array" do
+    node = Arel::Nodes::HomogeneousIn.new([], @table[:id], :notin)
+    expect(compile(node)).to match(/"USERS"\."ID"\s+NOT IN\s+\(NULL\)/)
+  end
+
+  it "chunks :in into multiple IN groups joined by OR when values exceed in_clause_length" do
+    node = Arel::Nodes::HomogeneousIn.new((1..1001).to_a, @table[:id], :in)
+    sql = compile(node)
+    expect(sql.scan(/"USERS"\."ID" IN \(/).size).to eq(2)
+    expect(sql).to include(" OR ")
+    expect(sql).to start_with("(")
+    expect(sql).to end_with(")")
+    expect(sql).to include("IN (1001)")
+  end
+
+  it "chunks :notin into multiple NOT IN groups joined by AND when values exceed in_clause_length" do
+    node = Arel::Nodes::HomogeneousIn.new((1..1001).to_a, @table[:id], :notin)
+    sql = compile(node)
+    expect(sql.scan(/"USERS"\."ID" NOT IN \(/).size).to eq(2)
+    expect(sql).to include(" AND ")
+    expect(sql).to start_with("(")
+    expect(sql).to end_with(")")
+    expect(sql).to include("NOT IN (1001)")
+  end
+
+  it "chunks :in the same way via Arel::Visitors::Oracle" do
+    oracle = Arel::Visitors::Oracle.new(ActiveRecord::Base.connection)
+    node = Arel::Nodes::HomogeneousIn.new((1..1001).to_a, @table[:id], :in)
+    sql = compile(node, visitor: oracle)
+    expect(sql.scan(/"USERS"\."ID" IN \(/).size).to eq(2)
+    expect(sql).to include(" OR ")
+  end
+
+  it "chunks :notin the same way via Arel::Visitors::Oracle" do
+    oracle = Arel::Visitors::Oracle.new(ActiveRecord::Base.connection)
+    node = Arel::Nodes::HomogeneousIn.new((1..1001).to_a, @table[:id], :notin)
+    sql = compile(node, visitor: oracle)
+    expect(sql.scan(/"USERS"\."ID" NOT IN \(/).size).to eq(2)
+    expect(sql).to include(" AND ")
+  end
+end

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle12_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle12_spec.rb
@@ -116,16 +116,4 @@ RSpec.describe "Arel::Visitors::Oracle12" do
       expect(sql).to be_like %{ "USERS"."NAME" IS NOT NULL }
     end
   end
-
-  describe "visit_Arel_Nodes_HomogeneousIn" do
-    it "marks the collector as not preparable" do
-      type_caster = Class.new { def type_for_attribute(_name) = ActiveRecord::Type::Value.new }.new
-      table = Arel::Table.new(:users, type_caster: type_caster)
-      node = Arel::Nodes::HomogeneousIn.new([1, 2, 3], table[:id], :in)
-      collector = Arel::Collectors::SQLString.new
-      collector.preparable = true
-      @visitor.accept(node, collector)
-      expect(collector.preparable).to be(false)
-    end
-  end
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle_spec.rb
@@ -252,16 +252,4 @@ RSpec.describe "Arel::Visitors::Oracle" do
       }
     end
   end
-
-  describe "visit_Arel_Nodes_HomogeneousIn" do
-    it "marks the collector as not preparable" do
-      type_caster = Class.new { def type_for_attribute(_name) = ActiveRecord::Type::Value.new }.new
-      table = Arel::Table.new(:users, type_caster: type_caster)
-      node = Arel::Nodes::HomogeneousIn.new([1, 2, 3], table[:id], :in)
-      collector = Arel::Collectors::SQLString.new
-      collector.preparable = true
-      @visitor.accept(node, collector)
-      expect(collector.preparable).to be(false)
-    end
-  end
 end


### PR DESCRIPTION
## Summary
- Second slice of #2663 (task A). Moves `visit_Arel_Nodes_HomogeneousIn` out of `lib/arel/visitors/oracle.rb` and `lib/arel/visitors/oracle12.rb` (where the implementation was functionally identical — oracle.rb had an extra explicit `collector` return line that oracle12.rb relied on the if/else's implicit value for, but the SQL output is the same) into `lib/arel/visitors/oracle_common.rb`, alongside the `visit_Arel_Nodes_In` / `visit_Arel_Nodes_NotIn` variants added by #2664. Removes ~47 lines of duplication and keeps all list-of-values clause handling in one module.
- Drops a long-standing dead-code clause in the same method: `!Array === values || ...`. Ruby's operator precedence parses that as `(!Array) === values` (i.e. `false === values`), which is always false because `o.casted_values.map` always returns an Array. The visitor's behavior is unchanged; this is purely a hygiene clean-up made obvious by the move.
- Replaces the single visitor-level test in `oracle_spec.rb` and `oracle12_spec.rb` (which only asserted `preparable = false`) with a new direct spec at `spec/active_record/connection_adapters/oracle_enhanced/arel/homogeneous_in_spec.rb` that exercises every branch the existing implementation took on integration alone:
  - `:in` / `:notin` happy paths render `"USERS"."ID" IN (1,2,3)` / `NOT IN (1,2,3)`.
  - empty `values` array falls back to `IN (NULL)` / `NOT IN (NULL)` via `@connection.quote(nil)`.
  - `values.length > in_clause_length` triggers the chunked form: `(col IN (...) OR col IN (...))` for `:in` and `(col NOT IN (...) AND col NOT IN (...))` for `:notin`, which is how the visitor avoids ORA-01795 ("maximum number of expressions in a list is 1000").
  - `collector.preparable` is forced to `false` (preserves the assertion that the previous spec made).
  - `Arel::Visitors::Oracle` (legacy ROWNUM) and `Arel::Visitors::Oracle12` produce identical SQL for **both** `:in` and `:notin` chunked forms, since both pick up `OracleCommon`.
- Tasks B (`UpdateStatement` order stripping), C (`order_hacks` NULLS handling), D (`build_subselect` orders=[]), E (literal limit/offset `value_before_type_cast`) from #2663 are left for follow-up PRs. Task F shipped in #2779; task C shipped in #2782.

## Test plan
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/arel/homogeneous_in_spec.rb` — 9 examples, 0 failures (Oracle Free 23.26 / FREEPDB1)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/arel/` — 44 examples, 0 failures (no regressions in the surrounding `arel/` specs)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb -e "homogeneous in" -e "Arel In and NoIn"` — 3 examples, 0 failures (the integration paths through HomogeneousIn / In / NotIn still work after the move)
- [x] `bundle exec rubocop lib/arel/visitors/ spec/active_record/connection_adapters/oracle_enhanced/arel/` — no offenses
