### PR TITLE
Cover the literal limit/offset path through value_before_type_cast (#2663 task E)

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/value_before_type_cast_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/value_before_type_cast_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+RSpec.describe "Arel::Visitors::Oracle literal limit/offset via value_before_type_cast" do
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+  end
+
+  before(:each) do
+    @visitor = Arel::Visitors::Oracle.new(ActiveRecord::Base.connection)
+    @table = Arel::Table.new(:users)
+  end
+
+  def compile(node)
+    @visitor.accept(node, Arel::Collectors::SQLString.new).value
+  end
+
+  describe "value_before_type_cast helper" do
+    it "returns the value unchanged when the argument does not respond to value_before_type_cast" do
+      expect(@visitor.send(:value_before_type_cast, 42)).to eq(42)
+    end
+
+    it "unwraps an object that responds to value_before_type_cast" do
+      casted = Arel::Nodes::Casted.new(7, @table[:id])
+      expect(@visitor.send(:value_before_type_cast, casted)).to eq(7)
+    end
+  end
+
+  describe "bind_limit_offset? helper" do
+    it "returns true when the limit expr exposes ActiveModel::Type::Value via #type" do
+      typed = Struct.new(:type).new(ActiveModel::Type::Value.new)
+      expect(@visitor.send(:bind_limit_offset?, typed, 10)).to be(true)
+    end
+
+    it "returns true when the offset expr exposes ActiveModel::Type::Value via #type" do
+      typed = Struct.new(:type).new(ActiveModel::Type::Value.new)
+      expect(@visitor.send(:bind_limit_offset?, 5, typed)).to be(true)
+    end
+
+    it "returns false when neither limit nor offset is a BindParam or typed-Value" do
+      expect(@visitor.send(:bind_limit_offset?, 5, 10)).to be(false)
+    end
+  end
+
+  describe "SELECT with both limit and offset" do
+    it "renders plain Integer limit+offset as literals summed into the rownum upper bound" do
+      stmt = Arel::Nodes::SelectStatement.new
+      stmt.limit = Arel::Nodes::Limit.new(5)
+      stmt.offset = Arel::Nodes::Offset.new(10)
+      sql = compile(stmt)
+      expect(sql).to include("rownum <= 15")
+      expect(sql).to include("raw_rnum_ > 10")
+      expect(sql).not_to match(/:a\d/)
+    end
+
+    it "unwraps Arel::Nodes::Casted limit+offset via value_before_type_cast" do
+      stmt = Arel::Nodes::SelectStatement.new
+      stmt.limit = Arel::Nodes::Limit.new(Arel::Nodes::Casted.new(5, @table[:id]))
+      stmt.offset = Arel::Nodes::Offset.new(Arel::Nodes::Casted.new(10, @table[:id]))
+      sql = compile(stmt)
+      expect(sql).to include("rownum <= 15")
+      expect(sql).to include("raw_rnum_ > 10")
+      expect(sql).not_to match(/:a\d/)
+    end
+
+    it "switches to the bind path when both limit and offset are BindParams" do
+      stmt = Arel::Nodes::SelectStatement.new
+      stmt.limit = Arel::Nodes::Limit.new(Arel::Nodes::BindParam.new(5))
+      stmt.offset = Arel::Nodes::Offset.new(Arel::Nodes::BindParam.new(10))
+      sql = compile(stmt)
+      expect(sql).to match(/:a\d/)
+      expect(sql).not_to match(/rownum <= 15/)
+    end
+
+    it "switches to the bind path when only the offset arrives as a BindParam" do
+      stmt = Arel::Nodes::SelectStatement.new
+      stmt.limit = Arel::Nodes::Limit.new(5)
+      stmt.offset = Arel::Nodes::Offset.new(Arel::Nodes::BindParam.new(10))
+      sql = compile(stmt)
+      expect(sql).to match(/:a\d/)
+      expect(sql).not_to match(/rownum <= 15/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Sixth and final slice of #2663 (task E). The `Arel::Visitors::Oracle` (legacy ROWNUM) visitor takes two paths for a SELECT that carries both a `LIMIT` and an `OFFSET`:
  - **BindParam / typed-Value path**: each expr is `visit`-ed, producing bind variables (`:a1`, `:a2`) in the SQL. The gate is `bind_limit_offset?(limit, offset)` which returns true when either side is a `BindParam` or exposes `ActiveModel::Type::Value` via `#type`.
  - **Literal path**: each expr is unwrapped via the private `value_before_type_cast` helper and the resulting Integers are summed into the `rownum <= #{offset + limit}` interpolation.
- The literal path was added in #2661 (commit `ddeeb3d3`) and had only integration coverage. This PR adds direct visitor-level assertions in `spec/active_record/connection_adapters/oracle_enhanced/arel/value_before_type_cast_spec.rb` for each branch:
  - `value_before_type_cast` returns its argument unchanged when the argument does not respond to `value_before_type_cast` (the plain-Integer case).
  - `value_before_type_cast` unwraps an `Arel::Nodes::Casted` to its `value_before_type_cast` (the AR-cast-from-attribute case).
  - `bind_limit_offset?` returns true when either the limit or the offset expr exposes `ActiveModel::Type::Value` via `#type` (the typed-Value branch of the `any?` OR, covered directly so both sides of the OR are exercised by name rather than only via the BindParam variant).
  - `bind_limit_offset?` returns false when neither side is a `BindParam` nor a typed-Value (sanity).
  - A SELECT with plain Integer `Limit` and `Offset` renders the literal sum form (`rownum <= 15`, `raw_rnum_ > 10`) with no bind variables.
  - A SELECT with `Casted` Limit/Offset also renders the literal sum form (Casted goes through `value_before_type_cast`) and emits no bind variables.
  - A SELECT with `BindParam` Limit and Offset switches to the bind path and emits `:aN` instead of the literal sum.
  - The bind path also wins when only the offset arrives as a `BindParam` — `bind_limit_offset?` returns true if either side matches, so the literal branch is correctly gated.
- Spec-only; no `lib/` change.
- This is the last task in #2663. Task F shipped in #2779; A in #2780; B in #2781; C in #2782; D in #2783.

## Test plan
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/arel/value_before_type_cast_spec.rb` — 9 examples, 0 failures (Oracle Free 23.26 / FREEPDB1)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/arel/` — no regressions in the surrounding `arel/` specs
- [x] `bundle exec rubocop spec/active_record/connection_adapters/oracle_enhanced/arel/` — no offenses
