### PR TITLE
Align INSERT plumbing with Rails main's returning-based reshape

### DIFF
--- a/.github/workflows/ruby_head.yml
+++ b/.github/workflows/ruby_head.yml
@@ -93,6 +93,8 @@ jobs:
         run: |
           bundle exec rspec
       - name: Run bug report templates
+        env:
+          ORACLE_ENHANCED_PATH: ${{ github.workspace }}
         run: |
           cd guides/bug_report_templates
           ruby active_record_gem.rb

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,6 +112,8 @@ jobs:
         run: |
           bundle exec rspec
       - name: Run bug report templates
+        env:
+          ORACLE_ENHANCED_PATH: ${{ github.workspace }}
         run: |
           cd guides/bug_report_templates
           ruby active_record_gem.rb

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -114,6 +114,8 @@ jobs:
         run: |
           bundle exec rspec
       - name: Run bug report templates
+        env:
+          ORACLE_ENHANCED_PATH: ${{ github.workspace }}
         run: |
           cd guides/bug_report_templates
           ruby active_record_gem.rb

--- a/.github/workflows/test_11g_ojdbc11.yml
+++ b/.github/workflows/test_11g_ojdbc11.yml
@@ -100,6 +100,8 @@ jobs:
         run: |
           bundle exec rspec
       - name: Run bug report templates
+        env:
+          ORACLE_ENHANCED_PATH: ${{ github.workspace }}
         run: |
           cd guides/bug_report_templates
           ruby active_record_gem.rb

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 group :development do
   gem "rspec"
   gem "rake"
-  gem "activerecord",   github: "rails/rails", branch: "main"
+  # rails/rails@9b63a64d = merge of rails/rails#58296, the last of the INSERT
+  # reshape PRs this adapter version tracks; bump per follow-up Rails change
+  gem "activerecord",   github: "rails/rails", ref: "9b63a64daa9482111f583c37d1cdb39b0b37bb4a"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do

--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -8,7 +8,12 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   gem "activerecord", github: "rails/rails", branch: "main"
-  gem "activerecord-oracle_enhanced-adapter",  github: "rsim/oracle-enhanced", branch: "master"
+  # CI sets ORACLE_ENHANCED_PATH to run the template against the checkout under test
+  if ENV["ORACLE_ENHANCED_PATH"]
+    gem "activerecord-oracle_enhanced-adapter", path: ENV["ORACLE_ENHANCED_PATH"]
+  else
+    gem "activerecord-oracle_enhanced-adapter", github: "rsim/oracle-enhanced", branch: "master"
+  end
   gem "minitest"
 
   platforms :ruby do

--- a/guides/bug_report_templates/active_record_gem_spec.rb
+++ b/guides/bug_report_templates/active_record_gem_spec.rb
@@ -8,7 +8,12 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   gem "activerecord", github: "rails/rails", branch: "main"
-  gem "activerecord-oracle_enhanced-adapter",  github: "rsim/oracle-enhanced", branch: "master"
+  # CI sets ORACLE_ENHANCED_PATH to run the template against the checkout under test
+  if ENV["ORACLE_ENHANCED_PATH"]
+    gem "activerecord-oracle_enhanced-adapter", path: ENV["ORACLE_ENHANCED_PATH"]
+  else
+    gem "activerecord-oracle_enhanced-adapter", github: "rsim/oracle-enhanced", branch: "master"
+  end
   gem "rspec", require: "rspec/autorun"
 
   platforms :ruby do

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -44,15 +44,11 @@ module ActiveRecord
           # https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/EXPLAIN-PLAN.html#GUID-FD540872-4ED3-4936-96A2-362539931BA0
         end
 
-        def insert(arel, name = nil, pk = nil, id_value = nil, sequence_name = nil, binds = [], returning: nil)
-          pk = nil if id_value
-          Array(super || id_value)
-        end
-
-        def _exec_insert(intent, pk = nil, sequence_name = nil, returning: nil) # :nodoc:
+        def _exec_insert(intent, sequence_name = nil, returning: nil) # :nodoc:
           raw_sql = intent.raw_sql
           original_binds_count = intent.binds.size
