### PR TITLE
Use engine-only ruby-version where only the latest release is needed

### DIFF
--- a/.github/workflows/check_method_signatures.yml
+++ b/.github/workflows/check_method_signatures.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.4'
+          ruby-version: 'ruby'
           rubygems: latest
       - name: Create symbolic link for libaio library compatibility
         run: |

--- a/.github/workflows/check_method_visibility.yml
+++ b/.github/workflows/check_method_visibility.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.4'
+          ruby-version: 'ruby'
           rubygems: latest
       - name: Create symbolic link for libaio library compatibility
         run: |

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: Set up Ruby 4.0
+      - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 4.0
+          ruby-version: ruby
           rubygems: latest
       - name: Yamllint
         uses: karancode/yamllint-github-action@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '4.0'
+          ruby-version: 'ruby'
           rubygems: latest
       - name: Build gem
         run: gem build activerecord-oracle_enhanced-adapter.gemspec
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 'jruby-10.1.1.0'
+          ruby-version: 'jruby'
           rubygems: latest
       - name: Build gem
         run: gem build activerecord-oracle_enhanced-adapter.gemspec
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '4.0'
+          ruby-version: 'ruby'
           rubygems: latest
       - name: Configure RubyGems credentials
         uses: rubygems/configure-rubygems-credentials@main

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: Set up Ruby 4.0
+      - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 4.0
+          ruby-version: ruby
           rubygems: latest
       - name: Build and run RuboCop
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,10 @@ jobs:
           '4.0',
           '3.4',
           '3.3',
-          'jruby-10.1.1.0',
+          'jruby',
         ]
         include:
-          - ruby: 'jruby-10.1.1.0'
+          - ruby: 'jruby'
             jruby_opts: '--dev'
     env:
       CI: true

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -22,10 +22,10 @@ jobs:
           '4.0',
           '3.4',
           '3.3',
-          'jruby-10.1.1.0',
+          'jruby',
         ]
         include:
-          - ruby: 'jruby-10.1.1.0'
+          - ruby: 'jruby'
             jruby_opts: '--dev'
     env:
       CI: true

--- a/.github/workflows/test_11g_ojdbc11.yml
+++ b/.github/workflows/test_11g_ojdbc11.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [
-          'jruby-10.1.1.0',
+          'jruby',
         ]
     env:
       CI: true

--- a/.github/workflows/test_prepared_statements_false.yml
+++ b/.github/workflows/test_prepared_statements_false.yml
@@ -11,11 +11,11 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [
-          '4.0',
-          'jruby-10.1.1.0',
+          'ruby',
+          'jruby',
         ]
         include:
-          - ruby: 'jruby-10.1.1.0'
+          - ruby: 'jruby'
             jruby_opts: '--dev'
     env:
       CI: true


### PR DESCRIPTION
ruby/setup-ruby resolves an engine-only `ruby-version` such as `ruby` or `jruby` to the latest stable release of that engine ([Supported Version Syntax](https://github.com/ruby/setup-ruby#supported-version-syntax)). This pull request switches the jobs that only need one Ruby to that form, so new CRuby and JRuby releases are picked up without a bump pull request such as rsim/oracle-enhanced#2824.

- CRuby `4.0` to `ruby`: RuboCop, Linting, release (build-cruby and release jobs)
- CRuby `3.4` to `ruby`: check_method_signatures, check_method_visibility. 3.4 was the newest release when these workflows were added, so they now run on the current release.
- JRuby `jruby-10.1.1.0` to `jruby`: release (build-jruby) and the JRuby rows of test, test_11g, test_11g_ojdbc11, test_prepared_statements_false
- test_prepared_statements_false also switches its single CRuby row from `4.0` to `ruby`

Unchanged on purpose: the multi-version CRuby matrices (`4.0`, `3.4`, `3.3`) in test and test_11g, and the ruby_head / jruby_head jobs. The `startsWith(matrix.ruby, 'jruby')` conditions keep matching `jruby`.