### PR TITLE
Bump Rails to rails/rails@3b5ed2cf for reading table options of many tables

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 group :development do
   gem "rspec"
   gem "rake"
-  # rails/rails@a6e2d541 = merge of rails/rails#58494 (read the columns of many
-  # tables in one query); bump per follow-up Rails change
-  gem "activerecord",   github: "rails/rails", ref: "ae739c38542dc7f0522854d9b253d3814bfcc465"
+  # rails/rails@3b5ed2cf = merge of rails/rails#58498 (read the table options of
+  # many tables at once); bump per follow-up Rails change
+  gem "activerecord",   github: "rails/rails", ref: "3b5ed2cf6224593136592f556175214ece248237"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_dumper.rb
@@ -190,7 +190,7 @@ module ActiveRecord # :nodoc:
                 tbl.print ", id: false"
               end
 
-              table_options = @connection.table_options(table)
+              table_options = @table_options[table]
               if table_options.present?
                 tbl.print ", #{format_options(table_options)}"
               end

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -609,12 +609,6 @@ module ActiveRecord
           SQL
         end
 
-        def table_options(table_name) # :nodoc:
-          if comment = table_comment(table_name)
-            { comment: comment }
-          end
-        end
-
         def column_comment(table_name, column_name) # :nodoc:
           # TODO: it  does not exist in Abstract adapter
           (_owner, table_name) = resolve_data_source_name(table_name)
@@ -830,6 +824,13 @@ module ActiveRecord
         end
 
         private
+          def fetch_table_options(tables)
+            tables.index_with do |table_name|
+              comment = table_comment(table_name)
+              { comment: comment } if comment
+            end
+          end
+
           def fetch_indexes(tables)
             tables.index_with do |table_name|
               (_owner, table_name) = resolve_data_source_name(table_name)

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_readers_many_tables_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_readers_many_tables_spec.rb
@@ -3,19 +3,19 @@
 require "spec_helper"
 
 # Ported from activerecord/test/cases/connection_adapters/schema_statements_test.rb
-# (rails/rails#58421, #58494): each schema reader also accepts an Array of table names
+# (rails/rails#58421, #58494, #58498): each schema reader also accepts an Array of table names
 # and answers with a Hash keyed by the names it was given.
 RSpec.describe "OracleEnhancedAdapter schema readers for many tables" do
   include SchemaSpecHelper
 
-  READERS = %i[columns primary_keys indexes foreign_keys check_constraints unique_constraints].freeze
+  READERS = %i[columns primary_keys indexes foreign_keys check_constraints unique_constraints table_options].freeze
   TABLES = %w[test_reader_parents test_reader_children].freeze
 
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
     @conn = ActiveRecord::Base.lease_connection
     schema_define do
-      create_table :test_reader_parents, force: true do |t|
+      create_table :test_reader_parents, force: true, comment: "reader parents" do |t|
         t.string :code
         t.unique_constraint :code, name: "test_reader_parents_code_uq"
       end


### PR DESCRIPTION
Tracks rails/rails#58498 (merged as rails/rails@3b5ed2cf6224593136592f556175214ece248237), which makes `table_options` accept an Array of tables and answer with a Hash keyed by table name, with `SchemaDumper#tables` reading every table's options up front through `read_schema_metadata`. AR core now owns the public `table_options` wrapper and asks the adapter for a private `fetch_table_options(tables)`, defaulting to `tables.index_with(nil)`.

- Drops the Oracle `table_options` override in favour of that hook: reads each table's comment from `all_tab_comments` inside `index_with` and keeps returning `{ comment: ... }` only when a comment exists.
- The Oracle dumper reads `@table_options[table]` like core.
- The list-form reader spec now covers `table_options` against a commented table.
- Bumps the `activerecord` pin from rails/rails@a6e2d541ba (rails/rails#58494) to rails/rails@3b5ed2cf62 (rails/rails#58498).

Verification: MRI full suite at this pin — 1116 examples, 0 failures, no deprecation leaks; RuboCop clean.

Stacked on #2846 (rails/rails#58437 model schema context), which is stacked on #2838; the diff carries the parent commits until they merge. The former MRI failures on this PR were the rails/rails#58437 cold-cache issue fixed by #2846. JRuby rows: with the Rails main commits in this pin window, `require "active_record"` raises `NameError: uninitialized constant ActiveSupport::Ractors::Ractor` on JRuby 10.1 (observed on the CI-parity host at rails/rails@f70a767d), so the JRuby jobs cannot boot; that is upstream and independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sjgDUFVzHpDXPLyyeCRv5

