### PR TITLE
Bump Rails to rails/rails@42274c88 for schema readers over many tables

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 group :development do
   gem "rspec"
   gem "rake"
-  # rails/rails@342dafc5 = merge of rails/rails#58239 (CommandRecorder stores
-  # args and kwargs separately); bump per follow-up Rails change
-  gem "activerecord",   github: "rails/rails", ref: "342dafc5351d9c9e303ee3c1e378c4dcf2277ffd"
+  # rails/rails@42274c88 = merge of rails/rails#58421 (schema readers answer for
+  # many tables at once); bump per follow-up Rails change
+  gem "activerecord",   github: "rails/rails", ref: "42274c880590c8f05ee553709701ef97dfaa0860"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -17,16 +17,16 @@ module ActiveRecord # :nodoc:
           def tables(stream)
             # do not include materialized views in schema dump - they should be created separately after schema creation
             sorted_tables = (@connection.tables - @connection.materialized_views).sort
+            not_ignored_tables = sorted_tables.reject { |table_name| ignored?(table_name) }
             @trigger_backed_tables = @connection.trigger_backed_table_names
-            sorted_tables.each do |tbl|
-              # add table prefix or suffix for schema_migrations
-              next if ignored? tbl
+            read_schema_metadata(not_ignored_tables)
+
+            not_ignored_tables.each do |tbl|
               table(tbl, stream)
             end
             # following table definitions
             # add foreign keys if table has them
-            sorted_tables.each do |tbl|
-              next if ignored? tbl
+            not_ignored_tables.each do |tbl|
               foreign_keys(tbl, stream) if @connection.use_foreign_keys?
               divergent_unique_constraints(tbl, stream)
             end
@@ -48,7 +48,7 @@ module ActiveRecord # :nodoc:
           end
 
           def _indexes(table, stream)
-            if (indexes = @connection.indexes(table)).any?
+            if (indexes = @indexes[table]).any?
               indexes = reject_unique_constraint_indexes(table, indexes)
 
               add_index_statements = indexes.filter_map do |index|
@@ -81,7 +81,7 @@ module ActiveRecord # :nodoc:
           end
 
           def indexes_in_create(table, stream)
-            if (indexes = @connection.indexes(table)).any?
+            if (indexes = @indexes[table]).any?
               indexes = reject_unique_constraint_indexes(table, indexes)
 
               index_statements = indexes.map do |index|
@@ -97,7 +97,7 @@ module ActiveRecord # :nodoc:
           def reject_unique_constraint_indexes(table, indexes)
             return indexes unless @connection.supports_unique_constraints?
 
-            unique_constraints = @connection.unique_constraints(table)
+            unique_constraints = @unique_constraints[table]
             return indexes if unique_constraints.empty?
 
             backing_index_names = unique_constraints.filter_map { |uc| uc.using_index ? nil : uc.name }
@@ -110,7 +110,7 @@ module ActiveRecord # :nodoc:
           def unique_constraints_in_create(table, stream)
             return unless @connection.supports_unique_constraints?
 
-            inline_ucs = @connection.unique_constraints(table).reject { |uc| uc.using_index }
+            inline_ucs = @unique_constraints[table].reject { |uc| uc.using_index }
             return if inline_ucs.empty?
 
             statements = inline_ucs.map do |uc|
@@ -126,7 +126,7 @@ module ActiveRecord # :nodoc:
           def divergent_unique_constraints(table, stream)
             return unless @connection.supports_unique_constraints?
 
-            ucs = @connection.unique_constraints(table).select { |uc| uc.using_index }
+            ucs = @unique_constraints[table].select { |uc| uc.using_index }
             return if ucs.empty?
 
             statements = ucs.map do |uc|
@@ -158,12 +158,8 @@ module ActiveRecord # :nodoc:
               tbl = StringIO.new
 
               # first dump primary key column
-              if @connection.respond_to?(:primary_keys)
-                pk = @connection.primary_keys(table)
-                pk = pk.first unless pk.size > 1
-              else
-                pk = @connection.primary_key(table)
-              end
+              pk = @primary_keys[table]
+              pk = pk.first unless pk.size > 1
 
               tbl.print "  create_table #{remove_prefix_and_suffix(table).inspect}"
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -89,101 +89,8 @@ module ActiveRecord
         end
 
         def indexes(table_name) # :nodoc:
-          (_owner, table_name) = resolve_data_source_name(table_name)
-          default_tablespace_name = default_tablespace
-
-          # `all_indexes.visibility` was introduced in Oracle 11g R1. Pre-11g
-          # connections do not have the column, so substitute a literal
-          # 'VISIBLE' so the rest of the reader works unchanged.
-          visibility_column = supports_disabling_indexes? ? "i.visibility" : "'VISIBLE' AS visibility"
-          result = select_all(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name)])
-            SELECT LOWER(i.table_name) AS table_name, LOWER(i.index_name) AS index_name, i.uniqueness,
-              i.index_type, i.ityp_owner, i.ityp_name, i.parameters,
-              LOWER(i.tablespace_name) AS tablespace_name, #{visibility_column},
-              LOWER(c.column_name) AS column_name, c.descend, e.column_expression,
-              atc.virtual_column
-            FROM all_indexes i
-              JOIN all_ind_columns c ON c.index_name = i.index_name AND c.index_owner = i.owner
-              LEFT OUTER JOIN all_ind_expressions e ON e.index_name = i.index_name AND
-                e.index_owner = i.owner AND e.column_position = c.column_position
-              LEFT OUTER JOIN all_tab_cols atc ON i.table_name = atc.table_name AND
-                c.column_name = atc.column_name AND i.owner = atc.owner AND atc.hidden_column = 'NO'
-            WHERE i.owner = SYS_CONTEXT('userenv', 'current_schema')
-               AND i.table_owner = SYS_CONTEXT('userenv', 'current_schema')
-               AND i.table_name = :table_name
-               AND NOT EXISTS (SELECT uc.index_name FROM all_constraints uc
-                WHERE uc.index_name = i.index_name AND uc.owner = i.owner AND uc.constraint_type = 'P')
-            ORDER BY i.index_name, c.column_position
-          SQL
-
-          current_index = nil
-          all_schema_indexes = []
-
-          result.each do |row|
-            # have to keep track of indexes because above query returns dups
-            # there is probably a better query we could figure out
-            if current_index != row["index_name"]
-              statement_parameters = nil
-              if row["index_type"] == "DOMAIN" && row["ityp_owner"] == "CTXSYS" && row["ityp_name"] == "CONTEXT"
-                procedure_name = default_datastore_procedure(row["index_name"])
-                source = select_values(<<~SQL.squish, "SCHEMA", [bind_string("procedure_name", procedure_name.upcase)]).join
-                  SELECT text
-                  FROM all_source
-                  WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
-                    AND name = :procedure_name
-                  ORDER BY line
-                SQL
-                if source =~ /-- add_context_index_parameters (.+)\n/
-                  statement_parameters = $1
-                end
-              end
-              all_schema_indexes << OracleEnhanced::IndexDefinition.new(
-                row["table_name"],
-                row["index_name"],
-                row["uniqueness"] == "UNIQUE",
-                [],
-                {},
-                type: row["index_type"] == "DOMAIN" ? "#{row['ityp_owner']}.#{row['ityp_name']}" : nil,
-                parameters: row["parameters"],
-                statement_parameters: statement_parameters,
-                enabled: row["visibility"] != "INVISIBLE",
-                tablespace: row["tablespace_name"] == default_tablespace_name ? nil : row["tablespace_name"])
-              current_index = row["index_name"]
-            end
-
-            expression = row["column_expression"]
-            user_defined_virtual_column = row["virtual_column"] == "YES"
-            column = if user_defined_virtual_column || expression.nil?
-              # Plain column or user-defined virtual column. Re-creating a
-              # virtual-column index as an expression (instead of using the
-              # virtual column's name) results in ORA-54018, so use the
-              # column name in both cases.
-              row["column_name"].downcase
-            elsif row["descend"] == "DESC" && expression =~ /\A"([^"]+)"\z/ # quoted-bare-identifier ("LAST_NAME"); function expressions like LOWER("NAME") fail to match
-              # Oracle implements `(col DESC)` via a system-generated virtual
-              # column whose column_expression is the quoted user column
-              # name. Peel that off so the orders hash keys off the bare name.
-              # Example: column_name = SYS_NC00003$, column_expression = "LAST_NAME"
-              # -> column = "last_name", orders["last_name"] = :desc.
-              $1.downcase
-            else
-              # Function-based expression (e.g. `LOWER("NAME")`).
-              expression
-            end
-            all_schema_indexes.last.columns << column
-            # Track DESC only for plain column names. A function-based DESC index
-            # (column = expression) would dump as `order: { LOWER("NAME"): :desc }`,
-            # which AR core's hash formatter emits in symbol-shorthand form and
-            # produces invalid Ruby. Plain columns / DESC-marker virtuals are safe
-            # because `column` is downcased and identifier-like.
-            if row["descend"] == "DESC" && column != expression
-              all_schema_indexes.last.orders[column] = :desc
-            end
-          end
-
-          # Return the indexes just for the requested table, since AR is structured that way
-          table_name = table_name.downcase
-          all_schema_indexes.select { |i| i.table == table_name }
+          result = fetch_indexes(Array(table_name).map(&:to_s))
+          table_name.is_a?(Array) ? result : result[table_name.to_s]
         end
 
         def columns(table_name)
