### PR TITLE
Bump JRuby to 10.1.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 'jruby-10.1.0.0'
+          ruby-version: 'jruby-10.1.1.0'
           rubygems: latest
       - name: Build gem
         run: gem build activerecord-oracle_enhanced-adapter.gemspec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,10 @@ jobs:
           '4.0',
           '3.4',
           '3.3',
-          'jruby-10.1.0.0',
+          'jruby-10.1.1.0',
         ]
         include:
-          - ruby: 'jruby-10.1.0.0'
+          - ruby: 'jruby-10.1.1.0'
             jruby_opts: '--dev'
     env:
       CI: true

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -22,10 +22,10 @@ jobs:
           '4.0',
           '3.4',
           '3.3',
-          'jruby-10.1.0.0',
+          'jruby-10.1.1.0',
         ]
         include:
-          - ruby: 'jruby-10.1.0.0'
+          - ruby: 'jruby-10.1.1.0'
             jruby_opts: '--dev'
     env:
       CI: true

--- a/.github/workflows/test_11g_ojdbc11.yml
+++ b/.github/workflows/test_11g_ojdbc11.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [
-          'jruby-10.1.0.0',
+          'jruby-10.1.1.0',
         ]
     env:
       CI: true

--- a/.github/workflows/test_prepared_statements_false.yml
+++ b/.github/workflows/test_prepared_statements_false.yml
@@ -12,10 +12,10 @@ jobs:
       matrix:
         ruby: [
           '4.0',
-          'jruby-10.1.0.0',
+          'jruby-10.1.1.0',
         ]
         include:
-          - ruby: 'jruby-10.1.0.0'
+          - ruby: 'jruby-10.1.1.0'
             jruby_opts: '--dev'
     env:
       CI: true


### PR DESCRIPTION
This PR bumps the JRuby version used in CI (and the release workflow) from 10.1.0.0 to 10.1.1.0.

JRuby 10.1.1.0 was released on 2026-07-22: https://www.jruby.org/2026/07/22/jruby-10-1-1-0.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)