### PR TITLE
Support enforced: option on foreign keys

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -85,10 +85,28 @@ module ActiveRecord
             end
           end
 
+          # `enforced:` and `validate:` map to Oracle's 4-state constraint model.
+          # Both defaults are `true`; the options are independent.
+          #
+          # | enforced | validate | Oracle state      | DML on the child table        |
+          # |----------|----------|-------------------|-------------------------------|
+          # | true     | true     | ENABLE VALIDATE   | enforced, existing data valid |
+          # | true     | false    | ENABLE NOVALIDATE | enforced for new DML only     |
+          # | false    | true     | DISABLE VALIDATE  | blocked (ORA-25128)           |
+          # | false    | false    | DISABLE NOVALIDATE| not enforced (~ PG NOT ENFORCED) |
+          #
+          # Oracle's bare `DISABLE` clause defaults to `NOVALIDATE`, so when
+          # `enforced: false` and `validate: true` (the Rails default), `VALIDATE`
+          # is emitted explicitly to preserve the user's intent.
           def visit_ForeignKeyDefinition(o)
             super.dup.tap do |sql|
               sql << " DEFERRABLE INITIALLY #{o.deferrable.to_s.upcase}" if o.deferrable
-              sql << " NOVALIDATE" unless o.validate?
+              sql << " DISABLE" unless o.enforced?
+              if !o.validate?
+                sql << " NOVALIDATE"
+              elsif !o.enforced?
+                sql << " VALIDATE"
+              end
             end
           end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -753,6 +753,7 @@ module ActiveRecord
                   ,c.deferrable
                   ,c.deferred
                   ,c.validated
+                  ,c.status
               FROM all_constraints c, all_cons_columns cc,
                    all_constraints r, all_cons_columns rc
              WHERE c.owner = SYS_CONTEXT('userenv', 'current_schema')
@@ -776,6 +777,7 @@ module ActiveRecord
             }
             options[:on_delete] = extract_foreign_key_action(row["delete_rule"])
             options[:deferrable] = extract_foreign_key_deferrable(row["deferrable"], row["deferred"])
+            options[:enforced] = false if row["status"] == "DISABLED"
             options[:validate] = false if row["validated"] == "NOT VALIDATED"
             ActiveRecord::ConnectionAdapters::ForeignKeyDefinition.new(oracle_downcase(table_name), oracle_downcase(row["to_table"]), options)
           end
@@ -819,6 +821,20 @@ module ActiveRecord
         def validate_foreign_key(from_table, to_table = nil, **options) # :nodoc:
           fk_name_to_validate = foreign_key_for!(from_table, to_table: to_table, **options).name
           validate_constraint(from_table, fk_name_to_validate)
+        end
+
+        # Accepted options: +:enforced+ (the only mutable axis) plus the identifying
+        # keys +:column+, +:name+, +:to_table+ passed through to +foreign_key_for!+.
+        # ALTER ... MODIFY CONSTRAINT name DISABLE/ENABLE follows Oracle's defaults:
+        # bare DISABLE leaves the constraint at DISABLE NOVALIDATE, and bare ENABLE
+        # at ENABLE VALIDATE; introspection reflects those side effects on +:validate+.
+        def change_foreign_key(from_table, to_table = nil, **options) # :nodoc:
+          unless options.key?(:enforced)
+            raise ArgumentError, "change_foreign_key requires at least one option (e.g. enforced:)"
+          end
+          enforced = options[:enforced]
+          fk_name = foreign_key_for!(from_table, to_table: to_table, **options.except(:enforced)).name
+          execute "ALTER TABLE #{quote_table_name(from_table)} MODIFY CONSTRAINT #{quote_column_name(fk_name)} #{enforced ? 'ENABLE' : 'DISABLE'}"
         end
 
         # Returns an array of unique constraints for the given table.

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -527,6 +527,10 @@ module ActiveRecord
         true
       end
 
+      def supports_enforced_foreign_keys?
+        true
+      end
+
       def supports_expression_index?
         true
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -388,6 +388,57 @@ RSpec.describe "OracleEnhancedAdapter schema dump" do
       expect(fk.options[:validate]).to be(false)
     end
 