@@ -746,68 +653,13 @@ module ActiveRecord
 
         # get table foreign keys for schema dump
         def foreign_keys(table_name) # :nodoc:
-          (_owner, desc_table_name) = resolve_data_source_name(table_name)
-
-          fk_info = select_all(<<~SQL.squish, "SCHEMA", [bind_string("desc_table_name", desc_table_name)])
-            SELECT r.table_name to_table
-                  ,rc.column_name references_column
-                  ,cc.column_name
-                  ,c.constraint_name name
-                  ,c.delete_rule
-                  ,c.deferrable
-                  ,c.deferred
-                  ,c.validated
-                  ,c.status
-              FROM all_constraints c, all_cons_columns cc,
-                   all_constraints r, all_cons_columns rc
-             WHERE c.owner = SYS_CONTEXT('userenv', 'current_schema')
-               AND c.table_name = :desc_table_name
-               AND c.constraint_type = 'R'
-               AND cc.owner = c.owner
-               AND cc.constraint_name = c.constraint_name
-               AND r.constraint_name = c.r_constraint_name
-               AND r.owner = c.owner
-               AND rc.owner = r.owner
-               AND rc.constraint_name = r.constraint_name
-               AND rc.position = cc.position
-            ORDER BY name, to_table, column_name, references_column
-          SQL
-
-          fk_info.map do |row|
-            options = {
-              column: oracle_downcase(row["column_name"]),
-              name: oracle_downcase(row["name"]),
-              primary_key: oracle_downcase(row["references_column"])
-            }
-            options[:on_delete] = extract_foreign_key_action(row["delete_rule"])
-            options[:deferrable] = extract_foreign_key_deferrable(row["deferrable"], row["deferred"])
-            options[:enforced] = false if row["status"] == "DISABLED"
-            options[:validate] = false if row["validated"] == "NOT VALIDATED"
-            ActiveRecord::ConnectionAdapters::ForeignKeyDefinition.new(oracle_downcase(table_name), oracle_downcase(row["to_table"]), options)
-          end
+          result = fetch_foreign_keys(Array(table_name).map(&:to_s))
+          table_name.is_a?(Array) ? result : result[table_name.to_s]
         end
 
-        # `generated = 'USER NAME'` skips implicit NOT NULL checks (system-named, type 'C').
         def check_constraints(table_name) # :nodoc:
-          (_owner, desc_table_name) = resolve_data_source_name(table_name)
-
-          # `search_condition` is LONG; cannot appear in WHERE (ORA-00997).
-          rows = select_all(<<~SQL.squish, "SCHEMA", [bind_string("desc_table_name", desc_table_name)])
-            SELECT constraint_name AS name, search_condition, validated
-              FROM all_constraints
-             WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
-               AND table_name = :desc_table_name
-               AND constraint_type = 'C'
-               AND generated = 'USER NAME'
-             ORDER BY constraint_name
-          SQL
-
-          rows.filter_map do |row|
-            next if row["search_condition"].nil?
-            options = { name: oracle_downcase(row["name"]) }
-            options[:validate] = false if row["validated"] == "NOT VALIDATED"
-            CheckConstraintDefinition.new(oracle_downcase(table_name), row["search_condition"], options)
-          end
+          result = fetch_check_constraints(Array(table_name).map(&:to_s))
+          table_name.is_a?(Array) ? result : result[table_name.to_s]
         end
 
         def validate_constraint(table_name, constraint_name) # :nodoc:
@@ -841,43 +693,11 @@ module ActiveRecord
           execute "ALTER TABLE #{quote_table_name(from_table)} MODIFY CONSTRAINT #{quote_column_name(fk_name)} #{enforced ? 'ENABLE' : 'DISABLE'}"
         end
 
-        # Returns an array of unique constraints for the given table.
-        # The unique constraints are represented as UniqueConstraintDefinition objects.
+        # Returns an array of unique constraints for the given table, or a Hash of
+        # them keyed by table name when given an Array of tables.
         def unique_constraints(table_name) # :nodoc:
-          (_owner, desc_table_name) = resolve_data_source_name(table_name)
-
-          rows = select_all(<<~SQL.squish, "SCHEMA", [bind_string("desc_table_name", desc_table_name)])
-            SELECT c.constraint_name AS name,
-                   c.index_name,
-                   c.deferrable,
-                   c.deferred,
-                   cc.column_name,
-                   cc.position
-              FROM all_constraints c
-              JOIN all_cons_columns cc
-                ON cc.owner = c.owner
-               AND cc.constraint_name = c.constraint_name
-             WHERE c.owner = SYS_CONTEXT('userenv', 'current_schema')
-               AND c.table_name = :desc_table_name
-               AND c.constraint_type = 'U'
-             ORDER BY c.constraint_name, cc.position
-          SQL
-
-          grouped = rows.group_by { |row| row["name"] }
-          grouped.map do |name, group|
-            columns = group.sort_by { |r| r["position"] }.map { |r| oracle_downcase(r["column_name"]) }
-            sample = group.first
-            constraint_name = oracle_downcase(name)
-            index_name = oracle_downcase(sample["index_name"])
-
-            options = { name: constraint_name }
-            options[:deferrable] = extract_foreign_key_deferrable(sample["deferrable"], sample["deferred"])
-            if index_name && index_name != constraint_name
-              options[:using_index] = index_name
-            end
-
-            OracleEnhanced::UniqueConstraintDefinition.new(oracle_downcase(table_name), columns, options)
-          end
+          result = fetch_unique_constraints(Array(table_name).map(&:to_s))
+          table_name.is_a?(Array) ? result : result[table_name.to_s]
         end
 
         # Adds a new unique constraint to the table.
@@ -1011,6 +831,214 @@ module ActiveRecord
         end
 
         private
