### PR TITLE
Bump Rails to rails/rails@38b1f04f for schema_ignored_tables

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 group :development do
   gem "rspec"
   gem "rake"
-  # rails/rails@f70a767d = merge of rails/rails#58049 (drive result delivery
-  # through QueryIntent); bump per follow-up Rails change
-  gem "activerecord",   github: "rails/rails", ref: "f70a767d2fad00af0bf33bc780125cadcbb95092"
+  # rails/rails@38b1f04f = merge of rails/rails#58554 (add
+  # config.active_record.schema_ignored_tables); bump per follow-up Rails change
+  gem "activerecord",   github: "rails/rails", ref: "38b1f04ffd98eaa1d4594b2f3ef82e9a6cd3f135"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do

--- a/spec/active_record/connection_adapters/oracle_enhanced/identity_primary_key_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/identity_primary_key_spec.rb
@@ -315,9 +315,9 @@ RSpec.describe "identity primary keys" do
       end
 
       stream = StringIO.new
-      ActiveRecord::SchemaDumper.ignore_tables = @conn.data_sources - ["test_identity_pks"]
+      ActiveRecord.schema_ignored_tables = @conn.data_sources - ["test_identity_pks"]
       ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection_pool, stream)
-      ActiveRecord::SchemaDumper.ignore_tables = []
+      ActiveRecord.schema_ignored_tables = []
 
       expect(stream.string).to include('create_table "test_identity_pks"')
       expect(stream.string).to include("identity: true")
@@ -331,9 +331,9 @@ RSpec.describe "identity primary keys" do
       end
 
       stream = StringIO.new
-      ActiveRecord::SchemaDumper.ignore_tables = @conn.data_sources - ["test_identity_pks"]
+      ActiveRecord.schema_ignored_tables = @conn.data_sources - ["test_identity_pks"]
       ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection_pool, stream)
-      ActiveRecord::SchemaDumper.ignore_tables = []
+      ActiveRecord.schema_ignored_tables = []
 
       expect(stream.string).to include('create_table "test_identity_pks"')
       expect(stream.string).not_to include("identity: true")

--- a/spec/active_record/connection_adapters/oracle_enhanced/primary_key_trigger_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/primary_key_trigger_spec.rb
@@ -232,9 +232,9 @@ RSpec.describe "primary_key_trigger" do
       end
 
       stream = StringIO.new
-      ActiveRecord::SchemaDumper.ignore_tables = @conn.data_sources - ["test_pk_triggers"]
+      ActiveRecord.schema_ignored_tables = @conn.data_sources - ["test_pk_triggers"]
       ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection_pool, stream)
-      ActiveRecord::SchemaDumper.ignore_tables = []
+      ActiveRecord.schema_ignored_tables = []
 
       expect(stream.string).to include('create_table "test_pk_triggers"')
       expect(stream.string).to include("primary_key_trigger: true")
@@ -248,9 +248,9 @@ RSpec.describe "primary_key_trigger" do
       end
 
       stream = StringIO.new
-      ActiveRecord::SchemaDumper.ignore_tables = @conn.data_sources - ["test_pk_triggers"]
+      ActiveRecord.schema_ignored_tables = @conn.data_sources - ["test_pk_triggers"]
       ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection_pool, stream)
-      ActiveRecord::SchemaDumper.ignore_tables = []
+      ActiveRecord.schema_ignored_tables = []
 
       expect(stream.string).to include('create_table "test_pk_triggers"')
       expect(stream.string).not_to include("primary_key_trigger")
@@ -266,9 +266,9 @@ RSpec.describe "primary_key_trigger" do
       end
 
       stream = StringIO.new
-      ActiveRecord::SchemaDumper.ignore_tables = @conn.data_sources - ["test_pk_triggers"]
+      ActiveRecord.schema_ignored_tables = @conn.data_sources - ["test_pk_triggers"]
       ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection_pool, stream)
-      ActiveRecord::SchemaDumper.ignore_tables = []
+      ActiveRecord.schema_ignored_tables = []
 
       expect(stream.string).to include('create_table "test_pk_triggers"')
       expect(stream.string).to include("identity: true")
@@ -283,9 +283,9 @@ RSpec.describe "primary_key_trigger" do
       end
 
       stream = StringIO.new
-      ActiveRecord::SchemaDumper.ignore_tables = @conn.data_sources - ["test_pk_triggers"]
+      ActiveRecord.schema_ignored_tables = @conn.data_sources - ["test_pk_triggers"]
       ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection_pool, stream)
-      ActiveRecord::SchemaDumper.ignore_tables = []
+      ActiveRecord.schema_ignored_tables = []
 
       expect(stream.string).to include("primary_key_trigger: true")
       expect(stream.string).to include('trigger_name: "custom_pkt"')
