### PR TITLE
Add SQL linter using sqlfluff

### DIFF
--- a/.github/workflows/sql_lint.yml
+++ b/.github/workflows/sql_lint.yml
@@ -1,0 +1,23 @@
+name: SQL Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  sql-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "4.0"
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install sqlfluff
+        run: pip install sqlfluff
+      - name: Run SQL lint
+        run: ruby script/sql_lint

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -21,7 +21,7 @@ dialect = oracle
 #   RF01  References from. Triggers false positives when an alias is
 #         used only inside a `#{...}` interpolation, which we replace
 #         with an opaque placeholder before linting.
-rules = AL04,AL06,AL08,AL09,AL10,AM01,AM02,AM06,CP04,CP05,CV03,CV04,CV05,LT06,LT07,LT08,LT10,LT11,LT12,ST03,ST08
+rules = AL04,AL06,AL08,AL09,AL10,AM01,AM02,AM06,CP01,CP04,CP05,CV03,CV04,CV05,LT06,LT07,LT08,LT10,LT11,LT12,ST03,ST08
 
 # Match the surrounding Ruby code style: this project indents with two
 # spaces, so SQL inside heredocs reads naturally when sqlfluff expects

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -21,7 +21,7 @@ dialect = oracle
 #   RF01  References from. Triggers false positives when an alias is
 #         used only inside a `#{...}` interpolation, which we replace
 #         with an opaque placeholder before linting.
-rules = AL02,AL04,AL06,AL08,AL09,AL10,AM01,AM02,AM06,CP01,CP03,CP04,CP05,CV03,CV04,CV05,LT01,LT06,LT07,LT08,LT10,LT11,LT12,ST03,ST08
+rules = AL02,AL04,AL05,AL06,AL08,AL09,AL10,AM01,AM02,AM06,CP01,CP03,CP04,CP05,CV03,CV04,CV05,LT01,LT02,LT06,LT07,LT08,LT10,LT11,LT12,ST03,ST08
 
 # Match the surrounding Ruby code style: this project indents with two
 # spaces, so SQL inside heredocs reads naturally when sqlfluff expects

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,0 +1,55 @@
+[sqlfluff]
+dialect = oracle
+
+# Enabled subset of sqlfluff's core rule set. The five core rules below
+# are intentionally OMITTED:
+#
+#   AL03  Column expression without alias. Flags simple column references
+#         (e.g. `i.parameters`) in a SELECT list that otherwise uses
+#         aliases. Adapter queries mix aliased calc columns with plain
+#         column passthroughs — forcing `AS` on every passthrough adds
+#         noise without value.
+#   CP02  Identifier capitalisation. Oracle SQL routinely mixes upper
+#         (dictionary view names like `TEST_POSTS`) and lower (Rails
+#         convention like `test_posts`) identifiers. No single policy
+#         fits the codebase. Tracked separately: see GitHub issue.
+#   JJ01  Jinja templating padding. We do not use Jinja in heredocs;
+#         rule is inert.
+#   LT05  Line too long. Most heredocs are `.squish`ed before execution,
+#         so the SQL sent to Oracle is one line regardless. The line
+#         length in the Ruby source is constrained by RuboCop instead.
+#   RF01  References from. Triggers false positives when an alias is
+#         used only inside a `#{...}` interpolation, which we replace
+#         with an opaque placeholder before linting.
+rules = AL04,AL06,AL08,AL09,AL10,AM01,AM02,AM06,CP04,CP05,CV03,CV04,CV05,LT06,LT07,LT08,LT10,LT11,LT12,ST03,ST08
+
+# Match the surrounding Ruby code style: this project indents with two
+# spaces, so SQL inside heredocs reads naturally when sqlfluff expects
+# the same unit. sqlfluff's default is four spaces.
+[sqlfluff:indentation]
+indent_unit = space
+tab_space_size = 2
+
+# Keywords: enforce upper case (`SELECT`, `FROM`, `WHERE`, `JOIN`...).
+# Oracle docs and dictionary views use upper case, and the explicit
+# policy avoids the "consistent" loophole that lets a fully lowercase
+# heredoc pass.
+[sqlfluff:rules:capitalisation.keywords]
+capitalisation_policy = upper
+
+# Functions: enforce upper case (`UPPER`, `DECODE`, `NVL`, `MAX`).
+# Same reasoning as keywords. Note: CP03 uses the `extended_` variant
+# of the policy key — the plain `capitalisation_policy` is silently
+# ignored and the rule falls back to `consistent`.
+[sqlfluff:rules:capitalisation.functions]
+extended_capitalisation_policy = upper
+
+# Boolean/NULL literals: enforce upper case (`NULL`, `TRUE`, `FALSE`).
+# Without an explicit policy CP04 falls back to `consistent`.
+[sqlfluff:rules:capitalisation.literals]
+capitalisation_policy = upper
+
+# Datatypes: enforce upper case (`NUMBER`, `VARCHAR2`, `DATE`...).
+# CP05, like CP03, requires the `extended_` policy key.
+[sqlfluff:rules:capitalisation.types]
+extended_capitalisation_policy = upper

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -21,7 +21,7 @@ dialect = oracle
 #   RF01  References from. Triggers false positives when an alias is
 #         used only inside a `#{...}` interpolation, which we replace
 #         with an opaque placeholder before linting.
-rules = AL04,AL06,AL08,AL09,AL10,AM01,AM02,AM06,CP01,CP03,CP04,CP05,CV03,CV04,CV05,LT06,LT07,LT08,LT10,LT11,LT12,ST03,ST08
+rules = AL02,AL04,AL06,AL08,AL09,AL10,AM01,AM02,AM06,CP01,CP03,CP04,CP05,CV03,CV04,CV05,LT06,LT07,LT08,LT10,LT11,LT12,ST03,ST08
 
 # Match the surrounding Ruby code style: this project indents with two
 # spaces, so SQL inside heredocs reads naturally when sqlfluff expects

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -21,7 +21,7 @@ dialect = oracle
 #   RF01  References from. Triggers false positives when an alias is
 #         used only inside a `#{...}` interpolation, which we replace
 #         with an opaque placeholder before linting.
-rules = AL04,AL06,AL08,AL09,AL10,AM01,AM02,AM06,CP01,CP04,CP05,CV03,CV04,CV05,LT06,LT07,LT08,LT10,LT11,LT12,ST03,ST08
+rules = AL04,AL06,AL08,AL09,AL10,AM01,AM02,AM06,CP01,CP03,CP04,CP05,CV03,CV04,CV05,LT06,LT07,LT08,LT10,LT11,LT12,ST03,ST08
 
 # Match the surrounding Ruby code style: this project indents with two
 # spaces, so SQL inside heredocs reads naturally when sqlfluff expects

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -21,7 +21,7 @@ dialect = oracle
 #   RF01  References from. Triggers false positives when an alias is
 #         used only inside a `#{...}` interpolation, which we replace
 #         with an opaque placeholder before linting.
-rules = AL02,AL04,AL06,AL08,AL09,AL10,AM01,AM02,AM06,CP01,CP03,CP04,CP05,CV03,CV04,CV05,LT06,LT07,LT08,LT10,LT11,LT12,ST03,ST08
+rules = AL02,AL04,AL06,AL08,AL09,AL10,AM01,AM02,AM06,CP01,CP03,CP04,CP05,CV03,CV04,CV05,LT01,LT06,LT07,LT08,LT10,LT11,LT12,ST03,ST08
 
 # Match the surrounding Ruby code style: this project indents with two
 # spaces, so SQL inside heredocs reads naturally when sqlfluff expects

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -254,10 +254,10 @@ module ActiveRecord # :nodoc:
           def extract_expression_for_virtual_column(column)
             column_name = column.name
             @connection.select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name.upcase), bind_string("column_name", column_name.upcase)]).inspect
-              select data_default from all_tab_columns
-              where owner = SYS_CONTEXT('userenv', 'current_schema')
-              and table_name = :table_name
-              and column_name = :column_name
+              SELECT data_default FROM all_tab_columns
+              WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
+              AND table_name = :table_name
+              AND column_name = :column_name
             SQL
           end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -255,9 +255,10 @@ module ActiveRecord # :nodoc:
             column_name = column.name
             @connection.select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name.upcase), bind_string("column_name", column_name.upcase)]).inspect
               SELECT data_default FROM all_tab_columns
-              WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
-              AND table_name = :table_name
-              AND column_name = :column_name
+              WHERE
+                owner = SYS_CONTEXT('userenv', 'current_schema')
+                AND table_name = :table_name
+                AND column_name = :column_name
             SQL
           end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -746,10 +746,10 @@ module ActiveRecord
           (_owner, desc_table_name) = resolve_data_source_name(table_name)
 
           fk_info = select_all(<<~SQL.squish, "SCHEMA", [bind_string("desc_table_name", desc_table_name)])
-            SELECT r.table_name to_table
-                  ,rc.column_name references_column
+            SELECT r.table_name AS to_table
+                  ,rc.column_name AS references_column
                   ,cc.column_name
-                  ,c.constraint_name name
+                  ,c.constraint_name AS name
                   ,c.delete_rule
                   ,c.deferrable
                   ,c.deferred

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -17,7 +17,7 @@ module ActiveRecord
             FROM all_tables
             WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
             AND secondary = 'N'
-            minus
+            MINUS
             SELECT DECODE(mview_name, UPPER(mview_name), LOWER(mview_name), mview_name)
             FROM all_mviews
             WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
@@ -79,7 +79,7 @@ module ActiveRecord
         def synonyms
           result = select_all(<<~SQL.squish, "SCHEMA")
             SELECT synonym_name, table_owner, table_name
-            FROM all_synonyms where owner = SYS_CONTEXT('userenv', 'current_schema')
+            FROM all_synonyms WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
           SQL
 
           result.collect do |row|

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -746,15 +746,15 @@ module ActiveRecord
           (_owner, desc_table_name) = resolve_data_source_name(table_name)
 
           fk_info = select_all(<<~SQL.squish, "SCHEMA", [bind_string("desc_table_name", desc_table_name)])
-            SELECT r.table_name AS to_table
-                  ,rc.column_name AS references_column
-                  ,cc.column_name
-                  ,c.constraint_name AS name
-                  ,c.delete_rule
-                  ,c.deferrable
-                  ,c.deferred
-                  ,c.validated
-                  ,c.status
+            SELECT r.table_name AS to_table,
+                   rc.column_name AS references_column,
+                   cc.column_name,
+                   c.constraint_name AS name,
+                   c.delete_rule,
+                   c.deferrable,
+                   c.deferred,
+                   c.validated,
+                   c.status
               FROM all_constraints c, all_cons_columns cc,
                    all_constraints r, all_cons_columns rc
              WHERE c.owner = SYS_CONTEXT('userenv', 'current_schema')

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -13,10 +13,11 @@ module ActiveRecord
         def tables # :nodoc:
           select_values(<<~SQL.squish, "SCHEMA")
             SELECT
-            DECODE(table_name, UPPER(table_name), LOWER(table_name), table_name)
+              DECODE(table_name, UPPER(table_name), LOWER(table_name), table_name)
             FROM all_tables
-            WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
-            AND secondary = 'N'
+            WHERE
+              owner = SYS_CONTEXT('userenv', 'current_schema')
+              AND secondary = 'N'
             MINUS
             SELECT DECODE(mview_name, UPPER(mview_name), LOWER(mview_name), mview_name)
             FROM all_mviews