+          def fetch_indexes(tables)
+            tables.index_with do |table_name|
+              (_owner, table_name) = resolve_data_source_name(table_name)
+              default_tablespace_name = default_tablespace
+
+              # `all_indexes.visibility` was introduced in Oracle 11g R1. Pre-11g
+              # connections do not have the column, so substitute a literal
+              # 'VISIBLE' so the rest of the reader works unchanged.
+              visibility_column = supports_disabling_indexes? ? "i.visibility" : "'VISIBLE' AS visibility"
+              result = select_all(<<~SQL.squish, "SCHEMA", [bind_string("table_name", table_name)])
+                SELECT LOWER(i.table_name) AS table_name, LOWER(i.index_name) AS index_name, i.uniqueness,
+                  i.index_type, i.ityp_owner, i.ityp_name, i.parameters,
+                  LOWER(i.tablespace_name) AS tablespace_name, #{visibility_column},
+                  LOWER(c.column_name) AS column_name, c.descend, e.column_expression,
+                  atc.virtual_column
+                FROM all_indexes i
+                  JOIN all_ind_columns c ON c.index_name = i.index_name AND c.index_owner = i.owner
+                  LEFT OUTER JOIN all_ind_expressions e ON e.index_name = i.index_name AND
+                    e.index_owner = i.owner AND e.column_position = c.column_position
+                  LEFT OUTER JOIN all_tab_cols atc ON i.table_name = atc.table_name AND
+                    c.column_name = atc.column_name AND i.owner = atc.owner AND atc.hidden_column = 'NO'
+                WHERE i.owner = SYS_CONTEXT('userenv', 'current_schema')
+                   AND i.table_owner = SYS_CONTEXT('userenv', 'current_schema')
+                   AND i.table_name = :table_name
+                   AND NOT EXISTS (SELECT uc.index_name FROM all_constraints uc
+                    WHERE uc.index_name = i.index_name AND uc.owner = i.owner AND uc.constraint_type = 'P')
+                ORDER BY i.index_name, c.column_position
+              SQL
+
+              current_index = nil
+              all_schema_indexes = []
+
+              result.each do |row|
+                # have to keep track of indexes because above query returns dups
+                # there is probably a better query we could figure out
+                if current_index != row["index_name"]
+                  statement_parameters = nil
+                  if row["index_type"] == "DOMAIN" && row["ityp_owner"] == "CTXSYS" && row["ityp_name"] == "CONTEXT"
+                    procedure_name = default_datastore_procedure(row["index_name"])
+                    source = select_values(<<~SQL.squish, "SCHEMA", [bind_string("procedure_name", procedure_name.upcase)]).join
+                      SELECT text
+                      FROM all_source
+                      WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
+                        AND name = :procedure_name
+                      ORDER BY line
+                    SQL
+                    if source =~ /-- add_context_index_parameters (.+)\n/
+                      statement_parameters = $1
+                    end
+                  end
+                  all_schema_indexes << OracleEnhanced::IndexDefinition.new(
+                    row["table_name"],
+                    row["index_name"],
+                    row["uniqueness"] == "UNIQUE",
+                    [],
+                    {},
+                    type: row["index_type"] == "DOMAIN" ? "#{row['ityp_owner']}.#{row['ityp_name']}" : nil,
+                    parameters: row["parameters"],
+                    statement_parameters: statement_parameters,
+                    enabled: row["visibility"] != "INVISIBLE",
+                    tablespace: row["tablespace_name"] == default_tablespace_name ? nil : row["tablespace_name"])
+                  current_index = row["index_name"]
+                end
+
+                expression = row["column_expression"]
+                user_defined_virtual_column = row["virtual_column"] == "YES"
+                column = if user_defined_virtual_column || expression.nil?
+                  # Plain column or user-defined virtual column. Re-creating a
+                  # virtual-column index as an expression (instead of using the
+                  # virtual column's name) results in ORA-54018, so use the
+                  # column name in both cases.
+                  row["column_name"].downcase
+                elsif row["descend"] == "DESC" && expression =~ /\A"([^"]+)"\z/ # quoted-bare-identifier ("LAST_NAME"); function expressions like LOWER("NAME") fail to match
+                  # Oracle implements `(col DESC)` via a system-generated virtual
+                  # column whose column_expression is the quoted user column
+                  # name. Peel that off so the orders hash keys off the bare name.
+                  # Example: column_name = SYS_NC00003$, column_expression = "LAST_NAME"
+                  # -> column = "last_name", orders["last_name"] = :desc.
+                  $1.downcase
+                else
+                  # Function-based expression (e.g. `LOWER("NAME")`).
+                  expression
+                end
+                all_schema_indexes.last.columns << column
+                # Track DESC only for plain column names. A function-based DESC index
+                # (column = expression) would dump as `order: { LOWER("NAME"): :desc }`,
+                # which AR core's hash formatter emits in symbol-shorthand form and
+                # produces invalid Ruby. Plain columns / DESC-marker virtuals are safe
+                # because `column` is downcased and identifier-like.
+                if row["descend"] == "DESC" && column != expression
+                  all_schema_indexes.last.orders[column] = :desc
+                end
+              end
+
+              # Return the indexes just for the requested table, since AR is structured that way
+              table_name = table_name.downcase
+              all_schema_indexes.select { |i| i.table == table_name }
+            end
+          end
+
+          def fetch_foreign_keys(tables)
+            tables.index_with do |table_name|
+              (_owner, desc_table_name) = resolve_data_source_name(table_name)
+
+              fk_info = select_all(<<~SQL.squish, "SCHEMA", [bind_string("desc_table_name", desc_table_name)])
+                SELECT r.table_name to_table
+                      ,rc.column_name references_column
+                      ,cc.column_name
+                      ,c.constraint_name name
+                      ,c.delete_rule
+                      ,c.deferrable
+                      ,c.deferred
+                      ,c.validated
+                      ,c.status
+                  FROM all_constraints c, all_cons_columns cc,
+                       all_constraints r, all_cons_columns rc
+                 WHERE c.owner = SYS_CONTEXT('userenv', 'current_schema')
+                   AND c.table_name = :desc_table_name
+                   AND c.constraint_type = 'R'
+                   AND cc.owner = c.owner
+                   AND cc.constraint_name = c.constraint_name
+                   AND r.constraint_name = c.r_constraint_name
+                   AND r.owner = c.owner
+                   AND rc.owner = r.owner
+                   AND rc.constraint_name = r.constraint_name
+                   AND rc.position = cc.position
+                ORDER BY name, to_table, column_name, references_column
+              SQL
+
+              fk_info.map do |row|
+                options = {
+                  column: oracle_downcase(row["column_name"]),
+                  name: oracle_downcase(row["name"]),
+                  primary_key: oracle_downcase(row["references_column"])
+                }
+                options[:on_delete] = extract_foreign_key_action(row["delete_rule"])
+                options[:deferrable] = extract_foreign_key_deferrable(row["deferrable"], row["deferred"])
+                options[:enforced] = false if row["status"] == "DISABLED"
+                options[:validate] = false if row["validated"] == "NOT VALIDATED"
+                ActiveRecord::ConnectionAdapters::ForeignKeyDefinition.new(oracle_downcase(table_name), oracle_downcase(row["to_table"]), options)
+              end
+            end
+          end
+
+          # `generated = 'USER NAME'` skips implicit NOT NULL checks (system-named, type 'C').
+          def fetch_check_constraints(tables)
+            tables.index_with do |table_name|
+              (_owner, desc_table_name) = resolve_data_source_name(table_name)
+
+              # `search_condition` is LONG; cannot appear in WHERE (ORA-00997).
+              rows = select_all(<<~SQL.squish, "SCHEMA", [bind_string("desc_table_name", desc_table_name)])
+                SELECT constraint_name AS name, search_condition, validated
+                  FROM all_constraints
+                 WHERE owner = SYS_CONTEXT('userenv', 'current_schema')
+                   AND table_name = :desc_table_name
+                   AND constraint_type = 'C'
+                   AND generated = 'USER NAME'
+                 ORDER BY constraint_name
+              SQL
+
+              rows.filter_map do |row|
+                next if row["search_condition"].nil?
+                options = { name: oracle_downcase(row["name"]) }
+                options[:validate] = false if row["validated"] == "NOT VALIDATED"
+                CheckConstraintDefinition.new(oracle_downcase(table_name), row["search_condition"], options)
+              end
+            end
+          end
+
+          def fetch_unique_constraints(tables)
+            tables.index_with do |table_name|
+              (_owner, desc_table_name) = resolve_data_source_name(table_name)
+
+              rows = select_all(<<~SQL.squish, "SCHEMA", [bind_string("desc_table_name", desc_table_name)])
+                SELECT c.constraint_name AS name,
+                       c.index_name,
+                       c.deferrable,
+                       c.deferred,
+                       cc.column_name,
+                       cc.position
+                  FROM all_constraints c
+                  JOIN all_cons_columns cc
+                    ON cc.owner = c.owner
+                   AND cc.constraint_name = c.constraint_name
+                 WHERE c.owner = SYS_CONTEXT('userenv', 'current_schema')
+                   AND c.table_name = :desc_table_name
+                   AND c.constraint_type = 'U'
+                 ORDER BY c.constraint_name, cc.position
+              SQL
+
+              grouped = rows.group_by { |row| row["name"] }
+              grouped.map do |name, group|
+                columns = group.sort_by { |r| r["position"] }.map { |r| oracle_downcase(r["column_name"]) }
+                sample = group.first
+                constraint_name = oracle_downcase(name)
+                index_name = oracle_downcase(sample["index_name"])
+
+                options = { name: constraint_name }
+                options[:deferrable] = extract_foreign_key_deferrable(sample["deferrable"], sample["deferred"])
+                if index_name && index_name != constraint_name
+                  options[:using_index] = index_name
+                end
+
+                OracleEnhanced::UniqueConstraintDefinition.new(oracle_downcase(table_name), columns, options)
+              end
+            end
+          end
+
           # Oracle does not allow inline `COMMENT '...'` in `ALTER TABLE
           # ADD` / `MODIFY`, so column comments are issued as separate
           # `COMMENT ON COLUMN` statements after the column DDL is in

