### PR TITLE
Fix explain for Arel input carrying AST binds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 group :development do
   gem "rspec"
   gem "rake"
-  # rails/rails@d82d391e = merge of rails/rails#58310 (deprecate passing `binds`
-  # to `to_sql`); bump per follow-up Rails change
-  gem "activerecord",   github: "rails/rails", ref: "d82d391e5a2a88fe561bde3ea21249db14368d12"
+  # rails/rails@e8310986 = merge of rails/rails#58311 (fix explain for Arel
+  # input with AST binds); bump per follow-up Rails change
+  gem "activerecord",   github: "rails/rails", ref: "e83109864e42f538ef1e4772d51d849df37cd7da"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -28,8 +28,9 @@ module ActiveRecord
           true
         end
 
-        def explain(arel, binds = [], options = []) # :nodoc:
-          sql = "EXPLAIN PLAN FOR #{to_sql(arel)}"
+        def explain(arel_or_sql, binds = [], options = []) # :nodoc:
+          sql, binds = to_sql_and_binds(arel_or_sql, binds)
+          sql = "EXPLAIN PLAN FOR #{sql}"
           return if sql.include?("FROM all_")
           if ORACLE_ENHANCED_CONNECTION == :jdbc
             exec_query(sql, "EXPLAIN", binds)

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -832,6 +832,12 @@ RSpec.describe "OracleEnhancedAdapter" do
       expect(explain.inspect).to include("Cost")
       expect(explain.inspect).to include("INDEX UNIQUE SCAN").or include("TABLE ACCESS FULL")
     end
+
+    # Arel input carries its binds in the AST; parity with rails/rails#58311.
+    it "should explain query built from Arel with binds in the AST" do
+      explain = ActiveRecord::Base.lease_connection.explain(TestPost.where(id: 1).arel)
+      expect(explain).to include("Cost")
+    end
   end
 
   describe "using offset and limit" do


### PR DESCRIPTION
Tracks rails/rails#58311 (merged as rails/rails@e8310986), which fixed `connection.explain(arel)` for Arel input whose binds live in the AST by resolving SQL and binds together through `to_sql_and_binds`.

The Oracle implementation had the same gap: `to_sql(arel)` discarded the AST binds, so the JDBC branch executed `EXPLAIN PLAN FOR ... :a1` with nothing bound and failed with ORA-17041 (the OCI branch only parses the statement, so it happened to work). Resolve SQL and binds together, rename the parameter to `arel_or_sql` in line with rails/rails#58309, and add a lock-in spec.

Also bumps the `activerecord` pin from rails/rails@d82d391e to rails/rails@e8310986 per the one-PR-per-tracked-Rails-change workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
