### PR TITLE
Bump Rails to rails/rails@4362885d to catch up with latest main

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 group :development do
   gem "rspec"
   gem "rake"
-  # rails/rails@0dd408e2 = merge of rails/rails#58578 (make model schema
-  # attribute state Ractor-safe); bump per follow-up Rails change
-  gem "activerecord",   github: "rails/rails", ref: "0dd408e2d3fd86566b5aa1c325e23cf59eed16fe"
+  # rails/rails@4362885d = latest main (merge of rails/rails#58647); the swept
+  # window has no adapter-facing Active Record changes; bump per follow-up Rails change
+  gem "activerecord",   github: "rails/rails", ref: "4362885dac36a4aae6921bfeb7fec606cd4f06a3"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do


### PR DESCRIPTION
Advances the Gemfile pin from rails/rails#58578 to the current rails/rails main head, rails/rails@4362885dac36a4aae6921bfeb7fec606cd4f06a3 (merge of rails/rails#58647).

The swept window contains no adapter-facing Active Record changes:

- rails/rails#58653 freezes the `on:` arrays of transaction callbacks
- rails/rails#58642 makes Active Record railtie config handling Ractor-safe
- rails/rails#58636 removes leftover `perform_query` test stubs
- rails/rails#58639 fixes `fetch_multi` local cache ordering (Active Support)
- the rest are actionpack/actionview Ractor-safety changes

Gemfile-only bump; the full spec suite passes unchanged.

Rebased onto master after #2850 merged.

Full spec suite passes locally against Oracle Free (1121 examples, 0 failures).
