### PR TITLE
Stop creating a unique constraint for add_index unique: true in Migration[8.2]+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 group :development do
   gem "rspec"
   gem "rake"
-  # rails/rails@74bb87c5 = merge of rails/rails#58684 (load Active Support on
-  # JRuby without Ractor); bump per follow-up Rails change
-  gem "activerecord",   github: "rails/rails", ref: "74bb87c5888b3489fc519f048e6a0cd9cc615a5d"
+  gem "activerecord",   github: "yahonda/rails", branch: "per-adapter-migration-compatibility-v7"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do

--- a/lib/active_record/connection_adapters/oracle_enhanced/compatibility_behavior.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/compatibility_behavior.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module OracleEnhanced
+      module CompatibilityBehavior # :nodoc: all
+        Base = ActiveRecord::Migration::CompatibilityBehavior
+        extend Base::Resolver
+
+        # A behavior applies to migrations declaring its own version and older:
+        # Migration[8.2]+ resolves to V8_2, Migration[8.1] and earlier to V8_1.
+        class V8_2 < Base; end
+        class V8_1 < V8_2; end
+      end
+    end
+  end
+end

--- a/lib/active_record/connection_adapters/oracle_enhanced/compatibility_behavior.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/compatibility_behavior.rb
@@ -10,7 +10,58 @@ module ActiveRecord
         # A behavior applies to migrations declaring its own version and older:
         # Migration[8.2]+ resolves to V8_2, Migration[8.1] and earlier to V8_1.
         class V8_2 < Base; end
-        class V8_1 < V8_2; end
+
+        # Migration[8.1] and earlier keep the pre-8.2 implicit-UNIQUE-CONSTRAINT
+        # behavior for `add_index unique: true`, so existing migrations replay
+        # unchanged. The +_implicit_unique_constraint+ flag is consumed and
+        # deleted by the adapter before any further processing. Callers that
+        # need a constraint on Migration[8.2]+ should call
+        # `add_unique_constraint :t, :col, name: :n` directly.
+        class V8_1 < V8_2
+          def create_table(table_name, **options)
+            options[:_implicit_unique_constraint] = true
+            super
+          end
+
+          def add_index(table_name, column_name, **options)
+            options[:_implicit_unique_constraint] = true
+            super
+          end
+
+          def add_reference(table_name, *ref_names, **options)
+            index = options[:index]
+            if index.is_a?(Hash) && index[:unique]
+              options[:index] = index.merge(_implicit_unique_constraint: true)
+            end
+            super
+          end
+          alias :add_belongs_to :add_reference
+
+          def create_join_table(table_1, table_2, **options)
+            options[:_implicit_unique_constraint] = true
+            super
+          end
+
+          # Prepended onto the change_table receiver by the framework's
+          # compatible_table_definition. Inject only there: the create_table
+          # path is covered by the table-level flag, and Rails validates
+          # per-index option keys while creating the table.
+          module TableDefinition
+            def index(column_name, **options)
+              options[:_implicit_unique_constraint] = true if ActiveRecord::ConnectionAdapters::Table === self
+              super
+            end
+
+            def references(*args, **options)
+              index = options[:index]
+              if ActiveRecord::ConnectionAdapters::Table === self && index.is_a?(Hash) && index[:unique]
+                options[:index] = index.merge(_implicit_unique_constraint: true)
+              end
+              super
+            end
+            alias :belongs_to :references
+          end
+        end
       end
     end
   end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -142,6 +142,8 @@ module ActiveRecord
             raise ArgumentError, "Options `:force` and `:if_not_exists` cannot be used simultaneously."
           end
 
+          implicit_unique_constraint = options.delete(:_implicit_unique_constraint)
+
           identity = options[:identity]
           validate_identity_options!(identity, id, primary_key)
           validate_primary_key_trigger_options!(options[:primary_key_trigger], identity, id, primary_key)
@@ -161,7 +163,7 @@ module ActiveRecord
             yield td if block_given?
           end
 
-          add_inline_unique_constraints(table_name, captured_td)
+          add_inline_unique_constraints(table_name, captured_td, implicit_unique_constraint)
 
           create_pk_sequence(table_name, options) if should_create_sequence?(captured_td, id, identity)
           create_pk_trigger(table_name, primary_key, options) if options[:primary_key_trigger]
@@ -184,6 +186,8 @@ module ActiveRecord
         end
 
         def drop_table(*table_names, **options) # :nodoc:
+          # Arrives via CommandRecorder inversions of V8_1-flagged create_table calls.
+          options.delete(:_implicit_unique_constraint)
           # :sequence_name names a single sequence, so it cannot unambiguously
           # apply across multiple tables; honor it only for single-table drops.
           custom_sequence_name = table_names.size == 1 ? options[:sequence_name] : nil
@@ -214,13 +218,14 @@ module ActiveRecord
         end
 
         def add_index(table_name, column_name, **options) # :nodoc:
+          implicit_unique_constraint = options.delete(:_implicit_unique_constraint)
           create_index = build_create_index_definition(table_name, column_name, **options)
           return unless create_index
 
           execute schema_creation.accept(create_index)
 
           index = create_index.index
