### PR TITLE
Make the sequence-value spec independent of example order

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe "OracleEnhancedAdapter" do
       end
 
       it "should get sequence value at next time" do
+        @conn.clear_table_caches(:test_employees)
         TestEmployee.create!
         expect(@logger.logged(:debug).first).not_to match(/SELECT "TEST_EMPLOYEES_SEQ".NEXTVAL FROM dual/im)
         @logger.clear(:debug)


### PR DESCRIPTION
`should get sequence value at next time` in `oracle_enhanced_adapter_spec.rb` asserts that the first `create!` logs a schema lookup before `SELECT "TEST_EMPLOYEES_SEQ".NEXTVAL FROM dual`, which only holds while the connection's column / primary-key caches for `test_employees` are cold. With seeds that run the cache-warming siblings in the same group first, the first debug line is already the NEXTVAL query and the example fails; `bundle exec rspec spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb --seed 14895` (or `--seed 61014`) reproduces it on master.

- Clears the table caches at the start of the example, the way the sibling `should get columns from database at first time` already does, so the cold-cache precondition is part of the example instead of an accident of ordering.

Verification: the file passes with seeds 14895, 61014 and 34951; RuboCop clean.

Rebased onto master after the RuboCop 1.90 fix (#2834/#2844) merged, so this PR now carries only the spec change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sjgDUFVzHpDXPLyyeCRv5
