### PR TITLE
Bump Rails to rails/rails@2ecdae99 for shuffle_unordered_selects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 group :development do
   gem "rspec"
   gem "rake"
-  # rails/rails@38b1f04f = merge of rails/rails#58554 (add
-  # config.active_record.schema_ignored_tables); bump per follow-up Rails change
-  gem "activerecord",   github: "rails/rails", ref: "38b1f04ffd98eaa1d4594b2f3ef82e9a6cd3f135"
+  # rails/rails@2ecdae99 = merge of rails/rails#58548 (add
+  # config.active_record.shuffle_unordered_selects); bump per follow-up Rails change
+  gem "activerecord",   github: "rails/rails", ref: "2ecdae997fb89463da54ce880023968d7743861d"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do

--- a/spec/active_record/connection_adapters/oracle_enhanced/shuffle_unordered_selects_spec.rb
+++ b/spec/active_record/connection_adapters/oracle_enhanced/shuffle_unordered_selects_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+RSpec.describe "OracleEnhancedAdapter shuffle unordered selects" do
+  include SchemaSpecHelper
+
+  SAMPLES = 10
+
+  before(:all) do
+    ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
+    schema_define do
+      create_table :test_posts, force: true do |t|
+        t.string :title
+      end
+    end
+    class ::TestPost < ActiveRecord::Base
+    end
+    TestPost.transaction do
+      (1..10).each do |id|
+        TestPost.create!(id: id, title: "Title #{id}")
+      end
+    end
+  end
+
+  after(:all) do
+    schema_define do
+      drop_table :test_posts
+    end
+    Object.send(:remove_const, "TestPost")
+    ActiveRecord::Base.clear_cache!
+  end
+
+  def with_shuffle(value)
+    old_value = ActiveRecord.shuffle_unordered_selects
+    ActiveRecord.shuffle_unordered_selects = value
+    yield
+  ensure
+    ActiveRecord.shuffle_unordered_selects = old_value
+  end
+
+  def sample(&block)
+    Array.new(SAMPLES, &block).uniq
+  end
+
+  it "shuffles unordered relations" do
+    natural = with_shuffle(false) { TestPost.all.map(&:id) }
+    orders = with_shuffle(true) { sample { TestPost.all.map(&:id) } }
+
+    expect(orders.size).to be > 1
+    orders.each { |ids| expect(ids.sort).to eq(natural.sort) }
+  end
+
+  it "shuffles unordered pluck" do
+    natural = with_shuffle(false) { TestPost.pluck(:id) }
+    orders = with_shuffle(true) { sample { TestPost.pluck(:id) } }
+
+    expect(orders.size).to be > 1
+    orders.each { |ids| expect(ids.sort).to eq(natural.sort) }
+  end
+
+  it "leaves ordered relations alone" do
+    natural = with_shuffle(false) { TestPost.order(:id).map(&:id) }
+
+    expect(with_shuffle(true) { sample { TestPost.order(:id).map(&:id) } }).to eq([natural])
+  end
+
+  it "leaves raw SQL alone" do
+    sql = TestPost.all.to_sql
+    natural = with_shuffle(false) { TestPost.find_by_sql(sql).map(&:id) }
+
+    expect(with_shuffle(true) { sample { TestPost.find_by_sql(sql).map(&:id) } }).to eq([natural])
+  end
+end


### PR DESCRIPTION
Tracks rails/rails#58548, which adds `config.active_record.shuffle_unordered_selects`: when enabled, the rows of every SELECT Active Record generates without an ORDER BY clause are shuffled after the database returns them, so code relying on accidental row order fails loudly.

Pins the Gemfile to rails/rails@2ecdae997fb89463da54ce880023968d7743861d (the merge commit of that PR).

The adapter itself needs no change: the shuffle runs in `QueryIntent#cast_result` and in the query cache's `select_all`, and the Oracle adapter routes all result delivery through those paths. This PR adds specs mirroring the Rails ones (`shuffle_unordered_selects_test.rb`) to lock in that the Oracle result pipeline honors the flag — unordered relations and pluck get shuffled, while ordered relations and raw SQL stay untouched.

Rebased onto master after #2848 merged.

Full spec suite passes locally against Oracle Free (1121 examples, 0 failures).