@@ -47,8 +48,9 @@ module ActiveRecord
           select_values(<<~SQL.squish, "SCHEMA", [bind_string("owner", table_owner), bind_string("table_name", table_name)]).any?
             SELECT owner, table_name
             FROM all_tables
-            WHERE owner = :owner
-            AND table_name = :table_name
+            WHERE
+              owner = :owner
+              AND table_name = :table_name
           SQL
         end
 
@@ -64,14 +66,16 @@ module ActiveRecord
         def views # :nodoc:
           select_values(<<~SQL.squish, "SCHEMA")
             SELECT
-            LOWER(view_name) FROM all_views WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
+              LOWER(view_name)
+            FROM all_views WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
           SQL
         end
 
         def materialized_views # :nodoc:
           select_values(<<~SQL.squish, "SCHEMA")
             SELECT
-            LOWER(mview_name) FROM all_mviews WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
+              LOWER(mview_name)
+            FROM all_mviews WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
           SQL
         end
 
@@ -97,22 +101,40 @@ module ActiveRecord
           # 'VISIBLE' so the rest of the reader works unchanged.
           visibility_column = supports_disabling_indexes? ? "i.visibility" : "'VISIBLE' AS visibility"
           result = select_all(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name)])
-            SELECT LOWER(i.table_name) AS table_name, LOWER(i.index_name) AS index_name, i.uniqueness,
+            SELECT
+              LOWER(i.table_name) AS table_name, LOWER(i.index_name) AS index_name, i.uniqueness,
               i.index_type, i.ityp_owner, i.ityp_name, i.parameters,
               LOWER(i.tablespace_name) AS tablespace_name, #{visibility_column},
               LOWER(c.column_name) AS column_name, c.descend, e.column_expression,
               atc.virtual_column
             FROM all_indexes i
-              JOIN all_ind_columns c ON c.index_name = i.index_name AND c.index_owner = i.owner
-              LEFT OUTER JOIN all_ind_expressions e ON e.index_name = i.index_name AND
-                e.index_owner = i.owner AND e.column_position = c.column_position
-              LEFT OUTER JOIN all_tab_cols atc ON i.table_name = atc.table_name AND
-                c.column_name = atc.column_name AND i.owner = atc.owner AND atc.hidden_column = 'NO'
-            WHERE i.owner = SYS_CONTEXT('userenv', 'current_schema')
-               AND i.table_owner = SYS_CONTEXT('userenv', 'current_schema')
-               AND i.table_name = :table_name
-               AND NOT EXISTS (SELECT uc.index_name FROM all_constraints uc
-                WHERE uc.index_name = i.index_name AND uc.owner = i.owner AND uc.constraint_type = 'P')
+            JOIN all_ind_columns c
+              ON
+                c.index_name = i.index_name
+                AND c.index_owner = i.owner
+            LEFT OUTER JOIN all_ind_expressions e
+              ON
+                e.index_name = i.index_name
+                AND e.index_owner = i.owner
+                AND e.column_position = c.column_position
+            LEFT OUTER JOIN all_tab_cols atc
+              ON
+                i.table_name = atc.table_name
+                AND c.column_name = atc.column_name
+                AND i.owner = atc.owner
+                AND atc.hidden_column = 'NO'
+            WHERE
+              i.owner = SYS_CONTEXT('userenv', 'current_schema')
+              AND i.table_owner = SYS_CONTEXT('userenv', 'current_schema')
+              AND i.table_name = :table_name
+              AND NOT EXISTS (
+                SELECT uc.index_name
+                FROM all_constraints uc
+                WHERE
+                  uc.index_name = i.index_name
+                  AND uc.owner = i.owner
+                  AND uc.constraint_type = 'P'
+              )
             ORDER BY i.index_name, c.column_position
           SQL
 
@@ -129,7 +151,8 @@ module ActiveRecord
                 source = select_values(<<~SQL.squish, "SCHEMA", [bind_string("procedure_name", procedure_name.upcase)]).join
                   SELECT text
                   FROM all_source
-                  WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
+                  WHERE
+                    owner = SYS_CONTEXT('userenv', 'current_schema')
                     AND name = :procedure_name
                   ORDER BY line
                 SQL
@@ -404,10 +427,11 @@ module ActiveRecord
           (_owner, table_name) = resolve_data_source_name(table_name)
           result = select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name), bind_string("index_name", index_name.to_s.upcase)])
             SELECT 1 FROM all_indexes i
-            WHERE i.owner = SYS_CONTEXT('userenv', 'current_schema')
-               AND i.table_owner = SYS_CONTEXT('userenv', 'current_schema')
-               AND i.table_name = :table_name
-               AND i.index_name = :index_name
+            WHERE
+              i.owner = SYS_CONTEXT('userenv', 'current_schema')
+              AND i.table_owner = SYS_CONTEXT('userenv', 'current_schema')
+              AND i.table_name = :table_name
+              AND i.index_name = :index_name
           SQL
           result == 1
         end
@@ -695,7 +719,8 @@ module ActiveRecord
           (_owner, table_name) = resolve_data_source_name(table_name)
           select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name)])
             SELECT comments FROM all_tab_comments
-            WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
+            WHERE
+              owner = SYS_CONTEXT('userenv', 'current_schema')
               AND table_name = :table_name
           SQL
         end
@@ -711,7 +736,8 @@ module ActiveRecord
           (_owner, table_name) = resolve_data_source_name(table_name)
           select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name), bind_string("column_name", column_name.upcase)])
             SELECT comments FROM all_col_comments
-            WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
+            WHERE
+              owner = SYS_CONTEXT('userenv', 'current_schema')
               AND table_name = :table_name
               AND column_name = :column_name
           SQL
@@ -729,8 +755,9 @@ module ActiveRecord
           select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name.to_s.upcase)])
             SELECT tablespace_name
             FROM all_tables
-            WHERE table_name = :table_name
-            AND owner = SYS_CONTEXT('userenv', 'current_schema')
+            WHERE
+              table_name = :table_name
+              AND owner = SYS_CONTEXT('userenv', 'current_schema')
           SQL
         end
 
@@ -746,27 +773,32 @@ module ActiveRecord
           (_owner, desc_table_name) = resolve_data_source_name(table_name)
 
           fk_info = select_all(<<~SQL.squish, "SCHEMA", [bind_string("desc_table_name", desc_table_name)])
-            SELECT r.table_name AS to_table,
-                   rc.column_name AS references_column,
-                   cc.column_name,
-                   c.constraint_name AS name,
-                   c.delete_rule,
-                   c.deferrable,
-                   c.deferred,
-                   c.validated,
-                   c.status
-              FROM all_constraints c, all_cons_columns cc,
-                   all_constraints r, all_cons_columns rc
-             WHERE c.owner = SYS_CONTEXT('userenv', 'current_schema')
-               AND c.table_name = :desc_table_name
-               AND c.constraint_type = 'R'
-               AND cc.owner = c.owner
-               AND cc.constraint_name = c.constraint_name
-               AND r.constraint_name = c.r_constraint_name
-               AND r.owner = c.owner
-               AND rc.owner = r.owner
-               AND rc.constraint_name = r.constraint_name
-               AND rc.position = cc.position
+            SELECT
+              r.table_name AS to_table,
+              rc.column_name AS references_column,
+              cc.column_name,
+              c.constraint_name AS name,
+              c.delete_rule,
+              c.deferrable,
+              c.deferred,
+              c.validated,
+              c.status
+            FROM
+              all_constraints c,
+              all_cons_columns cc,
+              all_constraints r,
+              all_cons_columns rc
+            WHERE
+              c.owner = SYS_CONTEXT('userenv', 'current_schema')
+              AND c.table_name = :desc_table_name
+              AND c.constraint_type = 'R'
+              AND cc.owner = c.owner
+              AND cc.constraint_name = c.constraint_name
+              AND r.constraint_name = c.r_constraint_name
+              AND r.owner = c.owner
+              AND rc.owner = r.owner
+              AND rc.constraint_name = r.constraint_name
+              AND rc.position = cc.position
             ORDER BY name, to_table, column_name, references_column
           SQL
 
@@ -791,12 +823,13 @@ module ActiveRecord
           # `search_condition` is LONG; cannot appear in WHERE (ORA-00997).
           rows = select_all(<<~SQL.squish, "SCHEMA", [bind_string("desc_table_name", desc_table_name)])
             SELECT constraint_name AS name, search_condition, validated
-              FROM all_constraints
-             WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
-               AND table_name = :desc_table_name
-               AND constraint_type = 'C'
-               AND generated = 'USER NAME'
-             ORDER BY constraint_name
+            FROM all_constraints
+            WHERE
+              owner = SYS_CONTEXT('userenv', 'current_schema')
+              AND table_name = :desc_table_name
+              AND constraint_type = 'C'
+              AND generated = 'USER NAME'
+            ORDER BY constraint_name
           SQL
 
           rows.filter_map do |row|
@@ -844,20 +877,23 @@ module ActiveRecord
           (_owner, desc_table_name) = resolve_data_source_name(table_name)
 
           rows = select_all(<<~SQL.squish, "SCHEMA", [bind_string("desc_table_name", desc_table_name)])
-            SELECT c.constraint_name AS name,
-                   c.index_name,
-                   c.deferrable,
-                   c.deferred,
-                   cc.column_name,
-                   cc.position
-              FROM all_constraints c
-              JOIN all_cons_columns cc
-                ON cc.owner = c.owner
-               AND cc.constraint_name = c.constraint_name
-             WHERE c.owner = SYS_CONTEXT('userenv', 'current_schema')
-               AND c.table_name = :desc_table_name
-               AND c.constraint_type = 'U'
-             ORDER BY c.constraint_name, cc.position
+            SELECT
+              c.constraint_name AS name,
+              c.index_name,
+              c.deferrable,
+              c.deferred,
+              cc.column_name,
+              cc.position
+            FROM all_constraints c
+            JOIN all_cons_columns cc
+              ON
+                cc.owner = c.owner
+                AND cc.constraint_name = c.constraint_name
+            WHERE
+              c.owner = SYS_CONTEXT('userenv', 'current_schema')
+              AND c.table_name = :desc_table_name
+              AND c.constraint_type = 'U'
+            ORDER BY c.constraint_name, cc.position
           SQL
 
           grouped = rows.group_by { |row| row["name"] }
@@ -939,8 +975,9 @@ module ActiveRecord
         def disable_referential_integrity(&block) # :nodoc:
           old_constraints = select_all(<<~SQL.squish, "SCHEMA")
             SELECT constraint_name, owner, table_name
-              FROM all_constraints
-              WHERE constraint_type = 'R'
+            FROM all_constraints
+            WHERE
+              constraint_type = 'R'
               AND status = 'ENABLED'
               AND owner = SYS_CONTEXT('userenv', 'current_schema')
           SQL
@@ -1518,9 +1555,10 @@ module ActiveRecord
 
             index_name = select_value(<<~SQL.squish, "Index name for primary key",  [bind_string("table_name", table_name.upcase)])
               SELECT index_name FROM all_constraints
-                  WHERE table_name = :table_name
-                  AND constraint_type = 'P'
-                  AND owner = SYS_CONTEXT('userenv', 'current_schema')
+              WHERE
+                table_name = :table_name
+                AND constraint_type = 'P'
+                AND owner = SYS_CONTEXT('userenv', 'current_schema')
             SQL
 
             return unless index_name

--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -10,9 +10,10 @@ module ActiveRecord # :nodoc:
         def structure_dump # :nodoc:
           sequences = select_all(<<~SQL.squish, "SCHEMA")
             SELECT
