### PR TITLE
Fail the devcontainer CI job when rake spec fails

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -21,6 +21,7 @@ jobs:
         uses: devcontainers/ci@v0.3
         with:
           runCmd: |
+            set -e
             uname -a
             lsb_release -a
             ruby --version


### PR DESCRIPTION
## Summary

`.github/workflows/devcontainer.yml`'s `runCmd` is a multi-line bash script with no `set -e`, so a non-zero exit from `bundle exec rake spec` does not propagate. The script keeps running, executes `bundle exec rubocop`, and the script's exit code becomes RuboCop's exit code. As long as RuboCop is clean, GitHub Actions marks the job green even when rspec is red.

[Run 26084989755](https://github.com/rsim/oracle-enhanced/actions/runs/26084989755/job/76695706353) hit this: 4 ORA-01805 failures in `rake spec`, but the job was reported as success because RuboCop passed.

Add `set -e` so the first non-zero exit aborts the script and surfaces through `devcontainers/ci` as a job failure.

## Notes

- Independent of #2799 (which fixes the underlying ORA-01805 source). With this in place, once #2799 lands, the next `devcontainer` workflow dispatch on master will correctly report green; before #2799, it would correctly report red.
- Scope kept intentionally minimal: one `set -e` line. Could go further with `set -euo pipefail`, but `-u` risks tripping on unset-but-harmless variables and the immediate bug is just exit-code propagation.

## Test plan

- [ ] After this merges, manually dispatch the `devcontainer` workflow on master (still without #2799) and confirm the job goes red on the ORA-01805 failures.
- [ ] After #2799 also lands, manually dispatch again and confirm green.
