### PR TITLE
Fix the limit-only ROWNUM rewrite mutating the caller's SelectCore.wheres

### DIFF
--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -14,6 +14,7 @@ module Arel # :nodoc: all
           # if need to select first records without ORDER BY and GROUP BY and without DISTINCT
           # then can use simple ROWNUM in WHERE clause
           if o.limit && o.orders.empty? && o.cores.first.groups.empty? && !o.offset && !o.cores.first.set_quantifier.class.to_s.include?("Distinct")
+            o = o.dup
             o.cores.last.wheres.push Nodes::LessThanOrEqual.new(
               Nodes::SqlLiteral.new("ROWNUM", retryable: true), o.limit.expr
             )

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/rownum_push_idempotency_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/rownum_push_idempotency_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.describe "Arel::Visitors::Oracle limit-only ROWNUM rewrite preserves the input SelectStatement" do
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+  end
+
+  before(:each) do
+    @visitor = Arel::Visitors::Oracle.new(ActiveRecord::Base.connection)
+  end
+
+  def compile(node, visitor: @visitor)
+    visitor.accept(node, Arel::Collectors::SQLString.new).value
+  end
+
+  def build_limit_only_select
+    stmt = Arel::Nodes::SelectStatement.new
+    stmt.limit = Arel::Nodes::Limit.new(10)
+    stmt
+  end
+
+  it "leaves the original SelectCore's wheres array reference unchanged" do
+    stmt = build_limit_only_select
+    original_wheres = stmt.cores.last.wheres
+    compile(stmt)
+    expect(stmt.cores.last.wheres).to equal(original_wheres)
+  end
+
+  it "does not push the ROWNUM clause onto the original wheres array" do
+    stmt = build_limit_only_select
+    compile(stmt)
+    expect(stmt.cores.last.wheres).to be_empty
+  end
+
+  it "produces the same SQL when the same SelectStatement is compiled twice" do
+    stmt = build_limit_only_select
+    sql1 = compile(stmt)
+    sql2 = compile(stmt)
+    expect(sql2).to eq(sql1)
+  end
+
+  it "does not accumulate ROWNUM clauses when compiled twice" do
+    stmt = build_limit_only_select
+    compile(stmt)
+    sql = compile(stmt)
+    expect(sql.scan(/ROWNUM\b/i).size).to eq(1)
+  end
+
+  it "still emits the ROWNUM upper bound in the compiled SQL" do
+    stmt = build_limit_only_select
+    sql = compile(stmt)
+    expect(sql).to match(/ROWNUM\s*<=\s*10/i)
+  end
+end


### PR DESCRIPTION
## Summary
- `visit_Arel_Nodes_SelectStatement` in `lib/arel/visitors/oracle.rb` has a fast-path for SELECTs that have a `LIMIT` but no ORDER BY, no GROUP BY, no OFFSET, and no DISTINCT: it rewrites them as `SELECT ... WHERE ROWNUM <= <limit>` instead of the heavier ROWNUM-subquery form used by the other branches. The fast-path implemented this by calling `o.cores.last.wheres.push` directly on the input SelectStatement, **mutating the caller's `SelectCore.wheres` array**. Compiling the same AST twice accumulated `ROWNUM <= <limit>` predicates (`WHERE ROWNUM <= 10 AND ROWNUM <= 10`).
- The other three branches in the same method (`if o.limit && o.offset`, `if o.limit`, `if o.offset`) already start with `o = o.dup`. The limit-only branch was the outlier.
- Switch this branch to `dup`-before-mutate as well. `o.dup` reaches the wheres array transitively: `Arel::Nodes::SelectStatement#initialize_copy` clones each core, and `Arel::Nodes::SelectCore#initialize_copy` clones its `@wheres` array, so `o.cores.last.wheres.push` on the duped statement no longer touches the caller's AST. Output SQL is byte-identical to before.
- Adds a direct spec at `spec/active_record/connection_adapters/oracle_enhanced/arel/rownum_push_idempotency_spec.rb` covering each guarantee that previously had no assertion:
  - The original SelectCore's `wheres` array reference is unchanged after compile.
  - The original `wheres` array is still empty after compile.
  - The same SelectStatement compiled twice produces identical SQL.
  - The compiled SQL contains exactly one `ROWNUM` token on repeated compile.
  - The compiled SQL still emits `ROWNUM <= 10` as before, so the visitor's external behavior is unchanged.
- The three behavioral assertions (no push, idempotent SQL, no ROWNUM accumulation) **fail against the pre-fix code**, confirming the regression-detection power of the spec.
- Surfaced during the deep review of #2785; same class of AST-mutation bug as #2785 (Matches) and #2786 (order_hacks). With this PR the three known AST-mutation sites in the Oracle visitors are all addressed.

## Test plan
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/arel/rownum_push_idempotency_spec.rb` — 5 examples, 0 failures (Oracle Free 23.26 / FREEPDB1). Re-ran the same spec against the pre-fix `lib/arel/visitors/oracle.rb` for negative control — 3 of 5 examples fail, confirming the spec detects the regression.
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/arel/` — 89 examples, 0 failures (no regressions in the surrounding `arel/` specs, including `arel/oracle_spec.rb`'s existing `adds a rownum clause` / `is idempotent` cases).
- [x] `bundle exec rubocop lib/arel/visitors/oracle.rb spec/active_record/connection_adapters/oracle_enhanced/arel/rownum_push_idempotency_spec.rb` — no offenses.