-          sql, binds = sql_for_insert(raw_sql, pk, intent.binds, returning)
+          requested_cols = requested_returning_columns(raw_sql, returning)
+          sql, binds = sql_for_insert(raw_sql, intent.binds, returning)
           intent.raw_sql = sql
           intent.binds = binds
 
@@ -89,12 +85,24 @@ module ActiveRecord
               end
 
               rows = []
-              unless bind_specs.empty?
-                values = bind_specs.map do |position, klass|
+              unless requested_cols.empty?
+                returned = {}
+                bind_specs.each do |position, klass|
                   value = cursor.get_returning_param(position, klass)
-                  klass == Integer ? value.to_i : value
+                  col = binds[position - 1].name.delete_prefix("returning_")
+                  returned[col] = klass == Integer ? value.to_i : value
                 end
-                rows << values
+                # Align the row with the requested columns, echoing bound values
+                # for columns the INSERT already carries (e.g. the prefetched sequence PK).
+                row = requested_cols.map do |col|
+                  if returned.key?(col)
+                    returned[col]
+                  else
+                    index = binds[0...original_binds_count].index { |bind| bind.name == col }
+                    index && type_casted_binds[index]
+                  end
+                end
+                rows << row unless row.all?(&:nil?)
               end
               cursor.close unless cached
               build_result(columns: [], rows: rows)
@@ -280,14 +288,11 @@ module ActiveRecord
             result[:affected_rows_count]
           end
 
-          def sql_for_insert(sql, pk, binds, returning) # :nodoc:
+          def sql_for_insert(sql, binds, returning) # :nodoc:
             table_ref = extract_table_ref_from_insert_sql(sql)
-            # Mirror AbstractAdapter#sql_for_insert: when caller passes pk: nil,
-            # infer the primary key from the SQL via the schema cache so that
-            # generic `connection.exec_insert(sql, name, binds)` callers also
-            # benefit from RETURNING auto-fetch.
-            pk = schema_cache.primary_keys(table_ref) if pk.nil? && table_ref
-            cols = columns_for_returning_clause(sql, pk, binds, returning)
+            # Skip RETURNING only for columns `_exec_insert` can echo from binds;
+            # literal-carried values (unprepared statements, DEFAULT) are fetched back via RETURNING.
+            cols = requested_returning_columns(sql, returning).reject { |col| binds.any? { |bind| bind.name == col } }
             unless cols.empty?
               quoted_cols = cols.map { |c| quote_column_name(c) }.join(", ")
               placeholders = cols.map { |c| ":returning_#{c}" }.join(", ")
@@ -303,25 +308,14 @@ module ActiveRecord
             [sql, binds]
           end
 
-          def columns_for_returning_clause(sql, pk, binds, returning)
-            cols = if returning.is_a?(Array) && !returning.empty?
-              returning.map(&:to_s)
-            elsif pk.is_a?(Array)
-              pk.map(&:to_s)
-            elsif pk.is_a?(Symbol) || pk.is_a?(String)
-              [pk.to_s]
-            else
-              []
+          # Mirrors AbstractAdapter#sql_for_insert: infer the primary key from the
+          # SQL via the schema cache when the caller passes returning: nil.
+          def requested_returning_columns(sql, returning)
+            if returning.nil?
+              table_ref = extract_table_ref_from_insert_sql(sql)
+              returning = schema_cache.primary_keys(table_ref) if table_ref
             end
-            cols.reject do |col|
-              next true if binds.any? { |bind| bind.name == col }
-              # The all-defaults form (`VALUES (DEFAULT)` for single PK,
-              # `VALUES (DEFAULT, DEFAULT, ...)` for composite PK) needs RETURNING
-              # to read back the database-generated values, so do not let the
-              # column-list rejection below drop these columns from RETURNING.
-              next false if sql.match?(/VALUES\s*\(\s*DEFAULT(?:\s*,\s*DEFAULT)*\s*\)/i)
-              sql.include?(quote_column_name(col))
-            end
+            Array(returning).map(&:to_s)
           end
 
           # Identify the trailing binds appended by `sql_for_insert` by position, not by name,
