### PR TITLE
Make dev container bind mount work from git worktrees

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile
     volumes:
-      - ../..:/workspaces:cached
+      - ..:/workspaces/oracle-enhanced:cached
     command: sleep infinity
     network_mode: service:oracle
 


### PR DESCRIPTION
## Summary

- `.devcontainer/docker-compose.yml` mounted `../..:/workspaces:cached`, which relies on the repository being checked out into a directory literally named `oracle-enhanced` for `workspaceFolder: /workspaces/oracle-enhanced` to resolve.
- When opened from a git worktree (e.g. `<repo>/.worktrees/<branch>/`), `../..` resolves to `.worktrees/` instead of the repo's parent, Docker auto-creates an empty `/workspaces/oracle-enhanced` mount target on the host, and `postCreateCommand: bash .devcontainer/postCreateCommand.sh` fails with `No such file or directory` (exit 127).
- Mount the directory containing `.devcontainer/` directly as `/workspaces/oracle-enhanced` so it no longer depends on the host directory's name. Works from both the main checkout and any worktree.

`devcontainer.json` is unchanged: `workspaceFolder` still resolves to the same path inside the container, and `${localWorkspaceFolder}/.bundle` continues to resolve to the directory containing `devcontainer.json`, which is correct under both layouts.

## Test plan

- [ ] Open the dev container from the main checkout (`<repo>/`) → `postCreateCommand.sh` runs to `Dev container setup complete.`
- [ ] Open the dev container from a worktree (`<repo>/.worktrees/<branch>/`) → same result
- [ ] Inside the container: `pwd` is `/workspaces/oracle-enhanced` and `ls .devcontainer/postCreateCommand.sh` exists
