### PR TITLE
Bump Rails to rails/rails@f70a767d for QueryIntent result delivery

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 group :development do
   gem "rspec"
   gem "rake"
-  # rails/rails@3b5ed2cf = merge of rails/rails#58498 (read the table options of
-  # many tables at once); bump per follow-up Rails change
-  gem "activerecord",   github: "rails/rails", ref: "3b5ed2cf6224593136592f556175214ece248237"
+  # rails/rails@f70a767d = merge of rails/rails#58049 (drive result delivery
+  # through QueryIntent); bump per follow-up Rails change
+  gem "activerecord",   github: "rails/rails", ref: "f70a767d2fad00af0bf33bc780125cadcbb95092"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -3,6 +3,20 @@
 module ActiveRecord
   module ConnectionAdapters
     module OracleEnhanced
+      class ReturningAttribute < ActiveRecord::Relation::QueryAttribute # :nodoc:
+        def initialize(column_name, type)
+          super("returning_#{column_name}", nil, type)
+        end
+
+        def column_name
+          name.delete_prefix("returning_")
+        end
+
+        def ruby_class
+          type.is_a?(ActiveModel::Type::String) ? String : Integer
+        end
+      end
+
       module DatabaseStatements
         # DATABASE STATEMENTS ======================================
         #
@@ -45,6 +59,22 @@ module ActiveRecord
           # https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/EXPLAIN-PLAN.html#GUID-FD540872-4ED3-4936-96A2-362539931BA0
         end
 
+        def instrument_custom_method(sql, name, &block) # :nodoc:
+          # Custom create/update/delete blocks call ruby-plsql directly, bypassing
+          # AR's exec path. Flush any buffered BEGIN here so the PL/SQL call lands
+          # inside the materialized transaction.
+          materialize_transactions
+          instrumenter.instrument(
+            "sql.active_record",
+            sql: sql, name: name, binds: [], type_casted_binds: [], async: false, allow_retry: false,
+            connection: self, transaction: current_transaction.user_transaction.presence,
+            affected_rows: 0, row_count: 0,
+            &block
+          )
+        ensure
+          log_dbms_output if dbms_output_enabled?
+        end
+
         def _exec_insert(intent, sequence_name = nil, returning: nil) # :nodoc:
           raw_sql = intent.raw_sql
           original_binds_count = intent.binds.size
@@ -61,62 +91,23 @@ module ActiveRecord
           intent.raw_sql = sql
           intent.binds = binds
 
+          intent.execute!
+          result = intent.cast_result
+          return result if requested_cols.empty?
+
+          returned = result.columns.zip(result.rows.first || []).to_h
           type_casted_binds = intent.type_casted_binds
-          bind_specs = returning_bind_specs(binds, original_binds_count)
-
-          log(intent) do
-            cached = false
-            cursor = nil
-            with_raw_connection(allow_retry: true) do |raw_connection|
-              begin
-                if binds.nil? || binds.empty?
-                  cursor = raw_connection.prepare(sql)
-                else
-                  if prepared_statements?
-                    @statements[sql] ||= raw_connection.prepare(sql)
-                    cursor = @statements[sql]
-                    cached = true
-                  else
-                    cursor = raw_connection.prepare(sql)
-                  end
-
-                  cursor.bind_params(type_casted_binds)
-
-                  bind_specs.each do |position, klass|
-                    cursor.bind_returning_param(position, klass)
-                  end
-                end
-
-                cursor.exec_update
-              rescue
-                (cursor.close rescue nil) if cursor && !cached
-                raise
-              end
-
-              rows = []
-              unless requested_cols.empty?
-                returned = {}
-                bind_specs.each do |position, klass|
-                  value = cursor.get_returning_param(position, klass)
-                  col = binds[position - 1].name.delete_prefix("returning_")
-                  returned[col] = klass == Integer ? value.to_i : value
-                end
-                # Align the row with the requested columns, echoing bound values
-                # for columns the INSERT already carries (e.g. the prefetched sequence PK).
-                row = requested_cols.map do |col|
-                  if returned.key?(col)
-                    returned[col]
-                  else
-                    index = binds[0...original_binds_count].index { |bind| bind.name == col } if echoable_cols.include?(col)
-                    index && type_casted_binds[index]
-                  end
-                end
-                rows << row unless row.all?(&:nil?)
-              end
-              cursor.close unless cached
-              ActiveRecord::Result.new([], rows)
+          # Align the row with the requested columns, echoing bound values
+          # for columns the INSERT already carries (e.g. the prefetched sequence PK).
+          row = requested_cols.map do |col|
+            if returned.key?(col)
+              returned[col]
+            else
+              index = binds[0...original_binds_count].index { |bind| bind.name == col } if echoable_cols.include?(col)
+              index && type_casted_binds[index]
             end
           end
