### PR TITLE
Use documentation formatter for rspec in devcontainer CI

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -25,5 +25,5 @@ jobs:
             uname -a
             lsb_release -a
             ruby --version
-            bundle exec rake spec
+            SPEC_OPTS="--format documentation" bundle exec rake spec
             bundle exec rubocop


### PR DESCRIPTION
## Summary

`devcontainers/ci@v0.3` runs `runCmd` via `docker exec -t`, which gives the container a TTY. Ruby on a TTY sets `STDOUT.sync = true`, so rspec's progress formatter (which prints `.` per example with no newline) is flushed per character. The action's log capture treats each flush as a separate line, so for ~1094 examples the CI log ends up with ~1094 timestamped lines that each contain a single ANSI-wrapped dot.

[Example of the noise](https://github.com/rsim/oracle-enhanced/actions/runs/26086757886/job/76701712777) — `^[[32m.^[[0m` repeating one per log line.

Pass `SPEC_OPTS="--format documentation"` only for this workflow's `rake spec` invocation. The documentation formatter prints one full line per example (via `puts`, which includes a newline), so the action records one tidy log line per test instead of one per dot. Local `.rspec` is unchanged.

## Why not change `.rspec`

`.rspec` is shared with local development and other workflows (`test.yml`, `test_11g*.yml`) which run rspec without the docker-exec TTY layer and where progress dots batch correctly. Limiting the override to the devcontainer workflow avoids changing what everyone else sees locally.

## Test plan

- [ ] After merge, manually dispatch the `devcontainer` workflow and confirm the "Boot dev container and run tests" log shows one line per example (test name) instead of one line per dot.