-            sequence_name, min_value, max_value, increment_by, order_flag, cycle_flag
+              sequence_name, min_value, max_value, increment_by, order_flag, cycle_flag
             FROM all_sequences
-            WHERE sequence_owner = SYS_CONTEXT('userenv', 'current_schema')
+            WHERE
+              sequence_owner = SYS_CONTEXT('userenv', 'current_schema')
               AND sequence_name NOT LIKE 'ISEQ$$\\_%' ESCAPE '\\'
             ORDER BY 1
           SQL
@@ -22,23 +23,30 @@ module ActiveRecord # :nodoc:
           end
           tables = select_values(<<~SQL.squish, "SCHEMA")
             SELECT table_name FROM all_tables t
-            WHERE owner = SYS_CONTEXT('userenv', 'current_schema') AND secondary = 'N'
-            AND NOT EXISTS (SELECT mv.mview_name FROM all_mviews mv
-                            WHERE mv.owner = t.owner AND mv.mview_name = t.table_name)
-            AND NOT EXISTS (SELECT mvl.log_table FROM all_mview_logs mvl
-                            WHERE mvl.log_owner = t.owner AND mvl.log_table = t.table_name)
+            WHERE
+              owner = SYS_CONTEXT('userenv', 'current_schema') AND secondary = 'N'
+              AND NOT EXISTS (
+                SELECT mv.mview_name FROM all_mviews mv
+                WHERE mv.owner = t.owner AND mv.mview_name = t.table_name
+              )
+              AND NOT EXISTS (
+                SELECT mvl.log_table FROM all_mview_logs mvl
+                WHERE mvl.log_owner = t.owner AND mvl.log_table = t.table_name
+              )
             ORDER BY 1
           SQL
           identity_column_expr = supports_identity_columns? ? "atc.identity_column" : "'NO' AS identity_column"
           tables.each do |table_name|
             virtual_columns = virtual_columns_for(table_name) if supports_virtual_columns?
             ddl = +"CREATE#{ ' GLOBAL TEMPORARY' if temporary_table?(table_name)} TABLE \"#{table_name}\" (\n"
-            columns = select_all(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name)])
-              SELECT column_name, data_type, data_length, char_used, char_length,
-              data_precision, data_scale, data_default, nullable, #{identity_column_expr}
+            columns = select_all(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name)]) # sql_lint:disable=AL05 -- atc alias used by identity_column_expr interpolation
+              SELECT
+                column_name, data_type, data_length, char_used, char_length,
+                data_precision, data_scale, data_default, nullable, #{identity_column_expr}
               FROM all_tab_columns atc
-              WHERE table_name = :table_name
-              AND owner = SYS_CONTEXT('userenv', 'current_schema')
+              WHERE
+                table_name = :table_name
+                AND owner = SYS_CONTEXT('userenv', 'current_schema')
               ORDER BY column_id
             SQL
             cols = columns.map do |row|
@@ -104,13 +112,14 @@ module ActiveRecord # :nodoc:
           opts = { name: "", cols: [] }
           pks = select_all(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table.upcase)])
             SELECT a.constraint_name, a.column_name, a.position
-              FROM all_cons_columns a
-              JOIN all_constraints c
-                ON a.constraint_name = c.constraint_name
-             WHERE c.table_name = :table_name
-               AND c.constraint_type = 'P'
-               AND a.owner = c.owner
-               AND c.owner = SYS_CONTEXT('userenv', 'current_schema')
+            FROM all_cons_columns a
+            JOIN all_constraints c
+              ON a.constraint_name = c.constraint_name
+            WHERE
+              c.table_name = :table_name
+              AND c.constraint_type = 'P'
+              AND a.owner = c.owner
+              AND c.owner = SYS_CONTEXT('userenv', 'current_schema')
           SQL
           pks.each do |row|
             opts[:name] = row["constraint_name"]
@@ -131,15 +140,17 @@ module ActiveRecord # :nodoc:
           keys = {}
           metadata = {}
           uks = select_all(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table.upcase)])
-            SELECT a.constraint_name, a.column_name, a.position,
-                   c.index_name, c.deferrable, c.deferred
-              FROM all_cons_columns a
-              JOIN all_constraints c
-                ON a.constraint_name = c.constraint_name
-             WHERE c.table_name = :table_name
-               AND c.constraint_type = 'U'
-               AND a.owner = c.owner
-               AND c.owner = SYS_CONTEXT('userenv', 'current_schema')
+            SELECT
+              a.constraint_name, a.column_name, a.position,
+              c.index_name, c.deferrable, c.deferred
+            FROM all_cons_columns a
+            JOIN all_constraints c
+              ON a.constraint_name = c.constraint_name
+            WHERE
+              c.table_name = :table_name
+              AND c.constraint_type = 'U'
+              AND a.owner = c.owner
+              AND c.owner = SYS_CONTEXT('userenv', 'current_schema')
           SQL
           uks.each do |uk|
             keys[uk["constraint_name"]] ||= []
@@ -196,7 +207,8 @@ module ActiveRecord # :nodoc:
           check_constraints = select_all(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name.upcase)])
             SELECT constraint_name, search_condition, validated
             FROM all_constraints
-            WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
+            WHERE
+              owner = SYS_CONTEXT('userenv', 'current_schema')
               AND table_name = :table_name
               AND constraint_type = 'C'
               AND generated = 'USER NAME'
@@ -226,8 +238,10 @@ module ActiveRecord # :nodoc:
           comments = []
           columns = select_values(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name)])
             SELECT column_name FROM all_tab_columns
-            WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
-            AND table_name = :table_name ORDER BY column_id
+            WHERE
+              owner = SYS_CONTEXT('userenv', 'current_schema')
+              AND table_name = :table_name
+            ORDER BY column_id
           SQL
 
           columns.each do |column|
@@ -264,18 +278,21 @@ module ActiveRecord # :nodoc:
           all_source = select_all(<<~SQL.squish, "SCHEMA")
             SELECT DISTINCT name, type
             FROM all_source
-            WHERE type IN ('PROCEDURE', 'PACKAGE', 'PACKAGE BODY', 'FUNCTION', 'TRIGGER', 'TYPE')
-            AND name NOT LIKE 'BIN$%'
-            AND owner = SYS_CONTEXT('userenv', 'current_schema') ORDER BY type
+            WHERE
+              type IN ('PROCEDURE', 'PACKAGE', 'PACKAGE BODY', 'FUNCTION', 'TRIGGER', 'TYPE')
+              AND name NOT LIKE 'BIN$%'
+              AND owner = SYS_CONTEXT('userenv', 'current_schema')
+            ORDER BY type
           SQL
           all_source.each do |source|
             ddl = +"CREATE OR REPLACE   \n"
             texts = select_all(<<~SQL.squish, "all source at structure dump", [bind_string("source_name", source["name"]), bind_string("source_type", source["type"])])
               SELECT text
               FROM all_source
-              WHERE name = :source_name
-              AND type = :source_type
-              AND owner = SYS_CONTEXT('userenv', 'current_schema')
+              WHERE
+                name = :source_name
+                AND type = :source_type
+                AND owner = SYS_CONTEXT('userenv', 'current_schema')
               ORDER BY line
             SQL
             texts.each do |row|
@@ -319,7 +336,8 @@ module ActiveRecord # :nodoc:
         def structure_drop # :nodoc:
           sequences = select_values(<<~SQL.squish, "SCHEMA")
             SELECT sequence_name FROM all_sequences
-            WHERE sequence_owner = SYS_CONTEXT('userenv', 'current_schema')
+            WHERE
+              sequence_owner = SYS_CONTEXT('userenv', 'current_schema')
               AND sequence_name NOT LIKE 'ISEQ$$\\_%' ESCAPE '\\'
             ORDER BY 1
           SQL
@@ -328,11 +346,16 @@ module ActiveRecord # :nodoc:
           end
           tables = select_values(<<~SQL.squish, "SCHEMA")
             SELECT table_name FROM all_tables t
-            WHERE owner = SYS_CONTEXT('userenv', 'current_schema') AND secondary = 'N'
-            AND NOT EXISTS (SELECT mv.mview_name FROM all_mviews mv
-                            WHERE mv.owner = t.owner AND mv.mview_name = t.table_name)
-            AND NOT EXISTS (SELECT mvl.log_table FROM all_mview_logs mvl
-                            WHERE mvl.log_owner = t.owner AND mvl.log_table = t.table_name)
+            WHERE
+              owner = SYS_CONTEXT('userenv', 'current_schema') AND secondary = 'N'
+              AND NOT EXISTS (
+                SELECT mv.mview_name FROM all_mviews mv
+                WHERE mv.owner = t.owner AND mv.mview_name = t.table_name
+              )
+              AND NOT EXISTS (
+                SELECT mvl.log_table FROM all_mview_logs mvl
+                WHERE mvl.log_owner = t.owner AND mvl.log_table = t.table_name
+              )
             ORDER BY 1
           SQL
           tables.each do |table|
@@ -344,8 +367,10 @@ module ActiveRecord # :nodoc:
         def temp_table_drop # :nodoc:
           temporary_tables = select_values(<<~SQL.squish, "SCHEMA")
             SELECT table_name FROM all_tables
-            WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
-            AND secondary = 'N' AND temporary = 'Y' ORDER BY 1
+            WHERE
+              owner = SYS_CONTEXT('userenv', 'current_schema')
+              AND secondary = 'N' AND temporary = 'Y'
+            ORDER BY 1
           SQL
           statements = temporary_tables.map do |table|
             "DROP TABLE \"#{table}\" CASCADE CONSTRAINTS"
@@ -379,9 +404,10 @@ module ActiveRecord # :nodoc:
           select_all(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table.upcase)])
             SELECT column_name, data_default
             FROM all_tab_cols
-            WHERE virtual_column = 'YES'
-            AND owner = SYS_CONTEXT('userenv', 'current_schema')
-            AND table_name = :table_name
+            WHERE
+              virtual_column = 'YES'
+              AND owner = SYS_CONTEXT('userenv', 'current_schema')
+              AND table_name = :table_name
           SQL
         end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump.rb
@@ -12,7 +12,7 @@ module ActiveRecord # :nodoc:
             SELECT
             sequence_name, min_value, max_value, increment_by, order_flag, cycle_flag
             FROM all_sequences
-            where sequence_owner = SYS_CONTEXT('userenv', 'current_schema')
+            WHERE sequence_owner = SYS_CONTEXT('userenv', 'current_schema')
               AND sequence_name NOT LIKE 'ISEQ$$\\_%' ESCAPE '\\'
             ORDER BY 1
           SQL
@@ -327,7 +327,7 @@ module ActiveRecord # :nodoc:
             "DROP SEQUENCE \"#{seq}\""
           end
           tables = select_values(<<~SQL.squish, "SCHEMA")
-            SELECT table_name from all_tables t
+            SELECT table_name FROM all_tables t
             WHERE owner = SYS_CONTEXT('userenv', 'current_schema') AND secondary = 'N'
             AND NOT EXISTS (SELECT mv.mview_name FROM all_mviews mv
                             WHERE mv.owner = t.owner AND mv.mview_name = t.table_name)
@@ -389,7 +389,7 @@ module ActiveRecord # :nodoc:
           short_type = type == "materialized view" ? "mview" : type
           features = select_values(<<~SQL.squish, "SCHEMA")
             SELECT #{short_type}_name FROM all_#{short_type.tableize}