@@ -299,9 +299,9 @@ RSpec.describe "primary_key_trigger" do
       end
 
       stream = StringIO.new
-      ActiveRecord::SchemaDumper.ignore_tables = @conn.data_sources - ["test_pk_triggers"]
+      ActiveRecord.schema_ignored_tables = @conn.data_sources - ["test_pk_triggers"]
       ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection_pool, stream)
-      ActiveRecord::SchemaDumper.ignore_tables = []
+      ActiveRecord.schema_ignored_tables = []
 
       expect(stream.string).to include("primary_key_trigger: true")
       expect(stream.string).not_to include("trigger_name:")
@@ -550,9 +550,9 @@ RSpec.describe "primary_key_trigger" do
       SQL
 
       stream = StringIO.new
-      ActiveRecord::SchemaDumper.ignore_tables = @conn.data_sources - ["test_pk_triggers"]
+      ActiveRecord.schema_ignored_tables = @conn.data_sources - ["test_pk_triggers"]
       ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection_pool, stream)
-      ActiveRecord::SchemaDumper.ignore_tables = []
+      ActiveRecord.schema_ignored_tables = []
 
       expect(stream.string).to include('create_table "test_pk_triggers"')
       expect(stream.string).not_to include("primary_key_trigger")
@@ -646,9 +646,9 @@ RSpec.describe "primary_key_trigger" do
       end
 
       stream = StringIO.new
-      ActiveRecord::SchemaDumper.ignore_tables = @conn.data_sources - ["test_pk_triggers_renamed"]
+      ActiveRecord.schema_ignored_tables = @conn.data_sources - ["test_pk_triggers_renamed"]
       ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection_pool, stream)
-      ActiveRecord::SchemaDumper.ignore_tables = []
+      ActiveRecord.schema_ignored_tables = []
 
       expect(stream.string).to include("primary_key_trigger: true")
       # The default trigger name was renamed; no explicit :trigger_name should be needed.

--- a/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/schema_dumper_spec.rb
@@ -11,9 +11,12 @@ RSpec.describe "OracleEnhancedAdapter schema dump" do
 
   def standard_dump(options = {})
     stream = StringIO.new
-    ActiveRecord::SchemaDumper.ignore_tables = options[:ignore_tables] || []
+    old_ignore_tables = ActiveRecord.schema_ignored_tables
+    ActiveRecord.schema_ignored_tables = options[:ignore_tables] || []
     ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection_pool, stream)
     stream.string
+  ensure
+    ActiveRecord.schema_ignored_tables = old_ignore_tables
   end
 
   def create_test_posts_table(options = {})

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -149,13 +149,14 @@ end
 
 module SchemaDumpingHelper
   def dump_table_schema(table, connection = ActiveRecord::Base.lease_connection)
-    old_ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
-    ActiveRecord::SchemaDumper.ignore_tables = connection.data_sources - [table]
+    old_ignore_tables = ActiveRecord.schema_ignored_tables
+    prefixed_table = "#{ActiveRecord::Base.table_name_prefix}#{table}#{ActiveRecord::Base.table_name_suffix}"
+    ActiveRecord.schema_ignored_tables = connection.data_sources - [prefixed_table]
     stream = StringIO.new
     ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection_pool, stream)
     stream.string
   ensure
-    ActiveRecord::SchemaDumper.ignore_tables = old_ignore_tables
+    ActiveRecord.schema_ignored_tables = old_ignore_tables
   end
 end
 


### PR DESCRIPTION
Tracks rails/rails#58554, which unifies `ActiveRecord::SchemaDumper.ignore_tables` and `ActiveRecord.schema_cache_ignored_tables` into `config.active_record.schema_ignored_tables` and deprecates both old names.

Pins the Gemfile to rails/rails@38b1f04ffd98eaa1d4594b2f3ef82e9a6cd3f135 (the merge commit of that PR) and adapts the specs:

- Replace the deprecated `ActiveRecord::SchemaDumper.ignore_tables` with `ActiveRecord.schema_ignored_tables`. Without this, every schema-dumping example fails the CI deprecation-leak check.
- `SchemaDumper#ignored?` now matches raw table names instead of names with the configured prefix/suffix stripped. `dump_table_schema` now excludes the prefixed physical name from the ignore list, otherwise the target table itself is ignored under `table_name_prefix`/`table_name_suffix` and the context index dump examples come back empty.
- The unified list now also gates `SchemaCache#columns`. `standard_dump` used to leave its ignore list set globally, which was harmless when it only affected dumps; now it makes every later `TestPost` column lookup raise `Table 'test_posts' doesn't exist` (reproducible with `--seed 38478`). It restores the previous value the way `dump_table_schema` already does.

Full spec suite passes locally against Oracle Free (1117 examples, 0 failures), including a clean run at the previously failing seed 38478.
