### PR TITLE
Translate ORA-02290 to ActiveRecord::CheckViolation

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1442,6 +1442,8 @@ module ActiveRecord
             ActiveRecord::StatementInvalid.new(message, sql: sql, binds: binds, connection_pool: @pool)
           when 1400
             ActiveRecord::NotNullViolation.new(message, sql: sql, binds: binds, connection_pool: @pool)
+          when 2290
+            ActiveRecord::CheckViolation.new(message, sql: sql, binds: binds, connection_pool: @pool)
           when 2291, 2292
             InvalidForeignKey.new(message, sql: sql, binds: binds, connection_pool: @pool)
           when 12899

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -2108,6 +2108,15 @@ end
       end
       expect(@conn.check_constraints(:test_products).detect { |c| c.name == "ct_validate_bare" }.validate?).to be(true)
     end
+
+    it "raises ActiveRecord::CheckViolation when a check constraint is violated (ORA-02290)" do
+      schema_define do
+        add_check_constraint :test_products, "price > 0", name: "violation_check"
+      end
+      expect do
+        @conn.execute "INSERT INTO test_products (id, price) VALUES (1, -1)"
+      end.to raise_error(ActiveRecord::CheckViolation, /ORA-02290/)
+    end
   end
 
   describe "unique constraints" do


### PR DESCRIPTION
## Summary
- Oracle raises **ORA-02290** ("check constraint (…) violated") when an INSERT or UPDATE produces a row that fails a `CHECK` constraint. oracle-enhanced's `translate_exception` (`oracle_enhanced_adapter.rb:1433-1452`) had no entry for code 2290, so the error fell through to `AbstractAdapter#translate_exception` and surfaced as a generic `ActiveRecord::StatementInvalid`. Applications catching constraint violations could not distinguish a check failure from any other statement error.
- Map ORA-02290 to `ActiveRecord::CheckViolation` alongside the existing constraint-violation mappings:
  - ORA-01400 → `NotNullViolation`
  - **ORA-02290 → `CheckViolation`** (this PR)
  - ORA-02291 / ORA-02292 → `InvalidForeignKey`
  - ORA-12899 → `ValueTooLong`
- oracle-enhanced has supported `add_check_constraint` / `t.check_constraint` since #2717; the missing exception mapping was the remaining gap on the CHECK-constraint surface. With this PR `ActiveRecord::Base.connection.execute` (and AR's `create` / `update` paths) emit the AR-portable `CheckViolation` for check-constraint violations on Oracle, matching the PostgreSQL / MySQL / SQLite3 contract.
- Adds a direct integration assertion in the existing `describe "check constraints"` block of `spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb`: create a check constraint on `test_products`, attempt an INSERT that violates it, expect `ActiveRecord::CheckViolation` with a message matching `/ORA-02290/`. The assertion fails against the pre-change `case` (which routes 2290 to `StatementInvalid` via `super`), confirming the regression-detection power.
- No new public surface, no behavior change for non-2290 errors. Surfaced during a Rails-side follow-up audit prompted by rails/rails#57156 (see the survey in conversation; this is the one clean gap that emerged).

## Test plan
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb` — 205 examples, 0 failures, 1 pending (no regression in the surrounding `schema_statements_spec.rb`, including the existing `check constraints` and `foreign keys` integration tests). Oracle Free 23.26 / FREEPDB1.
- [x] Re-ran the same single example against the pre-change `case` for negative control — fails with `expected ActiveRecord::CheckViolation, got #<ActiveRecord::StatementInvalid …ORA-02290…>`, confirming the assertion exercises the new branch.
- [x] `bundle exec rubocop .` — 104 files, no offenses.