-            where owner = SYS_CONTEXT('userenv', 'current_schema')
+            WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
           SQL
           statements = features.map do |name|
             "DROP #{type.upcase} \"#{name}\""
@@ -400,7 +400,7 @@ module ActiveRecord # :nodoc:
         def drop_sql_for_object(type)
           objects = select_values(<<~SQL.squish, "SCHEMA", [bind_string("object_type", type.upcase)])
             SELECT object_name FROM all_objects
-            WHERE object_type = :object_type and owner = SYS_CONTEXT('userenv', 'current_schema')
+            WHERE object_type = :object_type AND owner = SYS_CONTEXT('userenv', 'current_schema')
           SQL
           statements = objects.map do |name|
             "DROP #{type.upcase} \"#{name}\""

--- a/lib/active_record/connection_adapters/oracle_enhanced/structure_dump/dbms_metadata.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/structure_dump/dbms_metadata.rb
@@ -108,19 +108,23 @@ module ActiveRecord # :nodoc:
               # MV / MV log surface as TABLE in all_objects.
               mview_filter = if non_mview_only
                 <<~SQL.squish
-                  AND NOT EXISTS (SELECT 1 FROM all_mviews mv
-                                  WHERE mv.owner = o.owner AND mv.mview_name = o.object_name)
-                  AND NOT EXISTS (SELECT 1 FROM all_mview_logs mvl
-                                  WHERE mvl.log_owner = o.owner AND mvl.log_table = o.object_name)
+                  AND NOT EXISTS (
+                    SELECT 1 FROM all_mviews mv
+                    WHERE mv.owner = o.owner AND mv.mview_name = o.object_name)
+                  AND NOT EXISTS (
+                    SELECT 1 FROM all_mview_logs mvl
+                    WHERE mvl.log_owner = o.owner AND mvl.log_table = o.object_name)
                 SQL
               else
                 ""
               end
-              select_values(<<~SQL.squish, "SCHEMA", binds)
-                SELECT object_name FROM all_objects o
-                WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
-                AND object_type = :object_type
-                AND object_name NOT LIKE 'BIN$%'
+              select_values(<<~SQL.squish, "SCHEMA", binds) # sql_lint:disable=AL05 -- alias o used by mview_filter interpolation
+                SELECT object_name
+                FROM all_objects o
+                WHERE
+                  owner = SYS_CONTEXT('userenv', 'current_schema')
+                  AND object_type = :object_type
+                  AND object_name NOT LIKE 'BIN$%'
                 #{mview_filter}
                 ORDER BY object_name
               SQL
@@ -130,9 +134,10 @@ module ActiveRecord # :nodoc:
             def constraint_backed_index_names
               select_values(<<~SQL.squish, "SCHEMA").map(&:upcase).to_set
                 SELECT index_name FROM all_constraints
-                WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
-                AND constraint_type IN ('P', 'U')
-                AND index_name IS NOT NULL
+                WHERE
+                  owner = SYS_CONTEXT('userenv', 'current_schema')
+                  AND constraint_type IN ('P', 'U')
+                  AND index_name IS NOT NULL
               SQL
             end
 
@@ -146,8 +151,9 @@ module ActiveRecord # :nodoc:
               return Set.new unless supports_disabling_indexes?
               select_values(<<~SQL.squish, "SCHEMA").map(&:upcase).to_set
                 SELECT index_name FROM all_indexes
-                WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
-                AND visibility = 'INVISIBLE'
+                WHERE
+                  owner = SYS_CONTEXT('userenv', 'current_schema')
+                  AND visibility = 'INVISIBLE'
               SQL
             end
 
@@ -167,8 +173,10 @@ module ActiveRecord # :nodoc:
               comments = []
               columns = select_values(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name)])
                 SELECT column_name FROM all_tab_columns
-                WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
-                AND table_name = :table_name ORDER BY column_id
+                WHERE
+                  owner = SYS_CONTEXT('userenv', 'current_schema')
+                  AND table_name = :table_name
+                ORDER BY column_id
               SQL
               columns.each do |column|
                 comment = column_comment(table_name, column)

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -904,7 +904,7 @@ module ActiveRecord
 
         if primary_key && sequence_name
           new_start_value = select_value(<<~SQL.squish, "SCHEMA")
-            select NVL(max(#{quote_column_name(primary_key)}),0) + 1 from #{quote_table_name(table_name)}
+            SELECT NVL(max(#{quote_column_name(primary_key)}),0) + 1 FROM #{quote_table_name(table_name)}
           SQL
 
           execute "DROP SEQUENCE #{quote_table_name(sequence_name)}"
@@ -1016,10 +1016,10 @@ module ActiveRecord
         (owner, desc_table_name) = resolve_data_source_name(table_name)
 
         seqs = select_values(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("sequence_name", default_sequence_name(desc_table_name, nil))])
-          select us.sequence_name
-          from all_sequences us
-          where us.sequence_owner = :owner
-          and us.sequence_name = upper(:sequence_name)
+          SELECT us.sequence_name
+          FROM all_sequences us
+          WHERE us.sequence_owner = :owner
+          AND us.sequence_name = upper(:sequence_name)
         SQL
 
         # changed back from user_constraints to all_constraints for consistency
@@ -1050,7 +1050,7 @@ module ActiveRecord
              AND c.constraint_type = 'P'
              AND cc.owner = c.owner
              AND cc.constraint_name = c.constraint_name
-             order by cc.position
+             ORDER BY cc.position
         SQL
         pks.map { |pk| oracle_downcase(pk) }
       end
@@ -1075,7 +1075,7 @@ module ActiveRecord
       def temporary_table?(table_name) # :nodoc:
         select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name.upcase)]) == "Y"
           SELECT
-          temporary FROM all_tables WHERE table_name = :table_name and owner = SYS_CONTEXT('userenv', 'current_schema')
+          temporary FROM all_tables WHERE table_name = :table_name AND owner = SYS_CONTEXT('userenv', 'current_schema')
         SQL
       end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -827,13 +827,16 @@ module ActiveRecord
           SELECT 1
           FROM all_tab_identity_cols itc
           JOIN all_cons_columns cc
-            ON cc.owner = itc.owner
-           AND cc.table_name = itc.table_name
-           AND cc.column_name = itc.column_name
+            ON
+              cc.owner = itc.owner
+              AND cc.table_name = itc.table_name
+              AND cc.column_name = itc.column_name
           JOIN all_constraints c
-            ON c.owner = cc.owner
-           AND c.constraint_name = cc.constraint_name
-          WHERE itc.owner = :owner
+            ON
+              c.owner = cc.owner
+              AND c.constraint_name = cc.constraint_name
+          WHERE
+            itc.owner = :owner
             AND itc.table_name = :table_name
             AND c.constraint_type = 'P'
         SQL
@@ -849,16 +852,19 @@ module ActiveRecord
         select_values(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("table_name", desc_table_name)]).any?
           SELECT 1
           FROM all_triggers t
-          WHERE t.owner = :owner
+          WHERE
+            t.owner = :owner
             AND t.table_name = :table_name
             AND t.trigger_type = 'BEFORE EACH ROW'
             AND t.triggering_event = 'INSERT'
             AND EXISTS (
-              SELECT 1 FROM all_source s
-               WHERE s.owner = t.owner
-                 AND s.name = t.trigger_name
-                 AND s.type = 'TRIGGER'
-                 AND UPPER(s.text) LIKE '%NEXTVAL INTO :NEW%'
+              SELECT 1
+              FROM all_source s
+              WHERE
+                s.owner = t.owner
+                AND s.name = t.trigger_name
+                AND s.type = 'TRIGGER'
+                AND UPPER(s.text) LIKE '%NEXTVAL INTO :NEW%'
             )
         SQL
       end
@@ -867,15 +873,18 @@ module ActiveRecord
         rows = select_all(<<~SQL.squish, "SCHEMA")
           SELECT t.table_name, t.trigger_name
           FROM all_triggers t
-          WHERE t.owner = SYS_CONTEXT('userenv', 'current_schema')
+          WHERE
+            t.owner = SYS_CONTEXT('userenv', 'current_schema')
             AND t.trigger_type = 'BEFORE EACH ROW'
             AND t.triggering_event = 'INSERT'
             AND EXISTS (
-              SELECT 1 FROM all_source s
-               WHERE s.owner = t.owner
-                 AND s.name = t.trigger_name
-                 AND s.type = 'TRIGGER'
-                 AND UPPER(s.text) LIKE '%NEXTVAL INTO :NEW%'
+              SELECT 1
+              FROM all_source s
+              WHERE
+                s.owner = t.owner
+                AND s.name = t.trigger_name
+                AND s.type = 'TRIGGER'
+                AND UPPER(s.text) LIKE '%NEXTVAL INTO :NEW%'
             )
         SQL
         rows.each_with_object({}) do |row, hash|
@@ -957,27 +966,33 @@ module ActiveRecord
         #   https://docs.oracle.com/en/database/oracle/oracle-database/23/refrn/ALL_TAB_IDENTITY_COLS.html
         identity_column_expr = supports_identity_columns? ? "cols.identity_column" : "'NO' AS identity_column"
 
-        select_all(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("table_name", desc_table_name)])
-          SELECT cols.column_name AS name, cols.data_type AS sql_type,
-                 cols.data_default, cols.nullable, cols.virtual_column, cols.hidden_column,
-                 #{identity_column_expr},
-                 cols.data_type_owner AS sql_type_owner,
-                 DECODE(cols.data_type, 'NUMBER', data_precision,
-                                   'FLOAT', data_precision,
-                                   'VARCHAR2', DECODE(char_used, 'C', char_length, data_length),
-                                   'RAW', DECODE(char_used, 'C', char_length, data_length),
-                                   'CHAR', DECODE(char_used, 'C', char_length, data_length),
-                                    NULL) AS limit,
-                 DECODE(data_type, 'NUMBER', data_scale, NULL) AS scale,
-                 comments.comments as column_comment
-            FROM all_tab_cols cols, all_col_comments comments
-           WHERE cols.owner      = :owner
-             AND cols.table_name = :table_name
-             AND cols.hidden_column = 'NO'
-             AND cols.owner = comments.owner
-             AND cols.table_name = comments.table_name
-             AND cols.column_name = comments.column_name
-           ORDER BY cols.column_id
+        select_all(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("table_name", desc_table_name)]) # sql_lint:disable=LT02 -- sqlfluff parses 'limit' as reserved word
+          SELECT
+            cols.column_name AS name, cols.data_type AS sql_type,
+            cols.data_default, cols.nullable, cols.virtual_column, cols.hidden_column,
+            #{identity_column_expr},
+            cols.data_type_owner AS sql_type_owner,
+            DECODE(
+              cols.data_type, 'NUMBER', data_precision,
+              'FLOAT', data_precision,
+              'VARCHAR2', DECODE(char_used, 'C', char_length, data_length),
+              'RAW', DECODE(char_used, 'C', char_length, data_length),
+              'CHAR', DECODE(char_used, 'C', char_length, data_length),
+              NULL
+            ) AS limit,
+            DECODE(data_type, 'NUMBER', data_scale, NULL) AS scale,
+            comments.comments as column_comment
+          FROM
+            all_tab_cols cols,
+            all_col_comments comments
+          WHERE
+            cols.owner      = :owner
+            AND cols.table_name = :table_name
+            AND cols.hidden_column = 'NO'
+            AND cols.owner = comments.owner
+            AND cols.table_name = comments.table_name
+            AND cols.column_name = comments.column_name
+          ORDER BY cols.column_id
         SQL
       end
 
