### PR TITLE
Bump Rails to rails/rails@ae739c38 for the model schema context

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :development do
   gem "rake"
   # rails/rails@a6e2d541 = merge of rails/rails#58494 (read the columns of many
   # tables in one query); bump per follow-up Rails change
-  gem "activerecord",   github: "rails/rails", ref: "a6e2d541ba017ed55ed8e377978fd2678377ac36"
+  gem "activerecord",   github: "rails/rails", ref: "ae739c38542dc7f0522854d9b253d3814bfcc465"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do

--- a/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced_adapter_spec.rb
@@ -99,6 +99,7 @@ RSpec.describe "OracleEnhancedAdapter" do
 
       it "should get sequence value at next time" do
         @conn.clear_table_caches(:test_employees)
+        TestEmployee.reset_column_information
         TestEmployee.create!
         expect(@logger.logged(:debug).first).not_to match(/SELECT "TEST_EMPLOYEES_SEQ".NEXTVAL FROM dual/im)
         @logger.clear(:debug)


### PR DESCRIPTION
Tracks rails/rails#58437 (merged as rails/rails@ae739c38542dc7f0522854d9b253d3814bfcc465), which extracts model schema state into a schema context that is populated on schema load and only replaced on schema reloads.

With that change, `connection.clear_table_caches` alone no longer makes the `should get sequence value at next time` example start cold: the model's schema context still holds the loaded schema state, so the first `create!` goes straight to `SELECT "TEST_EMPLOYEES_SEQ".NEXTVAL FROM dual` without any schema query, and the example's first-debug-line expectation fails independent of example order. This is what the MRI rows on #2839 and #2841 have been failing on (it was previously mistaken for the seed-dependent flake #2840 fixed, because the symptom is the same example).

- Adds `TestEmployee.reset_column_information` to the example's cold-cache setup, which replaces the schema context and restores the cold start the example asserts.
- Bumps the `activerecord` pin from rails/rails@a6e2d541 (rails/rails#58494) to rails/rails@ae739c38 (rails/rails#58437).

Verification: the boundary is exact — the example file passes with `--order defined` at the parent pin rails/rails@a6e2d541 and fails the same way at rails/rails@ae739c38 before this fix. With the fix, full suite at this pin is 1117 examples, 0 failures; the file passes with `--order defined` and seeds 59717, 14895, 61014, 34951; RuboCop clean.

Stacked between #2838 and #2839: based on #2838's branch, and #2839/#2841 will be rebased on top of this. JRuby rows fail at `require "active_record"` with the upstream `ActiveSupport::Ractors::Ractor` NameError described in #2835 and are allowed to fail per #2845.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ZgTBgTLHVWt3Qu2iT4dD9