-          if needs_unique_constraint?(index.unique, index.columns) && OracleEnhancedAdapter.add_index_unique_creates_constraint
+          if needs_unique_constraint?(index.unique, index.columns) && implicit_unique_constraint_active?(implicit_unique_constraint)
             warn_implicit_unique_constraint_deprecation
             execute add_unique_constraint_sql(index.table, index.columns, index.name)
           end
@@ -266,6 +271,8 @@ module ActiveRecord
         # Remove the given index from the table.
         # Gives warning if index does not exist
         def remove_index(table_name, column_name = nil, **options) # :nodoc:
+          # Arrives via CommandRecorder inversions of V8_1-flagged add_index calls.
+          options.delete(:_implicit_unique_constraint)
           return if options[:if_exists] && !index_exists?(table_name, column_name, **options)
 
           index_name = index_name_for_remove(table_name, column_name, options).to_s
@@ -1279,31 +1286,45 @@ module ActiveRecord
             "ALTER TABLE #{quote_table_name(table_name)} ADD CONSTRAINT #{quote_column_name(index_name)} UNIQUE (#{quoted_cols}) USING INDEX #{quote_column_name(index_name)}"
           end
 
-          def add_inline_unique_constraints(table_name, td)
+          def add_inline_unique_constraints(table_name, td, implicit_unique_constraint = false)
             td.indexes.each do |column_name, index_options|
               next unless needs_unique_constraint?(index_options[:unique], column_name)
-              next unless OracleEnhancedAdapter.add_index_unique_creates_constraint
+              next unless implicit_unique_constraint_active?(implicit_unique_constraint)
               warn_implicit_unique_constraint_deprecation
               inline_index_name = index_options[:name]&.to_s || index_name(table_name, column: index_column_names(column_name))
               execute add_unique_constraint_sql(table_name, column_name, inline_index_name)
             end
           end
 
+          # Implicit UNIQUE CONSTRAINT creation for `add_index unique: true`
+          # is gated by:
+          #
+          # * the global flag `add_index_unique_creates_constraint` (explicit
+          #   user opt-in), OR
+          # * the `_implicit_unique_constraint` flag set by the V8_1
+          #   compatibility behavior while a Migration[8.1] or earlier
+          #   migration is running (pre-Phase 2 default preserved).
+          #
+          # In Phase 2, the global flag defaults to `false`, so callers
+          # outside the V8_1 path (Migration[8.2]+, Schema.define, direct
+          # adapter calls) skip the implicit constraint by default.
+          def implicit_unique_constraint_active?(flag)
+            OracleEnhancedAdapter.add_index_unique_creates_constraint || flag == true
+          end
+
           def warn_implicit_unique_constraint_deprecation
             OracleEnhanced.deprecator.warn(<<~MSG)
               add_index :col, unique: true creates an implicit named UNIQUE constraint on Oracle,
-              in addition to the unique index. This implicit-constraint behavior will be removed
-              in a future oracle-enhanced release.
+              in addition to the unique index, because this migration replays the pre-8.2
+              behavior: it declares ActiveRecord::Migration[8.1] or earlier, or
+              `add_index_unique_creates_constraint` is enabled globally. This
+              implicit-constraint behavior will be removed in a future oracle-enhanced release.
 
-              To silence this warning, set the flag in an initializer:
-
-                ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.add_index_unique_creates_constraint = false
-
-              After setting the flag, choose the path that matches your intent:
+              Choose the path that matches your intent:
 
               * Unique INDEX only (typical when foreign keys reference primary keys):
-                no migration changes needed — add_index :col, unique: true keeps creating
-                the unique index, just without the extra UNIQUE CONSTRAINT.
+                declare the migration as ActiveRecord::Migration[8.2] or later —
+                add_index :col, unique: true then creates only the unique index.
 
               * Unique INDEX + UNIQUE CONSTRAINT (needed when this column is a non-PK
                 foreign-key target, which Oracle only allows against named constraints):
@@ -1311,6 +1332,12 @@ module ActiveRecord
                 its backing unique index in one call, e.g.
 
                   add_unique_constraint :sections, :position, name: :uniq_position
+
+              * If this warning comes from the global flag, remove
+
+                  ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.add_index_unique_creates_constraint = true
+
+                from your initializer.
             MSG
           end
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "openssl"
+require "active_record/connection_adapters/oracle_enhanced/compatibility_behavior"
 
 module ActiveRecord
   module ConnectionAdapters
@@ -9,6 +10,10 @@ module ActiveRecord
         # SCHEMA STATEMENTS ========================================
         #
         # see: abstract/schema_statements.rb
+
+        def compatibility_behavior_for(migration_class) # :nodoc:
+          OracleEnhanced::CompatibilityBehavior.for(migration_class)
+        end
 
         def tables # :nodoc:
           select_values(<<~SQL.squish, "SCHEMA")

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -244,15 +244,22 @@ module ActiveRecord
       # behavior was introduced so that Oracle-specific FK targetability worked
       # with Rails-standard <tt>add_index unique: true</tt> migrations, but the
       # explicit <tt>add_unique_constraint</tt> DSL is now the recommended path
-      # for callers who actually need a constraint. Defaults to +true+ for
-      # backward compatibility; will flip to +false+ in a future release.
+      # for callers who actually need a constraint.
       #
