### PR TITLE
Upgrade dev container to Ruby 4.0.4

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
   "workspaceFolder": "/workspaces/oracle-enhanced",
   "features": {
     "ghcr.io/rails/devcontainer/features/ruby:2": {
-      "version": "4.0.2"
+      "version": "4.0.4"
     }
   },
   "customizations": {


### PR DESCRIPTION
## Summary

- Bump `.devcontainer/devcontainer.json` Ruby feature pin from `4.0.2` to `4.0.4`.
- Ruby 4.0.4 is available in `ghcr.io/rails/devcontainer/features/ruby:2` since [rails/devcontainer#126](https://github.com/rails/devcontainer/pull/126).
- CI matrices (`'4.0'` floating constraint) and `CONTRIBUTING.md` ("Ruby 4.0") already track the major.minor and need no edits.

## Test plan

- [ ] Devcontainer rebuild picks up Ruby 4.0.4
- [ ] `ruby -v` inside the rebuilt container reports `ruby 4.0.4`
- [ ] CI green
