### PR TITLE
Make git work in the dev container when opened from a worktree

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     volumes:
       - ..:/workspaces/oracle-enhanced:cached
       - ./tzdata:/opt/tzdata:ro
+      - ${GIT_COMMON_DIR}:${GIT_COMMON_DIR}:cached
     command: sleep infinity
     network_mode: service:oracle
 

--- a/.devcontainer/initializeCommand.sh
+++ b/.devcontainer/initializeCommand.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 IMAGE=gvenzl/oracle-free:latest
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+WORKSPACE_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
 OUT_DIR="$SCRIPT_DIR/tzdata"
 
 docker pull "$IMAGE"
@@ -17,3 +18,16 @@ docker run --rm --entrypoint sh \
   -c 'cp "$ORACLE_HOME"/oracore/zoneinfo/timezlrg_*.dat /out/ && chmod a+r /out/*.dat'
 
 ls -1 "$OUT_DIR"
+
+# When opened from a git worktree, .git is a file whose `gitdir:` line points
+# at the main repo's .git/worktrees/<branch>. That host path is not visible
+# inside the dev container by default, so git commands inside the container
+# fail with "fatal: not a git repository". Resolve the common git dir on the
+# host and write it to .devcontainer/.env; docker-compose.yml bind-mounts it
+# at the same path inside the container so the gitdir reference resolves.
+GIT_COMMON_DIR=$(git -C "$WORKSPACE_DIR" rev-parse --git-common-dir)
+case "$GIT_COMMON_DIR" in
+  /*) ;;
+  *) GIT_COMMON_DIR=$(cd "$WORKSPACE_DIR/$GIT_COMMON_DIR" && pwd) ;;
+esac
+printf 'GIT_COMMON_DIR=%s\n' "$GIT_COMMON_DIR" > "$SCRIPT_DIR/.env"

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ ojdbc*.jar
 .byebug_history
 debug.log
 .devcontainer/tzdata/
+.devcontainer/.env


### PR DESCRIPTION
## Summary

When the dev container is opened from a git worktree (e.g. `<repo>/.worktrees/<branch>/`), the worktree's `.git` is a file whose `gitdir:` line points at a host path under the main repo's `.git/worktrees/<branch>`. That host path is not visible inside the container by default, so git inside the container fails with `fatal: not a git repository: (null)` — VS Code's `safe.directory` probe, `credential.helper` setup, and any developer git command all hit this. The dev container build itself completes, but the in-container git workflow is broken.

`initializeCommand.sh` already runs on the host, where git is available. Resolve the common git dir via `git rev-parse --git-common-dir`, write the absolute path into `.devcontainer/.env`, and have `docker-compose.yml` bind-mount that host path at the **same path inside the container**. The worktree's `.git` file's `gitdir:` reference then resolves cleanly.

For a main checkout the host path is `<repo>/.git`, and mounting it at `<repo>/.git` inside the container is a redundant no-op-shaped mount that doesn't conflict with the existing workspace mount.

## Changes

- `.devcontainer/initializeCommand.sh` — after the TZ extraction, compute `GIT_COMMON_DIR` and write `.devcontainer/.env`.
- `.devcontainer/docker-compose.yml` — bind-mount `${GIT_COMMON_DIR}:${GIT_COMMON_DIR}:cached` on the `app` service. docker-compose reads `.env` from the directory containing `docker-compose.yml` automatically.
- `.gitignore` — ignore `.devcontainer/.env` (generated per launch).

## Test plan

- [ ] Open the dev container from a worktree (`<repo>/.worktrees/<branch>/`) and confirm:
  - The dev container builds without "fatal: not a git repository" lines during `safe.directory` and `credential.helper` setup.
  - In an interactive terminal inside the container: `git status` succeeds and `git rev-parse --show-toplevel` prints `/workspaces/oracle-enhanced`.
- [ ] Open the dev container from the main checkout (`<repo>/`) and confirm the same — the extra bind mount should be harmless.