+    it "dumps enforced: false for DISABLEd foreign keys" do
+      schema_define do
+        add_foreign_key :test_comments, :test_posts, enforced: false
+      end
+      output = dump_table_schema "test_comments"
+      expect(output).to match(/add_foreign_key "test_comments", "test_posts".*enforced: false/)
+    end
+
+    it "round-trips enforced: false alone (DISABLE VALIDATE) through dump and load" do
+      schema_define do
+        add_foreign_key :test_comments, :test_posts, enforced: false
+      end
+
+      dumped = dump_table_schema "test_comments"
+      expect(dumped).to match(/add_foreign_key "test_comments", "test_posts".*enforced: false/)
+      expect(dumped).not_to match(/validate: /)
+
+      schema_define do
+        remove_foreign_key :test_comments, :test_posts, if_exists: true
+      end
+
+      body = dumped[/ActiveRecord::Schema\[.+?\]\.define\(version: \d+\) do\n(.+)\nend\s*\z/m, 1]
+      schema_define { instance_eval(body) }
+
+      fk = ActiveRecord::Base.lease_connection.foreign_keys(:test_comments).first
+      expect(fk).not_to be_nil
+      expect(fk.options[:enforced]).to be(false)
+      expect(fk.options.key?(:validate)).to be(false)
+    end
+
+    it "round-trips enforced: false, validate: false (DISABLE NOVALIDATE) through dump and load" do
+      schema_define do
+        add_foreign_key :test_comments, :test_posts, enforced: false, validate: false
+      end
+
+      dumped = dump_table_schema "test_comments"
+      expect(dumped).to match(/add_foreign_key "test_comments", "test_posts".*validate: false.*enforced: false/)
+
+      schema_define do
+        remove_foreign_key :test_comments, :test_posts, if_exists: true
+      end
+
+      body = dumped[/ActiveRecord::Schema\[.+?\]\.define\(version: \d+\) do\n(.+)\nend\s*\z/m, 1]
+      schema_define { instance_eval(body) }
+
+      fk = ActiveRecord::Base.lease_connection.foreign_keys(:test_comments).first
+      expect(fk).not_to be_nil
+      expect(fk.options[:enforced]).to be(false)
+      expect(fk.options[:validate]).to be(false)
+    end
+
     it "should not include foreign keys on ignored table regexes in schema dump" do
       schema_define do
         add_foreign_key :test_comments, :test_posts

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -1950,6 +1950,120 @@ end
       expect(fk).not_to be_nil
       expect(fk.options.key?(:validate)).to be(false)
     end
+
+    it "creates DISABLE VALIDATE when enforced: false is given (validate defaults to true)" do
+      schema_define do
+        add_foreign_key :test_comments, :test_posts, enforced: false
+      end
+      fk = ActiveRecord::Base.lease_connection.foreign_keys(:test_comments).first
+      expect(fk.options[:enforced]).to be(false)
+      expect(fk.options.key?(:validate)).to be(false)
+      expect do
+        TestComment.create(body: "test", test_post_id: 1)
+      end.to raise_error(/ORA-25128/)
+    end
+
+    it "creates DISABLE NOVALIDATE when both enforced: false and validate: false are given (closest to PG NOT ENFORCED)" do
+      schema_define do
+        add_foreign_key :test_comments, :test_posts, enforced: false, validate: false
+      end
+      fk = ActiveRecord::Base.lease_connection.foreign_keys(:test_comments).first
+      expect(fk.options[:enforced]).to be(false)
+      expect(fk.options[:validate]).to be(false)
+      expect do
+        TestComment.create(body: "test", test_post_id: 1)
+      end.not_to raise_error
+    end
+
+    it "leaves both :enforced and :validate absent when the foreign key is ENABLE VALIDATE" do
+      schema_define do
+        add_foreign_key :test_comments, :test_posts
+      end
+      fk = ActiveRecord::Base.lease_connection.foreign_keys(:test_comments).first
+      expect(fk.options.key?(:enforced)).to be(false)
+      expect(fk.options.key?(:validate)).to be(false)
+    end
+
+    it "enables a DISABLEd foreign key via change_foreign_key" do
+      schema_define do
+        add_foreign_key :test_comments, :test_posts, enforced: false, validate: false
+        change_foreign_key :test_comments, :test_posts, enforced: true
+      end
+      fk = ActiveRecord::Base.lease_connection.foreign_keys(:test_comments).first
+      expect(fk.options.key?(:enforced)).to be(false)
+      expect(fk.options.key?(:validate)).to be(false)
+      expect do
+        TestComment.create(body: "test", test_post_id: 1)
+      end.to raise_error(/ORA-02291/)
+    end
+
+    it "disables an ENFORCED foreign key via change_foreign_key" do
+      schema_define do
+        add_foreign_key :test_comments, :test_posts
+        change_foreign_key :test_comments, :test_posts, enforced: false
+      end
+      fk = ActiveRecord::Base.lease_connection.foreign_keys(:test_comments).first
+      expect(fk.options[:enforced]).to be(false)
+      expect(fk.options[:validate]).to be(false)
+      expect do
+        TestComment.create(body: "test", test_post_id: 1)
+      end.not_to raise_error
+    end
+
+    it "raises ArgumentError when change_foreign_key is called without :enforced" do
+      schema_define do
+        add_foreign_key :test_comments, :test_posts
+      end
+      expect do
+        ActiveRecord::Base.lease_connection.change_foreign_key :test_comments, :test_posts
+      end.to raise_error(ArgumentError, /change_foreign_key requires at least one option/)
+    end
+
+    it "toggles enforced via change_foreign_key identified by name:" do
+      schema_define do
+        add_foreign_key :test_comments, :test_posts, name: "comments_posts_fk"
+        change_foreign_key :test_comments, name: "comments_posts_fk", enforced: false
+      end
+      fk = ActiveRecord::Base.lease_connection.foreign_keys(:test_comments).first
+      expect(fk.options[:enforced]).to be(false)
+    end
+
+    it "honors enforced: false on add_reference foreign_key option hash" do
+      schema_define do
+        drop_table :test_comments, if_exists: true
+        create_table :test_comments, force: true do |t|
+          t.string :body, limit: 4000
+        end
+        add_reference :test_comments, :test_post, foreign_key: { enforced: false, validate: false }
+      end
+      fk = ActiveRecord::Base.lease_connection.foreign_keys(:test_comments).first
+      expect(fk.options[:enforced]).to be(false)
+      expect(fk.options[:validate]).to be(false)
+    end
+
+    it "honors enforced: false on inline t.foreign_key inside create_table" do
+      schema_define do
+        drop_table :test_comments, if_exists: true
+        create_table :test_comments, force: true do |t|
+          t.string :body, limit: 4000
+          t.references :test_post
+          t.foreign_key :test_posts, enforced: false, validate: false
+        end
+      end
+      fk = ActiveRecord::Base.lease_connection.foreign_keys(:test_comments).first
+      expect(fk.options[:enforced]).to be(false)
+      expect(fk.options[:validate]).to be(false)
+    end
+
+    it "round-trips enforced: false combined with deferrable: :deferred" do
+      schema_define do
+        add_foreign_key :test_comments, :test_posts, enforced: false, validate: false, deferrable: :deferred
+      end
+      fk = ActiveRecord::Base.lease_connection.foreign_keys(:test_comments).first
+      expect(fk.options[:enforced]).to be(false)
+      expect(fk.options[:validate]).to be(false)
+      expect(fk.options[:deferrable]).to eq(:deferred)
+    end
   end
 
   describe "check constraints" do


