### PR TITLE
Default to identity primary keys in Migration[8.2]+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 group :development do
   gem "rspec"
   gem "rake"
-  # rails/rails@74bb87c5 = merge of rails/rails#58684 (load Active Support on
-  # JRuby without Ractor); bump per follow-up Rails change
-  gem "activerecord",   github: "rails/rails", ref: "74bb87c5888b3489fc519f048e6a0cd9cc615a5d"
+  gem "activerecord",   github: "yahonda/rails", branch: "per-adapter-migration-compatibility-v7"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do

--- a/lib/active_record/connection_adapters/oracle_enhanced/compatibility_behavior.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/compatibility_behavior.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module OracleEnhanced
+      module CompatibilityBehavior # :nodoc: all
+        Base = ActiveRecord::Migration::CompatibilityBehavior
+        extend Base::Resolver
+
+        # A behavior applies to migrations declaring its own version and older:
+        # Migration[8.2]+ resolves to V8_2, Migration[8.1] and earlier to V8_1.
+        class V8_2 < Base; end
+        class V8_1 < V8_2; end
+      end
+    end
+  end
+end

--- a/lib/active_record/connection_adapters/oracle_enhanced/compatibility_behavior.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/compatibility_behavior.rb
@@ -9,8 +9,40 @@ module ActiveRecord
 
         # A behavior applies to migrations declaring its own version and older:
         # Migration[8.2]+ resolves to V8_2, Migration[8.1] and earlier to V8_1.
-        class V8_2 < Base; end
-        class V8_1 < V8_2; end
+
+        # Migration[8.2]+ migrations default to an Oracle identity primary
+        # key when the server supports it. Schema loads (plain and versioned
+        # `ActiveRecord::Schema[x.y].define`, both including
+        # +ActiveRecord::Schema::Definition+) and direct adapter calls keep
+        # the adapter's pre-existing sequence default so that schema dumps
+        # written by older releases reload unchanged. An explicit
+        # `identity:` value always wins.
+        class V8_2 < Base
+          def create_table(table_name, **options)
+            options[:identity] = true if default_to_identity?(options)
+            super
+          end
+
+          private
+            def default_to_identity?(options)
+              return false if migration.is_a?(ActiveRecord::Schema::Definition)
+              return false if options.key?(:identity)
+              return false if options[:sequence_name] || options[:sequence_start_value]
+              return false if options[:primary_key_trigger]
+              return false if options.fetch(:id, :primary_key) != :primary_key
+              return false if options[:primary_key].is_a?(Array)
+              connection.supports_identity_columns?
+            end
+        end
+
+        # Migration[8.1] and earlier keep the pre-8.2 sequence-backed primary
+        # key default so existing migrations replay unchanged.
+        class V8_1 < V8_2
+          def create_table(table_name, **options)
+            options[:identity] = false unless options.key?(:identity)
+            super
+          end
+        end
       end
     end
   end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "openssl"
+require "active_record/connection_adapters/oracle_enhanced/compatibility_behavior"
 
 module ActiveRecord
   module ConnectionAdapters
@@ -9,6 +10,10 @@ module ActiveRecord
         # SCHEMA STATEMENTS ========================================
         #
         # see: abstract/schema_statements.rb
+
+        def compatibility_behavior_for(migration_class) # :nodoc:
+          OracleEnhanced::CompatibilityBehavior.for(migration_class)
+        end
 
         def tables # :nodoc:
           select_values(<<~SQL.squish, "SCHEMA")

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -174,8 +174,11 @@ module ActiveRecord
           end
           schema_cache.clear_data_source_cache!(table_name.to_s)
           schema_cache.clear_data_source_cache!(new_name.to_s)
+          identity_pk = identity_pk?(table_name)
           execute "RENAME #{quote_table_name(table_name)} TO #{quote_table_name(new_name)}"
-          execute "RENAME #{default_sequence_name(table_name, nil)} TO #{default_sequence_name(new_name, nil)}" rescue nil
+          unless identity_pk
+            execute "RENAME #{default_sequence_name(table_name, nil)} TO #{default_sequence_name(new_name, nil)}" rescue nil
+          end
           rename_pk_trigger(table_name, new_name)
           clear_table_caches(table_name)
           clear_table_caches(new_name)
@@ -192,10 +195,13 @@ module ActiveRecord
 
           table_names.each do |table_name|
             schema_cache.clear_data_source_cache!(table_name.to_s)
