### PR TITLE
Rename auto_populated? to auto_populated_on_insert?

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/column.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/column.rb
@@ -32,7 +32,7 @@ module ActiveRecord
           @identity
         end
 
-        def auto_populated?
+        def auto_populated_on_insert?
           super || @trigger_assigned
         end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1304,7 +1304,7 @@ module ActiveRecord
           pk_col = primary_key_column_from_schema_cache(table_name)
           # Propagate false (cache says no-prefetch) and nil (caller must fall back) as-is.
           return pk_col unless pk_col.is_a?(OracleEnhanced::Column)
-          !(pk_col.auto_incremented_by_db? || pk_col.auto_populated?)
+          !(pk_col.auto_incremented_by_db? || pk_col.auto_populated_on_insert?)
         end
 
         def primary_key_column_from_schema_cache(table_name)

--- a/spec/active_record/connection_adapters/oracle_enhanced/primary_key_trigger_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/primary_key_trigger_spec.rb
@@ -453,7 +453,7 @@ RSpec.describe "primary_key_trigger" do
     end
   end
 
-  describe "auto_populated? on the primary key column" do
+  describe "auto_populated_on_insert? on the primary key column" do
     it "reports true for a trigger-backed primary key" do
       schema_define do
         create_table :test_pk_triggers, primary_key_trigger: true do |t|
@@ -462,7 +462,7 @@ RSpec.describe "primary_key_trigger" do
       end
 
       pk_column = @conn.columns(:test_pk_triggers).find { |c| c.name == "id" }
-      expect(pk_column.auto_populated?).to be true
+      expect(pk_column.auto_populated_on_insert?).to be true
     end
 
     it "reports false for a plain sequence-backed primary key" do
@@ -473,7 +473,7 @@ RSpec.describe "primary_key_trigger" do
       end
 
       pk_column = @conn.columns(:test_pk_triggers).find { |c| c.name == "id" }
-      expect(pk_column.auto_populated?).to be false
+      expect(pk_column.auto_populated_on_insert?).to be false
     end
 
     it "reports false when only an unrelated BEFORE INSERT trigger exists" do
@@ -493,7 +493,7 @@ RSpec.describe "primary_key_trigger" do
       SQL
 
       pk_column = @conn.columns(:test_pk_triggers).find { |c| c.name == "id" }
-      expect(pk_column.auto_populated?).to be false
+      expect(pk_column.auto_populated_on_insert?).to be false
     end
 
     it "drives _returning_columns_for_insert for trigger-backed tables" do

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_cache_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_cache_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe "OracleEnhancedAdapter schema cache" do
       expect(restored.instance_variable_get(:@identity)).to eq(original.instance_variable_get(:@identity))
       expect(restored.instance_variable_get(:@trigger_assigned)).to eq(original.instance_variable_get(:@trigger_assigned))
       expect(restored.auto_incremented_by_db?).to eq(original.auto_incremented_by_db?)
-      expect(restored.auto_populated?).to eq(original.auto_populated?)
+      expect(restored.auto_populated_on_insert?).to eq(original.auto_populated_on_insert?)
     end
 
     it "leaves @identity and @trigger_assigned undefined when YAML predates these keys" do
@@ -213,10 +213,10 @@ RSpec.describe "OracleEnhancedAdapter schema cache" do
 
       it "carries trigger_assigned = true through the YAML round trip" do
         original = schema_cache.columns("test_schema_cache_legacy_posts").find { |c| c.name == "id" }
-        expect(original.auto_populated?).to be true
+        expect(original.auto_populated_on_insert?).to be true
 
         restored = YAML.safe_load(YAML.dump(original), permitted_classes: PERMITTED_YAML_CLASSES, aliases: true)
-        expect(restored.auto_populated?).to be true
+        expect(restored.auto_populated_on_insert?).to be true
         expect(restored.instance_variable_get(:@trigger_assigned)).to be true
       end
     end


### PR DESCRIPTION
Rails main [rails/rails#48628](https://github.com/rails/rails/pull/48628) (merged as [rails/rails@de7b8c8eed](https://github.com/rails/rails/commit/de7b8c8eed) on 2026-05-14) renamed `ActiveRecord::ConnectionAdapters::Column#auto_populated?` to `auto_populated_on_insert?` and kept `auto_populated?` as a deprecated alias.

The `deprecate` wrapper changes `auto_populated?`'s arity to `(*args, **, &block)`, which trips our `check_method_signatures` CI job against this adapter's zero-arity override (see e.g. https://github.com/rsim/oracle-enhanced/actions/runs/25891216708).

This PR migrates the override (and its in-tree callers/specs) to the new method name so we override the live method and stay clear of the deprecation warning. Behavior is unchanged.

## Changes

- `lib/active_record/connection_adapters/oracle_enhanced/column.rb` — rename `auto_populated?` → `auto_populated_on_insert?`
- `lib/active_record/connection_adapters/oracle_enhanced_adapter.rb` — update the lone caller
- `spec/active_record/connection_adapters/oracle_enhanced/schema_cache_spec.rb` — update assertions
- `spec/active_record/connection_adapters/oracle_enhanced/primary_key_trigger_spec.rb` — update the `describe` block name + assertions

## Verification

- `bundle exec rubocop` clean
- `bundle exec ruby -Ilib ci/check_method_signatures.rb` → `OK: every overridden method matches the Rails counterpart's signature.`
- 63 examples pass in the two affected spec files against FREEPDB1 (Oracle 23ai)

## References

- Upstream Rails PR: https://github.com/rails/rails/pull/48628
- Upstream Rails commit: https://github.com/rails/rails/commit/de7b8c8eed
