### PR TITLE
Align dev container Instant Client TZ data with Oracle server

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
       ]
     }
   },
-  "initializeCommand": "docker pull gvenzl/oracle-free:latest",
+  "initializeCommand": "bash .devcontainer/initializeCommand.sh",
   "postCreateCommand": "bash .devcontainer/postCreateCommand.sh",
   "remoteEnv": {
     "DATABASE_NAME": "FREEPDB1",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ..:/workspaces/oracle-enhanced:cached
+      - ./tzdata:/opt/tzdata:ro
     command: sleep infinity
     network_mode: service:oracle
 

--- a/.devcontainer/initializeCommand.sh
+++ b/.devcontainer/initializeCommand.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+IMAGE=gvenzl/oracle-free:latest
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+OUT_DIR="$SCRIPT_DIR/tzdata"
+
+docker pull "$IMAGE"
+
+mkdir -p "$OUT_DIR"
+rm -f "$OUT_DIR"/timezlrg_*.dat "$OUT_DIR"/timezdif_*.dat
+
+docker run --rm --entrypoint sh \
+  -v "$OUT_DIR:/out" \
+  "$IMAGE" \
+  -c 'cp "$ORACLE_HOME"/oracore/zoneinfo/timezlrg_*.dat /out/ && chmod a+r /out/*.dat'
+
+ls -1 "$OUT_DIR"

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -5,6 +5,18 @@ set -e
 gem update --system
 bundle install
 
+# Match Instant Client TZ data to the Oracle server's to avoid ORA-01805.
+# The file is extracted from the gvenzl image into .devcontainer/tzdata/ by
+# initializeCommand.sh and bind-mounted read-only at /opt/tzdata.
+TZ_FILE=$(ls /opt/tzdata/timezlrg_*.dat 2>/dev/null | head -1)
+if [ -n "$TZ_FILE" ]; then
+  echo "Using $TZ_FILE for Instant Client TZ data."
+  export ORA_TZFILE="$TZ_FILE"
+  echo "export ORA_TZFILE=$TZ_FILE" | sudo tee /etc/profile.d/ora-tzfile.sh > /dev/null
+else
+  echo "Warning: no timezlrg_*.dat found under /opt/tzdata; skipping ORA_TZFILE setup." >&2
+fi
+
 echo "Waiting for Oracle to be ready..."
 oracle_ready=false
 for i in $(seq 1 30); do

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Gemfile.lock
 ojdbc*.jar
 .byebug_history
 debug.log
+.devcontainer/tzdata/


### PR DESCRIPTION
## Summary

Apply the workaround from #2734 to the dev container. CI fixed `ORA-01805: possible error in date/time operation` by copying the running Oracle server's `timezlrg_*.dat` into the Instant Client's `oracore/zoneinfo/` and pointing `ORA_TZFILE` at it. The dev container is exposed to the same drift between `gvenzl/oracle-free:latest` and the bundled Instant Client and benefits from the same fix.

The earlier revision of this PR did the copy from inside the dev container via `docker exec` / `docker cp`, which dragged in the `docker-outside-of-docker` feature, a `/var/run/docker.sock` bind mount, and a `moby: false` workaround for Debian trixie — and made the dev container build hit a build-time GPG-key fetch that was flaky.

This revision moves the copy to the host, where Docker is already available.

## Changes

- `.devcontainer/initializeCommand.sh` (new) — pull `gvenzl/oracle-free:latest`, then extract `$ORACLE_HOME/oracore/zoneinfo/timezlrg_*.dat` from an ephemeral container into `.devcontainer/tzdata/` on the host. No DB start, no readiness wait — the file ships in the image.
- `.devcontainer/devcontainer.json` — `initializeCommand` now runs the new script (it previously just did the inline `docker pull`).
- `.devcontainer/docker-compose.yml` — bind-mount `.devcontainer/tzdata` read-only at `/opt/tzdata` inside the `app` service.
- `.devcontainer/postCreateCommand.sh` — set `ORA_TZFILE` from `/opt/tzdata/timezlrg_*.dat` and persist it via `/etc/profile.d/ora-tzfile.sh` so interactive shells and `bundle exec` runs pick it up.
- `.gitignore` — ignore `.devcontainer/tzdata/`.

No `docker-outside-of-docker` feature, no `/var/run/docker.sock` bind, no `moby: false` workaround, and no network access during the dev container build.

## Lifecycle

Matches #2734 — the step is unconditional and becomes a near-zero-cost no-op once the Instant Client and gvenzl image realign on a single TZ data version. Safe to remove together with the CI counterpart at that point.

## Test plan

- [ ] Rebuild the dev container; `initializeCommand` logs the pulled image and the extracted `timezlrg_*.dat` filename.
- [ ] `postCreateCommand` logs "Using /opt/tzdata/timezlrg_*.dat for Instant Client TZ data."
- [ ] In a fresh terminal inside the rebuilt container, `echo $ORA_TZFILE` resolves to the persisted path.
- [ ] `bundle exec rspec spec/active_record/oracle_enhanced/type/timestamp_spec.rb` passes (all four examples).