-      # Set to +false+ in an initializer to opt out of the implicit-constraint
-      # behavior (and silence the deprecation warning) immediately:
+      # Phase 2 default: +false+. <tt>Migration[8.2]+</tt> migrations,
+      # <tt>Schema.define</tt> blocks, and direct adapter calls all default
+      # to "create the unique index only". <tt>Migration[8.1]</tt> and earlier
+      # migrations opt back into the pre-8.2 implicit-constraint behavior via
+      # the +CompatibilityBehavior+ so existing migrations keep working
+      # unchanged.
       #
-      #   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.add_index_unique_creates_constraint = false
+      # Set to +true+ explicitly to force the pre-8.2 implicit-constraint
+      # behavior project-wide (e.g. when migrating a long-running multi-DB
+      # application that depends on it):
+      #
+      #   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.add_index_unique_creates_constraint = true
       cattr_accessor :add_index_unique_creates_constraint
-      self.add_index_unique_creates_constraint = true
+      self.add_index_unique_creates_constraint = false
 
       ##
       # :singleton-method:

--- a/spec/active_record/connection_adapters/oracle_enhanced/dbms_metadata_structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/dbms_metadata_structure_dump_spec.rb
@@ -144,19 +144,21 @@ RSpec.describe "OracleEnhancedAdapter DBMS_METADATA structure dump" do
     # as VISIBLE.
     it "emits ALTER INDEX ... INVISIBLE for an INVISIBLE constraint-backed index" do
       skip "Not supported in this database version" unless @conn.supports_disabling_indexes?
-      schema_define do
-        create_table :test_dbms_meta_inv_uniq, force: true do |t|
-          t.string :email
+      with_implicit_unique_constraint_enabled do
+        schema_define do
+          create_table :test_dbms_meta_inv_uniq, force: true do |t|
+            t.string :email
+          end
+          add_index :test_dbms_meta_inv_uniq, :email,
+                    unique: true, name: "ix_dbms_meta_inv_uniq", enabled: false
         end
-        add_index :test_dbms_meta_inv_uniq, :email,
-                  unique: true, name: "ix_dbms_meta_inv_uniq", enabled: false
-      end
 
-      dump = @conn.structure_dump
-      alter_stmt = dump.split("\n\n/\n\n").find do |stmt|
-        stmt.match?(/\AALTER\s+INDEX\s+"?IX_DBMS_META_INV_UNIQ"?\s+INVISIBLE\s*\z/i)
+        dump = @conn.structure_dump
+        alter_stmt = dump.split("\n\n/\n\n").find do |stmt|
+          stmt.match?(/\AALTER\s+INDEX\s+"?IX_DBMS_META_INV_UNIQ"?\s+INVISIBLE\s*\z/i)
+        end
+        expect(alter_stmt).not_to be_nil
       end
-      expect(alter_stmt).not_to be_nil
     ensure
       schema_define { drop_table :test_dbms_meta_inv_uniq, if_exists: true }
     end
@@ -230,7 +232,14 @@ RSpec.describe "OracleEnhancedAdapter DBMS_METADATA structure dump" do
         create_table :test_dbms_metadata_posts, force: true do |t|
           t.string :email
         end
-        add_index :test_dbms_metadata_posts, :email, unique: true, name: "ix_test_dbms_metadata_email"
+      end
+      # Use the pre-8.2 implicit-constraint path so this Oracle 12.1+
+      # DBMS_METADATA path test exercises the "unique index backed by a
+      # same-name UNIQUE constraint" scenario it was written for.
+      with_implicit_unique_constraint_enabled do
+        schema_define do
+          add_index :test_dbms_metadata_posts, :email, unique: true, name: "ix_test_dbms_metadata_email"
+        end
       end
       dump = @conn.structure_dump
       stmts = dump.split("\n\n/\n\n")
@@ -262,7 +271,13 @@ RSpec.describe "OracleEnhancedAdapter DBMS_METADATA structure dump" do
         create_table :test_dbms_metadata_posts, force: true do |t|
           t.string :email
         end
-        add_index :test_dbms_metadata_posts, :email, unique: true, name: "ix_test_dbms_metadata_email"
+      end
+      # The pre-8.2 implicit-constraint path recreates the multi-statement
+      # `GET_DDL` CLOB shape this regression test documents.
+      with_implicit_unique_constraint_enabled do
+        schema_define do
+          add_index :test_dbms_metadata_posts, :email, unique: true, name: "ix_test_dbms_metadata_email"
+        end
       end
 
       temp_file = Tempfile.create(["oracle_enhanced_roundtrip", ".sql"]).path

--- a/spec/active_record/connection_adapters/oracle_enhanced/migration_compatibility_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/migration_compatibility_spec.rb
@@ -26,3 +26,222 @@ RSpec.describe "OracleEnhanced::CompatibilityBehavior resolution" do
     expect(@conn.compatibility_behavior_for(ActiveRecord::Migration)).to eq ActiveRecord::Migration::CompatibilityBehavior
   end
 end