+          ActiveRecord::Result.new([], row.all?(&:nil?) ? [] : [row])
         end
 
         def begin_db_transaction # :nodoc:
@@ -311,7 +302,7 @@ module ActiveRecord
               returning_cols.each do |col|
                 column = table_ref ? columns(table_ref).find { |c| c.name == col } : nil
                 type = column&.cast_type || Type::OracleEnhanced::Integer.new
-                binds << ActiveRecord::Relation::QueryAttribute.new("returning_#{col}", nil, type)
+                binds << OracleEnhanced::ReturningAttribute.new(col, type)
               end
             end
             # Skip super: AR's abstract appends PG-style `RETURNING col1, col2` which conflicts with Oracle's `RETURNING ... INTO :bind` form (ORA-00925).
@@ -328,14 +319,9 @@ module ActiveRecord
             Array(returning).map(&:to_s)
           end
 
-          # Identify the trailing binds appended by `sql_for_insert` by position, not by name,
-          # so a user column happening to share the placeholder name cannot collide.
-          def returning_bind_specs(binds, original_binds_count)
-            return [] if binds.size <= original_binds_count
-            (original_binds_count...binds.size).map do |i|
-              klass = binds[i].type.is_a?(ActiveModel::Type::String) ? String : Integer
-              [i + 1, klass]
-            end
+          def returning_binds(binds)
+            return [] if binds.nil?
+            binds.each_with_index.filter_map { |bind, index| [index + 1, bind] if bind.is_a?(OracleEnhanced::ReturningAttribute) }
           end
 
           def perform_query(raw_connection, intent)
@@ -343,6 +329,7 @@ module ActiveRecord
             binds = intent.binds
             type_casted_binds = intent.type_casted_binds
 
+            returning = returning_binds(binds)
             cursor = nil
             cached = false
             begin
@@ -358,23 +345,34 @@ module ActiveRecord
                 end
 
                 cursor.bind_params(type_casted_binds)
+                returning.each do |position, bind|
+                  cursor.bind_returning_param(position, bind.ruby_class)
+                end
               end
-              cursor.exec
+              returning.empty? ? cursor.exec : cursor.exec_update
             rescue
               (cursor.close rescue nil) if cursor && !cached
               raise
             end
 
-            columns = cursor.get_col_names.map do |col_name|
-              oracle_downcase(col_name)
-            end
-
-            rows = []
-            if cursor.select_statement?
-              fetch_options = { get_lob_value: (intent.name != "Writable Large Object") }
-              while row = cursor.fetch(fetch_options)
-                rows << row
+            if returning.empty?
+              columns = cursor.get_col_names.map do |col_name|
+                oracle_downcase(col_name)
               end
+
+              rows = []
+              if cursor.select_statement?
+                fetch_options = { get_lob_value: (intent.name != "Writable Large Object") }
+                while row = cursor.fetch(fetch_options)
+                  rows << row
+                end
+              end
+            else
+              columns = returning.map { |_position, bind| bind.column_name }
+              rows = [returning.map do |position, bind|
+                value = cursor.get_returning_param(position, bind.ruby_class)
+                bind.ruby_class == Integer ? value.to_i : value
+              end]
             end
 
             affected_rows_count = cursor.row_count
@@ -386,13 +384,9 @@ module ActiveRecord
             { columns: columns, rows: rows, affected_rows_count: affected_rows_count }
           end
 
-          def handle_warnings(raw_result, sql)
-            @notice_receiver_sql_warnings.each do |warning|
-              next if warning_ignored?(warning)
-
-              warning.sql = sql
-              ActiveRecord.db_warnings_action.call(warning)
-            end
+          def collect_warnings(_raw_result)
+            warnings, @notice_receiver_sql_warnings = @notice_receiver_sql_warnings, []
+            warnings
           end
 
           # Compile each insert row to `VALUES (...)` individually via Arel, so

--- a/lib/active_record/connection_adapters/oracle_enhanced/dbms_output.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/dbms_output.rb
@@ -30,13 +30,13 @@ module ActiveRecord
           @enable_dbms_output
         end
 
-      private
-        def log(intent_or_sql, name = "SQL", binds = [], type_casted_binds = [], async: false, allow_retry: false, &block)
+        def execute_intent(intent) # :nodoc:
           super
         ensure
           log_dbms_output if dbms_output_enabled?
         end
 
+      private
         def set_dbms_output_plsql_connection
           raise OracleEnhanced::ConnectionException, "ruby-plsql gem is required for logging DBMS output" unless self.respond_to?(:plsql)
           # do not reset plsql connection if it is the same (as resetting will clear PL/SQL metadata cache)