@@ -1018,19 +1033,23 @@ module ActiveRecord
         seqs = select_values(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("sequence_name", default_sequence_name(desc_table_name, nil))])
           SELECT us.sequence_name
           FROM all_sequences us
-          WHERE us.sequence_owner = :owner
-          AND us.sequence_name = UPPER(:sequence_name)
+          WHERE
+            us.sequence_owner = :owner
+            AND us.sequence_name = UPPER(:sequence_name)
         SQL
 
         # changed back from user_constraints to all_constraints for consistency
         pks = select_values(<<~SQL.squish, "SCHEMA", [bind_string("owner", owner), bind_string("table_name", desc_table_name)])
           SELECT cc.column_name
-            FROM all_constraints c, all_cons_columns cc
-           WHERE c.owner = :owner
-             AND c.table_name = :table_name
-             AND c.constraint_type = 'P'
-             AND cc.owner = c.owner
-             AND cc.constraint_name = c.constraint_name
+          FROM
+            all_constraints c,
+            all_cons_columns cc
+          WHERE
+            c.owner = :owner
+            AND c.table_name = :table_name
+            AND c.constraint_type = 'P'
+            AND cc.owner = c.owner
+            AND cc.constraint_name = c.constraint_name
         SQL
 
         case pks.size
@@ -1044,13 +1063,16 @@ module ActiveRecord
 
         pks = select_values(<<~SQL.squish, "SCHEMA", [bind_string("table_name", desc_table_name)])
           SELECT cc.column_name
-            FROM all_constraints c, all_cons_columns cc
-           WHERE c.owner = SYS_CONTEXT('userenv', 'current_schema')
-             AND c.table_name = :table_name
-             AND c.constraint_type = 'P'
-             AND cc.owner = c.owner
-             AND cc.constraint_name = c.constraint_name
-             ORDER BY cc.position
+          FROM
+            all_constraints c,
+            all_cons_columns cc
+          WHERE
+            c.owner = SYS_CONTEXT('userenv', 'current_schema')
+            AND c.table_name = :table_name
+            AND c.constraint_type = 'P'
+            AND cc.owner = c.owner
+            AND cc.constraint_name = c.constraint_name
+          ORDER BY cc.position
         SQL
         pks.map { |pk| oracle_downcase(pk) }
       end
@@ -1074,8 +1096,11 @@ module ActiveRecord
 
       def temporary_table?(table_name) # :nodoc:
         select_value(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name.upcase)]) == "Y"
-          SELECT
-          temporary FROM all_tables WHERE table_name = :table_name AND owner = SYS_CONTEXT('userenv', 'current_schema')
+          SELECT temporary
+          FROM all_tables
+          WHERE
+            table_name = :table_name
+            AND owner = SYS_CONTEXT('userenv', 'current_schema')
         SQL
       end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -904,7 +904,7 @@ module ActiveRecord
 
         if primary_key && sequence_name
           new_start_value = select_value(<<~SQL.squish, "SCHEMA")
