### PR TITLE
Bump Rails to rails/rails@a6e2d541 for reading columns of many tables

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 group :development do
   gem "rspec"
   gem "rake"
-  # rails/rails@42274c88 = merge of rails/rails#58421 (schema readers answer for
-  # many tables at once); bump per follow-up Rails change
-  gem "activerecord",   github: "rails/rails", ref: "42274c880590c8f05ee553709701ef97dfaa0860"
+  # rails/rails@a6e2d541 = merge of rails/rails#58494 (read the columns of many
+  # tables in one query); bump per follow-up Rails change
+  gem "activerecord",   github: "rails/rails", ref: "a6e2d541ba017ed55ed8e377978fd2678377ac36"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -151,7 +151,7 @@ module ActiveRecord # :nodoc:
           end
 
           def table(table, stream)
-            columns = @connection.columns(table)
+            columns = @columns[table]
             begin
               self.table_name = table
 

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -94,12 +94,11 @@ module ActiveRecord
         end
 
         def columns(table_name)
-          table_name = table_name.to_s
-          if @columns_cache[table_name]
-            @columns_cache[table_name]
-          else
-            @columns_cache[table_name] = super(table_name)
-          end
+          tables = Array(table_name).map(&:to_s)
+          uncached = tables.reject { |table| @columns_cache[table] }
+          super(uncached).each { |table, columns| @columns_cache[table] = columns } unless uncached.empty?
+          result = tables.index_with { |table| @columns_cache[table] }
+          table_name.is_a?(Array) ? result : result[table_name.to_s]
         end
         # Additional options for +create_table+ method in migration files.
         #

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_readers_many_tables_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_readers_many_tables_spec.rb
@@ -3,12 +3,12 @@
 require "spec_helper"
 
 # Ported from activerecord/test/cases/connection_adapters/schema_statements_test.rb
-# (rails/rails#58421): each schema reader also accepts an Array of table names
+# (rails/rails#58421, #58494): each schema reader also accepts an Array of table names
 # and answers with a Hash keyed by the names it was given.
 RSpec.describe "OracleEnhancedAdapter schema readers for many tables" do
   include SchemaSpecHelper
 
-  READERS = %i[primary_keys indexes foreign_keys check_constraints unique_constraints].freeze
+  READERS = %i[columns primary_keys indexes foreign_keys check_constraints unique_constraints].freeze
   TABLES = %w[test_reader_parents test_reader_children].freeze
 
   before(:all) do
@@ -51,6 +51,13 @@ RSpec.describe "OracleEnhancedAdapter schema readers for many tables" do
       TABLES.each do |table|
         expect(attributes(listed[table])).to eq(attributes(@conn.public_send(reader, table))), "#{reader} answered differently for #{table} in a list"
       end
+    end
+  end
+
+  it "a list reads columns in the same order as one table" do
+    listed = @conn.columns(TABLES)
+    TABLES.each do |table|
+      expect(listed[table].map(&:name)).to eq(@conn.columns(table).map(&:name))
     end
   end
 


### PR DESCRIPTION
Tracks rails/rails#58494 (merged as rails/rails@a6e2d541ba017ed55ed8e377978fd2678377ac36), which makes `columns` accept an Array of tables and answer with a Hash keyed by table name, feeding both `SchemaDumper#tables` (through `read_schema_metadata`) and the schema cache's bulk column reads.

The Oracle `columns` override memoises per table in `@columns_cache` and stringified whatever it was given, so an Array became a single bogus key and `super` was asked to describe `["a", "b"]` (the schema cache dump specs failed with `"DESC [...]" failed; does it exist?`).

- Resolves the cache per table, asks `super` only for the tables that are not cached yet (as an Array, so AR core's `fetch_column_definitions` does the looping), and returns the Hash or the single table's columns the way AR core does.
- The Oracle dumper reads `@columns[table]` like core.
- The list-form reader spec now covers `columns`, including the column-order check rails/rails#58494 added.
- Bumps the `activerecord` pin from rails/rails@42274c8805 (rails/rails#58421) to rails/rails@a6e2d541ba (rails/rails#58494).

Verification: MRI full suite at this pin — 1116 examples, 0 failures, no deprecation leaks; RuboCop clean.

Stacked on #2837; the diff carries that PR's commits until it merges. JRuby rows: with the Rails main commits in this pin window, `require "active_record"` raises `NameError: uninitialized constant ActiveSupport::Ractors::Ractor` on JRuby 10.1 (observed on the CI-parity host at rails/rails@f70a767d), so the JRuby jobs cannot boot; that is upstream and independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sjgDUFVzHpDXPLyyeCRv5