-            seq_name = custom_sequence_name || default_sequence_name(table_name, nil)
+            # Identity-backed tables never carry a default `<table>_seq`, so
+            # skip the sequence drop entirely on those. `identity_pk?` must
+            # run before the table drop, while the table is still present.
+            seq_name = custom_sequence_name || (identity_pk?(table_name) ? nil : default_sequence_name(table_name, nil))
 
             drop_if_exists("TABLE", table_name, cascade_constraints: cascade, if_exists: if_exists)
-            drop_if_exists("SEQUENCE", seq_name, if_exists: true)
+            drop_if_exists("SEQUENCE", seq_name, if_exists: true) if seq_name
           ensure
             clear_table_caches(table_name)
           end
@@ -1263,6 +1269,18 @@ module ActiveRecord
           def missing_object_ora_code?(message, object_type)
             code = MISSING_OBJECT_ORA_CODES[object_type.to_s.upcase]
             code && message.include?(code)
+          end
+
+          # True when +table_name+ exists and its primary key column is an Oracle
+          # identity column. Returns false when the table is not present (e.g.
+          # +drop_table if_exists:+ for a missing table) or when the database does
+          # not support identity columns.
+          def identity_pk?(table_name)
+            return false unless supports_identity_columns?
+            owner, desc_table_name = resolve_data_source_name(table_name)
+            identity_primary_key?(owner, desc_table_name)
+          rescue OracleEnhanced::ConnectionException
+            false
           end
 
           def index_column_names(column_names) # :nodoc:

--- a/spec/active_record/connection_adapters/oracle_enhanced/identity_primary_key_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/identity_primary_key_spec.rb
@@ -336,7 +336,7 @@ RSpec.describe "identity primary keys" do
       ActiveRecord.schema_ignored_tables = []
 
       expect(stream.string).to include('create_table "test_identity_pks"')
-      expect(stream.string).not_to include("identity: true")
+      expect(stream.string).not_to include("identity:")
     end
   end
 
@@ -350,6 +350,116 @@ RSpec.describe "identity primary keys" do
       expect {
         @conn.empty_insert_statement_value(nil)
       }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "identity counterparts to sequence-prerequisite behavior" do
+    before do
+      skip "requires Oracle 12.1+" unless @conn.database_version >= "12"
+    end
+
+    it "renames a long-named identity table without touching a non-existent sequence" do
+      long_source = "a" * (@conn.max_identifier_length - 3)
+      schema_define do
+        create_table long_source.to_sym, force: true, identity: true do |t|
+          t.string :name
+        end
+      end
+
+      expected_old_seq = @conn.default_sequence_name(long_source, nil).upcase
+      expected_new_seq = @conn.default_sequence_name("renamed_identity_long", nil).upcase
+
+      expect {
+        @conn.rename_table(long_source, "renamed_identity_long")
+      }.not_to raise_error
+
+      sequences = @conn.select_values(
+        "SELECT sequence_name FROM user_sequences WHERE sequence_name IN ('#{expected_old_seq}', '#{expected_new_seq}')"
+      )
+      expect(sequences).to be_empty
+    ensure
+      schema_define do
+        drop_table :renamed_identity_long, if_exists: true
+        drop_table long_source.to_sym, if_exists: true
+      end
+    end
+
+    it "returns a nil sequence_name from pk_and_sequence_for for identity tables" do
+      schema_define do
+        create_table :test_identity_pks, identity: true do |t|
+          t.string :name
+        end
+      end
+
+      expect(@conn.pk_and_sequence_for(:test_identity_pks)).to eq(["id", nil])
+    end
+
+    it "does not query NEXTVAL when inserting into an identity table" do
+      schema_define do
+        create_table :test_identity_pks, identity: true do |t|
+          t.string :name
+        end
+      end
+      klass = Class.new(ActiveRecord::Base) { self.table_name = "test_identity_pks" }
+
+      set_logger
+      begin
+        klass.create!(name: "alpha")
+        klass.create!(name: "bravo")
+        # Match sequence fetches (`"<name>_SEQ".NEXTVAL`) but not the
+        # has_primary_key_trigger? lookup, whose SQL text contains the
+        # literal 'NEXTVAL INTO :NEW'.
+        expect(@logger.output(:debug)).not_to match(/\.NEXTVAL/i)
+      ensure
+        clear_logger
+      end
+    end
+
+    it "omits DROP SEQUENCE from full_drop output for identity-backed tables" do
+      schema_define do
+        create_table :test_identity_pks, identity: true do |t|
+          t.string :name
+        end
+      end
+
+      drop = @conn.full_drop
+
+      expect(drop).to match(/DROP TABLE "TEST_IDENTITY_PKS" CASCADE CONSTRAINTS/)
+      expect(drop).not_to match(/DROP SEQUENCE "TEST_IDENTITY_PKS_SEQ"/)
+    end
+
+    it "rename_table leaves an unrelated <table>_seq sequence alone for identity tables" do
+      schema_define do
+        create_table :test_identity_pks, identity: true do |t|
+          t.string :name
+        end
+      end
+      @conn.execute "CREATE SEQUENCE test_identity_pks_seq"
+
+      @conn.rename_table(:test_identity_pks, :test_identity_pks_renamed)
+
+      expect(sequence_exists?(:test_identity_pks_seq)).to be true
+      expect(sequence_exists?(:test_identity_pks_renamed_seq)).to be false
+    ensure
+      @conn.execute("DROP SEQUENCE test_identity_pks_seq") rescue nil
+      schema_define do
+        drop_table :test_identity_pks_renamed, if_exists: true
+      end
+    end
+
+    it "drop_table leaves an unrelated <table>_seq sequence alone for identity tables" do
+      schema_define do
+        create_table :test_identity_pks, identity: true do |t|
+          t.string :name
+        end
+      end
+      @conn.execute "CREATE SEQUENCE test_identity_pks_seq"
+
+      @conn.drop_table(:test_identity_pks)
+
+      expect(sequence_exists?(:test_identity_pks_seq)).to be true
+    ensure
+      @conn.execute("DROP SEQUENCE test_identity_pks_seq") rescue nil
     end
   end
 end

