### PR TITLE
Allow JRuby matrix rows to fail without failing the workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    continue-on-error: ${{ startsWith(matrix.ruby, 'jruby') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -15,6 +15,7 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     runs-on: ubuntu-latest
+    continue-on-error: ${{ startsWith(matrix.ruby, 'jruby') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test_11g_ojdbc11.yml
+++ b/.github/workflows/test_11g_ojdbc11.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ startsWith(matrix.ruby, 'jruby') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test_prepared_statements_false.yml
+++ b/.github/workflows/test_prepared_statements_false.yml
@@ -7,6 +7,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    continue-on-error: ${{ startsWith(matrix.ruby, 'jruby') }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Rails main currently cannot boot on JRuby: activesupport's `ractors.rb` references the bare `Ractor` constant at require time from inside `module ActiveSupport::Ractors` (the `if Ractor.respond_to?(:store_if_absent)` guard), and JRuby defines no `Ractor` constant, so `require "active_record"` raises `NameError: uninitialized constant ActiveSupport::Ractors::Ractor` before any example runs. This is upstream (still present on rails main as of 2026-09-01, no fix or issue filed yet) and affects every Rails-pin bump from rails/rails@6a7dc137 onward, turning the JRuby rows red on otherwise-green pull requests such as #2835 for reasons the adapter cannot address.

This PR adds `continue-on-error: ${{ startsWith(matrix.ruby, 'jruby') }}` to the `test`, `test_11g`, `test_11g_ojdbc11`, and `test_prepared_statements_false` matrices, so JRuby failures stop failing the workflow run while the CRuby rows keep gating merges. Once merged, the pending Rails-pin stack (#2835–#2841) will be rebased onto it so those PRs can go green.

Notes:

- With job-level `continue-on-error`, a failed JRuby job no longer fails the run; the failure remains visible in the job's own log and annotations.
- The scheduled `jruby_head` workflow is intentionally left untouched as the JRuby canary, and `release.yml`'s JRuby usage (gem build) is unaffected.
- Released Rails (8.x) + JRuby remains green today; this only concerns rails-main-tracking pins. If Rails guards the constant (or JRuby grows a minimal `Ractor` surface), this can be reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ZgTBgTLHVWt3Qu2iT4dD9