@@ -332,10 +326,6 @@ module ActiveRecord
               klass = binds[i].type.is_a?(ActiveModel::Type::String) ? String : Integer
               [i + 1, klass]
             end
-          end
-
-          def returning_column_values(result)
-            result.rows.first
           end
 
           def perform_query(raw_connection, intent)

--- a/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/jdbc_connection.rb
@@ -387,9 +387,8 @@ module ActiveRecord
           def bind_returning_param(position, bind_type)
             @returning_positions ||= []
             @returning_positions << position
-            if bind_type == Integer
-              @raw_statement.registerReturnParameter(position, java.sql.Types::BIGINT)
-            end
+            java_type = bind_type == Integer ? java.sql.Types::BIGINT : java.sql.Types::VARCHAR
+            @raw_statement.registerReturnParameter(position, java_type)
           end
 
           def exec
@@ -450,8 +449,8 @@ module ActiveRecord
             rs = @raw_statement.getReturnResultSet
             if rs.next
               # Assuming that primary key will not be larger as long max value
-              returning_id = rs.getLong(rs_position)
-              rs.wasNull ? nil : returning_id
+              value = type == Integer ? rs.getLong(rs_position) : rs.getString(rs_position)
+              rs.wasNull ? nil : value
             else
               nil
             end

--- a/spec/active_record/connection_adapters/oracle_enhanced/primary_key_trigger_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/primary_key_trigger_spec.rb
@@ -324,14 +324,14 @@ RSpec.describe "primary_key_trigger" do
     end
 
     it "returns the generated id from connection.insert" do
-      insert_id = Array(@conn.insert("INSERT INTO test_pk_triggers (name) VALUES ('alpha')", nil, "id")).first
+      insert_id = @conn.insert("INSERT INTO test_pk_triggers (name) VALUES ('alpha')", nil, returning: "id")
       expect(@conn.select_value("SELECT test_pk_triggers_seq.currval FROM dual")).to eq(insert_id)
     end
 
     it "does not raise NoMethodError for :returning_id Symbol when logging" do
       set_logger
       @conn.reconnect! unless @conn.active?
-      @conn.insert("INSERT INTO test_pk_triggers (name) VALUES ('alpha')", nil, "id")
+      @conn.insert("INSERT INTO test_pk_triggers (name) VALUES ('alpha')", nil, returning: "id")
       expect(@logger.output(:error)).not_to match(/Could not log .*NoMethodError.*returning_id/)
       clear_logger
     end

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -167,14 +167,14 @@ RSpec.describe "OracleEnhancedAdapter" do
       end
 
       # AbstractAdapter#sql_for_insert infers the primary key from the SQL when
-      # the caller passes pk: nil. Generic callers that go through this path
-      # without an explicit `pk` used to miss out on RETURNING auto-fetch on
-      # Oracle because the fallback was not mirrored locally; this spec locks
-      # in the parity introduced for issue #2732.
-      it "infers the primary key from the SQL when pk: nil (parity with AbstractAdapter)" do
+      # the caller passes returning: nil. Generic callers that go through this
+      # path without an explicit `returning` used to miss out on RETURNING
+      # auto-fetch on Oracle because the fallback was not mirrored locally;
+      # this spec locks in the parity introduced for issue #2732.
+      it "infers the primary key from the SQL when returning: nil (parity with AbstractAdapter)" do
         conn = ActiveRecord::Base.lease_connection
         insert_sql = "INSERT INTO #{conn.quote_table_name('test_returning_identity_items')} (#{conn.quote_column_name('name')}) VALUES ('direct-call')"
-        out_sql, out_binds = conn.send(:sql_for_insert, insert_sql, nil, [], nil)
+        out_sql, out_binds = conn.send(:sql_for_insert, insert_sql, [], nil)
         expect(out_sql).to match(/RETURNING\s+"ID"\s+INTO\s+:returning_id/i)
         expect(out_binds.last.name).to eq("returning_id")
       end


