### PR TITLE
Pass the name: keyword to Arel::Table.new in specs

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/build_subselect_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/build_subselect_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Arel::Visitors::OracleCommon#build_subselect" do
 
   before(:each) do
     @visitor = Arel::Visitors::Oracle12.new(ActiveRecord::Base.connection)
-    @table = Arel::Table.new(:users)
+    @table = Arel::Table.new(name: :users)
   end
 
   def build_delete(orders: [], limit: nil, offset: nil, wheres: [])

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/homogeneous_in_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/homogeneous_in_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Arel::Visitors::OracleCommon#visit_Arel_Nodes_HomogeneousIn" do
   before(:each) do
     @visitor = Arel::Visitors::Oracle12.new(ActiveRecord::Base.connection)
     type_caster = Class.new { def type_for_attribute(_name) = ActiveRecord::Type::Value.new }.new
-    @table = Arel::Table.new(:users, type_caster: type_caster)
+    @table = Arel::Table.new(name: :users, type_caster: type_caster)
   end
 
   def compile(node, visitor: @visitor)

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/matches_idempotency_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/matches_idempotency_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Arel::Visitors::OracleCommon#visit_Arel_Nodes_Matches preserves 
 
   before(:each) do
     @visitor = Arel::Visitors::Oracle12.new(ActiveRecord::Base.connection)
-    @table = Arel::Table.new(:users)
+    @table = Arel::Table.new(name: :users)
   end
 
   def compile(node, visitor: @visitor)

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle12_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle12_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Arel::Visitors::Oracle12" do
 
   before(:each) do
     @visitor = Arel::Visitors::Oracle12.new(ActiveRecord::Base.connection)
-    @table = Arel::Table.new(:users)
+    @table = Arel::Table.new(name: :users)
   end
 
   def compile(node)

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle_common_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle_common_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Arel::Visitors::OracleCommon" do
 
   before(:each) do
     @visitor = Arel::Visitors::Oracle12.new(ActiveRecord::Base.connection)
-    @table = Arel::Table.new(:test_oracle_common_lobs)
+    @table = Arel::Table.new(name: :test_oracle_common_lobs)
   end
 
   def compile(node)
@@ -51,7 +51,7 @@ RSpec.describe "Arel::Visitors::OracleCommon" do
     end
 
     it "falls through to plain `=` when the table is not in the schema cache" do
-      unknown_table = Arel::Table.new(:test_oracle_common_no_such_table)
+      unknown_table = Arel::Table.new(name: :test_oracle_common_no_such_table)
       node = Arel::Nodes::Equality.new(unknown_table[:any], Arel::Nodes::Casted.new("x", unknown_table[:any]))
       expect(compile(node)).not_to match(/DBMS_LOB/)
     end

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/oracle_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Arel::Visitors::Oracle" do
 
   before(:each) do
     @visitor = Arel::Visitors::Oracle.new(ActiveRecord::Base.connection)
-    @table = Arel::Table.new(:users)
+    @table = Arel::Table.new(name: :users)
   end
 
   def compile(node)

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/order_hacks_idempotency_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/order_hacks_idempotency_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Arel::Visitors::OracleCommon#order_hacks preserves the input Sel
 
   before(:each) do
     @visitor = Arel::Visitors::Oracle.new(ActiveRecord::Base.connection)
-    @table = Arel::Table.new(:users)
+    @table = Arel::Table.new(name: :users)
   end
 
   def compile(node, visitor: @visitor)

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/update_statement_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/update_statement_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Arel::Visitors::OracleCommon#visit_Arel_Nodes_UpdateStatement" d
 
   before(:each) do
     @visitor = Arel::Visitors::Oracle12.new(ActiveRecord::Base.connection)
-    @table = Arel::Table.new(:users)
+    @table = Arel::Table.new(name: :users)
   end
 
   def compile(node, visitor: @visitor)

--- a/spec/active_record/connection_adapters/oracle_enhanced/arel/value_before_type_cast_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/arel/value_before_type_cast_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Arel::Visitors::Oracle literal limit/offset via value_before_typ
 
   before(:each) do
     @visitor = Arel::Visitors::Oracle.new(ActiveRecord::Base.connection)
-    @table = Arel::Table.new(:users)
+    @table = Arel::Table.new(name: :users)
   end
 
   def compile(node)

--- a/spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/columns_for_distinct_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "OracleEnhancedAdapter#columns_for_distinct" do
   end
 
   it "strips DESC NULLS LAST from an Arel ordering node" do
-    order_node = Arel::Table.new(:posts)[:created_at].desc.nulls_last
+    order_node = Arel::Table.new(name: :posts)[:created_at].desc.nulls_last
     sql = @conn.columns_for_distinct(["posts.id"], [order_node])
     expect(sql).to match(/FIRST_VALUE\("POSTS"\."CREATED_AT"\)/i)
     expect(sql).not_to match(/\bDESC\b/i)
@@ -80,7 +80,7 @@ RSpec.describe "OracleEnhancedAdapter#columns_for_distinct" do
     end
 
     it "preserves DESC NULLS LAST in the outer ORDER BY for an Arel ordering node" do
-      order_node = Arel::Table.new(:posts)[:created_at].desc.nulls_last
+      order_node = Arel::Table.new(name: :posts)[:created_at].desc.nulls_last
       sql = compile_distinct_order(["posts.id"], order_node)
       expect(sql).to include("ORDER BY alias_0__ DESC NULLS LAST")
     end


### PR DESCRIPTION
rails/rails#57829 (merged 2026-06-24) refactored `Arel::Table.new` to take the table name as a `name:` keyword argument instead of a positional one:

```ruby
def initialize(name: nil, as: nil, klass: nil, type_caster: klass&.type_caster)
```

The Gemfile already targets rails/rails `main`, so the existing `Arel::Table.new(:users)` spec setups now raise `ArgumentError: wrong number of arguments (given 1, expected 0)`, and the Arel / `columns_for_distinct` specs fail on every Ruby (CRuby and JRuby).

This passes the table name as `name:` in the affected specs.

## On equivalent tests

rails/rails#57829 itself added no new tests — every test change in it is a balanced, mechanical migration of `Arel::Table.new(...)` call sites (lib + all Arel test cases) to the `name:` keyword. This change is the Oracle adapter's equivalent migration for its own Arel specs; there is no new behavior in rails/rails#57829 that would warrant additional test cases here.
