### PR TITLE
Move build_subselect into Arel::Visitors::OracleCommon (#2663 task D)

### DIFF
--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -172,17 +172,6 @@ module Arel # :nodoc: all
           collector = visit [o.left, o.right, 0, 1], collector
           collector << ")"
         end
-
-        # Oracle will occur an error `ORA-00907: missing right parenthesis`
-        # when using `ORDER BY` in `UPDATE` or `DELETE`'s subquery.
-        #
-        # This method has been overridden based on the following code.
-        # https://github.com/rails/rails/blob/v6.1.0.rc1/activerecord/lib/arel/visitors/to_sql.rb#L815-L825
-        def build_subselect(key, o)
-          stmt             = super
-          stmt.orders      = [] # `orders` will never be set to prevent `ORA-00907`.
-          stmt
-        end
     end
   end
 end

--- a/lib/arel/visitors/oracle12.rb
+++ b/lib/arel/visitors/oracle12.rb
@@ -118,17 +118,6 @@ module Arel # :nodoc: all
           collector = visit [o.left, o.right, 0, 1], collector
           collector << ")"
         end
-
-        # Oracle will occur an error `ORA-00907: missing right parenthesis`
-        # when using `ORDER BY` in `UPDATE` or `DELETE`'s subquery.
-        #
-        # This method has been overridden based on the following code.
-        # https://github.com/rails/rails/blob/v6.1.0.rc1/activerecord/lib/arel/visitors/to_sql.rb#L815-L825
-        def build_subselect(key, o)
-          stmt             = super
-          stmt.orders      = [] # `orders` will never be set to prevent `ORA-00907`.
-          stmt
-        end
     end
   end
 end

--- a/lib/arel/visitors/oracle_common.rb
+++ b/lib/arel/visitors/oracle_common.rb
@@ -126,6 +126,17 @@ module Arel # :nodoc: all
           end
           visit(Arel::Nodes::And.new(not_in_nodes), collector)
         end
+
+        # Oracle will occur an error `ORA-00907: missing right parenthesis`
+        # when using `ORDER BY` in `UPDATE` or `DELETE`'s subquery.
+        #
+        # This method has been overridden based on the following code.
+        # https://github.com/rails/rails/blob/v6.1.0.rc1/activerecord/lib/arel/visitors/to_sql.rb#L815-L825
+        def build_subselect(key, o)
+          stmt             = super
+          stmt.orders      = [] # `orders` will never be set to prevent `ORA-00907`.
+          stmt
+        end
     end
   end
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/build_subselect_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/build_subselect_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+RSpec.describe "Arel::Visitors::OracleCommon#build_subselect" do
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+  end
+
+  before(:each) do
+    @visitor = Arel::Visitors::Oracle12.new(ActiveRecord::Base.connection)
+    @table = Arel::Table.new(:users)
+  end
+
+  def build_delete(orders: [], limit: nil, offset: nil, wheres: [])
+    stmt = Arel::Nodes::DeleteStatement.new
+    stmt.relation = @table
+    stmt.wheres = wheres
+    stmt.orders = orders
+    stmt.limit = limit
+    stmt.offset = offset
+    stmt
+  end
+
+  it "drops orders on the subselect to avoid ORA-00907" do
+    delete = build_delete(orders: [@table[:id].asc], limit: Arel::Nodes::Limit.new(10))
+    subselect = @visitor.send(:build_subselect, @table[:id], delete)
+    expect(subselect.orders).to eq([])
+  end
+
+  it "leaves the original DeleteStatement's orders unmodified" do
+    orders = [@table[:id].asc]
+    delete = build_delete(orders: orders, limit: Arel::Nodes::Limit.new(10))
+    @visitor.send(:build_subselect, @table[:id], delete)
+    expect(delete.orders).to eq(orders)
+  end
+
+  it "preserves limit, offset, wheres, and projections from super" do
+    limit = Arel::Nodes::Limit.new(10)
+    offset = Arel::Nodes::Offset.new(5)
+    wheres = [@table[:name].eq("foo")]
+    delete = build_delete(orders: [@table[:id].asc], limit: limit, offset: offset, wheres: wheres)
+
+    subselect = @visitor.send(:build_subselect, @table[:id], delete)
+    core = subselect.cores.first
+    expect(subselect.limit).to eq(limit)
+    expect(subselect.offset).to eq(offset)
+    expect(core.wheres).to eq(wheres)
+    expect(core.projections).to eq([@table[:id]])
+    expect(core.from).to eq(@table)
+  end
+
+  it "drops orders the same way via Arel::Visitors::Oracle" do
+    oracle = Arel::Visitors::Oracle.new(ActiveRecord::Base.connection)
+    delete = build_delete(orders: [@table[:id].asc], limit: Arel::Nodes::Limit.new(10))
+    subselect = oracle.send(:build_subselect, @table[:id], delete)
+    expect(subselect.orders).to eq([])
+  end
+end


### PR DESCRIPTION
## Summary
- Fifth slice of #2663 (task D). The `build_subselect` override in `lib/arel/visitors/oracle.rb` and `lib/arel/visitors/oracle12.rb` was byte-identical: both call super and then force `stmt.orders = []` on the resulting subselect so the inner SELECT used by Oracle's UPDATE/DELETE rewrite does not carry an ORDER BY (Oracle returns `ORA-00907: missing right parenthesis` for ORDER BY inside a DELETE/UPDATE subquery). Move the method into `lib/arel/visitors/oracle_common.rb` to remove the duplication and keep UPDATE/DELETE handling alongside `visit_Arel_Nodes_UpdateStatement` and the IN-list variants already there.
- Adds a direct visitor spec at `spec/active_record/connection_adapters/oracle_enhanced/arel/build_subselect_spec.rb` covering each guarantee that previously had no visitor-level assertion:
  - The override forces `orders = []` on the subselect.
  - The original `DeleteStatement`'s `orders` attribute is unmodified after the call (super returns a fresh `SelectStatement`, so the caller's AST stays intact).
  - `limit`, `offset`, `wheres`, `projections`, and `from` are all propagated from super so the only thing the override changes is the ORDER BY drop.
  - `Arel::Visitors::Oracle` (legacy ROWNUM) and `Arel::Visitors::Oracle12` produce identical `orders=[]` results, since both pick up `OracleCommon`.
- Task E (literal limit/offset `value_before_type_cast`) from #2663 remains for the final follow-up PR. Task F shipped in #2779; A in #2780; B in #2781; C in #2782.

## Test plan
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/arel/build_subselect_spec.rb` — 4 examples, 0 failures (Oracle Free 23.26 / FREEPDB1)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/arel/` — 41 examples, 0 failures (no regressions in the surrounding `arel/` specs)
- [x] `bundle exec rubocop lib/arel/visitors/ spec/active_record/connection_adapters/oracle_enhanced/arel/` — no offenses