--- a/spec/active_record/connection_adapters/oracle_enhanced/migration_compatibility_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/migration_compatibility_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe "OracleEnhanced::CompatibilityBehavior resolution" do
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @conn = ActiveRecord::Base.lease_connection
+  end
+
+  def oracle_behavior
+    ActiveRecord::ConnectionAdapters::OracleEnhanced::CompatibilityBehavior
+  end
+
+  it "resolves Migration[8.2] to V8_2" do
+    expect(@conn.compatibility_behavior_for(ActiveRecord::Migration[8.2])).to eq oracle_behavior::V8_2
+  end
+
+  it "resolves Migration[8.1] to V8_1" do
+    expect(@conn.compatibility_behavior_for(ActiveRecord::Migration[8.1])).to eq oracle_behavior::V8_1
+  end
+
+  it "resolves Migration[7.0] to V8_1, which covers its own version and older" do
+    expect(@conn.compatibility_behavior_for(ActiveRecord::Migration[7.0])).to eq oracle_behavior::V8_1
+  end
+
+  it "resolves an unversioned migration to the no-op base behavior" do
+    expect(@conn.compatibility_behavior_for(ActiveRecord::Migration)).to eq ActiveRecord::Migration::CompatibilityBehavior
+  end
+end

--- a/spec/active_record/connection_adapters/oracle_enhanced/migration_compatibility_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/migration_compatibility_spec.rb
@@ -26,3 +26,227 @@ RSpec.describe "OracleEnhanced::CompatibilityBehavior resolution" do
     expect(@conn.compatibility_behavior_for(ActiveRecord::Migration)).to eq ActiveRecord::Migration::CompatibilityBehavior
   end
 end