--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -1040,19 +1040,8 @@ module ActiveRecord
       end
 
       def primary_keys(table_name) # :nodoc:
-        (_owner, desc_table_name) = resolve_data_source_name(table_name)
-
-        pks = select_values(<<~SQL.squish, "SCHEMA", [bind_string("table_name", desc_table_name)])
-          SELECT cc.column_name
-            FROM all_constraints c, all_cons_columns cc
-           WHERE c.owner = SYS_CONTEXT('userenv', 'current_schema')
-             AND c.table_name = :table_name
-             AND c.constraint_type = 'P'
-             AND cc.owner = c.owner
-             AND cc.constraint_name = c.constraint_name
-             order by cc.position
-        SQL
-        pks.map { |pk| oracle_downcase(pk) }
+        result = fetch_primary_keys(Array(table_name).map(&:to_s))
+        table_name.is_a?(Array) ? result : result[table_name.to_s]
       end
 
       def columns_for_distinct(columns, orders) # :nodoc:
@@ -1304,6 +1293,24 @@ module ActiveRecord
       ActiveRecord::Type.register(:json, Type::OracleEnhanced::Json, adapter: :oracle_enhanced)
 
       private
+        def fetch_primary_keys(tables)
+          tables.index_with do |table_name|
+            (_owner, desc_table_name) = resolve_data_source_name(table_name)
+
+            pks = select_values(<<~SQL.squish, "SCHEMA", [bind_string("table_name", desc_table_name)])
+              SELECT cc.column_name
+                FROM all_constraints c, all_cons_columns cc
+               WHERE c.owner = SYS_CONTEXT('userenv', 'current_schema')
+                 AND c.table_name = :table_name
+                 AND c.constraint_type = 'P'
+                 AND cc.owner = c.owner
+                 AND cc.constraint_name = c.constraint_name
+                 order by cc.position
+            SQL
+            pks.map { |pk| oracle_downcase(pk) }
+          end
+        end
+
         def prefetch_primary_key_from_schema_cache(table_name)
           pk_col = primary_key_column_from_schema_cache(table_name)
           # Propagate false (cache says no-prefetch) and nil (caller must fall back) as-is.

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_readers_many_tables_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_readers_many_tables_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Ported from activerecord/test/cases/connection_adapters/schema_statements_test.rb
+# (rails/rails#58421): each schema reader also accepts an Array of table names
+# and answers with a Hash keyed by the names it was given.
+RSpec.describe "OracleEnhancedAdapter schema readers for many tables" do
+  include SchemaSpecHelper
+
+  READERS = %i[primary_keys indexes foreign_keys check_constraints unique_constraints].freeze
+  TABLES = %w[test_reader_parents test_reader_children].freeze
+
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    @conn = ActiveRecord::Base.lease_connection
+    schema_define do
+      create_table :test_reader_parents, force: true do |t|
+        t.string :code
+        t.unique_constraint :code, name: "test_reader_parents_code_uq"
+      end
+      create_table :test_reader_children, force: true do |t|
+        t.references :test_reader_parent, foreign_key: true
+        t.string :name
+        t.index :name, name: "test_reader_children_name_idx"
+        t.check_constraint "LENGTH(name) > 0", name: "test_reader_children_name_chk"
+      end
+    end
+  end
+
+  after(:all) do
+    schema_define do
+      drop_table :test_reader_children, if_exists: true
+      drop_table :test_reader_parents, if_exists: true
+    end
+  end
+
+  def attributes(definitions)
+    Array(definitions).map { |definition| definition.is_a?(String) ? definition : definition.instance_values }
+  end
+
+  it "a list reads exactly the tables it is given" do
+    READERS.each do |reader|
+      expect(@conn.public_send(reader, TABLES).keys).to match_array(TABLES), "#{reader} did not answer for the tables it was given"
+    end
+  end
+
+  it "a list returns what asking for each table returns" do
+    READERS.each do |reader|
+      listed = @conn.public_send(reader, TABLES)
+      TABLES.each do |table|
+        expect(attributes(listed[table])).to eq(attributes(@conn.public_send(reader, table))), "#{reader} answered differently for #{table} in a list"
+      end
+    end
+  end
+
+  it "an empty list reads nothing" do
+    READERS.each do |reader|
+      queries = []
+      callback = ->(*, payload) { queries << payload[:sql] }
+      result = ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        @conn.public_send(reader, [])
+      end
+      expect(result).to eq({})
+      expect(queries).to be_empty, "#{reader}([]) queried the database"
+    end
+  end
+
+  it "a list keys each table by the name it was given" do
+    given = "TEST_READER_CHILDREN"
+    READERS.each do |reader|
+      listed = @conn.public_send(reader, [given])
+      expect(listed.keys).to eq([given]), "#{reader} did not key by the name it was given"
+      expect(attributes(listed[given])).to eq(attributes(@conn.public_send(reader, given)))
+    end
+    expect(@conn.foreign_keys([given])[given]).not_to be_empty
+  end
+end