### PR DESCRIPTION
### Summary

Rails main reshaped the INSERT plumbing around `returning:` (rails/rails#58283, rails/rails#58285, rails/rails#58290, rails/rails#58296; discussion in rails/rails#58255): `_insert_record` no longer passes positional `pk` / `id_value` / `sequence_name` to `connection.insert`, the prefetched sequence primary key is resolved into the INSERT values, and the record learns its id exclusively through `returning_columns.zip(returning_values)`.

This broke oracle-enhanced against Rails main: the adapter skips `RETURNING` for columns whose values the INSERT already carries, and the `id_value` echo channel that used to bring the prefetched id back to the record is gone, so `Model.create!` on a sequence-backed table (the adapter default) returned a record with nil `id`:

```
1) OracleEnhancedAdapter supports_insert_returning? with a sequence-prefetched primary key
   returns the sequence-fetched primary key from Model.create!
   Failure/Error: expect(record.id).to be_a(Integer)
     expected nil to be a kind of Integer
```

The same breakage showed up in the "Run bug report templates" CI step (`undefined method 'id' for nil`, associations querying `"POST_ID" IS NULL`).

### Changes

- Remove the `insert` override. `Array(super || id_value)` served the pre-rails/rails#58285 contract; the abstract implementation now provides the documented per-shape return contract (single value for `nil`/String `returning`, Array for Array).
- Match the abstract `_exec_insert(intent, sequence_name = nil, returning: nil)` signature, keeping `ci/check_method_signatures.rb` green.
- Build the result row in requested-column order: values fetched via `RETURNING ... INTO :bind` are merged with echoed bind values for columns the INSERT already carries (the prefetched id), so the prefetch path keeps its no-RETURNING SQL shape while the id round-trips again.
- Skip `RETURNING` only for bind-carried (echoable) columns. Literal-carried values (unprepared statements mode, `VALUES (DEFAULT)`) are fetched back via `RETURNING`, which also replaces the `VALUES (DEFAULT)` regex special case.
- Normalize `returning` with `Array()`, supporting the single-String form added in rails/rails#58290 (previously it fell through and the call returned nil).
- Remove `returning_column_values`; identical to the abstract implementation since rails/rails#58283 because `supports_insert_returning?` is true.
- **JRuby: register and fetch String RETURNING parameters.** The JDBC connection registered return parameters only for Integer binds and read them back with `getLong` unconditionally, so a `RETURNING` clause on a VARCHAR2 column failed with ORA-17173. This surfaced here because `schema_migrations`' VARCHAR2 `version` primary key is inserted as a literal, and literal-carried columns are now fetched back via RETURNING. Register `VARCHAR` for non-Integer parameters and read with `getString` — this also makes RETURNING on String primary keys (trigger-backed tables) work on JRuby.
- Specs: replace positional-`pk` `connection.insert(sql, nil, "id")` calls with `returning: "id"`, ahead of the positional-argument deprecation proposed in rails/rails#58297.
- Bug report templates: CI now sets `ORACLE_ENHANCED_PATH` so the templates resolve the adapter from the checkout under test instead of always fetching master; standalone copy-paste usage is unchanged.
- Pin activerecord to rails/rails@9b63a64d (the merge commit of rails/rails#58296, the last of the reshape PRs handled here). Each follow-up Rails change gets its own PR that bumps the pin and adapts the adapter together — first up: rails/rails#58310 (`to_sql` binds deprecation).

### Verification

Against rails/rails@9b63a64d:

- MRI (Oracle Database Free 23ai, macOS): `bundle exec rspec` 1107 examples, 0 failures related to this change; RuboCop, `ci/check_method_signatures.rb`, `ci/check_method_visibility.rb` all clean
- JRuby 10.1.1.0 / OpenJDK 21 (Oracle Database Free 23ai, Ubuntu): full suite 1114 examples, 0 failures — reproduces ORA-17173 without the JDBC commit and passes with it
- Bug report templates green against this branch with `ORACLE_ENHANCED_PATH` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)
