### PR TITLE
Track rails/rails main instead of pinning a commit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 group :development do
   gem "rspec"
   gem "rake"
-  # rails/rails@74bb87c5 = merge of rails/rails#58684 (load Active Support on
-  # JRuby without Ractor); bump per follow-up Rails change
-  gem "activerecord",   github: "rails/rails", ref: "74bb87c5888b3489fc519f048e6a0cd9cc615a5d"
+  gem "activerecord",   github: "rails/rails", branch: "main"
   gem "ruby-plsql", github: "rsim/ruby-plsql", branch: "master"
 
   platforms :ruby do


### PR DESCRIPTION
Replaces the Gemfile pin on rails/rails@74bb87c5 (rsim/oracle-enhanced#2852) with `branch: "main"`, the form used before f30d0f02 introduced the pin and the form `guides/bug_report_templates/*.rb` already use.

The pin verified each adapter change against the exact Rails commit it targeted, but every follow-up Rails change then needed its own bump pull request, including rsim/oracle-enhanced#2851 whose swept window had no adapter-facing Active Record changes. With `branch: "main"`, the scheduled workflows (test, test_11g, test_11g_ojdbc11, ruby_head and jruby_head run daily) pick up new Rails main commits on their own, so an incompatible Rails change shows up as a failing scheduled run instead of waiting for the next manual bump.

At the time of this change `bundle lock` resolves main to rails/rails@97f7349bfe (merge of rails/rails#58693). rails/rails#58688 (rubocop 1.90.0) and rails/rails#58690 (json 3.0) are in that window; neither needs adapter changes, and the RuboCop workflow on master already runs rubocop 1.90.0 with no offenses.

Gemfile-only change; verified by the CI runs on this pull request (no local Oracle instance was available for this change).