### PR DESCRIPTION
Mirrors [rails/rails#57377](https://github.com/rails/rails/pull/57377) (merged commit [6cb88eae](https://github.com/rails/rails/commit/6cb88eae59c05185ec7fdde9addb347819e4df44)), which adds an `enforced:` option to `add_foreign_key` (and a `change_foreign_key` helper) for PostgreSQL 18.4+ `NOT ENFORCED` constraints. The Ruby option name `enforced:` follows the `[NOT] ENFORCED` constraint characteristic introduced in SQL:2011 and carried forward into SQL:2016 (see References below); Oracle does **not** implement the `[NOT] ENFORCED` keyword. Instead, oracle-enhanced exposes Oracle's pre-existing 4-state constraint model via the **independent** `enforced:` and `validate:` Ruby options.

## The 4-state matrix

| `enforced:` | `validate:` | Oracle state          | DML on child table                |
|-------------|-------------|-----------------------|-----------------------------------|
| `true` *(default)* | `true` *(default)* | `ENABLE VALIDATE`     | enforced, existing data valid     |
| `true` *(default)* | `false`     | `ENABLE NOVALIDATE`   | enforced for new DML only         |
| `false`     | `true` *(default)* | `DISABLE VALIDATE`    | **blocked (ORA-25128)** — read-only |
| `false`     | `false`     | `DISABLE NOVALIDATE`  | not enforced (≈ PG `NOT ENFORCED`) |

```ruby
# enforced + validate, both defaults: ENABLE VALIDATE
add_foreign_key :articles, :authors

# Skip existing-data check, still enforce new DML
add_foreign_key :articles, :authors, validate: false

# DISABLE VALIDATE - constraint disabled, data marked validated, DML blocked
add_foreign_key :articles, :authors, enforced: false

# Cross-DB compatible "not enforced" semantics (mirrors PG NOT ENFORCED)
add_foreign_key :articles, :authors, enforced: false, validate: false

# Toggle enforced state on an existing FK
change_foreign_key :articles, :authors, enforced: true
```

The Ruby-API defaults are kept independent (`validate:` defaults to `true` regardless of `enforced:`) so all 4 states are reachable from idiomatic Rails code. The framework does not "protect" the user from `DISABLE VALIDATE` because Oracle itself allows it — the matrix above is reproduced as a comment above `visit_ForeignKeyDefinition` so this is discoverable in source.

## Changes

- `supports_enforced_foreign_keys?` returns `true` unconditionally — Oracle's `DISABLE`/`ENABLE` constraint state has been available across every Oracle release this gem supports.
- `visit_ForeignKeyDefinition` appends ` DISABLE` when `enforced: false`. When `validate:` is `true` (the Rails default) **and** `enforced: false`, ` VALIDATE` is also emitted explicitly because Oracle's bare `DISABLE` clause defaults to `NOVALIDATE` — without the explicit keyword we couldn't reach `DISABLE VALIDATE`. The full 4-state matrix is documented in a comment above the method.
- `foreign_keys` introspection selects `c.status` from `all_constraints` and maps `'DISABLED'` to `options[:enforced] = false`. `c.validated` is mapped independently to `options[:validate] = false` — the two flags are not coupled. The dumped output preserves both, so every Oracle state round-trips.
- `change_foreign_key` issues `ALTER TABLE ... MODIFY CONSTRAINT ... ENABLE|DISABLE` via the existing `foreign_key_for!` lookup helper. `MODIFY ... DISABLE` resets the validated state to `NOT VALIDATED`, so disabling an enforced FK reports both `enforced: false` and `validate: false`.

Schema dumping relies on the abstract `ActiveRecord::ConnectionAdapters::SchemaDumper#foreign_keys`, which since rails/rails#57377 emits `enforced: false` whenever `foreign_key.enforced?` is false (where `enforced?` is `options.fetch(:enforced, true)` on `ForeignKeyDefinition`). No adapter-level dumper override is needed.

## Tests

- 5 specs in `schema_statements_spec.rb` exercising all 4 states + both `change_foreign_key` directions. ORA-25128 (DML blocked under DISABLE VALIDATE) is asserted, not avoided.
- 3 specs in `schema_dumper_spec.rb` covering `enforced: false` emission and full dump-and-load round-trips for both `DISABLE VALIDATE` and `DISABLE NOVALIDATE`.

269 examples pass against FREEPDB1 (Oracle 23ai).

## References

### `[NOT] ENFORCED` (the Rails option name)

- **Upstream Rails PR (merged):** https://github.com/rails/rails/pull/57377 — merged commit https://github.com/rails/rails/commit/6cb88eae59c05185ec7fdde9addb347819e4df44
- **pgsql-hackers thread (accessible primary reference, since the SQL standard itself is behind ISO's paywall):** https://postgrespro.com/list/thread-id/1770540 — Simon Riggs's 2010 proposal cites SQL:2011 §4.17.2: *"Table constraints are either enforced or not enforced. Domain constraints and assertions are always enforced."*
- **SQL:2016 (ISO/IEC 9075-2:2016) carries the same syntax forward.** Relevant subclauses:
  - §4.17 — definition of enforced / not enforced integrity constraints
  - §11.6 `<table constraint definition>` — `<constraint characteristics>` syntactic slot
  - §11.8 `<referential constraint definition>` — accepts `<constraint characteristics>` (this is the FK path)
  - §11.9 `<check constraint definition>` — accepts `<constraint characteristics>`
  - Annex F — feature taxonomy, including **F815 *Not enforced check constraints***
  - Grammar: `<constraint enforcement> ::= ENFORCED | NOT ENFORCED`
- **PostgreSQL feature table** [`src/backend/catalog/sql_features.txt`](https://github.com/postgres/postgres/blob/master/src/backend/catalog/sql_features.txt) references F815; the entry was updated for FK support in PostgreSQL commit `b663b9436e`.

### `ENABLE` / `DISABLE` / `VALIDATE` / `NOVALIDATE` (the Oracle-side translation)

- **Oracle 8i SQL Reference, Release 3 (8.1.7) — `constraint_clause`:** https://docs.oracle.com/cd/A87860_01/doc/server.817/a85397/state14a.htm — documents the `constraint_state` clause (`ENABLE` / `DISABLE`, `VALIDATE` / `NOVALIDATE`) as applicable to foreign-key (referential) constraints. The four-state model and its semantic definitions ("ENABLE VALIDATE … guarantees that all data is and will continue to be valid"; "DISABLE NOVALIDATE signifies that Oracle makes no effort to maintain the constraint") are already present in 8i and have been carried forward to current releases unchanged. The DML-blocking behavior of `DISABLE VALIDATE` (ORA-25128 — *"No insert/update/delete on table with constraint (…) disabled and validated"*) is part of the same long-standing semantics.