+
+RSpec.describe "migration compatibility for identity primary keys" do
+  include SchemaSpecHelper
+
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @conn = ActiveRecord::Base.connection
+    @oracle12c_or_higher = @conn.database_version >= "12"
+  end
+
+  after(:each) do
+    ActiveRecord::Migration.suppress_messages do
+      schema_define do
+        drop_table :test_identity_pks, if_exists: true
+        drop_table :test_identity_pks_composite, if_exists: true
+        drop_table :test_identity_pks_no_id, if_exists: true
+      end
+    end
+    @conn.schema_cache.clear!
+  end
+
+  def run_migration(version, &block)
+    migration = Class.new(ActiveRecord::Migration[version]) do
+      define_method(:change, &block)
+    end.new
+
+    ActiveRecord::Migration.suppress_messages { migration.migrate(:up) }
+  end
+
+  def sequence_exists?(name)
+    @conn.select_value(<<~SQL.squish, "SCHEMA").present?
+      SELECT 1 FROM user_sequences WHERE sequence_name = '#{name.to_s.upcase}' AND ROWNUM = 1
+    SQL
+  end
+
+  def identity_column_exists?(table_name, column_name)
+    @conn.select_value(<<~SQL.squish, "SCHEMA").present?
+      SELECT 1 FROM user_tab_identity_cols
+       WHERE table_name = '#{table_name.to_s.upcase}'
+         AND column_name = '#{column_name.to_s.upcase}'
+         AND ROWNUM = 1
+    SQL
+  end
+
+  context "on Oracle 12.1 or higher" do
+    before do
+      skip "requires Oracle 12.1+" unless @oracle12c_or_higher
+    end
+
+    describe "Migration[8.2]+ default behavior" do
+      it "creates an identity primary key by default" do
+        run_migration(8.2) { create_table :test_identity_pks }
+
+        expect(identity_column_exists?(:test_identity_pks, :id)).to be true
+        expect(sequence_exists?(:test_identity_pks_seq)).to be false
+      end
+
+      it "honors per-table opt-out via identity: false" do
+        run_migration(8.2) { create_table :test_identity_pks, identity: false }
+
+        expect(identity_column_exists?(:test_identity_pks, :id)).to be false
+        expect(sequence_exists?(:test_identity_pks_seq)).to be true
+      end
+
+      it "skips prefetch_primary_key? for the identity table" do
+        run_migration(8.2) { create_table :test_identity_pks }
+
+        expect(@conn.prefetch_primary_key?(:test_identity_pks)).to be false
+      end
+
+      it "skips auto-injection when id: false is passed" do
+        run_migration(8.2) do
+          create_table :test_identity_pks_no_id, id: false do |t|
+            t.string :name
+          end
+        end
+
+        expect(identity_column_exists?(:test_identity_pks_no_id, :id)).to be false
+      end
+
+      it "skips auto-injection when id: :integer is passed" do
+        run_migration(8.2) do
+          create_table :test_identity_pks, id: :integer do |t|
+            t.string :name
+          end
+        end
+
+        expect(identity_column_exists?(:test_identity_pks, :id)).to be false
+        expect(sequence_exists?(:test_identity_pks_seq)).to be true
+      end
+
+      it "skips auto-injection when a composite primary key is passed" do
+        run_migration(8.2) do
+          create_table :test_identity_pks_composite, primary_key: [:a, :b] do |t|
+            t.integer :a
+            t.integer :b
+          end
+        end
+
+        expect(identity_column_exists?(:test_identity_pks_composite, :a)).to be false
+        expect(identity_column_exists?(:test_identity_pks_composite, :b)).to be false
+      end
+    end
+
+    describe "Migration[8.1] (per-migration opt-out)" do
+      it "creates a sequence-backed primary key by default" do
+        run_migration(8.1) { create_table :test_identity_pks }
+
+        expect(identity_column_exists?(:test_identity_pks, :id)).to be false
+        expect(sequence_exists?(:test_identity_pks_seq)).to be true
+      end
+
+      it "still honors explicit identity: true (DB-supported)" do
+        run_migration(8.1) { create_table :test_identity_pks, identity: true }
+
+        expect(identity_column_exists?(:test_identity_pks, :id)).to be true
+        expect(sequence_exists?(:test_identity_pks_seq)).to be false
+      end
+    end
+
+    describe "Migration[7.0] (older versions)" do
+      it "creates a sequence-backed primary key by default" do
+        run_migration(7.0) { create_table :test_identity_pks }
+
+        expect(identity_column_exists?(:test_identity_pks, :id)).to be false
+        expect(sequence_exists?(:test_identity_pks_seq)).to be true
+      end
+    end
+
+    describe "Schema.define / direct connection.create_table" do
+      it "creates a sequence-backed primary key by default (no migration version context)" do
+        schema_define do
+          create_table :test_identity_pks do |t|
+            t.string :name
+          end
+        end
+
+        expect(identity_column_exists?(:test_identity_pks, :id)).to be false
+        expect(sequence_exists?(:test_identity_pks_seq)).to be true
+      end
+
+      it "still honors explicit identity: true" do
+        schema_define do
+          create_table :test_identity_pks, identity: true do |t|
+            t.string :name
+          end
+        end
+
+        expect(identity_column_exists?(:test_identity_pks, :id)).to be true
+        expect(sequence_exists?(:test_identity_pks_seq)).to be false
+      end
+
+      it "keeps the sequence default when loading a versioned ActiveRecord::Schema[8.2] dump" do
+        ActiveRecord::Migration.suppress_messages do
+          ActiveRecord::ConnectionAdapters::OracleEnhanced.deprecator.silence do
+            ActiveRecord::Schema[8.2].define do
+              create_table :test_identity_pks, force: true do |t|
+                t.string :name
+              end
+            end
+          end
+        end
+
+        expect(identity_column_exists?(:test_identity_pks, :id)).to be false
+        expect(sequence_exists?(:test_identity_pks_seq)).to be true
+      end
+    end
+
+    describe "Migration[8.2]+ with explicit Oracle sequence options" do
+      it "treats sequence_name: as opt-out of the identity default" do
+        run_migration(8.2) do
+          create_table :test_identity_pks, sequence_name: "explicit_seq" do |t|
+            t.string :name
+          end
+        end
+
+        expect(identity_column_exists?(:test_identity_pks, :id)).to be false
+        expect(sequence_exists?("explicit_seq")).to be true
+      ensure
+        @conn.execute("DROP SEQUENCE explicit_seq") rescue nil
+      end
+
+      it "treats sequence_start_value: as opt-out of the identity default" do
+        run_migration(8.2) do
+          create_table :test_identity_pks, sequence_start_value: 10000 do |t|
+            t.string :name
+          end
+        end
+
+        expect(identity_column_exists?(:test_identity_pks, :id)).to be false
+        expect(sequence_exists?(:test_identity_pks_seq)).to be true
+      end
+
+      it "treats primary_key_trigger: true as opt-out of the identity default" do
+        run_migration(8.2) do
+          create_table :test_identity_pks, primary_key_trigger: true do |t|
+            t.string :name
+          end
+        end
+
+        expect(identity_column_exists?(:test_identity_pks, :id)).to be false
+        expect(sequence_exists?(:test_identity_pks_seq)).to be true
+      end
+    end
+  end
+
+  context "on Oracle below 12.1" do
+    before do
+      skip "applies only to Oracle versions before 12.1" if @oracle12c_or_higher
+    end
+
+    it "Migration[8.2]+ falls back to sequence (auto-inject is gated by supports_identity_columns?)" do
+      run_migration(8.2) { create_table :test_identity_pks }
+
+      expect(sequence_exists?(:test_identity_pks_seq)).to be true
+    end
+
+    it "Migration[8.2]+ with explicit identity: true raises ArgumentError" do
+      expect {
+        run_migration(8.2) { create_table :test_identity_pks, identity: true }
+      }.to raise_error(ArgumentError, /Oracle Database 12\.1 or higher/)
+    end
+  end
+end


