### PR TITLE
Fix Layout/SpaceBeforeFirstArg offenses flagged by RuboCop 1.90

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/composite_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/composite_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "OracleEnhancedAdapter should support composite primary" do
       end
 
       create_table :test_books, force: true do |t|
-        t.string    :title,       limit: 20
+        t.string :title,       limit: 20
       end
 
       create_table :test_authors_test_books, primary_key: ["test_author_id", "test_book_id"], force: true do |t|

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "OracleEnhancedAdapter schema definition" do
     before do
       schema_define do
         create_table :keyboards, force: true, id: false do |t|
-          t.string      :name
+          t.string :name
         end
         add_column :keyboards, :id, :primary_key
       end
@@ -35,7 +35,7 @@ RSpec.describe "OracleEnhancedAdapter schema definition" do
           t.string      :name
         end
         create_table :id_keyboards, force: true do |t|
-          t.string      :name
+          t.string :name
         end
       end
       class ::Keyboard < ActiveRecord::Base

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe "OracleEnhancedAdapter" do
           if ActiveRecord::Base.lease_connection.supports_virtual_columns?
             t.virtual :full_name, as: "(first_name || ' ' || last_name)"
           else
-            t.string  :full_name, limit: 46
+            t.string :full_name, limit: 46
           end
-          t.date    :hire_date
+          t.date :hire_date
         end
       end
       schema_define do
@@ -291,7 +291,7 @@ RSpec.describe "OracleEnhancedAdapter" do
     before(:all) do
       schema_define do
         create_table :test_posts do |t|
-          t.string      :title
+          t.string :title
         end
         create_table :test_comments do |t|
           t.integer     :test_post_id
@@ -330,7 +330,7 @@ RSpec.describe "OracleEnhancedAdapter" do
     before(:all) do
       schema_define do
         create_table :test_posts do |t|
-          t.string      :title
+          t.string :title
         end
         create_table :test_comments do |t|
           t.integer     :test_post_id


### PR DESCRIPTION
RuboCop 1.90.0 started flagging column-aligned schema definitions such as `t.string    :title` under `Layout/SpaceBeforeFirstArg`. The RuboCop workflow resolves the newest gem on every run (`BUNDLE_ONLY=rubocop bundle install`), so master's RuboCop job went red on 2026-08-25 without any adapter change (rsim/oracle-enhanced@924d9060: green on 08-24, red on 08-25).

- Applies the autocorrect to the 7 offending spec lines; no behaviour change.

Verification: `bundle exec rubocop` with RuboCop 1.90.0 — 104 files inspected, no offenses.

This is the base of a stack of Rails-pin PRs that follow (one per Rails main change); they carry this commit until it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sjgDUFVzHpDXPLyyeCRv5