+
+RSpec.describe "OracleEnhanced::CompatibilityBehavior for add_index unique: true" do
+  include SchemaSpecHelper
+
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @conn = ActiveRecord::Base.lease_connection
+  end
+
+  before(:each) do
+    schema_define do
+      create_table :test_compat_warn, force: true do |t|
+        t.string :first_name
+      end
+    end
+  end
+
+  after(:each) do
+    schema_define do
+      drop_table :test_compat_warn, if_exists: true
+    end
+  end
+
+  def run_migration(migration_class, &body)
+    klass = Class.new(migration_class) do
+      define_method(:change, &body)
+    end
+    klass.migrate(:up)
+  end
+
+  describe "Migration[8.2] (current default — Phase 2)" do
+    it "does not create an implicit UNIQUE constraint and does not warn" do
+      expect {
+        run_migration(ActiveRecord::Migration[8.2]) do
+          add_index :test_compat_warn, :first_name, unique: true, name: :uniq_v82
+        end
+      }.not_to output(/implicit named UNIQUE constraint/).to_stderr
+
+      expect(@conn.indexes(:test_compat_warn).map(&:name)).to include("uniq_v82")
+      expect(@conn.unique_constraints(:test_compat_warn).map(&:name)).not_to include("uniq_v82")
+    end
+
+    it "does not create the implicit constraint for inline t.index :col, unique: true" do
+      run_migration(ActiveRecord::Migration[8.2]) do
+        create_table :test_v82_inline, force: true do |t|
+          t.string :name
+          t.index :name, unique: true, name: :uniq_v82_inline
+        end
+      end
+
+      expect(@conn.indexes(:test_v82_inline).map(&:name)).to include("uniq_v82_inline")
+      expect(@conn.unique_constraints(:test_v82_inline).map(&:name)).not_to include("uniq_v82_inline")
+    ensure
+      schema_define { drop_table :test_v82_inline, if_exists: true }
+    end
+
+    it "does not create the implicit constraint for inline t.index inside change_table" do
+      expect {
+        run_migration(ActiveRecord::Migration[8.2]) do
+          change_table :test_compat_warn do |t|
+            t.index :first_name, unique: true, name: :uniq_v82_chg
+          end
+        end
+      }.not_to output(/implicit named UNIQUE constraint/).to_stderr
+
+      expect(@conn.indexes(:test_compat_warn).map(&:name)).to include("uniq_v82_chg")
+      expect(@conn.unique_constraints(:test_compat_warn).map(&:name)).not_to include("uniq_v82_chg")
+    end
+
+    it "does not create the implicit constraint for add_reference index: { unique: true }" do
+      expect {
+        run_migration(ActiveRecord::Migration[8.2]) do
+          add_reference :test_compat_warn, :author, index: { unique: true, name: :uniq_v82_ref }
+        end
+      }.not_to output(/implicit named UNIQUE constraint/).to_stderr
+
+      expect(@conn.indexes(:test_compat_warn).map(&:name)).to include("uniq_v82_ref")
+      expect(@conn.unique_constraints(:test_compat_warn).map(&:name)).not_to include("uniq_v82_ref")
+    end
+  end
+
+  describe "Migration[8.1] (pre-8.2 — V8_1 behavior preserves the implicit-constraint default)" do
+    it "creates the implicit UNIQUE constraint and emits the deprecation warning" do
+      expect {
+        run_migration(ActiveRecord::Migration[8.1]) do
+          add_index :test_compat_warn, :first_name, unique: true, name: :uniq_v81
+        end
+      }.to output(/implicit named UNIQUE constraint/).to_stderr
+
+      expect(@conn.indexes(:test_compat_warn).map(&:name)).to include("uniq_v81")
+      expect(@conn.unique_constraints(:test_compat_warn).map(&:name)).to include("uniq_v81")
+    end
+
+    it "creates the implicit constraint for inline t.index :col, unique: true" do
+      expect {
+        run_migration(ActiveRecord::Migration[8.1]) do
+          create_table :test_v81_inline, force: true do |t|
+            t.string :name
+            t.index :name, unique: true, name: :uniq_v81_inline
+          end
+        end
+      }.to output(/implicit named UNIQUE constraint/).to_stderr
+
+      expect(@conn.indexes(:test_v81_inline).map(&:name)).to include("uniq_v81_inline")
+      expect(@conn.unique_constraints(:test_v81_inline).map(&:name)).to include("uniq_v81_inline")
+    ensure
+      schema_define { drop_table :test_v81_inline, if_exists: true }
+    end
+
+    it "creates the implicit constraint for inline t.index inside change_table" do
+      expect {
+        run_migration(ActiveRecord::Migration[8.1]) do
+          change_table :test_compat_warn do |t|
+            t.index :first_name, unique: true, name: :uniq_v81_chg
+          end
+        end
+      }.to output(/implicit named UNIQUE constraint/).to_stderr
+
+      expect(@conn.indexes(:test_compat_warn).map(&:name)).to include("uniq_v81_chg")
+      expect(@conn.unique_constraints(:test_compat_warn).map(&:name)).to include("uniq_v81_chg")
+    end
+
+    it "creates the implicit constraint for add_reference index: { unique: true }" do
+      expect {
+        run_migration(ActiveRecord::Migration[8.1]) do
+          add_reference :test_compat_warn, :author, index: { unique: true, name: :uniq_v81_ref }
+        end
+      }.to output(/implicit named UNIQUE constraint/).to_stderr
+
+      expect(@conn.indexes(:test_compat_warn).map(&:name)).to include("uniq_v81_ref")
+      expect(@conn.unique_constraints(:test_compat_warn).map(&:name)).to include("uniq_v81_ref")
+    end
+
+    it "creates the implicit constraint for t.references index: { unique: true } inside change_table" do
+      expect {
+        run_migration(ActiveRecord::Migration[8.1]) do
+          change_table :test_compat_warn do |t|
+            t.references :editor, index: { unique: true, name: :uniq_v81_chg_ref }
+          end
+        end
+      }.to output(/implicit named UNIQUE constraint/).to_stderr
+
+      expect(@conn.indexes(:test_compat_warn).map(&:name)).to include("uniq_v81_chg_ref")
+      expect(@conn.unique_constraints(:test_compat_warn).map(&:name)).to include("uniq_v81_chg_ref")
+    end
+
+    it "creates the implicit constraint for inline t.index inside create_join_table" do
+      expect {
+        run_migration(ActiveRecord::Migration[8.1]) do
+          create_join_table :apples, :pears do |t|
+            t.index :apple_id, unique: true, name: :uniq_v81_join
+          end
+        end
+      }.to output(/implicit named UNIQUE constraint/).to_stderr
+
+      expect(@conn.indexes(:apples_pears).map(&:name)).to include("uniq_v81_join")
+      expect(@conn.unique_constraints(:apples_pears).map(&:name)).to include("uniq_v81_join")
+    ensure
+      schema_define { drop_table :apples_pears, if_exists: true }
+    end
+
+    it "reverts a change migration cleanly (the flag reaches remove_index/drop_table via inversion)" do
+      migration = Class.new(ActiveRecord::Migration[8.1]) do
+        def change
+          create_table :test_v81_revert, force: true do |t|
+            t.string :name
+          end
+          add_index :test_v81_revert, :name, unique: true, name: :uniq_v81_revert
+        end
+      end
+
+      deprecator = ActiveRecord::ConnectionAdapters::OracleEnhanced.deprecator
+      deprecator.silence { migration.migrate(:up) }
+      expect(@conn.unique_constraints(:test_v81_revert).map(&:name)).to include("uniq_v81_revert")
+
+      expect {
+        deprecator.silence { migration.migrate(:down) }
+      }.not_to raise_error
+      expect(@conn.table_exists?(:test_v81_revert)).to be false
+    ensure
+      schema_define { drop_table :test_v81_revert, if_exists: true }
+    end
+  end
+
+  describe "Migration[7.0] (resolves to the V8_1 behavior, below the 8.1 boundary)" do
+    it "creates the implicit UNIQUE constraint and emits the deprecation warning" do
+      expect {
+        run_migration(ActiveRecord::Migration[7.0]) do
+          add_index :test_compat_warn, :first_name, unique: true, name: :uniq_v70
+        end
+      }.to output(/implicit named UNIQUE constraint/).to_stderr
+
+      expect(@conn.indexes(:test_compat_warn).map(&:name)).to include("uniq_v70")
+      expect(@conn.unique_constraints(:test_compat_warn).map(&:name)).to include("uniq_v70")
+    end
+  end
+
+  describe "explicit global flag overrides Migration[8.2] default" do
+    around(:each) do |example|
+      adapter = ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter
+      previous = adapter.add_index_unique_creates_constraint
+      example.run
+    ensure
+      adapter.add_index_unique_creates_constraint = previous
+    end
+
+    it "creates the implicit constraint when the flag is true even under Migration[8.2]" do
+      ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.add_index_unique_creates_constraint = true
+
+      expect {
+        run_migration(ActiveRecord::Migration[8.2]) do
+          add_index :test_compat_warn, :first_name, unique: true, name: :uniq_flag_override
+        end
+      }.to output(/implicit named UNIQUE constraint/).to_stderr
+
+      expect(@conn.unique_constraints(:test_compat_warn).map(&:name)).to include("uniq_flag_override")
+    end
+  end
+end

