### PR TITLE
Alias add_belongs_to to add_reference at the connection level

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -462,6 +462,7 @@ module ActiveRecord
         def add_reference(table_name, ref_name, **options)
           OracleEnhanced::ReferenceDefinition.new(ref_name, **options).add_to(update_table_definition(table_name, self))
         end
+        alias :add_belongs_to :add_reference
 
         def add_column(table_name, column_name, type, **options) # :nodoc:
           # Adding a `GENERATED ... AS IDENTITY` column with `ALTER TABLE` is

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -1706,6 +1706,27 @@ end
     end
   end
 
+  describe "add reference" do
+    before(:each) do
+      schema_define do
+        create_table :test_employees, force: true
+      end
+    end
+
+    after(:each) do
+      schema_define do
+        drop_table :test_employees, if_exists: true
+      end
+    end
+
+    it "creates the reference column as NUMBER(38) via add_belongs_to" do
+      @conn.add_belongs_to("test_employees", "test_post")
+
+      column = @conn.columns("test_employees").find { |c| c.name == "test_post_id" }
+      expect(column.sql_type).to match(/NUMBER\(38\)/i)
+    end
+  end
+
   describe "add_column / change_column comment handling" do
     before(:each) do
       schema_define do


### PR DESCRIPTION
Ruby's `alias` copies the method entry at alias time, so the `add_belongs_to` alias declared in Rails' abstract adapter still points at the stock `add_reference` and bypasses this adapter's override. As a result, `add_belongs_to` built the reference column through the stock `ReferenceDefinition` (default `type: :bigint`, NUMBER(19)) instead of `OracleEnhanced::ReferenceDefinition` (default `type: :integer`, NUMBER(38)):

```ruby
add_reference :test_employees, :test_post   # test_post_id NUMBER(38)
add_belongs_to :test_employees, :test_post  # test_post_id NUMBER(19)
```

This re-declares the alias next to the override, following the convention used across Rails itself (every layer that overrides `add_reference`/`references` re-declares its alias) and already followed by this adapter at the table definition level (`alias :belongs_to :references` in schema_definitions.rb).

The added spec fails without the alias (`expected "NUMBER(19)" to match /NUMBER\(38\)/i`) and passes with it.