### PR TITLE
Run bug report templates against the Gemfile's pinned Rails ref

### DIFF
--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -2,12 +2,23 @@
 
 require "bundler/inline"
 
+# Mirror the checkout's pinned Rails ref so the template exercises the same
+# Rails the specs are verified against; standalone copies fall back to main.
+oracle_enhanced_root = ENV["ORACLE_ENHANCED_PATH"] || File.expand_path("../..", __dir__)
+gemfile_path = File.join(oracle_enhanced_root, "Gemfile")
+rails_ref = File.exist?(gemfile_path) &&
+  File.read(gemfile_path)[/gem "activerecord",\s+github: "rails\/rails", ref: "(\h{40})"/, 1]
+
 gemfile(true) do
   source "https://rubygems.org"
 
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-  gem "activerecord", github: "rails/rails", branch: "main"
+  if rails_ref
+    gem "activerecord", github: "rails/rails", ref: rails_ref
+  else
+    gem "activerecord", github: "rails/rails", branch: "main"
+  end
   # CI sets ORACLE_ENHANCED_PATH to run the template against the checkout under test
   if ENV["ORACLE_ENHANCED_PATH"]
     gem "activerecord-oracle_enhanced-adapter", path: ENV["ORACLE_ENHANCED_PATH"]

--- a/guides/bug_report_templates/active_record_gem_spec.rb
+++ b/guides/bug_report_templates/active_record_gem_spec.rb
@@ -2,12 +2,23 @@
 
 require "bundler/inline"
 
+# Mirror the checkout's pinned Rails ref so the template exercises the same
+# Rails the specs are verified against; standalone copies fall back to main.
+oracle_enhanced_root = ENV["ORACLE_ENHANCED_PATH"] || File.expand_path("../..", __dir__)
+gemfile_path = File.join(oracle_enhanced_root, "Gemfile")
+rails_ref = File.exist?(gemfile_path) &&
+  File.read(gemfile_path)[/gem "activerecord",\s+github: "rails\/rails", ref: "(\h{40})"/, 1]
+
 gemfile(true) do
   source "https://rubygems.org"
 
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-  gem "activerecord", github: "rails/rails", branch: "main"
+  if rails_ref
+    gem "activerecord", github: "rails/rails", ref: rails_ref
+  else
+    gem "activerecord", github: "rails/rails", branch: "main"
+  end
   # CI sets ORACLE_ENHANCED_PATH to run the template against the checkout under test
   if ENV["ORACLE_ENHANCED_PATH"]
     gem "activerecord-oracle_enhanced-adapter", path: ENV["ORACLE_ENHANCED_PATH"]


### PR DESCRIPTION
The bug report templates fetched rails main at run time, so upstream breakage landed in CI regardless of the Gemfile pin the specs are verified against. Concretely: rails/rails@af95ef17 introduced `ActiveSupport::Ractors`, which raises `NameError: uninitialized constant ActiveSupport::Ractors::Ractor` on JRuby (no `Ractor` constant there), turning every JRuby template step red — see the failures on #2828.

The templates now mirror the checkout's pinned `activerecord` ref (read from the repo Gemfile via `ORACLE_ENHANCED_PATH` or the template's location), keeping `branch: "main"` as the fallback for standalone copies of the template pasted into bug reports.

Trade-off made explicit: this retires the last rails-main canary in CI. New Rails main changes now land exclusively through the per-PR pin-bump workflow instead of breaking scheduled runs.

Verified locally on MRI: the template resolves the pinned ref and passes (1 run, 3 assertions, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
