### PR TITLE
Skip rdoc on JRuby to avoid the rbs native extension

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,12 +6,12 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 group :development do
   gem "rspec"
-  gem "rdoc"
   gem "rake"
   gem "activerecord",   github: "rails/rails", branch: "main"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do
+    gem "rdoc"
     gem "ruby-oci8",    github: "kubo/ruby-oci8"
     gem "debug", require: false
   end


### PR DESCRIPTION
## Symptom

Every JRuby CI job (`build (jruby-10.1.0.0)`) fails at `bundle install`:

```
Installing rbs 4.0.3 with native extensions
/home/runner/.rubies/jruby-10.1.0.0/bin/jruby extconf.rb
*** extconf.rb failed
An error occurred while installing rbs (4.0.3), and Bundler cannot continue.
  rdoc was resolved to 8.0.0, which depends on rbs
```

## Cause

rdoc 8.0.0 (released 2026-06-26) added a runtime dependency on `rbs (>= 4.0.0)`. rbs 4.x ships a C extension and currently has no stable JRuby (java-platform) gem — only `rbs 4.1.0.pre.2` is published for `java` — so Bundler resolves `rbs 4.0.3` (ruby platform) on JRuby and its native-extension build fails.

This is **not** a Java/JRuby version problem: `ruby/setup-ruby` already handles the JRuby 10.1.0.0 Java requirement and falls back to Java 21 on its own:

```
attempting to run with existing JAVA_HOME → temurin-17 → UnsupportedClassVersionError
JRuby failed to start, try Java 21 envs
Setting JAVA_HOME to JAVA_HOME_21_X64 path /usr/lib/jvm/temurin-21-jdk-amd64
```

The runner OS is unchanged (ubuntu-24.04). The only change is rdoc 8.0.0 landing two days ago, which the unpinned `gem "rdoc"` picked up.

## Fix

rdoc is only used for documentation generation, which the JRuby jobs don't run, so move it into the existing `platforms :ruby` block alongside `ruby-oci8` (the other native-extension, MRI-only gem). The CRuby jobs keep rdoc 8.0.0 (where rbs builds normally); JRuby skips rdoc and therefore rbs.
