### PR TITLE
Make RETURNING-shape specs aware of prepared_statements: false

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -165,6 +165,7 @@ RSpec.describe "OracleEnhancedAdapter schema definition" do
     end
 
     it "skips RETURNING when the caller supplies the String primary key value" do
+      skip "the bound-value echo needs prepared statements" unless @conn.prepared_statements
       schema_define do
         create_table :test_lookups, force: true, id: false do |t|
           t.primary_key :code, :string, limit: 10, null: false
@@ -180,6 +181,32 @@ RSpec.describe "OracleEnhancedAdapter schema definition" do
       begin
         klass.create!(code: "ABC", name: "alpha")
         expect(@logger.output(:debug)).not_to match(/RETURNING/i)
+      ensure
+        clear_logger
+      end
+    end
+
+    # Without prepared statements the values are inlined into the SQL, so there
+    # are no binds to echo the primary key from; it comes back via RETURNING.
+    it "emits RETURNING for the String primary key when prepared_statements is false" do
+      schema_define do
+        create_table :test_lookups, force: true, id: false do |t|
+          t.primary_key :code, :string, limit: 10, null: false
+          t.string :name
+        end
+      end
+      klass = Class.new(ActiveRecord::Base) do
+        self.table_name = "test_lookups"
+        self.primary_key = "code"
+      end
+
+      set_logger
+      begin
+        @conn.unprepared_statement do
+          klass.create!(code: "ABC", name: "alpha")
+        end
+        expect(@logger.output(:debug)).to match(/RETURNING\s+"CODE"\s+INTO/i)
+        expect(klass.find("ABC").name).to eq("alpha")
       ensure
         clear_logger
       end

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -216,6 +216,7 @@ RSpec.describe "OracleEnhancedAdapter" do
       end
 
       it "binds the sequence-fetched id into the INSERT and does NOT emit RETURNING" do
+        skip "the bound-value echo needs prepared statements" unless ActiveRecord::Base.lease_connection.prepared_statements
         TestReturningSeqItem.create!(name: "alpha")
         insert_log = @logger.logged(:debug).find { |line| line.include?("INSERT INTO") && line.include?("TEST_RETURNING_SEQ_ITEMS") }
         expect(insert_log).not_to be_nil, "INSERT statement was not logged"
@@ -224,6 +225,19 @@ RSpec.describe "OracleEnhancedAdapter" do
         # a quoted column or `INTO :bind`; avoids false matches on the table
         # name (which contains the substring "RETURNING").
         expect(insert_log).not_to match(/\bRETURNING\b\s+(?:"|INTO\b)/i)
+      end
+
+      # Without prepared statements the sequence-fetched id is inlined into the
+      # SQL, so there is no bind to echo it from; it comes back via RETURNING.
+      it "emits RETURNING for the sequence-fetched id and still returns it when prepared_statements is false" do
+        record = ActiveRecord::Base.lease_connection.unprepared_statement do
+          TestReturningSeqItem.create!(name: "alpha")
+        end
+        expect(record.id).to be_a(Integer)
+        expect(record.id).to be > 0
+        insert_log = @logger.logged(:debug).find { |line| line.include?("INSERT INTO") && line.include?("TEST_RETURNING_SEQ_ITEMS") }
+        expect(insert_log).not_to be_nil, "INSERT statement was not logged"
+        expect(insert_log).to match(/\bRETURNING\b\s+"ID"\s+INTO\b/i)
       end
     end
   end


### PR DESCRIPTION
The `test_prepared_statements_false` workflow fails exactly two specs on master ([run](https://github.com/rsim/oracle-enhanced/actions/runs/31187861979)): the two that assert the no-RETURNING SQL shape of the bound-value echo. The echo can skip `RETURNING ... INTO` only when the primary key value travels as a named bind; without prepared statements the visitor inlines every value into the SQL, so `intent.binds` is empty, nothing is echoable, and the id legitimately comes back via RETURNING. The rest of the suite (1109 examples), including the id round-trip specs next to the failing ones, passes in that mode — the behavior is correct, only the shape expectations were prepared-mode-specific.

- Skip the two bind-echo expectations when the connection runs unprepared (same guard AR core's own tests use: `lease_connection.prepared_statements`).
- Lock in the unprepared behavior with sibling examples — RETURNING is emitted and the String/sequence-fetched primary key still round-trips — running in **both** CI modes via `unprepared_statement`.

Verified locally:

- Full suite with `ORACLE_ENHANCED_PREPARED_STATEMENTS_FALSE=1` (the failing workflow's mode): 1111 examples, 0 failures
- Full suite in normal prepared mode: 1111 examples, 0 failures
- RuboCop: no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
