### PR TITLE
Tighten READ_QUERY for Oracle PL/SQL anonymous blocks

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -8,9 +8,9 @@ module ActiveRecord
         #
         # see: abstract/database_statements.rb
 
-        READ_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_read_query_regexp(
-          :close, :declare, :fetch, :move, :set, :show
-        ) # :nodoc:
+        # Custom regex (not AbstractAdapter.build_read_query_regexp) because Oracle
+        # BEGIN/DECLARE prefix PL/SQL anonymous blocks, not transaction control.
+        READ_QUERY = /\A(?:[(\s]|#{ActiveRecord::ConnectionAdapters::AbstractAdapter::COMMENT_REGEX})*(?:commit|explain|release|rollback|savepoint|select|with|set|show)/i # :nodoc:
         private_constant :READ_QUERY
 
         def write_query?(sql) # :nodoc:

--- a/spec/active_record/connection_adapters/oracle_enhanced/write_query_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/write_query_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "OracleEnhancedAdapter#write_query?" do
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @conn = ActiveRecord::Base.connection
+  end
+
+  describe "PL/SQL anonymous blocks (Oracle-specific)" do
+    it "classifies BEGIN ... END; as a write" do
+      sql = "BEGIN DELETE FROM dual WHERE 1=0; END;"
+      expect(@conn.write_query?(sql)).to be(true)
+    end
+
+    it "classifies DECLARE ... BEGIN ... END; as a write" do
+      sql = "DECLARE v NUMBER; BEGIN v := 1; END;"
+      expect(@conn.write_query?(sql)).to be(true)
+    end
+
+    it "classifies BEGIN with leading whitespace as a write" do
+      expect(@conn.write_query?("  BEGIN NULL; END;")).to be(true)
+    end
+
+    it "classifies BEGIN preceded by a SQL comment as a write" do
+      expect(@conn.write_query?("-- start of pl/sql\nBEGIN NULL; END;")).to be(true)
+    end
+
+    it "classifies BEGIN preceded by a /* */ block comment as a write" do
+      expect(@conn.write_query?("/* pl/sql */ BEGIN NULL; END;")).to be(true)
+    end
+
+    it "is case-insensitive on the BEGIN keyword" do
+      expect(@conn.write_query?("begin null; end;")).to be(true)
+    end
+  end
+
+  describe "SELECT and CTEs" do
+    it "classifies SELECT as a read" do
+      expect(@conn.write_query?("SELECT 1 FROM dual")).to be(false)
+    end
+
+    it "classifies SELECT wrapped in parentheses as a read" do
+      expect(@conn.write_query?("(SELECT 1 FROM dual)")).to be(false)
+    end
+
+    it "classifies WITH (CTE) as a read" do
+      sql = "WITH x AS (SELECT 1 AS c FROM dual) SELECT c FROM x"
+      expect(@conn.write_query?(sql)).to be(false)
+    end
+
+    it "classifies SELECT preceded by a SQL comment as a read" do
+      expect(@conn.write_query?("-- comment\nSELECT 1 FROM dual")).to be(false)
+    end
+  end
+
+  describe "Transaction control and session statements" do
+    it "classifies COMMIT as a read" do
+      expect(@conn.write_query?("COMMIT")).to be(false)
+    end
+
+    it "classifies ROLLBACK as a read" do
+      expect(@conn.write_query?("ROLLBACK")).to be(false)
+    end
+
+    it "classifies SAVEPOINT as a read" do
+      expect(@conn.write_query?("SAVEPOINT sp1")).to be(false)
+    end
+
+    it "classifies RELEASE SAVEPOINT as a read" do
+      expect(@conn.write_query?("RELEASE SAVEPOINT sp1")).to be(false)
+    end
+
+    it "classifies SET TRANSACTION ISOLATION LEVEL as a read" do
+      expect(@conn.write_query?("SET TRANSACTION ISOLATION LEVEL READ COMMITTED")).to be(false)
+    end
+
+    it "classifies SHOW (e.g. SHOW PARAMETER) as a read" do
+      expect(@conn.write_query?("SHOW PARAMETER nls_date_format")).to be(false)
+    end
+
+    it "classifies EXPLAIN PLAN FOR SELECT as a read" do
+      expect(@conn.write_query?("EXPLAIN PLAN FOR SELECT 1 FROM dual")).to be(false)
+    end
+  end
+
+  describe "DML and DDL (writes)" do
+    it "classifies INSERT as a write" do
+      expect(@conn.write_query?("INSERT INTO users (id) VALUES (1)")).to be(true)
+    end
+
+    it "classifies UPDATE as a write" do
+      expect(@conn.write_query?("UPDATE users SET name='x'")).to be(true)
+    end
+
+    it "classifies DELETE as a write" do
+      expect(@conn.write_query?("DELETE FROM users WHERE id=1")).to be(true)
+    end
+
+    it "classifies MERGE as a write" do
+      sql = "MERGE INTO users u USING dual ON (u.id=1) WHEN MATCHED THEN UPDATE SET u.name='x'"
+      expect(@conn.write_query?(sql)).to be(true)
+    end
+
+    it "classifies CREATE TABLE as a write" do
+      expect(@conn.write_query?("CREATE TABLE t (id NUMBER)")).to be(true)
+    end
+
+    it "classifies ALTER TABLE as a write" do
+      expect(@conn.write_query?("ALTER TABLE t ADD c2 NUMBER")).to be(true)
+    end
+
+    it "classifies TRUNCATE as a write" do
+      expect(@conn.write_query?("TRUNCATE TABLE t")).to be(true)
+    end
+
+    it "classifies LOCK TABLE as a write" do
+      expect(@conn.write_query?("LOCK TABLE t IN EXCLUSIVE MODE")).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `AbstractAdapter.build_read_query_regexp` auto-merges `DEFAULT_READ_QUERY = [:begin, :commit, :explain, :release, :rollback, :savepoint, :select, :with]` into every adapter's regex. On Oracle that list contains two tokens that collide with the PL/SQL surface:
  - **`BEGIN`** never starts a transaction on Oracle. `begin_db_transaction` toggles `_connection.autocommit = false` directly; transactions start implicitly on the first statement. So any top-level SQL starting with `BEGIN` is necessarily the head of a PL/SQL anonymous block, and such blocks routinely perform writes (e.g. `BEGIN CTX_DDL.DROP_PREFERENCE('x'); END;` in `oracle_enhanced/context_index.rb`).
  - **`DECLARE`** is Oracle's PL/SQL variable-declaration header, not a cursor declaration (the PostgreSQL meaning). Same false-negative — a write disguised as a "read" prefix.
- Additionally, `:close, :fetch, :move` were carried over from PostgreSQL's cursor primitives and have no Oracle counterpart outside PL/SQL — they were dead weight in the Oracle context.
- Replace `build_read_query_regexp` with a custom regex that keeps `commit|explain|release|rollback|savepoint|select|with|set|show` as read prefixes and drops `:begin|:declare|:close|:fetch|:move`. PL/SQL blocks now classify as writes, so `while_preventing_writes` catches them. Output SQL of normal AR queries is unaffected; transaction control (`begin_db_transaction` etc.) does not go through `write_query?` and is unaffected.
- Adds a direct spec at `spec/active_record/connection_adapters/oracle_enhanced/write_query_spec.rb` covering:
  - PL/SQL `BEGIN ... END;` / `DECLARE ... BEGIN ... END;` classify as writes, including leading whitespace, `--` comment, `/* */` block comment, and lowercase variants.
  - `SELECT`, `(SELECT ...)`, `WITH ... SELECT ...`, commented `SELECT` remain reads.
  - `COMMIT`, `ROLLBACK`, `SAVEPOINT`, `RELEASE SAVEPOINT`, `SET TRANSACTION ISOLATION LEVEL ...`, `SHOW PARAMETER ...`, `EXPLAIN PLAN FOR ...` remain reads.
  - `INSERT`, `UPDATE`, `DELETE`, `MERGE`, `CREATE`, `ALTER`, `TRUNCATE`, `LOCK TABLE` are writes.
- The six PL/SQL assertions all **fail against the pre-change code**, confirming the regression-detection power of the spec. `context_index_spec.rb` (which exercises the `execute("BEGIN ... END;")` path under normal — not read-only — context) continues to pass unchanged.
- Surfaced from a review of rails/rails#57156, which adds `rails query` and routes user-supplied expressions through `while_preventing_writes`, making this latent gap user-visible. Closes #2788.

## Test plan
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/write_query_spec.rb` — 25 examples, 0 failures (Oracle Free 23.26 / FREEPDB1). Re-ran the same spec against the pre-change regex for negative control — 6 of 25 examples fail (all the PL/SQL assertions), confirming the regression-detection power.
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb spec/active_record/connection_adapters/oracle_enhanced/write_query_spec.rb` — 48 examples, 0 failures (the existing `execute("BEGIN CTX_DDL.DROP_PREFERENCE ...; END;")` path is not under `while_preventing_writes`, so its classification change has no behavioral impact).
- [x] `bundle exec rubocop lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb spec/active_record/connection_adapters/oracle_enhanced/write_query_spec.rb` — no offenses.

Refs rails/rails#34505 (origin of `write_query?` / `while_preventing_writes`), rails/rails#38042 (origin of `build_read_query_regexp` / `DEFAULT_READ_QUERY`), rails/rails#57156 (the `rails query` command that surfaced this).
