### PR TITLE
Bump Rails for the positional pk/id_value/sequence_name deprecation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 group :development do
   gem "rspec"
   gem "rake"
-  # rails/rails@e8310986 = merge of rails/rails#58311 (fix explain for Arel
-  # input with AST binds); bump per follow-up Rails change
-  gem "activerecord",   github: "rails/rails", ref: "e83109864e42f538ef1e4772d51d849df37cd7da"
+  # rails/rails@96afb7e4 = merge of rails/rails#58297 (deprecate positional
+  # pk/id_value/sequence_name for #insert); bump per follow-up Rails change
+  gem "activerecord",   github: "rails/rails", ref: "96afb7e44a030940e4868de65dcc48739b1d2f20"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do


### PR DESCRIPTION
Tracks rails/rails#58297 (merged as rails/rails@96afb7e4), which deprecates the positional `pk`, `id_value`, and `sequence_name` arguments to `DatabaseStatements#insert` for removal in Rails 8.3.

The adapter and specs already pass none of them since the returning-based reshape (#2825), so this is the pin bump plus verification: the full suite runs clean under the CI stderr gate, which fails any example that leaks a deprecation warning.

Bumps the `activerecord` pin from rails/rails@e8310986 to rails/rails@96afb7e4 per the one-PR-per-tracked-Rails-change workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
