### PR TITLE
Move visit_Arel_Nodes_UpdateStatement into Arel::Visitors::OracleCommon (#2663 task B)

### DIFF
--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -107,18 +107,6 @@ module Arel # :nodoc: all
           end
         end
 
-        def visit_Arel_Nodes_UpdateStatement(o, collector)
-          # Oracle does not allow ORDER BY/LIMIT in UPDATEs.
-          if o.orders.any? && o.limit.nil?
-            # However, there is no harm in silently eating the ORDER BY clause if no LIMIT has been provided,
-            # otherwise let the user deal with the error
-            o = o.dup
-            o.orders = []
-          end
-
-          super
-        end
-
         def is_distinct_from(o, collector)
           collector << "DECODE("
           collector = visit [o.left, o.right, 0, 1], collector

--- a/lib/arel/visitors/oracle12.rb
+++ b/lib/arel/visitors/oracle12.rb
@@ -55,18 +55,6 @@ module Arel # :nodoc: all
           collector << " )"
         end
 
-        def visit_Arel_Nodes_UpdateStatement(o, collector)
-          # Oracle does not allow ORDER BY/LIMIT in UPDATEs.
-          if o.orders.any? && o.limit.nil?
-            # However, there is no harm in silently eating the ORDER BY clause if no LIMIT has been provided,
-            # otherwise let the user deal with the error
-            o = o.dup
-            o.orders = []
-          end
-
-          super
-        end
-
         def is_distinct_from(o, collector)
           collector << "DECODE("
           collector = visit [o.left, o.right, 0, 1], collector

--- a/lib/arel/visitors/oracle_common.rb
+++ b/lib/arel/visitors/oracle_common.rb
@@ -98,6 +98,18 @@ module Arel # :nodoc: all
           array
         end
 
+        # Oracle does not allow ORDER BY in UPDATE statements. Strip it
+        # when no LIMIT is present; with a LIMIT, pass through so super
+        # surfaces Oracle's own error (LIMIT in UPDATE is unsupported too).
+        def visit_Arel_Nodes_UpdateStatement(o, collector)
+          if o.orders.any? && o.limit.nil?
+            o = o.dup
+            o.orders = []
+          end
+
+          super
+        end
+
         # To avoid ORA-01795: maximum number of expressions in a list is 1000
         # tell ActiveRecord to limit us to 1000 ids at a time
         def visit_Arel_Nodes_HomogeneousIn(o, collector)
@@ -143,18 +155,6 @@ module Arel # :nodoc: all
           end
 
           collector
-        end
-
-        def visit_Arel_Nodes_UpdateStatement(o, collector)
-          # Oracle does not allow ORDER BY/LIMIT in UPDATEs.
-          if o.orders.any? && o.limit.nil?
-            # However, there is no harm in silently eating the ORDER BY clause if no LIMIT has been provided,
-            # otherwise let the user deal with the error
-            o = o.dup
-            o.orders = []
-          end
-
-          super
         end
 
         def visit_Arel_Nodes_In(o, collector)

--- a/lib/arel/visitors/oracle_common.rb
+++ b/lib/arel/visitors/oracle_common.rb
@@ -145,6 +145,18 @@ module Arel # :nodoc: all
           collector
         end
 
+        def visit_Arel_Nodes_UpdateStatement(o, collector)
+          # Oracle does not allow ORDER BY/LIMIT in UPDATEs.
+          if o.orders.any? && o.limit.nil?
+            # However, there is no harm in silently eating the ORDER BY clause if no LIMIT has been provided,
+            # otherwise let the user deal with the error
+            o = o.dup
+            o.orders = []
+          end
+
+          super
+        end
+
         def visit_Arel_Nodes_In(o, collector)
           attr, values = o.left, o.right
           return super unless values.is_a?(Array)

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/update_statement_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/update_statement_spec.rb
@@ -48,4 +48,11 @@ RSpec.describe "Arel::Visitors::OracleCommon#visit_Arel_Nodes_UpdateStatement" d
     sql = compile(stmt, visitor: oracle)
     expect(sql).not_to match(/ORDER BY/i)
   end
+
+  it "is a no-op when the statement has no orders" do
+    stmt = build_update
+    sql = compile(stmt)
+    expect(sql).not_to match(/ORDER BY/i)
+    expect(stmt.orders).to eq([])
+  end
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/update_statement_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/update_statement_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+RSpec.describe "Arel::Visitors::OracleCommon#visit_Arel_Nodes_UpdateStatement" do
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+  end
+
+  before(:each) do
+    @visitor = Arel::Visitors::Oracle12.new(ActiveRecord::Base.connection)
+    @table = Arel::Table.new(:users)
+  end
+
+  def compile(node, visitor: @visitor)
+    visitor.accept(node, Arel::Collectors::SQLString.new).value
+  end
+
+  def build_update(orders: [], limit: nil)
+    stmt = Arel::Nodes::UpdateStatement.new
+    stmt.relation = @table
+    stmt.values = [Arel::Nodes::Assignment.new(@table[:name], Arel.sql("'foo'"))]
+    stmt.orders = orders
+    stmt.limit = limit
+    stmt
+  end
+
+  it "drops ORDER BY when no LIMIT is set" do
+    stmt = build_update(orders: [Arel.sql("id ASC")])
+    sql = compile(stmt)
+    expect(sql).not_to match(/ORDER BY/i)
+  end
+
+  it "keeps ORDER BY when a LIMIT is set (letting Oracle return the execute-time error)" do
+    stmt = build_update(orders: [Arel.sql("id ASC")], limit: Arel::Nodes::Limit.new(10))
+    sql = compile(stmt)
+    expect(sql).to match(/ORDER BY\s+id ASC/i)
+  end
+
+  it "leaves the original UpdateStatement's orders unmodified" do
+    orders = [Arel.sql("id ASC")]
+    stmt = build_update(orders: orders)
+    compile(stmt)
+    expect(stmt.orders).to eq(orders)
+  end
+
+  it "strips ORDER BY the same way via Arel::Visitors::Oracle" do
+    oracle = Arel::Visitors::Oracle.new(ActiveRecord::Base.connection)
+    stmt = build_update(orders: [Arel.sql("id ASC")])
+    sql = compile(stmt, visitor: oracle)
+    expect(sql).not_to match(/ORDER BY/i)
+  end
+end


### PR DESCRIPTION
## Summary
- Third slice of #2663 (task B). The `visit_Arel_Nodes_UpdateStatement` override in `lib/arel/visitors/oracle.rb` and `lib/arel/visitors/oracle12.rb` was byte-identical: both strip ORDER BY from an UPDATE that has `orders` but no `limit` (Oracle does not allow ORDER BY in UPDATE), and `dup` the statement before mutating so the caller's AST stays intact. Move the method into `lib/arel/visitors/oracle_common.rb` to remove the duplication and keep ORDER BY handling together (now adjacent to `order_hacks` / `split_order_string`).
- Tighten the override's comment so it reflects the actual contract: this override only strips ORDER BY. When a LIMIT is also present, the statement is passed through to `super` and Oracle's own error for the unsupported LIMIT-in-UPDATE surfaces — the visitor does not try to smooth that over.
- Adds a direct visitor spec at `spec/active_record/connection_adapters/oracle_enhanced/arel/update_statement_spec.rb` exercising each branch the implementation took on integration alone:
  - UPDATE with `orders` and no `limit` strips ORDER BY before `super` emits SQL.
  - UPDATE with `orders` and a `limit` keeps ORDER BY (Oracle returns the error at execute time).
  - The original `UpdateStatement.orders` attribute is unmodified after compilation (the `dup`-before-mutate invariant is preserved).
  - `Arel::Visitors::Oracle` (legacy ROWNUM) and `Arel::Visitors::Oracle12` produce identical stripped SQL.
  - The no-orders short-circuit is a no-op (does not raise, leaves `orders` as the empty array).
- Rebased onto current master after #2780 (task A) merged.
- Tasks D (`build_subselect` orders=[]) and E (literal limit/offset `value_before_type_cast`) from #2663 remain for follow-up PRs. Task F shipped in #2779; task A in #2780; task C in #2782.

## Test plan
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/arel/update_statement_spec.rb` — 5 examples, 0 failures (Oracle Free 23.26 / FREEPDB1)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/arel/` — 66 examples, 0 failures (no regressions in the surrounding `arel/` specs)
- [x] `bundle exec rubocop lib/arel/visitors/ spec/active_record/connection_adapters/oracle_enhanced/arel/` — no offenses
