### PR TITLE
Bump Rails to rails/rails@342dafc5 for CommandRecorder kwargs split

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 group :development do
   gem "rspec"
   gem "rake"
-  # rails/rails@6a7dc137 = merge of rails/rails#58217 (remove unused Active Record
-  # internals incl. AbstractAdapter#build_result); bump per follow-up Rails change
-  gem "activerecord",   github: "rails/rails", ref: "6a7dc1378c045b15eb6f0460fd76cf672d775742"
+  # rails/rails@342dafc5 = merge of rails/rails#58239 (CommandRecorder stores
+  # args and kwargs separately); bump per follow-up Rails change
+  gem "activerecord",   github: "rails/rails", ref: "342dafc5351d9c9e303ee3c1e378c4dcf2277ffd"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -604,13 +604,14 @@ module ActiveRecord
           drop_buf = []
           add_pending = [] # column names queued in add_buf — see :change_column branch
 
-          operations.each do |command, args|
+          operations.each do |command, args, kwargs|
             args = args.dup
             args.shift # remove table_name
 
             case command
             when :add_column
-              column_name, type, options = args[0], args[1], (args[2] || {})
+              column_name, type = args
+              options = kwargs
               if requires_full_command?(:add_column, type, options)
                 flush_bulk_buffers(table_name, add_buf, modify_buf, drop_buf)
                 add_pending.clear
@@ -621,7 +622,8 @@ module ActiveRecord
                 add_pending << quote_column_name(column_name)
               end
             when :change_column
-              column_name, type, options = args[0], args[1], (args[2] || {})
+              column_name, type = args
+              options = kwargs
               if requires_full_command?(:change_column, type, options)
                 flush_bulk_buffers(table_name, add_buf, modify_buf, drop_buf)
                 add_pending.clear
@@ -666,7 +668,7 @@ module ActiveRecord
             when :remove_columns
               flush_bulk_add_modify(table_name, add_buf, modify_buf)
               add_pending.clear
-              drop_buf.concat(args.reject { |a| a.is_a?(Hash) })
+              drop_buf.concat(args)
             else
               raise "missing dispatch branch for #{command.inspect}; update both SUPPORTED_BULK_COMMANDS and the case statement"
             end
@@ -1154,25 +1156,25 @@ module ActiveRecord
           # (`null: false`, `precision: 6` when supported).
           def expand_bulk_timestamps(operations)
             operations.flat_map do |operation|
-              command, args, block = operation
+              command, args, kwargs, block = operation
               case command
               when :add_timestamps
                 table_name = args[0]
                 # Strip `:comment` here — it is applied after the bulk
                 # flush via `apply_column_comments` (Oracle has no inline
                 # `COMMENT` in ADD); see #2739 for the non-bulk equivalent.
-                options = args[1].is_a?(Hash) ? args[1].except(:comment) : {}
+                options = kwargs.except(:comment)
                 options[:null] = false if options[:null].nil?
                 options[:precision] = 6 if !options.key?(:precision) && supports_datetime_with_precision?
                 [
-                  [:add_column, [table_name, :created_at, :datetime, options], block],
-                  [:add_column, [table_name, :updated_at, :datetime, options], block],
+                  [:add_column, [table_name, :created_at, :datetime], options, block],
+                  [:add_column, [table_name, :updated_at, :datetime], options, block],
                 ]
               when :remove_timestamps
                 table_name = args[0]
                 [
-                  [:remove_column, [table_name, :updated_at], block],
-                  [:remove_column, [table_name, :created_at], block],
+                  [:remove_column, [table_name, :updated_at], {}, block],
+                  [:remove_column, [table_name, :created_at], {}, block],
                 ]
               else
                 [operation]
@@ -1181,11 +1183,9 @@ module ActiveRecord
           end
 
           def collect_timestamps_comments(operations)
-            operations.each_with_object([]) do |(command, args, _block), acc|
-              next unless command == :add_timestamps
-              options = args[1]
-              next unless options.is_a?(Hash) && options.key?(:comment)
-              acc << options[:comment]
+            operations.each_with_object([]) do |(command, _args, kwargs), acc|
+              next unless command == :add_timestamps && kwargs.key?(:comment)
+              acc << kwargs[:comment]
             end
           end
 


### PR DESCRIPTION
Tracks rails/rails#58239 (merged as rails/rails@342dafc5351d9c9e303ee3c1e378c4dcf2277ffd), which makes `CommandRecorder` store positional args and keyword args separately, so `bulk_change_table` now receives `[command, args, kwargs, block]` tuples instead of a trailing options Hash inside `args`.

The Oracle `bulk_change_table` override still read the options from `args[2]`, which silently dropped every keyword: `limit:`, `precision:`, `scale:` and `null:` on `add_column` / `change_column`, and `precision:` on `add_timestamps`, all fell back to their defaults in the generated `ALTER TABLE` (8 failures in `schema_statements_spec.rb` — `VARCHAR2(255)` instead of `VARCHAR2(8)`, `TIMESTAMP(6)` instead of `TIMESTAMP(3)`, a `MODIFY` without `NOT NULL`).

- Reads the options from the kwargs slot in the dispatcher and in the two `:add_timestamps` helpers, and emits the synthesised `:add_column` / `:remove_column` operations in the same four-element shape.
- Bumps the `activerecord` pin from rails/rails@6a7dc1378c (rails/rails#58217) to rails/rails@342dafc535 (rails/rails#58239).

Verification: MRI full suite at this pin — 1111 examples, 0 failures, no deprecation leaks; RuboCop clean.

Stacked on #2835; the diff carries that PR's commits until it merges. JRuby rows: with the Rails main commits in this pin window, `require "active_record"` raises `NameError: uninitialized constant ActiveSupport::Ractors::Ractor` on JRuby 10.1 (observed on the CI-parity host at rails/rails@f70a767d), so the JRuby jobs cannot boot; that is upstream and independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sjgDUFVzHpDXPLyyeCRv5
