### PR TITLE
Address Layout/SpaceBeforeFirstArg offenses detected by RuboCop 1.90.0

### DIFF
--- a/spec/active_record/connection_adapters/oracle_enhanced/composite_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/composite_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "OracleEnhancedAdapter should support composite primary" do
       end
 
       create_table :test_books, force: true do |t|
-        t.string    :title,       limit: 20
+        t.string :title,       limit: 20
       end
 
       create_table :test_authors_test_books, primary_key: ["test_author_id", "test_book_id"], force: true do |t|

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_statements_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "OracleEnhancedAdapter schema definition" do
     before do
       schema_define do
         create_table :keyboards, force: true, id: false do |t|
-          t.string      :name
+          t.string :name
         end
         add_column :keyboards, :id, :primary_key
       end
@@ -35,7 +35,7 @@ RSpec.describe "OracleEnhancedAdapter schema definition" do
           t.string      :name
         end
         create_table :id_keyboards, force: true do |t|
-          t.string      :name
+          t.string :name
         end
       end
       class ::Keyboard < ActiveRecord::Base

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe "OracleEnhancedAdapter" do
           if ActiveRecord::Base.lease_connection.supports_virtual_columns?
             t.virtual :full_name, as: "(first_name || ' ' || last_name)"
           else
-            t.string  :full_name, limit: 46
+            t.string :full_name, limit: 46
           end
-          t.date    :hire_date
+          t.date :hire_date
         end
       end
       schema_define do
@@ -291,7 +291,7 @@ RSpec.describe "OracleEnhancedAdapter" do
     before(:all) do
       schema_define do
         create_table :test_posts do |t|
-          t.string      :title
+          t.string :title
         end
         create_table :test_comments do |t|
           t.integer     :test_post_id
@@ -330,7 +330,7 @@ RSpec.describe "OracleEnhancedAdapter" do
     before(:all) do
       schema_define do
         create_table :test_posts do |t|
-          t.string      :title
+          t.string :title
         end
         create_table :test_comments do |t|
           t.integer     :test_post_id


### PR DESCRIPTION
RuboCop's scheduled runs on master (and PR runs such as https://github.com/rsim/oracle-enhanced/actions/runs/33502031297/job/99837343029) have been failing since 2026-08-25 with 7 autocorrectable `Layout/SpaceBeforeFirstArg` offenses in spec files.

The last green run used RuboCop 1.89.0; the first failing run used 1.90.0 with all other RuboCop gems unchanged. RuboCop 1.90.0 changed `AllowForAlignment` to no longer treat a same-indentation line beyond the enclosing block as an alignment anchor for `Layout/SpaceBeforeFirstArg` (also `Layout/ExtraSpacing` and `Layout/SpaceAroundOperators`) via https://github.com/rubocop/rubocop/pull/15554 — so these long-standing aligned `t.string      :name`-style lines lost their alignment exemption.

This commit applies `bundle exec rubocop -a --only Layout/SpaceBeforeFirstArg`; the full-project `bundle exec rubocop` now reports no offenses. Neighboring aligned lines that still have an in-block alignment anchor (e.g. `t.integer     :test_post_id`) remain accepted by RuboCop and are left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ZgTBgTLHVWt3Qu2iT4dD9
