### PR TITLE
Fix visit_Arel_Nodes_Matches mutating the caller's Arel node

### DIFF
--- a/lib/arel/visitors/oracle_common.rb
+++ b/lib/arel/visitors/oracle_common.rb
@@ -26,6 +26,7 @@ module Arel # :nodoc: all
 
         def visit_Arel_Nodes_Matches(o, collector)
           if !o.case_sensitive && o.left && o.right
+            o = o.dup
             o.left = Arel::Nodes::NamedFunction.new("UPPER", [o.left])
             o.right = Arel::Nodes::NamedFunction.new("UPPER", [o.right])
           end

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/matches_idempotency_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/matches_idempotency_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+RSpec.describe "Arel::Visitors::OracleCommon#visit_Arel_Nodes_Matches preserves the input node" do
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+  end
+
+  before(:each) do
+    @visitor = Arel::Visitors::Oracle12.new(ActiveRecord::Base.connection)
+    @table = Arel::Table.new(:users)
+  end
+
+  def compile(node, visitor: @visitor)
+    visitor.accept(node, Arel::Collectors::SQLString.new).value
+  end
+
+  it "leaves the original Matches node's left attribute unchanged" do
+    node = Arel::Nodes::Matches.new(@table[:name], Arel.sql("'foo'"), nil, false)
+    original_left = node.left
+    compile(node)
+    expect(node.left).to equal(original_left)
+  end
+
+  it "leaves the original Matches node's right attribute unchanged" do
+    node = Arel::Nodes::Matches.new(@table[:name], Arel.sql("'foo'"), nil, false)
+    original_right = node.right
+    compile(node)
+    expect(node.right).to equal(original_right)
+  end
+
+  it "produces the same SQL when the same Matches node is compiled twice" do
+    node = Arel::Nodes::Matches.new(@table[:name], Arel.sql("'foo'"), nil, false)
+    sql1 = compile(node)
+    sql2 = compile(node)
+    expect(sql2).to eq(sql1)
+  end
+
+  it "does not double-wrap in UPPER when compiled twice" do
+    node = Arel::Nodes::Matches.new(@table[:name], Arel.sql("'foo'"), nil, false)
+    compile(node)
+    sql = compile(node)
+    expect(sql.scan(/UPPER\(/).size).to eq(2)
+    expect(sql).not_to match(/UPPER\(\s*UPPER\(/)
+  end
+
+  it "preserves the input node the same way via Arel::Visitors::Oracle" do
+    oracle = Arel::Visitors::Oracle.new(ActiveRecord::Base.connection)
+    node = Arel::Nodes::Matches.new(@table[:name], Arel.sql("'foo'"), nil, false)
+    original_left = node.left
+    original_right = node.right
+    compile(node, visitor: oracle)
+    expect(node.left).to equal(original_left)
+    expect(node.right).to equal(original_right)
+  end
+end


### PR DESCRIPTION
## Summary
- The case-insensitive branch of `visit_Arel_Nodes_Matches` in `lib/arel/visitors/oracle_common.rb` rewrote the input node's `left` and `right` attributes in place to wrap them in `UPPER()`. That made the override non-idempotent: compiling the same `Arel::Nodes::Matches` node twice produced `UPPER(UPPER(...))` on the second pass, and any other reader of the caller's AST observed the wrapped forms instead of the originals.
- Switch to `dup`-before-mutate, matching the idiom already used by `visit_Arel_Nodes_UpdateStatement` in the same module (which has guarded against the same AST-mutation pitfall for years).
- Adds a direct spec at `spec/active_record/connection_adapters/oracle_enhanced/arel/matches_idempotency_spec.rb` covering each guarantee that previously had no assertion:
  - The original Matches node's `left` is unchanged after compile.
  - The original Matches node's `right` is unchanged after compile.
  - Compiling the same node twice produces identical SQL.
  - The compiled SQL does not contain `UPPER(UPPER(...))` — exactly two `UPPER(` occurrences (one per side).
  - The same input-preservation guarantee holds via `Arel::Visitors::Oracle` (the legacy ROWNUM visitor), since `OracleCommon` is mixed into both visitors.
- Independent of #2779. Surfaced during the deep review of that PR. The two PRs do not touch the same lines: #2779 only adds `oracle_common_spec.rb`; this PR modifies `lib/arel/visitors/oracle_common.rb` and adds `matches_idempotency_spec.rb`. They can merge in either order.

## Test plan
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/arel/matches_idempotency_spec.rb` — 5 examples, 0 failures (Oracle Free 23.26 / FREEPDB1)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/arel/` — 42 examples, 0 failures (no regressions in the surrounding `arel/` specs)
- [x] `bundle exec rubocop lib/arel/visitors/oracle_common.rb spec/active_record/connection_adapters/oracle_enhanced/arel/matches_idempotency_spec.rb` — no offenses
