### PR TITLE
Use the rbs java-platform gem on JRuby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ group :development do
   end
 
   platforms :jruby do
+    gem "rbs", ">= 4.1.0.pre.2" # Use the java-platform gem so JRuby does not build the C extension
     gem "pry"
     gem "pry-nav"
   end


### PR DESCRIPTION
Alternative to #2819 (keeps `gem "rdoc"` where it is; adds one JRuby-only line instead of moving rdoc).

## Symptom

Every JRuby CI job fails at `bundle install`:

```
Installing rbs 4.0.3 with native extensions
/home/runner/.rubies/jruby-10.1.0.0/bin/jruby extconf.rb
*** extconf.rb failed
An error occurred while installing rbs (4.0.3), and Bundler cannot continue.
  rdoc was resolved to 8.0.0, which depends on rbs
```

## Cause

rdoc 8.0.0 added a runtime dependency on `rbs (>= 4.0.0)`. Stable rbs 4.0.x ships only the C-extension (ruby platform) gem, and its `extconf.rb` has no flag/env to skip the native build, so JRuby cannot compile it.

(Not a Java-version issue — `ruby/setup-ruby` already falls back to Java 21 for JRuby 10.1.0.0 on its own.)

## Fix

rbs publishes a java-platform gem (no C extension) starting with `4.1.0.pre.2`, so require `rbs ">= 4.1.0.pre.2"` on JRuby only. Bundler then resolves the java gem there and builds no native extension. CRuby keeps resolving the stable rbs (4.0.x via rdoc) and is unaffected.

This is a temporary CI workaround; it can be reverted by deleting the single added line once rbs ships a stable java-platform gem.
