### PR TITLE
Bump Rails to rails/rails@6a7dc137 for build_result removal

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 group :development do
   gem "rspec"
   gem "rake"
-  # rails/rails@e4bb4474 = merge of rails/rails#58323 (deprecate positional
-  # binds for #insert/#update/#delete); bump per follow-up Rails change
-  gem "activerecord",   github: "rails/rails", ref: "e4bb447415e4e169a7c621d3f727dddc0ab9ae11"
+  # rails/rails@6a7dc137 = merge of rails/rails#58217 (remove unused Active Record
+  # internals incl. AbstractAdapter#build_result); bump per follow-up Rails change
+  gem "activerecord",   github: "rails/rails", ref: "6a7dc1378c045b15eb6f0460fd76cf672d775742"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -114,7 +114,7 @@ module ActiveRecord
                 rows << row unless row.all?(&:nil?)
               end
               cursor.close unless cached
-              build_result(columns: [], rows: rows)
+              ActiveRecord::Result.new([], rows)
             end
           end
         end


### PR DESCRIPTION
Tracks rails/rails#58217 (merged as rails/rails@6a7dc1378c045b15eb6f0460fd76cf672d775742), which removes the unused `AbstractAdapter#build_result` hook.

`_exec_insert` still called `build_result(columns: [], rows: rows)` to wrap the `RETURNING ... INTO` row, so against that Rails commit every INSERT raised `NoMethodError: undefined method 'build_result'` (168 direct failures plus knock-ons in a full run at the merge commit).

- Builds the `ActiveRecord::Result` directly, which is all the hook ever did.
- Bumps the `activerecord` pin from rails/rails@e4bb4474 (rails/rails#58323) to rails/rails@6a7dc1378c (rails/rails#58217).

Verification: MRI full suite at this pin — 1109 examples, 0 failures, no deprecation leaks; RuboCop clean.

Rebased onto master after #2834 merged; the diff now carries only this PR's commit.

## Why the JRuby jobs fail

Both JRuby rows fail before any example runs: `require "active_record"` (spec_helper.rb:27) raises `NameError: uninitialized constant ActiveSupport::Ractors::Ractor`, so RSpec reports `0 examples, 1 error occurred outside of examples`.

The cause is upstream in Active Support's `ractors.rb`, which executes code referencing the bare `Ractor` constant at require time from inside `module ActiveSupport::Ractors` (on current rails main it is the `if Ractor.respond_to?(:store_if_absent)` guard around line 191). On CRuby the constant lookup falls through to the global `::Ractor`; JRuby does not define `Ractor` at all, so the lookup dies at load with the constant name qualified by the enclosing module. The reference needs a `defined?(Ractor)` guard upstream.

This affects every Rails commit in this pin window and is still present on rails main as of 2026-09-01 (it survived the 2026-08-12 rework in rails/rails@4b2edb1e79); no upstream issue or fix exists yet. It is independent of this PR's change — the JRuby rows go red at the Gemfile pin bump itself and will stay red on every stacked PR until Rails guards the constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ZgTBgTLHVWt3Qu2iT4dD9
