### PR TITLE
Do not install rdoc on JRuby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,18 +6,17 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 group :development do
   gem "rspec"
-  gem "rdoc"
   gem "rake"
   gem "activerecord",   github: "rails/rails", branch: "main"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do
     gem "ruby-oci8",    github: "kubo/ruby-oci8"
+    gem "rdoc"
     gem "debug", require: false
   end
 
   platforms :jruby do
-    gem "rbs", ">= 4.1.0.pre.2" # Use the java-platform gem so JRuby does not build the C extension
     gem "pry"
     gem "pry-nav"
   end

--- a/Rakefile
+++ b/Rakefile
@@ -30,12 +30,17 @@ task spec: :clear
 
 task default: :spec
 
-require "rdoc/task"
-Rake::RDocTask.new do |rdoc|
-  version = File.exist?("VERSION") ? File.read("VERSION") : ""
+begin
+  require "rdoc/task"
+rescue LoadError
+  # The Gemfile bundles rdoc only on platforms :ruby; skip the RDoc task without it
+else
+  Rake::RDocTask.new do |rdoc|
+    version = File.exist?("VERSION") ? File.read("VERSION") : ""
 
-  rdoc.rdoc_dir = "doc"
-  rdoc.title = "activerecord-oracle_enhanced-adapter #{version}"
-  rdoc.rdoc_files.include("README*")
-  rdoc.rdoc_files.include("lib/**/*.rb")
+    rdoc.rdoc_dir = "doc"
+    rdoc.title = "activerecord-oracle_enhanced-adapter #{version}"
+    rdoc.rdoc_files.include("README*")
+    rdoc.rdoc_files.include("lib/**/*.rb")
+  end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -36,10 +36,10 @@ rescue LoadError
   # The Gemfile bundles rdoc only on platforms :ruby; skip the RDoc task without it
 else
   Rake::RDocTask.new do |rdoc|
-    version = File.exist?("VERSION") ? File.read("VERSION") : ""
+    spec = Bundler::GemHelper.gemspec
 
     rdoc.rdoc_dir = "doc"
-    rdoc.title = "activerecord-oracle_enhanced-adapter #{version}"
+    rdoc.title = "#{spec.name} #{spec.version}"
     rdoc.rdoc_files.include("README*")
     rdoc.rdoc_files.include("lib/**/*.rb")
   end


### PR DESCRIPTION
### Summary

The `build (jruby-10.1.1.0)` rows fail during `Bundle install` (first seen on the 2026-07-29 scheduled runs, also on PR #2825):

```
RuntimeError: there was an error installing 'ruby-maven (~> 3.9)' . please install it manually:
  #<RuntimeError: conflicting chdir during another chdir block>
```

Dependency chain: `rdoc` (development group) → `rbs (>= 4.0.0)` → on JRuby the rbs java-platform gem declares a jar dependency (`org.snakeyaml:snakeyaml-engine`). Installing it triggers jar-dependencies' post-install hook, which lazily installs `ruby-maven (~> 3.9)` through a nested `Gem::DependencyInstaller` inside one of Bundler's parallel install workers. The nested install runs RubyGems' rdoc documentation hook, whose `Dir.chdir` block collides with another worker's `chdir`. MRI only warns about conflicting chdir; JRuby raises (jruby/jruby#5649), aborting `bundle install`.

### Fix

rdoc is only used for the local documentation Rake task, so stop installing it on JRuby instead of working around the race:

- Move `gem "rdoc"` to `platforms :ruby`. JRuby then resolves neither rdoc nor rbs, so no jar vendoring happens and ruby-maven is never needed.
- Drop the `platforms :jruby` rbs pin (`>= 4.1.0.pre.2`) that was added to avoid rbs's C-extension build — rbs is no longer installed on JRuby at all.
- Guard the Rakefile's `require "rdoc/task"` with a `LoadError` rescue for rubies without the rdoc gem.
- While touching the RDoc task, derive its title from the gemspec (`Bundler::GemHelper.gemspec`) instead of re-reading `VERSION` with a cwd-dependent path, a `File.exist?` guard that can never fail in practice, and a trailing newline interpolated into the title.

Publishing is unaffected: docs on rubydoc.info are generated server-side from the pushed gem, and `gem build`/`gem push` in release.yml never use the rdoc gem.

Verified on MRI: `bundle install` resolves, `rake -T` still lists the rdoc tasks, RuboCop clean. On an earlier CI run of this branch, the JRuby row's `Bundle install` step passed.

Note: the JRuby row's subsequent RSpec/template steps and the signature-check job still show master-level breakage that PR #2825 fixes (Rails main INSERT reshape) — rerunning after #2825 merges should turn them fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
