### PR TITLE
ci: Drop Bundler 4.0.6 pin now that Bundler 4.0.12 ships the fix (release81)

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -11,6 +11,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 4.0
+          rubygems: latest
       - name: Yamllint
         uses: karancode/yamllint-github-action@master
         with:

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -10,20 +10,13 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    env:
-      BUNDLER_VERSION: 4.0.6
     steps:
       - uses: actions/checkout@v6
       - name: Set up Ruby 4.0
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 4.0
-      - name: Pin Bundler to 4.0.6 (workaround for ruby/rubygems#9536)
-        run: |
-          gem install bundler -v 4.0.6
-          ruby --version
-          gem --version
-          bundle --version
+          rubygems: latest
       - name: Build and run RuboCop
         run: |
           BUNDLE_ONLY=rubocop bundle install --jobs 4 --retry 3


### PR DESCRIPTION
## Summary

Backport of #2805 to `release81`. Reverts the Bundler 4.0.6 pin (#2778, the release81 backport of #2767) now that [Bundler 4.0.12](https://blog.rubygems.org/2026/05/20/4.0.12-released.html) (released 2026-05-20) ships [ruby/rubygems#9544](https://github.com/ruby/rubygems/pull/9544), the fix for [ruby/rubygems#9536](https://github.com/ruby/rubygems/issues/9536).

## Changes

- `.github/workflows/rubocop.yml`: drop `BUNDLER_VERSION: 4.0.6` env, drop the "Pin Bundler" step, add `rubygems: latest` to the setup-ruby block.
- `.github/workflows/linting.yml`: add `rubygems: latest` for consistency.

## Test plan

- [ ] `RuboCop` workflow run on this PR passes.
- [ ] `Linting` workflow run on this PR still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
