### PR TITLE
Stop running the JRuby test rows while Rails main cannot boot on JRuby

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    continue-on-error: ${{ startsWith(matrix.ruby, 'jruby') }}
     strategy:
       fail-fast: false
       matrix:
@@ -19,11 +18,7 @@ jobs:
           '4.0',
           '3.4',
           '3.3',
-          'jruby-10.1.1.0',
         ]
-        include:
-          - ruby: 'jruby-10.1.1.0'
-            jruby_opts: '--dev'
     env:
       CI: true
       JRUBY_OPTS: ${{ matrix.jruby_opts }}

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -15,7 +15,6 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     runs-on: ubuntu-latest
-    continue-on-error: ${{ startsWith(matrix.ruby, 'jruby') }}
     strategy:
       fail-fast: false
       matrix:
@@ -23,11 +22,7 @@ jobs:
           '4.0',
           '3.4',
           '3.3',
-          'jruby-10.1.1.0',
         ]
-        include:
-          - ruby: 'jruby-10.1.1.0'
-            jruby_opts: '--dev'
     env:
       CI: true
       JRUBY_OPTS: ${{ matrix.jruby_opts }}

--- a/.github/workflows/test_prepared_statements_false.yml
+++ b/.github/workflows/test_prepared_statements_false.yml
@@ -7,17 +7,12 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    continue-on-error: ${{ startsWith(matrix.ruby, 'jruby') }}
     strategy:
       fail-fast: false
       matrix:
         ruby: [
           '4.0',
-          'jruby-10.1.1.0',
         ]
-        include:
-          - ruby: 'jruby-10.1.1.0'
-            jruby_opts: '--dev'
     env:
       CI: true
       JRUBY_OPTS: ${{ matrix.jruby_opts }}


### PR DESCRIPTION
Follow-up to #2845, replacing its approach: instead of letting the JRuby rows fail with `continue-on-error` (which keeps the run green but still burns two full JRuby jobs per push and leaves a red ✗ on every stacked PR), stop running them entirely while the upstream breakage lasts.

Background: Rails main raises `NameError: uninitialized constant ActiveSupport::Ractors::Ractor` at `require "active_record"` on JRuby — activesupport's `ractors.rb` references the bare `Ractor` constant at load time from inside `module ActiveSupport::Ractors`, and JRuby defines no `Ractor` constant (details in #2835). Every Rails-pin bump past rails/rails@6a7dc137 fails the JRuby rows before a single example runs; still present on rails main as of 2026-09-02 with no upstream issue or fix.

- Removes the `jruby-10.1.1.0` matrix entries (and their `include` blocks) from `test`, `test_11g`, and `test_prepared_statements_false`, along with the now-moot `continue-on-error` lines from #2845.
- The `Set up Java` steps and `JRUBY_OPTS` plumbing stay, so restoring the rows is a one-line matrix entry once Rails guards the constant (or JRuby grows a minimal `Ractor` surface).
- JRuby coverage remains via the scheduled `jruby_head` and `test_11g_ojdbc11` workflows, which run at the Gemfile's pinned Rails ref and still boot today.

Once merged, the Rails-pin stack (#2835 → #2836 → #2837 → #2838 → #2846 → #2839 → #2841) will be rebased onto it so those PRs show fully green checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ZgTBgTLHVWt3Qu2iT4dD9
