### PR TITLE
Fix order_hacks mutating the caller's Arel SelectStatement

### DIFF
--- a/lib/arel/visitors/oracle_common.rb
+++ b/lib/arel/visitors/oracle_common.rb
@@ -70,6 +70,7 @@ module Arel # :nodoc: all
               string
             end
           end.flatten
+          o = o.dup
           o.orders = []
           orders.each_with_index do |order, i|
             parts = ["alias_#{i}__"]

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/order_hacks_idempotency_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/order_hacks_idempotency_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+RSpec.describe "Arel::Visitors::OracleCommon#order_hacks preserves the input SelectStatement" do
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+  end
+
+  before(:each) do
+    @visitor = Arel::Visitors::Oracle.new(ActiveRecord::Base.connection)
+    @table = Arel::Table.new(:users)
+  end
+
+  def compile(node, visitor: @visitor)
+    visitor.accept(node, Arel::Collectors::SQLString.new).value
+  end
+
+  def build_first_value_select(order_literal = "foo")
+    stmt = Arel::Nodes::SelectStatement.new
+    stmt.cores.first.projections << Arel::Nodes::SqlLiteral.new(
+      "DISTINCT foo.id, FIRST_VALUE(projects.name) OVER (foo) AS alias_0__"
+    )
+    stmt.orders << Arel::Nodes::SqlLiteral.new(order_literal)
+    stmt
+  end
+
+  it "leaves the original SelectStatement's orders array reference unchanged" do
+    stmt = build_first_value_select
+    original_orders = stmt.orders
+    compile(stmt)
+    expect(stmt.orders).to equal(original_orders)
+  end
+
+  it "leaves the original order entries unchanged" do
+    stmt = build_first_value_select
+    original_first = stmt.orders.first
+    compile(stmt)
+    expect(stmt.orders.first).to equal(original_first)
+    expect(stmt.orders.first.to_s).to eq("foo")
+  end
+
+  it "produces the same SQL when the same SelectStatement is compiled twice" do
+    stmt = build_first_value_select
+    sql1 = compile(stmt)
+    sql2 = compile(stmt)
+    expect(sql2).to eq(sql1)
+  end
+
+  it "rewrites the order to alias_0__ in the compiled SQL while leaving the input intact" do
+    stmt = build_first_value_select
+    sql = compile(stmt)
+    expect(sql).to match(/ORDER BY\s+alias_0__/)
+    expect(stmt.orders.first.to_s).to eq("foo")
+  end
+
+  it "preserves NULLS FIRST/LAST in the original order while emitting it in the compiled SQL" do
+    stmt = build_first_value_select("foo DESC NULLS LAST")
+    original_first = stmt.orders.first
+    sql = compile(stmt)
+    expect(sql).to match(/ORDER BY\s+alias_0__\s+DESC\s+NULLS\s+LAST/)
+    expect(stmt.orders.first).to equal(original_first)
+    expect(stmt.orders.first.to_s).to eq("foo DESC NULLS LAST")
+  end
+end


### PR DESCRIPTION
## Summary
- `order_hacks` in `lib/arel/visitors/oracle_common.rb` rewrote the input SelectStatement's `orders` in place. The body did `o.orders = []` and then appended `alias_N__ [DESC] [NULLS X]` SqlLiterals back onto the caller's `@orders`. The original ORDER BY entries the caller passed in were lost from the AST after a single compile, even though the output SQL was self-stable (the rewritten `alias_N__` form maps back to itself on re-compile, which is why existing SQL-idempotency assertions in `arel/oracle_spec.rb` happened to pass and the bug stayed hidden).
- Switch to `dup`-before-mutate, the same idiom already used by `visit_Arel_Nodes_UpdateStatement` and `visit_Arel_Nodes_Matches` in the same module. The `o = o.dup` is placed **inside the rewrite path** (after the two early-return guards and the read-only `orders.map`), so the dup cost is only paid when we actually rewrite. Output SQL is byte-identical to before.
- Adds a direct spec at `spec/active_record/connection_adapters/oracle_enhanced/arel/order_hacks_idempotency_spec.rb` covering each guarantee that previously had no assertion:
  - The original SelectStatement's `orders` array reference is unchanged after compile (`stmt.orders.equal?(original_orders)`).
  - The original order entries are unchanged after compile (`stmt.orders.first.equal?(original_first)`).
  - The original order's textual form (`"foo"`, `"foo DESC NULLS LAST"`) is preserved on the input node after compile.
  - The same SelectStatement compiled twice produces identical SQL (defense-in-depth; matches the existing `arel/oracle_spec.rb` "is idempotent with crazy query" expectation but reaches it via the non-mutating path).
  - The compiled SQL still emits `ORDER BY alias_0__ [DESC] [NULLS ...]` as before, so the visitor's external behavior is unchanged.
- Surfaced during the deep review of #2785 (which fixed the same class of bug in `visit_Arel_Nodes_Matches`). Independent of any other open PR.

## Test plan
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/arel/order_hacks_idempotency_spec.rb` — 5 examples, 0 failures (Oracle Free 23.26 / FREEPDB1)
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/arel/` — 89 examples, 0 failures (no regressions in the surrounding `arel/` specs, including the existing `is idempotent with crazy query` / `splits orders with commas` cases in `arel/oracle_spec.rb`)
- [x] `bundle exec rubocop lib/arel/visitors/oracle_common.rb spec/active_record/connection_adapters/oracle_enhanced/arel/order_hacks_idempotency_spec.rb` — no offenses
