### PR TITLE
Bump Rails to rails/rails@0dd408e2 for Ractor-safe model schema attributes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 group :development do
   gem "rspec"
   gem "rake"
-  # rails/rails@2ecdae99 = merge of rails/rails#58548 (add
-  # config.active_record.shuffle_unordered_selects); bump per follow-up Rails change
-  gem "activerecord",   github: "rails/rails", ref: "2ecdae997fb89463da54ce880023968d7743861d"
+  # rails/rails@0dd408e2 = merge of rails/rails#58578 (make model schema
+  # attribute state Ractor-safe); bump per follow-up Rails change
+  gem "activerecord",   github: "rails/rails", ref: "0dd408e2d3fd86566b5aa1c325e23cf59eed16fe"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do


### PR DESCRIPTION
Tracks rails/rails#58578, which makes a model's attribute-derived state (attribute defaults, attribute types, and column defaults) Ractor-safe by moving it from eagerly-computed ivars on `SchemaContext` into a `SchemaContext::Attributes` object stored per Ractor.

Pins the Gemfile to rails/rails@0dd408e2d3fd86566b5aa1c325e23cf59eed16fe (the merge commit of that PR). The adapter does not touch any of the reworked internals and the full spec suite passes unchanged, so this is a Gemfile-only bump.

Rebased onto master after #2849 merged.

Full spec suite passes locally against Oracle Free (1121 examples, 0 failures).
