### PR TITLE
Mirror any activerecord git source in the bug report templates

### DIFF
--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -2,20 +2,21 @@
 
 require "bundler/inline"
 
-# Mirror the checkout's pinned Rails ref so the template exercises the same
-# Rails the specs are verified against; standalone copies fall back to main.
+# Mirror the checkout's activerecord git source (any repo, ref or branch) so
+# the template exercises the same Rails the specs are verified against;
+# standalone copies fall back to rails/rails main.
 oracle_enhanced_root = ENV["ORACLE_ENHANCED_PATH"] || File.expand_path("../..", __dir__)
 gemfile_path = File.join(oracle_enhanced_root, "Gemfile")
-rails_ref = File.exist?(gemfile_path) &&
-  File.read(gemfile_path)[/gem "activerecord",\s+github: "rails\/rails", ref: "(\h{40})"/, 1]
+rails_source = File.exist?(gemfile_path) &&
+  File.read(gemfile_path).match(/^\s*gem "activerecord",\s*github: "(?<repo>[^"]+)",\s*(?<kind>ref|branch): "(?<value>[^"]+)"/)
 
 gemfile(true) do
   source "https://rubygems.org"
 
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-  if rails_ref
-    gem "activerecord", github: "rails/rails", ref: rails_ref
+  if rails_source
+    gem "activerecord", github: rails_source[:repo], rails_source[:kind].to_sym => rails_source[:value]
   else
     gem "activerecord", github: "rails/rails", branch: "main"
   end

--- a/guides/bug_report_templates/active_record_gem_spec.rb
+++ b/guides/bug_report_templates/active_record_gem_spec.rb
@@ -2,20 +2,21 @@
 
 require "bundler/inline"
 
-# Mirror the checkout's pinned Rails ref so the template exercises the same
-# Rails the specs are verified against; standalone copies fall back to main.
+# Mirror the checkout's activerecord git source (any repo, ref or branch) so
+# the template exercises the same Rails the specs are verified against;
+# standalone copies fall back to rails/rails main.
 oracle_enhanced_root = ENV["ORACLE_ENHANCED_PATH"] || File.expand_path("../..", __dir__)
 gemfile_path = File.join(oracle_enhanced_root, "Gemfile")
-rails_ref = File.exist?(gemfile_path) &&
-  File.read(gemfile_path)[/gem "activerecord",\s+github: "rails\/rails", ref: "(\h{40})"/, 1]
+rails_source = File.exist?(gemfile_path) &&
+  File.read(gemfile_path).match(/^\s*gem "activerecord",\s*github: "(?<repo>[^"]+)",\s*(?<kind>ref|branch): "(?<value>[^"]+)"/)
 
 gemfile(true) do
   source "https://rubygems.org"
 
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-  if rails_ref
-    gem "activerecord", github: "rails/rails", ref: rails_ref
+  if rails_source
+    gem "activerecord", github: rails_source[:repo], rails_source[:kind].to_sym => rails_source[:value]
   else
     gem "activerecord", github: "rails/rails", branch: "main"
   end


### PR DESCRIPTION
Follow-up to #2829. The template mirroring only matched the pinned form `github: "rails/rails", ref: "<sha>"`, so branches whose Gemfile points activerecord at a fork branch — the per-adapter migration compatibility stack (#2823 / #2816 / #2817) points at `yahonda/rails per-adapter-migration-compatibility-v7` — fell back to rails main, where `ActiveRecord::Migration::CompatibilityBehavior` does not exist, and the template step failed with NameError on every MRI row.

Match any `github:` repo with either `ref:` or `branch:` and mirror it verbatim; standalone copies of the template still fall back to rails/rails main.

Verified locally on MRI against both forms: the master checkout (ref pin, resolves e4bb4474) and the #2816 worktree (branch pointer, resolves the v7 branch) — 1 run, 3 assertions, 0 failures each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
