### PR TITLE
Cover order_hacks NULLS handling in the Oracle visitor spec (#2663 task C)

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle_spec.rb
@@ -68,6 +68,56 @@ RSpec.describe "Arel::Visitors::Oracle" do
     expect(collector.retryable).to be(true)
   end
 
+  describe "order_hacks NULLS handling" do
+    let(:select) { "DISTINCT foo.id, FIRST_VALUE(projects.name) OVER (foo) AS alias_0__" }
+
+    def select_with_order(order_clause)
+      stmt = Arel::Nodes::SelectStatement.new
+      stmt.cores.first.projections << Arel::Nodes::SqlLiteral.new(select)
+      stmt.orders << Arel::Nodes::SqlLiteral.new(order_clause)
+      stmt
+    end
+
+    it "preserves NULLS FIRST on the rewritten alias" do
+      expect(compile(select_with_order("foo NULLS FIRST"))).to be_like %{
+        SELECT #{select} ORDER BY alias_0__ NULLS FIRST
+      }
+    end
+
+    it "preserves NULLS LAST on the rewritten alias" do
+      expect(compile(select_with_order("foo NULLS LAST"))).to be_like %{
+        SELECT #{select} ORDER BY alias_0__ NULLS LAST
+      }
+    end
+
+    it "preserves DESC combined with NULLS LAST on the rewritten alias" do
+      expect(compile(select_with_order("foo DESC NULLS LAST"))).to be_like %{
+        SELECT #{select} ORDER BY alias_0__ DESC NULLS LAST
+      }
+    end
+
+    it "upcases the NULLS keyword regardless of source casing" do
+      expect(compile(select_with_order("foo nulls first"))).to be_like %{
+        SELECT #{select} ORDER BY alias_0__ NULLS FIRST
+      }
+    end
+
+    it "leaves the ORDER BY untouched when no FIRST_VALUE projection is present" do
+      stmt = Arel::Nodes::SelectStatement.new
+      stmt.cores.first.projections << Arel::Nodes::SqlLiteral.new("foo.id")
+      stmt.orders << Arel::Nodes::SqlLiteral.new("foo NULLS FIRST")
+      expect(compile(stmt)).to be_like %{
+        SELECT foo.id ORDER BY foo NULLS FIRST
+      }
+    end
+
+    it "returns the SelectStatement unchanged when there are no orders" do
+      stmt = Arel::Nodes::SelectStatement.new
+      stmt.cores.first.projections << Arel::Nodes::SqlLiteral.new(select)
+      expect(compile(stmt)).to be_like %{ SELECT #{select} }
+    end
+  end
+
   describe "Nodes::SelectStatement" do
     describe "limit" do
       it "adds a rownum clause" do


### PR DESCRIPTION
## Summary
- Fourth slice of #2663 (task C). The DISTINCT + FIRST_VALUE ORDER BY rewrite in `order_hacks` (`lib/arel/visitors/oracle_common.rb`) already had visitor-level coverage for column aliasing, comma splitting, DESC, and the `collector.retryable` preservation. The NULLS FIRST / NULLS LAST preservation that the rewrite layers onto the aliased column had no direct assertion and was only exercised via integration. The two early-return branches in `order_hacks` were also implicit-only.
- Adds six spec examples in `spec/active_record/connection_adapters/oracle_enhanced/arel/oracle_spec.rb` under a new `describe "order_hacks NULLS handling"` block:
  - `ORDER BY "<col> NULLS FIRST"` rewrites to `alias_N__ NULLS FIRST`.
  - `ORDER BY "<col> NULLS LAST"` rewrites to `alias_N__ NULLS LAST`.
  - `ORDER BY "<col> DESC NULLS LAST"` rewrites to `alias_N__ DESC NULLS LAST`.
  - Lower-case `"nulls first"` is upcased to `NULLS FIRST` on output (the regex is case-insensitive on input but the output is normalised).
  - The ORDER BY is left untouched when no FIRST_VALUE projection is present (the no-FIRST_VALUE early-return branch of `order_hacks`).
  - The SelectStatement is returned unchanged when there are no orders, even when the projections contain FIRST_VALUE (the no-orders early-return branch of `order_hacks`).
- Spec-only; no `lib/` change.
- Tasks D (`build_subselect` orders=[]) and E (literal limit/offset `value_before_type_cast`) from #2663 remain for follow-up PRs. Task F shipped in #2779; task A is in #2780; task B is in #2781.

## Test plan
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/arel/oracle_spec.rb` — 30 examples, 0 failures (Oracle Free 23.26 / FREEPDB1)
- [x] `bundle exec rubocop spec/active_record/connection_adapters/oracle_enhanced/arel/oracle_spec.rb` — no offenses