-            SELECT NVL(max(#{quote_column_name(primary_key)}),0) + 1 FROM #{quote_table_name(table_name)}
+            SELECT NVL(MAX(#{quote_column_name(primary_key)}),0) + 1 FROM #{quote_table_name(table_name)}
           SQL
 
           execute "DROP SEQUENCE #{quote_table_name(sequence_name)}"
@@ -1019,7 +1019,7 @@ module ActiveRecord
           SELECT us.sequence_name
           FROM all_sequences us
           WHERE us.sequence_owner = :owner
-          AND us.sequence_name = upper(:sequence_name)
+          AND us.sequence_name = UPPER(:sequence_name)
         SQL
 
         # changed back from user_constraints to all_constraints for consistency

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -856,8 +856,8 @@ module ActiveRecord
             AND EXISTS (
               SELECT 1 FROM all_source s
                WHERE s.owner = t.owner
-                 AND s.name  = t.trigger_name
-                 AND s.type  = 'TRIGGER'
+                 AND s.name = t.trigger_name
+                 AND s.type = 'TRIGGER'
                  AND UPPER(s.text) LIKE '%NEXTVAL INTO :NEW%'
             )
         SQL
@@ -873,8 +873,8 @@ module ActiveRecord
             AND EXISTS (
               SELECT 1 FROM all_source s
                WHERE s.owner = t.owner
-                 AND s.name  = t.trigger_name
-                 AND s.type  = 'TRIGGER'
+                 AND s.name = t.trigger_name
+                 AND s.type = 'TRIGGER'
                  AND UPPER(s.text) LIKE '%NEXTVAL INTO :NEW%'
             )
         SQL
@@ -904,7 +904,7 @@ module ActiveRecord
 
         if primary_key && sequence_name
           new_start_value = select_value(<<~SQL.squish, "SCHEMA")
-            SELECT NVL(MAX(#{quote_column_name(primary_key)}),0) + 1 FROM #{quote_table_name(table_name)}
+            SELECT NVL(MAX(#{quote_column_name(primary_key)}), 0) + 1 FROM #{quote_table_name(table_name)}
           SQL
 
           execute "DROP SEQUENCE #{quote_table_name(sequence_name)}"

--- a/script/sql_lint
+++ b/script/sql_lint
@@ -1,0 +1,398 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# script/sql_lint -- lint SQL inside <<~SQL heredocs with sqlfluff.
+#
+# Extracts each <<~SQL heredoc body via Prism, replaces Ruby
+# interpolations with opaque placeholders, runs sqlfluff (Oracle
+# dialect) on a temp file, and reports violations mapped back to the
+# original Ruby source lines.
+#
+# Disabling rules per heredoc:
+#   The disable marker must appear on the SAME line as the heredoc
+#   opener (the line containing `<<~SQL`) as a trailing comment.
+#   Markers on preceding or following lines are NOT recognized.
+#
+#   # sql_lint:disable           -- skip all rules for this heredoc
+#   # sql_lint:disable=LT02      -- skip only LT02 for this heredoc
+#   # sql_lint:disable=AL05,LT02 -- skip multiple rules (no spaces)
+#
+# The marker is validated strictly. The run aborts (exit 2) when the
+# rule list is empty (e.g. `=` with nothing after it), contains
+# whitespace (e.g. `=LT02, AL05`), or uses a malformed code. Rule codes
+# are case-insensitive (normalized to upper before matching).
+#
+# A disable that names a rule not in the `.sqlfluff` `rules = ...` line
+# produces a stderr warning but does not abort — typos surface alongside
+# the still-firing violation, and intentionally disabling a rule we did
+# not enable (e.g. `=CP02`) stays a harmless no-op.
+#
+# Fixing violations:
+#   Most violations include an inline `[fix: ...]` hint showing the
+#   exact replacement text sqlfluff suggests. Apply it to the heredoc
+#   manually.
+#
+#   For multi-edit fixes (typical for LT02 indentation), run
+#     ruby script/sql_lint --fix-preview
+#   to see a unified diff of what sqlfluff would change per heredoc.
+#   The diff cannot be applied automatically because the wrapper
+#   replaces `#{...}` with placeholders before linting — copy the
+#   suggested SQL into the heredoc by hand.
+#
+# Exit codes:
+#   0  no violations
+#   1  lint violations found
+#   2  wrapper or sqlfluff invocation failed (crash, not findings)
+
+require "json"
+require "prism"
+require "shellwords"
+require "tempfile"
+
+SQLFLUFF_CMD = ENV.fetch("SQLFLUFF_CMD", "sqlfluff")
+PROJECT_ROOT = File.expand_path("..", __dir__)
+SQLFLUFF_CONFIG = File.join(PROJECT_ROOT, ".sqlfluff")
+
+# Sqlfluff rule codes that indicate the wrapper handed in something
+# sqlfluff could not parse (interpolation placeholders, Oracle-specific
+# DDL, or templating false positives). They are not actionable lint
+# findings against the Ruby source, so we report them only under
+# --verbose.
+PARSE_ERROR_CODES = %w[PRS LXR TMP].freeze
+
+PLSQL_PATTERN = %r{
+  \bCREATE\s+(?:OR\s+REPLACE\s+)?(?:PROCEDURE|FUNCTION|PACKAGE)\b |
+  \bDECLARE\b.*\bBEGIN\b |
+  \bBEGIN\b.*\bEND\s*;
+}mix
+
+# Match `# sql_lint:disable[=...]` only when it forms a trailing comment
+# on the opener line (optionally followed by ` -- reason`). The marker
+# must reach end-of-line (with optional trailing whitespace), so embedded
+# occurrences inside string literals do not trigger. The `=` form
+# captures non-space chars only — spaces in the rule list are caught at
+# validation time below rather than letting the regex match too eagerly.
+DISABLE_MARKER = /\#\s*sql_lint:disable(=\S*)?(?:\s+--.*)?\s*\Z/
+
+# Strict rule-list format after `=`: non-empty CSV of alphanumeric rule
+# codes with no spaces.
+RULE_LIST = /\A[A-Za-z][A-Za-z0-9]*(?:,[A-Za-z][A-Za-z0-9]*)*\z/
+
+# Exit 2 for wrapper/sqlfluff failures so CI can distinguish them from
+# exit 1 (lint findings).
+def crash(message)
+  warn message
+  exit 2
+end
+
+def load_enabled_rules
+  return Set.new unless File.exist?(SQLFLUFF_CONFIG)
+  in_sqlfluff_section = false
+  File.foreach(SQLFLUFF_CONFIG) do |line|
+    stripped = line.strip
+    if stripped.start_with?("[") && stripped.end_with?("]")
+      in_sqlfluff_section = (stripped == "[sqlfluff]")
+      next
+    end
+    next unless in_sqlfluff_section
+    match = stripped.match(/\Arules\s*=\s*(.+)\z/)
+    next unless match
+    # Strip trailing `# ...` or `; ...` comment so a future
+    # `rules = AL02,AL04 # default set` does not poison the parser.
+    value = match[1].split(/[#;]/, 2).first.to_s.strip
+    return value.split(",").map { |s| s.strip.upcase }.reject(&:empty?).to_set
+  end
+  Set.new
+end
+
+ENABLED_RULES = load_enabled_rules.freeze
+
+def find_ruby_files
+  %w[lib spec].flat_map do |dir|
+    Dir.glob(File.join(PROJECT_ROOT, dir, "**", "*.rb")).sort
+  end
+end
+
+def extract_sql_heredocs(file_path)
+  source = File.read(file_path)
+  source_lines = source.lines
+  result = Prism.parse(source)
+  heredocs = []
+  walk_ast(result.value, source_lines, heredocs)
+  heredocs
+end
+
+def walk_ast(node, source_lines, heredocs)
+  return unless node.is_a?(Prism::Node)
+
+  if (node.is_a?(Prism::InterpolatedStringNode) || node.is_a?(Prism::StringNode)) && sql_heredoc?(node)
+    sql, start_line = if node.is_a?(Prism::InterpolatedStringNode)
+      reconstruct_sql(node)
+    else
+      [node.unescaped, node.content_loc.start_line]
+    end
+    if sql && start_line
+      opening_line = source_lines[node.opening_loc.start_line - 1]
+      heredocs << { sql: sql, start_line: start_line, opening_line: opening_line }
+    end
+  end
+
+  node.child_nodes.compact.each { |child| walk_ast(child, source_lines, heredocs) }
+end
+
+# Returns :all, a Set of rule codes, or nil. Aborts on malformed markers.
+# Called from the main loop AFTER the PL/SQL skip check so that a
+# malformed marker on a PL/SQL heredoc — which the wrapper would not
+# lint anyway — does not crash the entire run.
+def parse_disable(opening_line)
+  match = opening_line.match(DISABLE_MARKER)
+  if match.nil?
+    # The marker is present in the line but didn't parse as a valid
+    # trailing comment — surface a warning rather than silently ignoring
+    # it. Common cause: spaces in the rule list (e.g. `=LT02, AL05`).
+    if opening_line.match?(/\#\s*sql_lint:disable/)
+      warn "Note: 'sql_lint:disable' on opener did not parse as a valid marker " \
+           "(format: `# sql_lint:disable[=RULE,...] [-- reason]`, no spaces in rule list)\n" \
+           "  Line: #{opening_line.strip}"
+    end
+    return nil
+  end
+  return :all if match[1].nil?
+
+  # match[1] is `=` followed by zero or more non-space chars. Strip the
+  # leading `=` and any trailing whitespace the regex tolerated.
+  spec = match[1][1..].rstrip
+
+  unless spec.match?(RULE_LIST)
+    crash "Invalid sql_lint:disable form #{("=" + spec).inspect}: " \
+          "expected non-empty comma-separated codes like =LT02,AL05 (no spaces) " \
+          "(line: #{opening_line.strip})"
+  end
+
+  rules = spec.upcase.split(",").to_set
+
+  # Warn (not crash) when a disabled rule isn't in our enabled list.
+  # Typos (e.g. =LT2 for LT02) surface as a warning *and* the original
+  # violation still fires, making the mistake obvious. Deliberately
+  # disabling a rule we did not enable (e.g. =CP02) is a harmless no-op
+  # so should not break the run. Skip the check entirely when
+  # ENABLED_RULES is empty (e.g. running without .sqlfluff) — otherwise
+  # every existing marker would fail.
+  unless ENABLED_RULES.empty?
+    unknown = rules - ENABLED_RULES
+    unless unknown.empty?
+      warn "Note: sql_lint:disable references rule(s) not enabled in .sqlfluff: " \
+           "#{unknown.to_a.sort.inspect} (no-op)\n" \
+           "  Line: #{opening_line.strip}"
+    end
+  end
+
+  rules
+end
+
+def sql_heredoc?(node)
+  return false unless node.respond_to?(:opening_loc) && node.opening_loc
+  node.opening_loc.slice.match?(/<<~SQL\b/)
+end
+
+def reconstruct_sql(node)
+  sql = +""
+  start_line = nil
+  placeholder_id = 0
+
+  node.parts.each do |part|
+    case part
+    when Prism::StringNode
+      start_line ||= part.content_loc.start_line
+      sql << part.unescaped
+    when Prism::EmbeddedStatementsNode, Prism::EmbeddedVariableNode
+      sql << "placeholder_#{placeholder_id}"
+      placeholder_id += 1
+    end
+  end
+
+  [sql, start_line]
+end
+
+def plsql?(sql)
+  PLSQL_PATTERN.match?(sql)
+end
+
+def check_sqlfluff_available!
+  return if system("#{SQLFLUFF_CMD.shellescape} --version > /dev/null 2>&1")
+  crash "sqlfluff command not found: #{SQLFLUFF_CMD} (set SQLFLUFF_CMD or install sqlfluff)"
+end
+
+def run_sqlfluff(sql)
+  Tempfile.create(["sql_lint", ".sql"]) do |f|
+    f.write(sql)
+    f.flush
+
+    cmd = [SQLFLUFF_CMD, "lint", "--format", "json"]
+    cmd += ["--config", SQLFLUFF_CONFIG] if File.exist?(SQLFLUFF_CONFIG)
+    cmd << f.path
+
+    output = `#{cmd.shelljoin} 2>/dev/null`
+    status = $?.exitstatus
+
+    # sqlfluff exit codes: 0 = clean, 1 = lint violations, others = errors.
+    # We treat 0/1 as success. Anything else (including nil from signals,
+    # 127 from missing binary that slipped past check_sqlfluff_available!,
+    # 2 from internal sqlfluff errors) is a hard failure.
+    if status.nil? || status > 1
+      crash "sqlfluff invocation failed (exit #{status.inspect}): #{cmd.shelljoin}"
+    end
+
+    return [] if output.strip.empty?
+
+    results = begin
+      JSON.parse(output)
+    rescue JSON::ParserError => e
+      crash "sqlfluff returned invalid JSON (#{e.message}): #{output[0, 200]}"
+    end
+
+    return [] if results.empty?
+    results[0].fetch("violations", [])
+  end
+end
+
+# Returns the SQL after `sqlfluff fix` has applied every fixable rule,
+# or the original SQL if sqlfluff did not change anything. Used by
+# --fix-preview.
+def fix_sql(sql)
+  Tempfile.create(["sql_lint_fix", ".sql"]) do |f|
+    f.write(sql)
+    f.flush
+
+    cmd = [SQLFLUFF_CMD, "fix"]
+    cmd += ["--config", SQLFLUFF_CONFIG] if File.exist?(SQLFLUFF_CONFIG)
+    cmd << f.path
+
+    `#{cmd.shelljoin} > /dev/null 2>&1`
+    File.read(f.path)
+  end
+end
+
+# Single-line summary of the first fix attached to a violation, for
+# inline display alongside the rule message. LT02 (indentation) tends
+# to carry multi-edit fixes — we print "(multi-edit)" rather than try
+# to summarise them line-by-line; users wanting the full picture run
+# --fix-preview.
+def fix_hint(violation)
+  fixes = violation["fixes"]
+  return nil if fixes.nil? || fixes.empty?
+  return "[fix: multi-edit]" if fixes.size > 1
+
+  fix = fixes.first
+  edit = fix["edit"].to_s
+  edit = edit.length > 40 ? "#{edit[0, 40]}…" : edit
+  edit_repr = edit.inspect # quoted, escapes whitespace
+
+  case fix["type"]
+  when "replace"    then "[fix: replace with #{edit_repr}]"
+  when "create_before", "create_after" then "[fix: insert #{edit_repr}]"
+  when "delete"     then "[fix: delete]"
+  else "[fix: #{fix["type"]}]"
+  end
+end
+
+def unified_diff(before, after, label)
+  Tempfile.create(["before"]) do |a|
+    Tempfile.create(["after"]) do |b|
+      a.write(before); a.flush
+      b.write(after);  b.flush
+      before_label = "#{label} (before)".shellescape
+      after_label = "#{label} (fixed)".shellescape
+      `diff -u --label #{before_label} --label #{after_label} #{a.path.shellescape} #{b.path.shellescape}`
+    end
+  end
+end
+
+verbose = ARGV.include?("--verbose")
+fix_preview = ARGV.include?("--fix-preview")
+
+check_sqlfluff_available!
+
+total_violations = 0
+total_parse_warnings = 0
+total_files = 0
+total_heredocs = 0
+skipped_plsql = 0
+skipped_disabled = 0
+
+files = find_ruby_files
+
+files.each do |file_path|
+  heredocs = extract_sql_heredocs(file_path)
+  next if heredocs.empty?
+
+  total_files += 1
+
+  heredocs.each do |heredoc|
+    total_heredocs += 1
+
+    if plsql?(heredoc[:sql])
+      skipped_plsql += 1
+      next
+    end
+
+    disabled = parse_disable(heredoc[:opening_line])
+    if disabled == :all
+      skipped_disabled += 1
+      next
+    end
+    disabled ||= Set.new
+
+    violations = run_sqlfluff(heredoc[:sql])
+    next if violations.empty?
+
+    rel_path = file_path.delete_prefix("#{PROJECT_ROOT}/")
+    heredoc_had_violation = false
+
+    violations.each do |v|
+      source_line = heredoc[:start_line] + v["start_line_no"] - 1
+      col = v["start_line_pos"]
+      code = v["code"]
+      desc = v["description"]
+
+      if PARSE_ERROR_CODES.include?(code)
+        total_parse_warnings += 1
+        if verbose
+          warn "#{rel_path}:#{source_line}:#{col}: #{code} #{desc} (parse warning, ignored)"
+        end
+        next
+      end
+
+      next if disabled.include?(code)
+
+      total_violations += 1
+      heredoc_had_violation = true
+      hint = fix_hint(v)
+      line = "#{rel_path}:#{source_line}:#{col}: #{code} #{desc}"
+      line += " #{hint}" if hint
+      puts line
+    end
+
+    if fix_preview && heredoc_had_violation
+      fixed = fix_sql(heredoc[:sql])
+      if fixed && fixed != heredoc[:sql]
+        diff = unified_diff(heredoc[:sql], fixed, "#{rel_path}:#{heredoc[:start_line]}")
+        puts diff unless diff.empty?
+      end
+    end
+  end
+end
+
+puts
+summary = "#{total_files} files, #{total_heredocs} SQL heredocs (#{skipped_plsql} PL/SQL skipped"
+summary += ", #{skipped_disabled} disabled" if skipped_disabled > 0
+summary += "), #{total_violations} violation(s)"
+summary += ", #{total_parse_warnings} parse warning(s)" if total_parse_warnings > 0
+puts summary
+
+if total_violations > 0 && !fix_preview
+  puts
+  puts "Rerun with --fix-preview to see sqlfluff's suggested fix for each heredoc as a unified diff."
+end
+
+exit(total_violations > 0 ? 1 : 0)

--- a/spec/active_record/connection_adapters/oracle_enhanced/identity_primary_key_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/identity_primary_key_spec.rb
@@ -28,8 +28,9 @@ RSpec.describe "identity primary keys" do
     return false unless @conn.supports_identity_columns?
     @conn.select_value(<<~SQL.squish, "SCHEMA").present?
       SELECT 1 FROM user_tab_identity_cols
-       WHERE table_name = '#{table_name.to_s.upcase}'
-         AND column_name = '#{column_name.to_s.upcase}'
+      WHERE
+        table_name = '#{table_name.to_s.upcase}'
+        AND column_name = '#{column_name.to_s.upcase}'
     SQL
   end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -483,7 +483,7 @@ RSpec.describe "OracleEnhancedAdapter schema dump" do
 
       @conn.execute <<~SQL
         ALTER TABLE TEST_COMMENTS
-        ADD CONSTRAINT TEST_COMMENTS_BAZ_ID_FK FOREIGN KEY (baz_id) REFERENCES test_posts(baz_id)
+        ADD CONSTRAINT TEST_COMMENTS_BAZ_ID_FK FOREIGN KEY (baz_id) REFERENCES test_posts (baz_id)
       SQL
 
       output = dump_table_schema "test_comments"

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -141,8 +141,9 @@ RSpec.describe "OracleEnhancedAdapter schema dump" do
       schema_define { instance_eval(body) }
       expr = ActiveRecord::Base.lease_connection.select_value(<<~SQL.squish)
         SELECT column_expression FROM all_ind_expressions
-         WHERE index_owner = SYS_CONTEXT('userenv', 'current_schema')
-           AND index_name = 'IX_RT_EXPR'
+        WHERE
+          index_owner = SYS_CONTEXT('userenv', 'current_schema')
+          AND index_name = 'IX_RT_EXPR'
       SQL
       expect(expr).to match(/LOWER\("?NAME"?\)/i)
     end
@@ -186,9 +187,10 @@ RSpec.describe "OracleEnhancedAdapter schema dump" do
       schema_define { instance_eval(body) }
       desc_count = ActiveRecord::Base.lease_connection.select_value(<<~SQL.squish)
         SELECT COUNT(*) FROM all_ind_columns
-         WHERE index_owner = SYS_CONTEXT('userenv', 'current_schema')
-           AND index_name = 'IX_RT_SORT'
-           AND descend = 'DESC'
+        WHERE
+          index_owner = SYS_CONTEXT('userenv', 'current_schema')
+          AND index_name = 'IX_RT_SORT'
+          AND descend = 'DESC'
       SQL
       expect(desc_count).to eq(1)
     end
@@ -255,8 +257,9 @@ RSpec.describe "OracleEnhancedAdapter schema dump" do
       schema_define { instance_eval(body) }
       visibility = ActiveRecord::Base.lease_connection.select_value(<<~SQL.squish)
         SELECT visibility FROM all_indexes
-         WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
-           AND index_name = 'IX_RT_INVISIBLE'
+        WHERE
+          owner = SYS_CONTEXT('userenv', 'current_schema')
+          AND index_name = 'IX_RT_INVISIBLE'
       SQL
       expect(visibility).to eq("INVISIBLE")
     end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -568,14 +568,16 @@ RSpec.describe "OracleEnhancedAdapter schema definition" do
       end
       idx_count = @conn.select_value(<<~SQL.squish)
         SELECT COUNT(*) FROM all_indexes
-         WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
-           AND index_name = 'IX_EXPR_LOWER_NAME'
+        WHERE
+          owner = SYS_CONTEXT('userenv', 'current_schema')
+          AND index_name = 'IX_EXPR_LOWER_NAME'
       SQL
       expect(idx_count).to eq(1)
       expr = @conn.select_value(<<~SQL.squish)
         SELECT column_expression FROM all_ind_expressions
-         WHERE index_owner = SYS_CONTEXT('userenv', 'current_schema')
-           AND index_name = 'IX_EXPR_LOWER_NAME'
+        WHERE
+          index_owner = SYS_CONTEXT('userenv', 'current_schema')
+          AND index_name = 'IX_EXPR_LOWER_NAME'
       SQL
       expect(expr).to match(/LOWER\("?NAME"?\)/i)
     ensure
@@ -598,9 +600,10 @@ RSpec.describe "OracleEnhancedAdapter schema definition" do
       end
       desc_count = @conn.select_value(<<~SQL.squish)
         SELECT COUNT(*) FROM all_ind_columns
-         WHERE index_owner = SYS_CONTEXT('userenv', 'current_schema')
-           AND index_name = 'IX_SORT_ORDER'
-           AND descend = 'DESC'
+        WHERE
+          index_owner = SYS_CONTEXT('userenv', 'current_schema')
+          AND index_name = 'IX_SORT_ORDER'
+          AND descend = 'DESC'
       SQL
       expect(desc_count).to eq(1)
     ensure
@@ -677,8 +680,9 @@ RSpec.describe "OracleEnhancedAdapter schema definition" do
         # Querying all_indexes directly confirms Oracle sees a UNIQUE INVISIBLE index.
         row = @conn.select_one(<<~SQL.squish)
           SELECT uniqueness, visibility FROM all_indexes
-           WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
-             AND index_name = 'IX_UNIQ_INVISIBLE'
+          WHERE
+            owner = SYS_CONTEXT('userenv', 'current_schema')
+            AND index_name = 'IX_UNIQ_INVISIBLE'
         SQL
         expect(row["uniqueness"]).to eq("UNIQUE")
         expect(row["visibility"]).to eq("INVISIBLE")
@@ -950,7 +954,8 @@ RSpec.describe "OracleEnhancedAdapter schema definition" do
 
         seq_exists = @conn.select_value(<<~SQL.squish) == 1
           SELECT COUNT(*) FROM all_sequences
-          WHERE sequence_owner = SYS_CONTEXT('userenv', 'current_schema')
+          WHERE
+            sequence_owner = SYS_CONTEXT('userenv', 'current_schema')
             AND sequence_name = 'TEST_BULK_PK_SEQ'
         SQL
         expect(seq_exists).to be(true)

--- a/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
@@ -56,14 +56,14 @@ RSpec.describe "OracleEnhancedAdapter structure dump" do
 
     it "should dump composite primary keys" do
       pk = @conn.send(:select_one, <<~SQL)
-        select constraint_name from user_constraints where table_name = 'TEST_POSTS' and constraint_type='P'
+        SELECT constraint_name FROM user_constraints WHERE table_name = 'TEST_POSTS' AND constraint_type='P'
       SQL
       @conn.execute <<~SQL
-        alter table test_posts drop constraint #{pk["constraint_name"]}
+        ALTER TABLE test_posts DROP CONSTRAINT #{pk["constraint_name"]}
       SQL
       @conn.execute <<~SQL
         ALTER TABLE TEST_POSTS
-        add CONSTRAINT pk_id_title PRIMARY KEY (id, title)
+        ADD CONSTRAINT pk_id_title PRIMARY KEY (id, title)
       SQL
       dump = ActiveRecord::Base.lease_connection.structure_dump
       expect(dump).to match(/CONSTRAINT (.+) PRIMARY KEY \("ID","TITLE"\)\n/)
@@ -169,7 +169,7 @@ RSpec.describe "OracleEnhancedAdapter structure dump" do
 
     it "should dump types" do
       @conn.execute <<~SQL
-        create or replace TYPE TEST_TYPE AS TABLE OF VARCHAR2(10);
+        CREATE OR REPLACE TYPE TEST_TYPE AS TABLE OF VARCHAR2(10);
       SQL
       dump = ActiveRecord::Base.lease_connection.structure_dump_db_stored_code.gsub(/\n|\s+/, " ")
       expect(dump).to match(/CREATE OR REPLACE TYPE TEST_TYPE/)
@@ -223,7 +223,7 @@ RSpec.describe "OracleEnhancedAdapter structure dump" do
     it "should dump unique keys" do
       @conn.execute <<~SQL
         ALTER TABLE test_posts
-          add CONSTRAINT uk_foo_foo_id UNIQUE (foo, foo_id)
+          ADD CONSTRAINT uk_foo_foo_id UNIQUE (foo, foo_id)
       SQL
       dump = ActiveRecord::Base.lease_connection.structure_dump_unique_keys("test_posts")
       expect(dump).to eq([%(ALTER TABLE "TEST_POSTS" ADD CONSTRAINT "UK_FOO_FOO_ID" UNIQUE ("FOO","FOO_ID"))])
@@ -240,7 +240,7 @@ RSpec.describe "OracleEnhancedAdapter structure dump" do
 
       @conn.execute <<~SQL
         ALTER TABLE test_posts
-          add CONSTRAINT uk_foo_foo_id UNIQUE (foo, foo_id)
+          ADD CONSTRAINT uk_foo_foo_id UNIQUE (foo, foo_id)
       SQL
 
       dump = ActiveRecord::Base.lease_connection.structure_dump
@@ -571,11 +571,11 @@ RSpec.describe "OracleEnhancedAdapter structure dump" do
       end
       # view
       @conn.execute <<~SQL
-        create or replace view full_drop_test_view (foo) as select id as "foo" from full_drop_test
+        CREATE OR REPLACE VIEW full_drop_test_view (foo) AS SELECT id AS "foo" FROM full_drop_test
       SQL
       # materialized view
       @conn.execute <<~SQL
-        create materialized view full_drop_test_mview (foo) as select id as "foo" from full_drop_test
+        CREATE MATERIALIZED VIEW full_drop_test_mview (foo) AS SELECT id AS "foo" FROM full_drop_test
       SQL
       # package
       @conn.execute <<~SQL
@@ -613,11 +613,11 @@ RSpec.describe "OracleEnhancedAdapter structure dump" do
       SQL
       # synonym
       @conn.execute <<~SQL
-        create or replace synonym full_drop_test_synonym for full_drop_test
+        CREATE OR REPLACE SYNONYM full_drop_test_synonym FOR full_drop_test
       SQL
       # type
       @conn.execute <<~SQL
-        create or replace type full_drop_test_type as table of number
+        CREATE OR REPLACE TYPE full_drop_test_type AS TABLE OF NUMBER
       SQL
     end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "OracleEnhancedAdapter structure dump" do
 
     it "should dump composite primary keys" do
       pk = @conn.send(:select_one, <<~SQL)
-        SELECT constraint_name FROM user_constraints WHERE table_name = 'TEST_POSTS' AND constraint_type='P'
+        SELECT constraint_name FROM user_constraints WHERE table_name = 'TEST_POSTS' AND constraint_type = 'P'
       SQL
       @conn.execute <<~SQL
         ALTER TABLE test_posts DROP CONSTRAINT #{pk["constraint_name"]}
@@ -72,7 +72,7 @@ RSpec.describe "OracleEnhancedAdapter structure dump" do
     it "should dump foreign keys" do
       @conn.execute <<~SQL
         ALTER TABLE TEST_POSTS
-        ADD CONSTRAINT fk_test_post_foo FOREIGN KEY (foo_id) REFERENCES foos(id)
+        ADD CONSTRAINT fk_test_post_foo FOREIGN KEY (foo_id) REFERENCES foos (id)
       SQL
       dump = ActiveRecord::Base.lease_connection.structure_dump
       expect(dump.split('\n').length).to eq(1)
@@ -91,7 +91,7 @@ RSpec.describe "OracleEnhancedAdapter structure dump" do
 
       @conn.execute <<~SQL
         ALTER TABLE TEST_POSTS
-        ADD CONSTRAINT fk_test_post_baz FOREIGN KEY (baz_id) REFERENCES foos(baz_id)
+        ADD CONSTRAINT fk_test_post_baz FOREIGN KEY (baz_id) REFERENCES foos (baz_id)
       SQL
 
       dump = ActiveRecord::Base.lease_connection.structure_dump
@@ -211,8 +211,8 @@ RSpec.describe "OracleEnhancedAdapter structure dump" do
     it "should dump NCLOB columns" do
       @conn.execute <<~SQL
         CREATE TABLE bars (
-          id          NUMBER(38,0) NOT NULL,
-          nclob_text  NCLOB,
+          id NUMBER(38, 0) NOT NULL,
+          nclob_text NCLOB,
           PRIMARY KEY (ID)
         )
       SQL
@@ -264,8 +264,8 @@ RSpec.describe "OracleEnhancedAdapter structure dump" do
     it "should dump RAW columns" do
       @conn.execute <<~SQL
         CREATE TABLE bars (
-          id          NUMBER(38,0) NOT NULL,
-          super       RAW(255),
+          id NUMBER(38, 0) NOT NULL,
+          super RAW(255),
           PRIMARY KEY (ID)
         )
       SQL
@@ -384,7 +384,7 @@ RSpec.describe "OracleEnhancedAdapter structure dump" do
     before(:all) do
       @conn.execute <<~SQL
         CREATE TABLE nvarchartable (
-          unq_nvarchar  NVARCHAR2(255) DEFAULT NULL
+          unq_nvarchar NVARCHAR2(255) DEFAULT NULL
         )
       SQL
     end

--- a/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe "OracleEnhancedAdapter structure dump" do
     it "should dump unique keys" do
       @conn.execute <<~SQL
         ALTER TABLE test_posts
-          ADD CONSTRAINT uk_foo_foo_id UNIQUE (foo, foo_id)
+        ADD CONSTRAINT uk_foo_foo_id UNIQUE (foo, foo_id)
       SQL
       dump = ActiveRecord::Base.lease_connection.structure_dump_unique_keys("test_posts")
       expect(dump).to eq([%(ALTER TABLE "TEST_POSTS" ADD CONSTRAINT "UK_FOO_FOO_ID" UNIQUE ("FOO","FOO_ID"))])
@@ -240,7 +240,7 @@ RSpec.describe "OracleEnhancedAdapter structure dump" do
 
       @conn.execute <<~SQL
         ALTER TABLE test_posts
-          ADD CONSTRAINT uk_foo_foo_id UNIQUE (foo, foo_id)
+        ADD CONSTRAINT uk_foo_foo_id UNIQUE (foo, foo_id)
       SQL
 
       dump = ActiveRecord::Base.lease_connection.structure_dump

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "OracleEnhancedAdapter date and datetime type detection based on 
     SQL
     @conn.execute <<~SQL
       CREATE SEQUENCE test_employees_seq MINVALUE 1
-        INCREMENT BY 1 START WITH 10040 CACHE 20 NOORDER NOCYCLE
+      INCREMENT BY 1 START WITH 10040 CACHE 20 NOORDER NOCYCLE
     SQL
   end
 

--- a/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_data_types_spec.rb
@@ -7,23 +7,23 @@ RSpec.describe "OracleEnhancedAdapter date and datetime type detection based on 
     @conn.drop_table "test_employees", if_exists: true
     @conn.execute <<~SQL
       CREATE TABLE test_employees (
-        employee_id   NUMBER(6,0) PRIMARY KEY,
-        first_name    VARCHAR2(20),
-        last_name     VARCHAR2(25),
-        email         VARCHAR2(25),
-        phone_number  VARCHAR2(20),
-        hire_date     DATE,
-        job_id        NUMBER(6,0),
-        salary        NUMBER(8,2),
-        commission_pct  NUMBER(2,2),
-        manager_id    NUMBER(6,0),
-        department_id NUMBER(4,0),
-        created_at    DATE,
-        updated_at    DATE
+        employee_id NUMBER(6, 0) PRIMARY KEY,
+        first_name VARCHAR2(20),
+        last_name VARCHAR2(25),
+        email VARCHAR2(25),
+        phone_number VARCHAR2(20),
+        hire_date DATE,
+        job_id NUMBER(6, 0),
+        salary NUMBER(8, 2),
+        commission_pct NUMBER(2, 2),
+        manager_id NUMBER(6, 0),
+        department_id NUMBER(4, 0),
+        created_at DATE,
+        updated_at DATE
       )
     SQL
     @conn.execute <<~SQL
-      CREATE SEQUENCE test_employees_seq  MINVALUE 1
+      CREATE SEQUENCE test_employees_seq MINVALUE 1
         INCREMENT BY 1 START WITH 10040 CACHE 20 NOORDER NOCYCLE
     SQL
   end

--- a/spec/active_record/oracle_enhanced/type/boolean_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/boolean_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "OracleEnhancedAdapter boolean type detection based on string col
     SQL
     @conn.execute <<~SQL
       CREATE SEQUENCE test3_employees_seq MINVALUE 1
-        INCREMENT BY 1 START WITH 10040 CACHE 20 NOORDER NOCYCLE
+      INCREMENT BY 1 START WITH 10040 CACHE 20 NOORDER NOCYCLE
     SQL
   end
 

--- a/spec/active_record/oracle_enhanced/type/boolean_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/boolean_spec.rb
@@ -6,27 +6,27 @@ RSpec.describe "OracleEnhancedAdapter boolean type detection based on string col
     @conn = ActiveRecord::Base.lease_connection
     @conn.execute <<~SQL
       CREATE TABLE test3_employees (
-        id            NUMBER PRIMARY KEY,
-        first_name    VARCHAR2(20),
-        last_name     VARCHAR2(25),
-        email         VARCHAR2(25),
-        phone_number  VARCHAR2(20),
-        hire_date     DATE,
-        job_id        NUMBER,
-        salary        NUMBER,
-        commission_pct  NUMBER(2,2),
-        manager_id    NUMBER(6),
-        department_id NUMBER(4,0),
-        created_at    DATE,
-        has_email     CHAR(1),
-        has_phone     VARCHAR2(1) DEFAULT 'Y',
-        active_flag   VARCHAR2(2),
-        manager_yn    VARCHAR2(3) DEFAULT 'N',
-        test_boolean  VARCHAR2(3)
+        id NUMBER PRIMARY KEY,
+        first_name VARCHAR2(20),
+        last_name VARCHAR2(25),
+        email VARCHAR2(25),
+        phone_number VARCHAR2(20),
+        hire_date DATE,
+        job_id NUMBER,
+        salary NUMBER,
+        commission_pct NUMBER(2, 2),
+        manager_id NUMBER(6),
+        department_id NUMBER(4, 0),
+        created_at DATE,
+        has_email CHAR(1),
+        has_phone VARCHAR2(1) DEFAULT 'Y',
+        active_flag VARCHAR2(2),
+        manager_yn VARCHAR2(3) DEFAULT 'N',
+        test_boolean VARCHAR2(3)
       )
     SQL
     @conn.execute <<~SQL
-      CREATE SEQUENCE test3_employees_seq  MINVALUE 1
+      CREATE SEQUENCE test3_employees_seq MINVALUE 1
         INCREMENT BY 1 START WITH 10040 CACHE 20 NOORDER NOCYCLE
     SQL
   end

--- a/spec/active_record/oracle_enhanced/type/character_string_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/character_string_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "OracleEnhancedAdapter processing CHAR column" do
     @conn = ActiveRecord::Base.lease_connection
     @conn.execute <<~SQL
       CREATE TABLE test_items (
-        id       NUMBER(6,0) PRIMARY KEY,
-        padded   CHAR(10)
+        id NUMBER(6, 0) PRIMARY KEY,
+        padded CHAR(10)
       )
     SQL
     @conn.execute "CREATE SEQUENCE test_items_seq"

--- a/spec/active_record/oracle_enhanced/type/integer_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/integer_spec.rb
@@ -7,24 +7,24 @@ RSpec.describe "OracleEnhancedAdapter integer type detection based on attribute 
     conn.execute "DROP TABLE test2_employees" rescue nil
     conn.execute <<~SQL
       CREATE TABLE test2_employees (
-        id            NUMBER PRIMARY KEY,
-        first_name    VARCHAR2(20),
-        last_name     VARCHAR2(25),
-        email         VARCHAR2(25),
-        phone_number  VARCHAR2(20),
-        hire_date     DATE,
-        job_id        NUMBER,
-        salary        NUMBER,
-        commission_pct  NUMBER(2,2),
-        manager_id    NUMBER(6),
-        is_manager    NUMBER(1),
-        department_id NUMBER(4,0),
-        created_at    DATE
+        id NUMBER PRIMARY KEY,
+        first_name VARCHAR2(20),
+        last_name VARCHAR2(25),
+        email VARCHAR2(25),
+        phone_number VARCHAR2(20),
+        hire_date DATE,
+        job_id NUMBER,
+        salary NUMBER,
+        commission_pct NUMBER(2, 2),
+        manager_id NUMBER(6),
+        is_manager NUMBER(1),
+        department_id NUMBER(4, 0),
+        created_at DATE
       )
     SQL
     conn.execute "DROP SEQUENCE test2_employees_seq" rescue nil
     conn.execute <<~SQL
-      CREATE SEQUENCE test2_employees_seq  MINVALUE 1
+      CREATE SEQUENCE test2_employees_seq MINVALUE 1
         INCREMENT BY 1 START WITH 10040 CACHE 20 NOORDER NOCYCLE
     SQL
   end

--- a/spec/active_record/oracle_enhanced/type/integer_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/integer_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "OracleEnhancedAdapter integer type detection based on attribute 
     conn.execute "DROP SEQUENCE test2_employees_seq" rescue nil
     conn.execute <<~SQL
       CREATE SEQUENCE test2_employees_seq MINVALUE 1
-        INCREMENT BY 1 START WITH 10040 CACHE 20 NOORDER NOCYCLE
+      INCREMENT BY 1 START WITH 10040 CACHE 20 NOORDER NOCYCLE
     SQL
   end
 

--- a/spec/active_record/oracle_enhanced/type/national_character_string_spec.rb
+++ b/spec/active_record/oracle_enhanced/type/national_character_string_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe "OracleEnhancedAdapter quoting of NCHAR and NVARCHAR2 columns" do
     @conn = ActiveRecord::Base.lease_connection
     @conn.execute <<~SQL
       CREATE TABLE test_items (
-        id                  NUMBER(6,0) PRIMARY KEY,
-        nchar_column        NCHAR(20),
-        nvarchar2_column    NVARCHAR2(20),
-        char_column         CHAR(20),
-        varchar2_column     VARCHAR2(20)
+        id NUMBER(6, 0) PRIMARY KEY,
+        nchar_column NCHAR(20),
+        nvarchar2_column NVARCHAR2(20),
+        char_column CHAR(20),
+        varchar2_column VARCHAR2(20)
       )
     SQL
     @conn.execute "CREATE SEQUENCE test_items_seq"


### PR DESCRIPTION
## Summary

- Add `script/sql_lint` that extracts SQL from `<<~SQL` heredocs using Prism AST, replaces `#{...}` interpolations with placeholders, and runs [sqlfluff](https://github.com/sqlfluff/sqlfluff) (Oracle dialect) to lint the SQL
- Add `.sqlfluff` config enforcing 27 sqlfluff rules (2-space indent), with inline comments explaining each decision
- Add `.github/workflows/sql_lint.yml` CI workflow (Ruby + Python + sqlfluff)
- PL/SQL blocks auto-skipped (sqlfluff limitation)
- Parse errors filtered as warnings (`--verbose` to see)
- Support `# sql_lint:disable` on the `<<~SQL` opening line to skip specific heredocs with known false positives
- Fix all existing violations:
  - CP01: uppercase SQL keywords
  - CP03: uppercase function names (`max` -> `MAX`)
  - AL02: explicit `AS` for column aliases
  - LT01: fix spacing (column alignment padding, comma spacing, operator spacing)
  - LT02: standardize SQL indentation to 2-space

### Enabled rules (27)
`AL02,AL04,AL05,AL06,AL08,AL09,AL10,AM01,AM02,AM06,CP01,CP03,CP04,CP05,CV03,CV04,CV05,LT01,LT02,LT06,LT07,LT08,LT10,LT11,LT12,ST03,ST08`

### Disabled heredocs (3, with `# sql_lint:disable`)
- `structure_dump.rb` — alias `atc` used by `#{identity_column_expr}` interpolation
- `dbms_metadata.rb` — alias `o` used by `#{mview_filter}` interpolation
- `oracle_enhanced_adapter.rb` — sqlfluff treats `limit` as reserved word

### Intentionally skipped core rules
| Rule | Reason |
|------|--------|
| AL03 | Flags simple column references without aliases — too strict for this codebase |
| CP02 | Identifier casing — Oracle vs Rails convention conflict, deferred to #2812 |
| JJ01 | Jinja templating padding — irrelevant for Ruby heredocs |
| LT05 | Line too long — most SQL uses `.squish` so line length is irrelevant |
| RF01 | False positives from `#{...}` interpolation placeholders |

## Test plan

- [ ] CI SQL Lint workflow passes with 0 violations
- [ ] CI test suite passes
- [ ] `ruby script/sql_lint` reports 0 violations locally
- [ ] PL/SQL heredocs in `context_index.rb` are skipped
- [ ] `--verbose` flag shows parse warnings on stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