--- a/spec/active_record/connection_adapters/oracle_enhanced/migration_compatibility_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/migration_compatibility_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe "OracleEnhanced::CompatibilityBehavior resolution" do
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @conn = ActiveRecord::Base.lease_connection
+  end
+
+  def oracle_behavior
+    ActiveRecord::ConnectionAdapters::OracleEnhanced::CompatibilityBehavior
+  end
+
+  it "resolves Migration[8.2] to V8_2" do
+    expect(@conn.compatibility_behavior_for(ActiveRecord::Migration[8.2])).to eq oracle_behavior::V8_2
+  end
+
+  it "resolves Migration[8.1] to V8_1" do
+    expect(@conn.compatibility_behavior_for(ActiveRecord::Migration[8.1])).to eq oracle_behavior::V8_1
+  end
+
+  it "resolves Migration[7.0] to V8_1, which covers its own version and older" do
+    expect(@conn.compatibility_behavior_for(ActiveRecord::Migration[7.0])).to eq oracle_behavior::V8_1
+  end
+
+  it "resolves an unversioned migration to the no-op base behavior" do
+    expect(@conn.compatibility_behavior_for(ActiveRecord::Migration)).to eq ActiveRecord::Migration::CompatibilityBehavior
+  end
+end

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -778,7 +778,7 @@ RSpec.describe "OracleEnhancedAdapter schema dump" do
 
     it "does not double-emit t.index unique: true for an index that backs a unique constraint" do
       schema_define do
