### PR TITLE
Honor foreign_keys: false database.yml option

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -27,7 +27,7 @@ module ActiveRecord # :nodoc:
             # add foreign keys if table has them
             sorted_tables.each do |tbl|
               next if ignored? tbl
-              foreign_keys(tbl, stream)
+              foreign_keys(tbl, stream) if @connection.use_foreign_keys?
               divergent_unique_constraints(tbl, stream)
             end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -735,6 +735,7 @@ module ActiveRecord
         end
 
         def add_foreign_key(from_table, to_table, **options)
+          return unless use_foreign_keys?
           assert_valid_deferrable(options[:deferrable])
 
           super

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -440,6 +440,84 @@ RSpec.describe "OracleEnhancedAdapter schema dump" do
     end
   end
 
+  describe "with use_foreign_keys? returning false (foreign_keys: false in database.yml)" do
+    before(:each) do
+      schema_define do
+        drop_table :test_comments, if_exists: true
+        drop_table :test_posts, if_exists: true
+        create_table :test_posts, force: true do |t|
+          t.string :title
+        end
+        create_table :test_comments, force: true do |t|
+          t.string :body, limit: 4000
+          t.references :test_post
+        end
+      end
+    end
+
+    after(:each) do
+      schema_define do
+        remove_foreign_key :test_comments, :test_posts, if_exists: true
+        drop_table :test_comments, if_exists: true
+        drop_table :test_posts, if_exists: true
+      end
+    end
+
+    it "schema dump omits add_foreign_key statements" do
+      schema_define do
+        add_foreign_key :test_comments, :test_posts
+      end
+      allow(@conn).to receive(:use_foreign_keys?).and_return(false)
+      expect(standard_dump).not_to match(/add_foreign_key/)
+    end
+
+    it "add_foreign_key is a silent no-op" do
+      allow(@conn).to receive(:use_foreign_keys?).and_return(false)
+      expect {
+        schema_define do
+          add_foreign_key :test_comments, :test_posts
+        end
+      }.not_to raise_error
+      expect(@conn.foreign_keys("test_comments")).to be_empty
+    end
+
+    it "add_foreign_key skips deferrable validation" do
+      allow(@conn).to receive(:use_foreign_keys?).and_return(false)
+      expect {
+        schema_define do
+          add_foreign_key :test_comments, :test_posts, deferrable: :always
+        end
+      }.not_to raise_error
+      expect(@conn.foreign_keys("test_comments")).to be_empty
+    end
+
+    it "create_table with inline t.references foreign_key: true does not create the FK" do
+      allow(@conn).to receive(:use_foreign_keys?).and_return(false)
+      schema_define do
+        drop_table :test_comments, if_exists: true
+        create_table :test_comments, force: true do |t|
+          t.string :body, limit: 4000
+          t.references :test_post, foreign_key: true
+        end
+      end
+      expect(@conn.foreign_keys("test_comments")).to be_empty
+    end
+
+    it "create_table inline t.references with an Oracle-invalid deferrable does not raise" do
+      allow(@conn).to receive(:use_foreign_keys?).and_return(false)
+      expect {
+        schema_define do
+          drop_table :test_comments, if_exists: true
+          create_table :test_comments, force: true do |t|
+            t.string :body, limit: 4000
+            t.references :test_post, foreign_key: { deferrable: :always }
+          end
+        end
+      }.not_to raise_error
+      expect(@conn.foreign_keys("test_comments")).to be_empty
+    end
+  end
+
   describe "synonyms" do
     after(:each) do
       schema_define do


### PR DESCRIPTION
## Summary

Rails 7.1 ([rails/rails#45301](https://github.com/rails/rails/pull/45301)) added the `foreign_keys: false` adapter option so apps can opt out of foreign-key constraints even when the database supports them. The upstream helper `use_foreign_keys?` gates `add_foreign_key`, `remove_foreign_key`, `foreign_key_for`, and `SchemaCreation` FK emission. oracle-enhanced's `SchemaCreation#visit_TableDefinition` already routes through `use_foreign_keys?`, and `remove_foreign_key` / `foreign_key_for` inherit Rails core's gates unchanged. Two oracle-enhanced overrides needed adjustment.

## Changes

- **`OracleEnhanced::SchemaDumper#tables`** — overrides Rails' base method and emitted `add_foreign_key` lines unconditionally. Apply the gate inline next to `divergent_unique_constraints(tbl, stream)` so the per-table interleave order (FK_a → UC_a → FK_b → UC_b) is preserved. Matches PR #45301's original dumper-gate intent (later inadvertently reverted upstream by rails/rails#48731 — so Oracle users get the benefit even though current Rails main does not).
- **`OracleEnhanced::SchemaStatements#add_foreign_key`** — ran `assert_valid_deferrable` before `super`, so an invalid `deferrable:` value still raised when FKs were globally disabled. Add `return unless use_foreign_keys?` at the top of the override, matching Rails core's silent no-op contract (and the first line of Rails' own `add_foreign_key`).
- **structure.sql is intentionally left untouched** — Rails core's `Tasks::*DatabaseTasks#structure_dump` (pg_dump / mysqldump / sqlite3) does not gate on `foreign_keys_enabled?` / `use_foreign_keys?`. Structure dumps reflect live DB state, not adapter config. Migrations run with `foreign_keys: false` create no FKs so the structure dump naturally has nothing to emit.

## Specs

Five new specs under "with `use_foreign_keys?` returning false" stub `@conn.use_foreign_keys?` (avoiding pool replacement, which leaks a stale `@conn` into other describe blocks):

- schema dump omits `add_foreign_key` lines
- `add_foreign_key` is a silent no-op
- `add_foreign_key` with Oracle-invalid `deferrable: :always` does not raise (validation skipped)
- inline `t.references :foo, foreign_key: true` does not create the FK
- inline `t.references :foo, foreign_key: { deferrable: :always }` does not raise (SchemaCreation gate skips the inline FK before Oracle sees the invalid DDL)

Integration-style verification that `foreign_keys: false` in adapter config flows through to `use_foreign_keys?` is Rails core's responsibility (`foreign_keys_enabled? = @config.fetch(:foreign_keys, true)`) and is covered upstream.

## Scope

master only (Rails 8.2.alpha). No backport to older oracle-enhanced branches in this PR.

## Test plan

- [x] `bundle exec rubocop` — clean
- [x] CI green on Oracle 23ai (test) and Oracle 11g (test_11g) across MRI Ruby 3.3 / 3.4 / 4.0 and JRuby 10.1