--- a/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/procedures.rb
@@ -186,15 +186,7 @@ module ActiveRecord # :nodoc:
       end
 
       def log_custom_method(sql, name, &block)
-        connection = self.class.lease_connection
-        # Custom create/update/delete blocks call ruby-plsql directly, bypassing
-        # AR's exec path. Flush any buffered BEGIN here so the PL/SQL call lands
-        # inside the materialized transaction.
-        connection.materialize_transactions
-        intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(
-          adapter: connection, raw_sql: sql, name: name, binds: []
-        )
-        connection.send(:log, intent, &block)
+        self.class.lease_connection.instrument_custom_method(sql, name, &block)
       end
 
       alias_method :update_record, :_update_record if private_method_defined?(:_update_record)

--- a/spec/active_record/connection_adapters/oracle_enhanced/adapter_leasing_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/adapter_leasing_spec.rb
@@ -125,10 +125,12 @@ RSpec.describe "OracleEnhancedAdapter#_exec_insert" do
     @adapter.drop_table(:test_allow_retry_inserts, if_exists: true)
   end
 
-  it "routes the INSERT cursor through with_raw_connection with allow_retry: true" do
-    allow(@adapter).to receive(:with_raw_connection).and_call_original
+  it "runs the INSERT through execute_intent as a non-retryable intent" do
+    allow(@adapter).to receive(:execute_intent).and_call_original
     @model_class.create!(name: "x")
-    expect(@adapter).to have_received(:with_raw_connection).with(allow_retry: true).at_least(:once)
+    expect(@adapter).to have_received(:execute_intent)
+      .with(satisfy { |intent| intent.raw_sql.match?(/\AINSERT INTO/i) && !intent.allow_retry })
+      .at_least(:once)
   end
 end
 


### PR DESCRIPTION
Tracks rails/rails#58049 (merged as rails/rails@f70a767d2fad00af0bf33bc780125cadcbb95092), which turns result delivery into an active step of the `QueryIntent`: `execute_intent` no longer wraps `perform_query` in `log` and `with_raw_connection`, warnings are collected by a private `collect_warnings(raw_result)` and handed to a public `handle_warnings(intent, warnings)` from `QueryIntent#ensure_result`, and `log` is deprecated for removal in Rails 8.3.

Against that commit the adapter cannot open a connection at all: the private `handle_warnings(raw_result, sql)` override shadows the new public method, so `QueryIntent#ensure_result` raises `NoMethodError: private method 'handle_warnings'` from `configure_connection` (the suite reports 0 examples). With only that fixed, `_exec_insert`'s `log(intent)` leaks a deprecation per `INSERT ... RETURNING` (failing most examples under the CI stderr gate), logs the intent object instead of the SQL, and — because the deprecated `log` no longer calls `processed_sql` — `while_preventing_writes` stops raising `ReadOnlyError` for inserts; DBMS_OUTPUT draining also silently stops.

- `collect_warnings` returns and clears the notice-receiver buffer, mirroring the PostgreSQL adapter.
- `_exec_insert` runs the INSERT as the intent itself: it still rewrites the statement and binds for `RETURNING ... INTO`, then calls `intent.execute!` / `intent.cast_result`; `perform_query` registers the OUT binds and reads them back. The RETURNING binds are a dedicated `OracleEnhanced::ReturningAttribute`, so `perform_query` recognises them by class rather than by position. INSERT intents are non-retryable in AR core, so the leasing spec pins that instead of `allow_retry: true`.
- `DbmsOutput` drains DBMS_OUTPUT from `execute_intent` (public, since `QueryIntent#run_query!` calls it on the adapter) instead of the removed `log` hook.
- Custom PL/SQL create/update/delete methods get `instrument_custom_method` on the adapter: the `sql.active_record` payload `log` used to build, plus the DBMS_OUTPUT drain.
- Bumps the `activerecord` pin from rails/rails@3b5ed2cf62 (rails/rails#58498) to rails/rails@f70a767d (rails/rails#58049).

Verification: MRI full suite at this pin under the CI stderr gate (`CI=1`) — 1116 examples, 0 deprecation leaks; the single failing example is the pre-existing seed-dependent `should get sequence value at next time` (it fails at the previous pin with the same seed and is fixed separately in #2840); RuboCop clean.

Stacked on #2839 (with #2846, the rails/rails#58437 model schema context fix, now between #2838 and #2839); the diff carries the parent commits until they merge. JRuby rows: with the Rails main commits in this pin window, `require "active_record"` raises `NameError: uninitialized constant ActiveSupport::Ractors::Ractor` on JRuby 10.1 (observed on the CI-parity host at rails/rails@f70a767d), so the JRuby jobs cannot boot; that is upstream and independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sjgDUFVzHpDXPLyyeCRv5