### PR DESCRIPTION
Tracks rails/rails#58421 (merged as rails/rails@42274c880590c8f05ee553709701ef97dfaa0860), which lets the schema readers answer for a list of tables: `primary_keys`, `indexes`, `foreign_keys`, `check_constraints` and `unique_constraints` take an Array and return a Hash keyed by the names they were given, and `SchemaDumper#tables` reads all of that metadata up front through `read_schema_metadata` before dumping each table.

The Oracle dumper overrides `tables` and never called the new hook, so the inherited `foreign_keys` / `check_constraints_in_create` dereferenced a nil `@foreign_keys` / `@check_constraints` and every schema dump raised `NoMethodError: undefined method '[]' for nil` (68 failures across `schema_dumper_spec.rb`, `primary_key_trigger_spec.rb` and `context_index_spec.rb`).

- Mirrors the shape Rails gave every adapter: each public reader wraps a private `fetch_*(tables)` and returns the per-table value for a single name. Oracle reads each table's dictionary rows one table at a time inside `tables.index_with`, the same way the SQLite adapter does in that PR; batching the dictionary queries with an `IN` list is left as a separate optimisation.
- The Oracle dumper now calls `read_schema_metadata` and reads primary keys, indexes and unique constraints from the ivars the hook fills (which also drops its `respond_to?(:primary_keys)` guard).
- Ports the list-form reader tests from `activerecord/test/cases/connection_adapters/schema_statements_test.rb` as `schema_readers_many_tables_spec.rb`.
- Bumps the `activerecord` pin from rails/rails@342dafc535 (rails/rails#58239) to rails/rails@42274c8805 (rails/rails#58421).

rails/rails#58488 (the schema cache reading primary keys and indexes for many tables) needs no further adapter change once these readers accept a list, so the next pin in the stack jumps over it.

Verification: MRI full suite at this pin — 1115 examples, 0 failures, no deprecation leaks; RuboCop clean.

Stacked on #2836; the diff carries that PR's commits until it merges. JRuby rows: with the Rails main commits in this pin window, `require "active_record"` raises `NameError: uninitialized constant ActiveSupport::Ractors::Ractor` on JRuby 10.1 (observed on the CI-parity host at rails/rails@f70a767d), so the JRuby jobs cannot boot; that is upstream and independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sjgDUFVzHpDXPLyyeCRv5