-        add_index :test_sections, :position, unique: true, name: :uniq_via_idx
+        add_unique_constraint :test_sections, :position, name: :uniq_via_idx
       end
       output = dump_table_schema "test_sections"
       expect(output).not_to match(/t\.index .*"uniq_via_idx".*unique: true/)

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -1393,9 +1393,11 @@ end
       expect(@conn.index_exists?(:test_employees, :first_name)).to be(false)
     end
 
-    it "drops a unique index together with its implicit constraint" do
-      schema_define do
-        add_index :test_employees, :first_name, unique: true, name: :uniq_test_employees_first_name
+    it "drops both the index and the same-name implicit constraint when add_index unique: true created them (legacy implicit-constraint path)" do
+      with_implicit_unique_constraint_enabled do
+        schema_define do
+          add_index :test_employees, :first_name, unique: true, name: :uniq_test_employees_first_name
+        end
       end
 
       sqls = capture_sql do
@@ -1441,15 +1443,14 @@ end
       expect(drop_index).not_to be_nil
     end
 
-    it "skips DROP CONSTRAINT after the implicit constraint was manually dropped" do
+    it "skips DROP CONSTRAINT for a unique index without a backing constraint" do
       schema_define do
-        add_index :test_employees, :first_name, unique: true, name: :uniq_manual_drop
+        add_index :test_employees, :first_name, unique: true, name: :uniq_no_constraint
       end
-      @conn.execute "ALTER TABLE test_employees DROP CONSTRAINT uniq_manual_drop"
 
       sqls = capture_sql do
         schema_define do
-          remove_index :test_employees, name: :uniq_manual_drop
+          remove_index :test_employees, name: :uniq_no_constraint
         end
       end
 
@@ -2320,11 +2321,6 @@ end
     it "allows attaching a unique constraint to an existing index via :using_index" do
       schema_define do
         add_index :test_sections, :position, unique: true, name: :idx_existing_unique
-      end
-      # The trailing constraint added by add_index already shares the index name; drop it
-      # so we can re-attach a constraint with a different name pointing at the same index.
-      @conn.execute "ALTER TABLE test_sections DROP CONSTRAINT idx_existing_unique"
-      schema_define do
         add_unique_constraint :test_sections, name: "uniq_via_idx", using_index: :idx_existing_unique
       end
       uc = @conn.unique_constraints(:test_sections).detect { |u| u.name == "uniq_via_idx" }
@@ -2461,9 +2457,6 @@ end
     it "preserves divergent constraint and index names on round-trip" do
       schema_define do
         add_index :test_sections, :position, unique: true, name: :idx_div
-      end
-      @conn.execute "ALTER TABLE test_sections DROP CONSTRAINT idx_div"
-      schema_define do
         add_unique_constraint :test_sections, name: "uniq_div", using_index: :idx_div
       end
       uc = @conn.unique_constraints(:test_sections).detect { |u| u.name == "uniq_div" }
@@ -3194,9 +3187,11 @@ end
       expect(@would_execute_sql).not_to include("ADD CONSTRAINT")
     end
 
-    it "should add unique constraint only to the index where it was defined" do
-      schema_define do
-        add_index :keyboards, ["name"], unique: true, name: :this_index
+    it "should add unique constraint only to the index where it was defined (legacy implicit-constraint path)" do
+      with_implicit_unique_constraint_enabled do
+        schema_define do
+          add_index :keyboards, ["name"], unique: true, name: :this_index
+        end
       end
       # Match anywhere in the captured SQL rather than asserting on
       # `lines.last`. `schema_define` calls `ActiveRecord::Schema.define`,
@@ -3208,11 +3203,13 @@ end
       expect(@would_execute_sql).to match(/ALTER +TABLE .* ADD CONSTRAINT .* UNIQUE \(.*\) USING INDEX "THIS_INDEX";/)
     end
 
-    it "should emit CREATE UNIQUE INDEX and ADD CONSTRAINT for inline t.index unique: true" do
-      schema_define do
-        create_table :test_inline_index_posts, force: true do |t|
-          t.string :title
-          t.index :title, unique: true, name: :uniq_inline_title
+    it "should emit CREATE UNIQUE INDEX and ADD CONSTRAINT for inline t.index unique: true (legacy implicit-constraint path)" do
+      with_implicit_unique_constraint_enabled do
+        schema_define do
+          create_table :test_inline_index_posts, force: true do |t|
+            t.string :title
+            t.index :title, unique: true, name: :uniq_inline_title
+          end
         end
       end
       expect(@would_execute_sql).to match(/CREATE UNIQUE INDEX "UNIQ_INLINE_TITLE" ON "TEST_INLINE_INDEX_POSTS" \("TITLE"\)/)
@@ -3251,28 +3248,30 @@ end
       expect(@would_execute_sql).to match(/CREATE INDEX "IDX_INLINE_TITLE_TS" ON "TEST_INLINE_INDEX_POSTS" \("TITLE"\) TABLESPACE bogus/)
     end
 
