### PR TITLE
Translate ORA-08177 to ActiveRecord::SerializationFailure

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1446,6 +1446,8 @@ module ActiveRecord
             ActiveRecord::CheckViolation.new(message, sql: sql, binds: binds, connection_pool: @pool)
           when 2291, 2292
             InvalidForeignKey.new(message, sql: sql, binds: binds, connection_pool: @pool)
+          when 8177
+            ActiveRecord::SerializationFailure.new(message, sql: sql, binds: binds, connection_pool: @pool)
           when 12899
             ValueTooLong.new(message, sql: sql, binds: binds, connection_pool: @pool)
           else

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -1185,6 +1185,30 @@ RSpec.describe "OracleEnhancedAdapter" do
       }.to raise_error(ActiveRecord::Deadlocked)
     end
 
+    it "Raises SerializationFailure when a serializable transaction cannot be serialized (ORA-08177)" do
+      post = TestPost.create!(title: "seed")
+      barrier = Concurrent::CyclicBarrier.new(2)
+
+      thread = Thread.new do
+        TestPost.transaction(isolation: :serializable) do
+          TestPost.find(post.id)
+          barrier.wait
+          barrier.wait
+          TestPost.find(post.id).update!(title: "second")
+        end
+      end
+
+      expect {
+        begin
+          barrier.wait
+          TestPost.transaction { post.update!(title: "first") }
+          barrier.wait
+        ensure
+          thread.join
+        end
+      }.to raise_error(ActiveRecord::SerializationFailure, /ORA-08177/)
+    end
+
     it "restarts the parent transaction on nested rollback without issuing a SAVEPOINT" do
       TestPost.transaction do
         TestPost.transaction(requires_new: true) do


### PR DESCRIPTION
## Summary

- Add `ORA-08177` → `ActiveRecord::SerializationFailure` to `translate_exception` in `OracleEnhancedAdapter`.
- ORA-08177 ("can't serialize access for this transaction") is the canonical SERIALIZABLE-isolation conflict in Oracle. Before this change, the adapter returned a generic `ActiveRecord::StatementInvalid`, which ActiveRecord's `retryable_transaction_error?` hook does not recognise as a retryable serialization conflict.
- Mapping it to `ActiveRecord::SerializationFailure` (a subclass of `TransactionRollbackError`) lets the existing AR retry contract work on Oracle. The mapping only fires for users who opt into `Model.transaction(isolation: :serializable)`; READ COMMITTED (oracle-enhanced's default) does not raise ORA-08177, so this is strictly additive with no risk of false retries on the default path.
- This is the SerializationFailure follow-up from #2790's mapping family (Deadlocked / SerializationFailure under `TransactionRollbackError`).

## Test plan

- [x] Added an integration example in `spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb` next to the existing ORA-00060 / Deadlocked test. Two threads coordinate with `Concurrent::CyclicBarrier` so that thread A holds a SERIALIZABLE snapshot, the main thread commits an update, and thread A then attempts an update — expected `ActiveRecord::SerializationFailure` matching `/ORA-08177/`.
- [x] Verified regression-detection power: with the new `when 8177` branch removed, the spec fails because the adapter returns `ActiveRecord::StatementInvalid`.
- [x] `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb` — 82 examples, 0 failures, 1 pending (pre-existing).
- [x] `bundle exec rubocop` — 104 files inspected, no offenses.
