### PR TITLE
Stop passing binds to to_sql in explain

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 group :development do
   gem "rspec"
   gem "rake"
-  # rails/rails@9b63a64d = merge of rails/rails#58296, the last of the INSERT
-  # reshape PRs this adapter version tracks; bump per follow-up Rails change
-  gem "activerecord",   github: "rails/rails", ref: "9b63a64daa9482111f583c37d1cdb39b0b37bb4a"
+  # rails/rails@d82d391e = merge of rails/rails#58310 (deprecate passing `binds`
+  # to `to_sql`); bump per follow-up Rails change
+  gem "activerecord",   github: "rails/rails", ref: "d82d391e5a2a88fe561bde3ea21249db14368d12"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -29,7 +29,7 @@ module ActiveRecord
         end
 
         def explain(arel, binds = [], options = []) # :nodoc:
-          sql = "EXPLAIN PLAN FOR #{to_sql(arel, binds)}"
+          sql = "EXPLAIN PLAN FOR #{to_sql(arel)}"
           return if sql.include?("FROM all_")
           if ORACLE_ENHANCED_CONNECTION == :jdbc
             exec_query(sql, "EXPLAIN", binds)


### PR DESCRIPTION
Tracks rails/rails#58310 (merged as rails/rails@d82d391e), which deprecates the `binds` argument of `to_sql`; it has been unused since bind parameters moved into the Arel AST in Rails 5.2. The `explain` implementation passed it on every EXPLAIN, which the CI stderr deprecation gate turns into spec failures.

Also bumps the `activerecord` pin from rails/rails@9b63a64d to rails/rails@d82d391e per the one-PR-per-tracked-Rails-change workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