-    it "produces the same SQL whether unique index is defined inline or via explicit add_index" do
-      schema_define do
-        create_table :test_explicit_idx_posts, force: true do |t|
-          t.string :title
+    it "produces the same SQL whether unique index is defined inline or via explicit add_index (legacy implicit-constraint path)" do
+      with_implicit_unique_constraint_enabled do
+        schema_define do
+          create_table :test_explicit_idx_posts, force: true do |t|
+            t.string :title
+          end
+          add_index :test_explicit_idx_posts, :title, unique: true, name: :uniq_title
         end
-        add_index :test_explicit_idx_posts, :title, unique: true, name: :uniq_title
-      end
-      explicit_sql = @would_execute_sql.dup
+        explicit_sql = @would_execute_sql.dup
 
-      @would_execute_sql.replace("")
-      schema_define do
-        drop_table :test_explicit_idx_posts, if_exists: true
-        create_table :test_explicit_idx_posts, force: true do |t|
-          t.string :title
-          t.index :title, unique: true, name: :uniq_title
+        @would_execute_sql.replace("")
+        schema_define do
+          drop_table :test_explicit_idx_posts, if_exists: true
+          create_table :test_explicit_idx_posts, force: true do |t|
+            t.string :title
+            t.index :title, unique: true, name: :uniq_title
+          end
         end
-      end
-      inline_sql = @would_execute_sql
+        inline_sql = @would_execute_sql
 
-      [/CREATE TABLE "TEST_EXPLICIT_IDX_POSTS"/, /CREATE UNIQUE INDEX "UNIQ_TITLE"/, /ALTER +TABLE "TEST_EXPLICIT_IDX_POSTS" ADD CONSTRAINT "UNIQ_TITLE" UNIQUE \("TITLE"\) USING INDEX "UNIQ_TITLE"/].each do |pattern|
-        expect(explicit_sql).to match(pattern)
-        expect(inline_sql).to match(pattern)
+        [/CREATE TABLE "TEST_EXPLICIT_IDX_POSTS"/, /CREATE UNIQUE INDEX "UNIQ_TITLE"/, /ALTER +TABLE "TEST_EXPLICIT_IDX_POSTS" ADD CONSTRAINT "UNIQ_TITLE" UNIQUE \("TITLE"\) USING INDEX "UNIQ_TITLE"/].each do |pattern|
+          expect(explicit_sql).to match(pattern)
+          expect(inline_sql).to match(pattern)
+        end
       end
     end
   end

--- a/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/structure_dump_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe "OracleEnhancedAdapter structure dump" do
     it "appends NOVALIDATE for foreign keys added with validate: false" do
       schema_define do
         add_column :test_posts, :foo_uniq, :integer
-        add_index :test_posts, :foo_uniq, unique: true, name: "ix_test_posts_foo_uniq"
+        add_unique_constraint :test_posts, :foo_uniq, name: "ix_test_posts_foo_uniq"
         add_foreign_key :test_posts, :test_posts, column: :foo_id, primary_key: :foo_uniq, name: "fk_novalidate_baz", validate: false
       end
       dump = ActiveRecord::Base.lease_connection.structure_dump

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -147,6 +147,21 @@ module SchemaSpecHelper
   end
 end
 
+# Wraps a block with the Phase 1 / pre-Phase 2 implicit-constraint
+# behavior of `add_index :col, unique: true`. Use this only in specs that
+# explicitly exercise the legacy implicit-constraint code path (#2702
+# Phase 3 will delete both this helper and the global flag together).
+module ImplicitUniqueConstraintHelper
+  def with_implicit_unique_constraint_enabled
+    adapter = ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter
+    previous = adapter.add_index_unique_creates_constraint
+    adapter.add_index_unique_creates_constraint = true
+    yield
+  ensure
+    adapter.add_index_unique_creates_constraint = previous
+  end
+end
+
 module SchemaDumpingHelper
   def dump_table_schema(table, connection = ActiveRecord::Base.lease_connection)
     old_ignore_tables = ActiveRecord.schema_ignored_tables
@@ -277,6 +292,8 @@ RSpec.configure do |config|
   config.disable_monkey_patching!
   config.order = :random
   Kernel.srand config.seed
+
+  config.include ImplicitUniqueConstraintHelper
 
   # In CI, fail any example that lets a DEPRECATION WARNING leak to
   # stderr — i.e. one that triggered a deprecation but did not consume


