### PR TITLE
Revert "Stop running the JRuby test rows while Rails main cannot boot on JRuby"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    continue-on-error: ${{ startsWith(matrix.ruby, 'jruby') }}
     strategy:
       fail-fast: false
       matrix:
@@ -18,7 +19,11 @@ jobs:
           '4.0',
           '3.4',
           '3.3',
+          'jruby-10.1.1.0',
         ]
+        include:
+          - ruby: 'jruby-10.1.1.0'
+            jruby_opts: '--dev'
     env:
       CI: true
       JRUBY_OPTS: ${{ matrix.jruby_opts }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    continue-on-error: ${{ startsWith(matrix.ruby, 'jruby') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -15,7 +15,6 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     runs-on: ubuntu-latest
-    continue-on-error: ${{ startsWith(matrix.ruby, 'jruby') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -15,6 +15,7 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     runs-on: ubuntu-latest
+    continue-on-error: ${{ startsWith(matrix.ruby, 'jruby') }}
     strategy:
       fail-fast: false
       matrix:
@@ -22,7 +23,11 @@ jobs:
           '4.0',
           '3.4',
           '3.3',
+          'jruby-10.1.1.0',
         ]
+        include:
+          - ruby: 'jruby-10.1.1.0'
+            jruby_opts: '--dev'
     env:
       CI: true
       JRUBY_OPTS: ${{ matrix.jruby_opts }}

--- a/.github/workflows/test_11g_ojdbc11.yml
+++ b/.github/workflows/test_11g_ojdbc11.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ startsWith(matrix.ruby, 'jruby') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test_prepared_statements_false.yml
+++ b/.github/workflows/test_prepared_statements_false.yml
@@ -7,12 +7,17 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    continue-on-error: ${{ startsWith(matrix.ruby, 'jruby') }}
     strategy:
       fail-fast: false
       matrix:
         ruby: [
           '4.0',
+          'jruby-10.1.1.0',
         ]
+        include:
+          - ruby: 'jruby-10.1.1.0'
+            jruby_opts: '--dev'
     env:
       CI: true
       JRUBY_OPTS: ${{ matrix.jruby_opts }}

--- a/.github/workflows/test_prepared_statements_false.yml
+++ b/.github/workflows/test_prepared_statements_false.yml
@@ -7,7 +7,6 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    continue-on-error: ${{ startsWith(matrix.ruby, 'jruby') }}
     strategy:
       fail-fast: false
       matrix:

--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 group :development do
   gem "rspec"
   gem "rake"
-  # rails/rails@4362885d = latest main (merge of rails/rails#58647); the swept
-  # window has no adapter-facing Active Record changes; bump per follow-up Rails change
-  gem "activerecord",   github: "rails/rails", ref: "4362885dac36a4aae6921bfeb7fec606cd4f06a3"
+  # rails/rails@74bb87c5 = merge of rails/rails#58684 (load Active Support on
+  # JRuby without Ractor); bump per follow-up Rails change
+  gem "activerecord",   github: "rails/rails", ref: "74bb87c5888b3489fc519f048e6a0cd9cc615a5d"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do


### PR DESCRIPTION
Reverts rsim/oracle-enhanced#2847 now that rails/rails#58684 (merged 2026-09-07) is on Rails main.

Background: rails/rails#58654 tracked the `NameError: uninitialized constant ActiveSupport::Ractors::Ractor` that `require "active_record"` raised on JRuby 10 since rails/rails@6a7dc137. rails/rails#58684 makes `ActiveSupport::Ractors` select the Ractor-backed implementation only when the `Ractor` constant is defined, so Rails main boots on JRuby again.

Commits:

- Bump the Rails pin to rails/rails@74bb87c5, the merge of rails/rails#58684. The previous pin 4362885d predates the fix, so the revert alone would bring the rows back red. The Active Record changes in the swept window do not touch the adapter (details in the commit message).
- Revert rsim/oracle-enhanced#2847: the `jruby-10.1.1.0` rows return to the `test`, `test_11g`, and `test_prepared_statements_false` matrices.
- Revert rsim/oracle-enhanced#2845: drop `continue-on-error` for the JRuby rows from all four workflows, so JRuby failures gate merges again. rsim/oracle-enhanced#2847 had left the `test_11g_ojdbc11` one in place. This commit is separable if keeping the allowance is preferred.

After the three commits the workflow files are byte-identical to their state before rsim/oracle-enhanced#2845.

Verification against Oracle Database 26ai Free:

| Check | Result |
|---|---|
| JRuby 10.1.0.0, `require "active_record"` at the previous pin | `NameError: uninitialized constant ActiveSupport::Ractors::Ractor` |
| JRuby 10.1.0.0, `require "active_record"` at the new pin | loads |
| JRuby 10.1.0.0, full spec suite | 1128 examples, 0 failures, 11 pending |
| CRuby 4.0.6, full spec suite | 1121 examples, 0 failures, 11 pending |

The CRuby run needs `ORA_TZFILE` pointed at the server's timezone file, as `test.yml` already does. Without it the four TIMESTAMP WITH TIME ZONE examples in `timestamp_spec.rb` fail with `ORA-01805`, independent of the Rails pin.
