### PR TITLE
Add CompatibilityBehavior plumbing for per-adapter migration compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 group :development do
   gem "rspec"
   gem "rake"
-  # rails/rails@74bb87c5 = merge of rails/rails#58684 (load Active Support on
-  # JRuby without Ractor); bump per follow-up Rails change
-  gem "activerecord",   github: "rails/rails", ref: "74bb87c5888b3489fc519f048e6a0cd9cc615a5d"
+  gem "activerecord",   github: "yahonda/rails", branch: "per-adapter-migration-compatibility-v7"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do

--- a/lib/active_record/connection_adapters/oracle_enhanced/compatibility_behavior.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/compatibility_behavior.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module OracleEnhanced
+      module CompatibilityBehavior # :nodoc: all
+        Base = ActiveRecord::Migration::CompatibilityBehavior
+        extend Base::Resolver
+
+        # A behavior applies to migrations declaring its own version and older:
+        # Migration[8.2]+ resolves to V8_2, Migration[8.1] and earlier to V8_1.
+        class V8_2 < Base; end
+        class V8_1 < V8_2; end
+      end
+    end
+  end
+end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "openssl"
+require "active_record/connection_adapters/oracle_enhanced/compatibility_behavior"
 
 module ActiveRecord
   module ConnectionAdapters
@@ -9,6 +10,10 @@ module ActiveRecord
         # SCHEMA STATEMENTS ========================================
         #
         # see: abstract/schema_statements.rb
+
+        def compatibility_behavior_for(migration_class) # :nodoc:
+          OracleEnhanced::CompatibilityBehavior.for(migration_class)
+        end
 
         def tables # :nodoc:
           select_values(<<~SQL.squish, "SCHEMA")

--- a/spec/active_record/connection_adapters/oracle_enhanced/migration_compatibility_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/migration_compatibility_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe "OracleEnhanced::CompatibilityBehavior resolution" do
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @conn = ActiveRecord::Base.lease_connection
+  end
+
+  def oracle_behavior
+    ActiveRecord::ConnectionAdapters::OracleEnhanced::CompatibilityBehavior
+  end
+
+  it "resolves Migration[8.2] to V8_2" do
+    expect(@conn.compatibility_behavior_for(ActiveRecord::Migration[8.2])).to eq oracle_behavior::V8_2
+  end
+
+  it "resolves Migration[8.1] to V8_1" do
+    expect(@conn.compatibility_behavior_for(ActiveRecord::Migration[8.1])).to eq oracle_behavior::V8_1
+  end
+
+  it "resolves Migration[7.0] to V8_1, which covers its own version and older" do
+    expect(@conn.compatibility_behavior_for(ActiveRecord::Migration[7.0])).to eq oracle_behavior::V8_1
+  end
+
+  it "resolves an unversioned migration to the no-op base behavior" do
+    expect(@conn.compatibility_behavior_for(ActiveRecord::Migration)).to eq ActiveRecord::Migration::CompatibilityBehavior
+  end
+end


### PR DESCRIPTION
Plumbing for Rails' per-adapter migration compatibility extension point (`compatibility_behavior_for` / `ActiveRecord::Migration::CompatibilityBehavior`, introduced by rails/rails#58162, tracked on `yahonda/rails` branch `per-adapter-migration-compatibility-v7`). **No behavior change** — this PR only gives Oracle-specific per-version migration behavior a place to live.

## Status (2026-09-03)

* The framework side is open as rails/rails#58162, rebased onto current rails main.
* This branch is rebased onto current master (after #2852 restored the JRuby rows and moved the pin to rails/rails@74bb87c5); the Gemfile conflict against the moving `activerecord` pin was resolved by keeping the branch pointer.
* Full spec suite green locally against Oracle Free (1125 examples, 0 failures); CI green.

## Implementation

* New `OracleEnhanced::CompatibilityBehavior` namespace (`extend ActiveRecord::Migration::CompatibilityBehavior::Resolver`), returned by the adapter's `compatibility_behavior_for(migration_class)` override. The Resolver maps a migration's declared `ActiveRecord::Migration[x.y]` version to the lowest defined behavior version covering it: `Migration[8.2]` and later resolve to `V8_2`, `Migration[8.1]` and earlier to `V8_1`, and an unversioned migration to the framework's no-op base.
* `V8_2` and `V8_1` are empty skeletons, so every operation runs exactly as before. The version-specific adjustments land in the two PRs built on this one — either can merge first once this PR lands:
  * #2816 — identity primary keys by default in `Migration[8.2]+`
  * #2817 — Phase 2 of the implicit-UNIQUE-CONSTRAINT deprecation

## Tests

`migration_compatibility_spec.rb` pins the version → behavior resolution: `Migration[8.2]` → `V8_2`; `Migration[8.1]` and `Migration[7.0]` → `V8_1`; an unversioned migration → the no-op base.

## Depends on

* rails/rails#58162, which introduces `compatibility_behavior_for` and `Migration::CompatibilityBehavior` (head: `yahonda/rails` branch `per-adapter-migration-compatibility-v7`). The Gemfile points at that branch until it lands.