### PR DESCRIPTION
Phase 2 of the implicit-UNIQUE-CONSTRAINT deprecation (#2702), built on the `Migration::CompatibilityBehavior` extension point (rails/rails#58162). Supersedes #2814 and #2710.

## Status (2026-09-03)

* Rebased onto current master (after #2852 restored the JRuby rows and moved the pin to rails/rails@74bb87c5), on top of #2823's rebased commit; the branch content is unchanged.
* rails/rails#58162 is open and rebased onto current rails main.
* Full spec suite green locally against Oracle Free (1138 examples, 0 failures); CI green.

## Behavior

`Migration[8.2]` and later treat `add_index :col, unique: true` as "create only the unique index" — matching Rails-core PostgreSQL/MySQL/SQLite. `Migration[8.1]` and earlier keep the pre-8.2 behavior of also creating a same-named UNIQUE CONSTRAINT, so existing migrations replay unchanged. Callers that need a constraint on Migration[8.2]+ should call `add_unique_constraint :t, :col, name: :n` directly.

## Implementation

* `OracleEnhanced::CompatibilityBehavior::V8_1` sets an internal `_implicit_unique_constraint: true` flag in `create_table`, `add_index`, `create_join_table`, and — inside the reference's index options — `add_reference`/`add_belongs_to`. The adapter consumes and deletes the flag before further processing (including `remove_index`/`drop_table`, which receive it through CommandRecorder inversions on `migrate :down`), so it never reaches DDL emission (an options flag rather than a thread-local: migrations are single-threaded).
* New `implicit_unique_constraint_active?` adapter helper ORs the global `add_index_unique_creates_constraint` flag with the per-call `_implicit_unique_constraint` flag.
* `OracleEnhancedAdapter.add_index_unique_creates_constraint` default flips from `true` to `false`. The flag remains as an explicit opt-in for projects that want the pre-8.2 behavior project-wide.
* Specs that exercise the pre-8.2 path use `with_implicit_unique_constraint_enabled` in `spec_helper.rb`, which toggles the global flag around a block.
* `migration_compatibility_spec.rb` gains a second top-level describe block covering `add_index`, inline `t.index` in `create_table`/`change_table`/`create_join_table`, `add_reference`/`t.references` with unique indexes, and a `migrate :down` cycle — each under both Migration[8.2] (no implicit constraint, no warning) and Migration[8.1] (implicit constraint + deprecation warning) — plus a Migration[7.0] case and an explicit-flag override case.

## Tests

`migration_compatibility_spec.rb` (behavior resolution + unique-constraint version matrix), `schema_dumper_spec.rb`, `schema_statements_spec.rb`, `structure_dump_spec.rb`, and `dbms_metadata_structure_dump_spec.rb`; CI runs the suite against Oracle.

## Depends on

* **#2823: Add CompatibilityBehavior plumbing for per-adapter migration compatibility** — merge that first; its commit is the first of the two commits in this PR's diff.
* rails/rails#58162, which introduces `compatibility_behavior_for` and `Migration::CompatibilityBehavior` (head: `yahonda/rails` branch `per-adapter-migration-compatibility-v7`). #2823's commit points the Gemfile at that branch.

Independent of #2816: after #2823, either PR can merge first; whichever merges second needs a trivial rebase (both touch `V8_1#create_table` and append to `migration_compatibility_spec.rb`).


## Review follow-up: `change_table` inline index coverage

A fresh review found that `change_table { |t| t.index :col, unique: true }` dispatches through `Table#index`, which called the connection's `add_index` directly and bypassed `CompatibilityBehavior::V8_1#add_index`. Under `Migration[8.1]` this dropped the implicit UNIQUE constraint for the `change_table` path only, so older migrations using inline unique indexes inside `change_table` would not replay unchanged.

The fix keeps this adapter-specific routing in the adapter: `V8_1` carries a nested `TableDefinition` module that the `yahonda/rails` `per-adapter-migration-compatibility-v7` branch's `compatible_table_definition` prepends generically onto the table object yielded by `create_table`/`change_table`. The framework stays free of any index-specific or adapter-only routing (it carries no per-adapter accessor either). The module injects the per-call flag only on the immediate-execution `change_table` receiver — the `create_table` path is covered by the table-level flag, and Rails validates per-index option keys during table creation. Any other `t.<method>` can be customized the same way if future version compatibility requires it.

This PR adds the matching coverage in `migration_compatibility_spec.rb`: `change_table { t.index unique: true }` under `Migration[8.2]` (index only, no warning) and `Migration[8.1]` (implicit constraint + deprecation warning), plus a `Migration[7.0]` `add_index` case confirming pre-8.1 versions resolve to the V8_1 behavior and keep the implicit constraint. The `Migration[8.1]` `change_table` case exercises the framework's `compatible_table_definition` prepending the `V8_1::TableDefinition` module.

## Review follow-up (2026-07-02, second pass)

A second review pass added the following, since folded into the single commit:

* **`add_reference index: { unique: true }` (and `t.references` inside `change_table`) was not version-aware.** The reference path builds a fresh `OracleEnhanced::Table` that never went through `compatible_table_definition`, so under `Migration[8.1]` the implicit constraint was silently dropped — no deprecation warning either — and a later `add_foreign_key` targeting that column would fail with ORA-02270. `V8_1#add_reference` (+ `add_belongs_to`) now injects the flag into the reference's index options, and the `V8_1::TableDefinition` module covers `t.references`/`t.belongs_to` inside `change_table` like `t.index`. `create_join_table` (which calls the connection's `create_table` internally, bypassing `V8_1#create_table`) is covered as well. Specs cover these paths under 8.2 and 8.1.
* **The deprecation message was rewritten for Phase 2.** After the flip the global flag already defaults to `false`, so the old "set the flag to false" advice silenced nothing in the main path that still warns (the V8_1 per-call flag). The message now states the trigger — the migration's declared version, or the global flag — and leads with the version-based remediation, keeping the `add_unique_constraint` guidance.
* **`migrate :down` flag hygiene + a vacuous spec.** CommandRecorder straight reversions replayed `remove_index`/`drop_table` with `_implicit_unique_constraint` still set; both methods now delete it at entry, with a spec pinning the up/down cycle. The dbms_metadata structure-dump round-trip spec had also become vacuous after the flip (no backing constraint was created any more); it now uses `with_implicit_unique_constraint_enabled` like its sibling.