### PR DESCRIPTION
Adopt the standalone `ActiveRecord::Migration::CompatibilityBehavior` extension point (rails/rails#58162, tracked on `yahonda/rails` branch `per-adapter-migration-compatibility-v7`) to default new-enough migrations to Oracle identity primary keys. Supersedes #2813 and #2596.

## Status (2026-09-03)

* Rebased onto current master (after #2852 restored the JRuby rows and moved the pin to rails/rails@74bb87c5), on top of #2823's rebased commit; the branch content is unchanged.
* rails/rails#58162 is open and rebased onto current rails main.
* Full spec suite green locally against Oracle Free (1148 examples, 0 failures); CI green.

## Behavior

A migration declaring `8.2` now creates an identity primary key on Oracle Database 12.1 or higher, with no change to the migration code:

```ruby
class CreatePosts < ActiveRecord::Migration[8.2]
  def change
    create_table :posts do |t|   # id: NUMBER GENERATED BY DEFAULT AS IDENTITY
      t.string :title
    end
  end
end
```

No `posts_seq` sequence is created, and inserts no longer query `posts_seq.NEXTVAL` — the database assigns the id.

The same table under `Migration[8.1]` or earlier keeps the sequence-backed primary key, so every existing migration replays unchanged:

```ruby
class CreatePosts < ActiveRecord::Migration[8.1]
  def change
    create_table :posts do |t|   # id: NUMBER + posts_seq sequence, as today
      t.string :title
    end
  end
end
```

An explicit `identity:` always wins over the version default, in both directions:

```ruby
class CreatePosts < ActiveRecord::Migration[8.1]
  def change
    create_table :posts, identity: true do |t|   # identity, even on 8.1
      t.string :title
    end
  end
end

class CreateAudits < ActiveRecord::Migration[8.2]
  def change
    create_table :audits, identity: false do |t| # sequence, even on 8.2
      t.string :action
    end
  end
end
```

### Resulting primary key by caller and option (Oracle Database 12.1+)

| caller | (no `identity:`) | `identity: true` | `identity: false` |
| --- | --- | --- | --- |
| `Migration[8.2]` and later | **identity** (the only cell this PR changes) | identity | sequence |
| `Migration[8.1]` and earlier | sequence | identity | sequence |
| `Schema.define` / `ActiveRecord::Schema[x.y].define` / direct `connection.create_table` | sequence | identity | sequence |

On Oracle Database releases before 12.1 every cell resolves to a sequence-backed key, except `identity: true`, which raises `ArgumentError` — both as today. A `Migration[8.2]`+ `create_table` passing a sequence-backed option (`sequence_name:`, `sequence_start_value:`, `primary_key_trigger:`) behaves like the middle row: the option opts it out of the identity default instead of raising about an `identity: true` the author never wrote.

Schema dumps written by older releases reload unchanged (schema loads keep the sequence default), and identity-backed tables are dumped with `identity: true`, so dump -> load round-trips preserve both kinds.

## Implementation

* Fills in the `V8_2`/`V8_1` behaviors that #2823 introduces as empty skeletons:
  * `V8_2#create_table` forces `options[:identity] = true` when no `:identity` is given, no sequence options are set, the connection supports identity columns, and the caller is not a schema load (checked via `ActiveRecord::Schema::Definition`, which both plain `Schema.define` and versioned `ActiveRecord::Schema[x.y].define` include), so schema dumps keep the sequence default.
  * `V8_1#create_table` forces `options[:identity] = false` to keep the pre-8.2 sequence default on older migrations.
* `rename_table` and `drop_table` become identity-aware: they skip the paired `<table>_seq` rename/drop when the table's primary key is an Oracle identity column, so unrelated application-owned sequences with matching names are left alone.
* The schema dumper emits `identity: true` for identity-backed primary keys. Sequence-backed primary keys carry no annotation: `identity: false` is the adapter's baseline default (`Schema.define`, direct `connection.create_table`, and Migration[8.1] and earlier all keep the sequence default), so emitting it on every sequence-backed table would be redundant for reload and add schema.rb churn.

## Tests

`identity_primary_key_spec.rb` (round-trip + identity-aware rename/drop; the previously always-skipped “identity counterparts” block now runs) and `migration_compatibility_spec.rb` covering the version matrix: Migration[8.2] / Migration[8.1] / Migration[7.0], plain `Schema.define` and versioned `ActiveRecord::Schema[8.2].define` loads, explicit `identity:` overrides, and the sequence-option / `primary_key_trigger:` opt-outs. CI runs the suite against Oracle.

## Depends on

* **#2823: Add CompatibilityBehavior plumbing for per-adapter migration compatibility** — merge that first; its commit is the first of the two commits in this PR's diff.
* rails/rails#58162, which introduces `compatibility_behavior_for` and `Migration::CompatibilityBehavior` (head: `yahonda/rails` branch `per-adapter-migration-compatibility-v7`). #2823's commit points the Gemfile at that branch.

Independent of #2817: after #2823, either PR can merge first; whichever merges second needs a trivial rebase (both touch `V8_1#create_table` and append to `migration_compatibility_spec.rb`).

## Review follow-up (2026-07-02)

A deeper review pass added the following fixes, since folded into the single commit:

* **Versioned schema loads kept the sequence default only for the unversioned form.** `rake db:schema:dump` writes `ActiveRecord::Schema[8.2].define`, whose anonymous class is not a subclass of `ActiveRecord::Schema`, so the `is_a?(ActiveRecord::Schema)` guard missed it and `db:schema:load` would have recreated every sequence-backed table as identity (breaking dump -> load -> dump idempotence). The guard now checks `ActiveRecord::Schema::Definition`, with a spec loading through `ActiveRecord::Schema[8.2].define`.
* **`primary_key_trigger: true` now opts out of the identity default.** Previously a `Migration[8.2]` `create_table :t, primary_key_trigger: true` raised about combining it with an `identity: true` the author never wrote.
* **The "identity counterparts" spec block was always skipped.** Its guard read `@oracle12c_or_higher`, which is never assigned in that file; it now uses the `database_version` comparison. The unskipped NEXTVAL assertion was tightened to `/\.NEXTVAL/` so it does not match the `has_primary_key_trigger?` lookup SQL, which contains the literal `NEXTVAL INTO :NEW`.
* Spec/comment cleanups: non-deprecated `database_version` comparison in a `before(:all)` hook, removal of an unused table cleanup.



