### PR TITLE
Handle Arel.sql-carried binds in insert and track the positional binds deprecation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 group :development do
   gem "rspec"
   gem "rake"
-  # rails/rails@96afb7e4 = merge of rails/rails#58297 (deprecate positional
-  # pk/id_value/sequence_name for #insert); bump per follow-up Rails change
-  gem "activerecord",   github: "rails/rails", ref: "96afb7e44a030940e4868de65dcc48739b1d2f20"
+  # rails/rails@e4bb4474 = merge of rails/rails#58323 (deprecate positional
+  # binds for #insert/#update/#delete); bump per follow-up Rails change
+  gem "activerecord",   github: "rails/rails", ref: "e4bb447415e4e169a7c621d3f727dddc0ab9ae11"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -49,7 +49,15 @@ module ActiveRecord
           raw_sql = intent.raw_sql
           original_binds_count = intent.binds.size
           requested_cols = requested_returning_columns(raw_sql, returning)
-          sql, binds = sql_for_insert(raw_sql, intent.binds, returning)
+          # Binds compiled from `Arel.sql("... ?", value)` are plain values, not
+          # named attributes (rails/rails#58323), so no requested column can be
+          # echoed from them; every requested column goes through RETURNING.
+          echoable_cols = if intent.arel.is_a?(Arel::Nodes::BoundSqlLiteral)
+            []
+          else
+            requested_cols.select { |col| intent.binds.any? { |bind| bind.name == col } }
+          end
+          sql, binds = sql_for_insert(raw_sql, intent.binds, requested_cols - echoable_cols)
           intent.raw_sql = sql
           intent.binds = binds
 
@@ -99,7 +107,7 @@ module ActiveRecord
                   if returned.key?(col)
                     returned[col]
                   else
-                    index = binds[0...original_binds_count].index { |bind| bind.name == col }
+                    index = binds[0...original_binds_count].index { |bind| bind.name == col } if echoable_cols.include?(col)
                     index && type_casted_binds[index]
                   end
                 end
@@ -289,17 +297,18 @@ module ActiveRecord
             result[:affected_rows_count]
           end
 
-          def sql_for_insert(sql, binds, returning) # :nodoc:
+          # `returning_cols` is the resolved column list computed by `_exec_insert`
+          # (the requested RETURNING columns minus those it can echo from binds);
+          # nil keeps AbstractAdapter parity for direct callers and infers the pk.
+          def sql_for_insert(sql, binds, returning_cols) # :nodoc:
+            returning_cols = requested_returning_columns(sql, returning_cols) if returning_cols.nil?
             table_ref = extract_table_ref_from_insert_sql(sql)
-            # Skip RETURNING only for columns `_exec_insert` can echo from binds;
-            # literal-carried values (unprepared statements, DEFAULT) are fetched back via RETURNING.
-            cols = requested_returning_columns(sql, returning).reject { |col| binds.any? { |bind| bind.name == col } }
-            unless cols.empty?
-              quoted_cols = cols.map { |c| quote_column_name(c) }.join(", ")
-              placeholders = cols.map { |c| ":returning_#{c}" }.join(", ")
+            unless returning_cols.empty?
+              quoted_cols = returning_cols.map { |c| quote_column_name(c) }.join(", ")
+              placeholders = returning_cols.map { |c| ":returning_#{c}" }.join(", ")
               sql = "#{sql} RETURNING #{quoted_cols} INTO #{placeholders}"
               binds = binds.dup
-              cols.each do |col|
+              returning_cols.each do |col|
                 column = table_ref ? columns(table_ref).find { |c| c.name == col } : nil
                 type = column&.cast_type || Type::OracleEnhanced::Integer.new
                 binds << ActiveRecord::Relation::QueryAttribute.new("returning_#{col}", nil, type)

--- a/spec/active_record/connection_adapters/oracle_enhanced/primary_key_trigger_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/primary_key_trigger_spec.rb
@@ -328,6 +328,11 @@ RSpec.describe "primary_key_trigger" do
       expect(@conn.select_value("SELECT test_pk_triggers_seq.currval FROM dual")).to eq(insert_id)
     end
 
+    it "returns the generated id when Arel.sql carries the binds" do
+      insert_id = @conn.insert(Arel.sql("INSERT INTO test_pk_triggers (name) VALUES (?)", "alpha"))
+      expect(@conn.select_value("SELECT test_pk_triggers_seq.currval FROM dual")).to eq(insert_id)
+    end
+
     it "does not raise NoMethodError for :returning_id Symbol when logging" do
       set_logger
       @conn.reconnect! unless @conn.active?


### PR DESCRIPTION
Tracks rails/rails#58323 (merged as rails/rails@e4bb447415e4e169a7c621d3f727dddc0ab9ae11), which deprecates the positional `binds` argument to `insert`, `update`, and `delete` for removal in Rails 8.3 and makes `Arel.sql(sql_with_placeholders, *binds)` the canonical way to run raw SQL with binds through those methods.

The adapter overrides none of the three methods and never passes positional binds, so the pin bump itself is warning-free. However, the newly canonical idiom exposed a latent assumption: binds compiled from an `Arel::Nodes::BoundSqlLiteral` are plain values, not named attributes, and both the RETURNING-column filter and the bound-value echo called `bind.name` on them, so

```ruby
connection.insert(Arel.sql("INSERT INTO test_pk_triggers (name) VALUES (?)", "alpha"))
```

raised `NoMethodError: undefined method 'name' for an instance of String`.

This PR mirrors rails/rails#58323's own discrimination (a `BoundSqlLiteral` is not an `Arel::InsertManager` and takes the raw-SQL path) instead of inspecting bind element classes:

- `_exec_insert` resolves the echoable columns from `intent.arel`: nothing is echoable for a `BoundSqlLiteral`, so every requested column is fetched via `RETURNING ... INTO`; attribute-built inputs keep the existing bind-name echo for the prefetched sequence PK.
- `sql_for_insert` now receives the resolved column list (nil still infers the pk, keeping AbstractAdapter parity for direct callers), which also drops its duplicated `requested_returning_columns` computation.
- Bumps the `activerecord` pin from rails/rails@96afb7e4 (rails/rails#58297) to rails/rails@e4bb4474 (rails/rails#58323).
- Adds a spec locking in the `insert(Arel.sql("... (?)", value))` idiom returning the generated id.

Verification: MRI full suite 1109 examples, 0 failures under the CI stderr gate; RuboCop clean; JRuby full suite run on a CI-parity environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
