### PR TITLE
Set up Java 21 explicitly for the JRuby CI jobs

### DIFF
--- a/.github/workflows/jruby_head.yml
+++ b/.github/workflows/jruby_head.yml
@@ -36,6 +36,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,12 @@ jobs:
           --health-retries 10
     steps:
       - uses: actions/checkout@v7
+      - name: Set up Java
+        if: startsWith(matrix.ruby, 'jruby')
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -56,6 +56,12 @@ jobs:
           --health-retries 10
     steps:
       - uses: actions/checkout@v7
+      - name: Set up Java
+        if: startsWith(matrix.ruby, 'jruby')
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/test_11g_ojdbc11.yml
+++ b/.github/workflows/test_11g_ojdbc11.yml
@@ -43,6 +43,12 @@ jobs:
           --health-retries 10
     steps:
       - uses: actions/checkout@v7
+      - name: Set up Java
+        if: startsWith(matrix.ruby, 'jruby')
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/test_prepared_statements_false.yml
+++ b/.github/workflows/test_prepared_statements_false.yml
@@ -44,6 +44,12 @@ jobs:
           --health-retries 10
     steps:
       - uses: actions/checkout@v7
+      - name: Set up Java
+        if: startsWith(matrix.ruby, 'jruby')
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
## What

Add an explicit `actions/setup-java@v4` (Temurin 21) step before `ruby/setup-ruby` on every JRuby job: `test`, `test_11g`, `test_11g_ojdbc11`, `test_prepared_statements_false`, `jruby_head`, and the `build-jruby` job in `release`.

## Why

JRuby 10.1.0.0 is built for Java 21 (class file version 65). CI already passes, because `ruby/setup-ruby` retries under Java 21 on its own — but only after the default Java 17 fails to launch JRuby, which logs an `UnsupportedClassVersionError` on every JRuby job:

```
.../temurin-17-jdk-amd64/bin/java -jar .../jruby.jar --version
Error: ... UnsupportedClassVersionError: org/jruby/main/Main ... class file
version 65.0, this version of the Java Runtime only recognizes class file
versions up to 61.0
JRuby failed to start, try Java 21 envs
Setting JAVA_HOME to JAVA_HOME_21_X64 ...
```

Setting up Java 21 first makes JRuby launch under a compatible JVM directly, removing the failed probe from the logs and making the Java version deterministic rather than relying on setup-ruby's fallback.

The matrix jobs guard the step with `if: startsWith(matrix.ruby, 'jruby')`, so the CRuby jobs are unaffected. `jruby_head` and `release`'s `build-jruby` are JRuby-only, so the step is unconditional there.
