### PR TITLE
Bump Oracle Instant Client to 21.23 and 23.26.3

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,8 +20,8 @@ RUN mkdir -p /opt/oracle
 WORKDIR /tmp
 RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then \
-        IC_VERSION="23.26.1.0.0"; \
-        IC_PATH="2326100"; \
+        IC_VERSION="23.26.3.0.0"; \
+        IC_PATH="2326300"; \
         BASE_URL="https://download.oracle.com/otn_software/linux/instantclient/${IC_PATH}"; \
         BASIC="instantclient-basic-linux.arm64-${IC_VERSION}.zip"; \
         SDK="instantclient-sdk-linux.arm64-${IC_VERSION}.zip"; \

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -30,8 +30,8 @@ jobs:
     env:
       CI: true
       JRUBY_OPTS: ${{ matrix.jruby_opts }}
-      ORACLE_HOME: /opt/oracle/instantclient_21_21
-      LD_LIBRARY_PATH: /opt/oracle/instantclient_21_21
+      ORACLE_HOME: /opt/oracle/instantclient_21_23
+      LD_LIBRARY_PATH: /opt/oracle/instantclient_21_23
       NLS_LANG: AMERICAN_AMERICA.AL32UTF8
       TNS_ADMIN: ./ci/network/admin
       DATABASE_NAME: XE
@@ -71,20 +71,20 @@ jobs:
           sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
       - name: Download Oracle instant client
         run: |
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2121000/instantclient-basic-linux.x64-21.21.0.0.0dbru.zip
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2121000/instantclient-sqlplus-linux.x64-21.21.0.0.0dbru.zip
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2121000/instantclient-sdk-linux.x64-21.21.0.0.0dbru.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/2123000/instantclient-basic-linux.x64-21.23.0.0.0dbru.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/2123000/instantclient-sqlplus-linux.x64-21.23.0.0.0dbru.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/2123000/instantclient-sdk-linux.x64-21.23.0.0.0dbru.zip
       - name: Install Oracle instant client
         run: |
           sudo mkdir -p /opt/oracle/
-          sudo unzip -q instantclient-basic-linux.x64-21.21.0.0.0dbru.zip -d /opt/oracle
-          sudo unzip -qo instantclient-sqlplus-linux.x64-21.21.0.0.0dbru.zip -d /opt/oracle
-          sudo unzip -qo instantclient-sdk-linux.x64-21.21.0.0.0dbru.zip -d /opt/oracle
-          echo "/opt/oracle/instantclient_21_21" >> $GITHUB_PATH
+          sudo unzip -q instantclient-basic-linux.x64-21.23.0.0.0dbru.zip -d /opt/oracle
+          sudo unzip -qo instantclient-sqlplus-linux.x64-21.23.0.0.0dbru.zip -d /opt/oracle
+          sudo unzip -qo instantclient-sdk-linux.x64-21.23.0.0.0dbru.zip -d /opt/oracle
+          echo "/opt/oracle/instantclient_21_23" >> $GITHUB_PATH
 
       - name: Install JDBC Driver
         run: |
-          wget -q https://download.oracle.com/otn-pub/otn_software/jdbc/23261/ojdbc17.jar -O ./lib/ojdbc17.jar
+          wget -q https://download.oracle.com/otn-pub/otn_software/jdbc/23263/ojdbc17.jar -O ./lib/ojdbc17.jar
       - name: Configure ORA_TZFILE to match Oracle 11g server
         run: |
           # Oracle 11g XE uses timezone file v14; the 21.x Instant Client

--- a/.github/workflows/test_11g_ojdbc11.yml
+++ b/.github/workflows/test_11g_ojdbc11.yml
@@ -16,8 +16,8 @@ jobs:
         ]
     env:
       CI: true
-      ORACLE_HOME: /opt/oracle/instantclient_21_21
-      LD_LIBRARY_PATH: /opt/oracle/instantclient_21_21
+      ORACLE_HOME: /opt/oracle/instantclient_21_23
+      LD_LIBRARY_PATH: /opt/oracle/instantclient_21_23
       NLS_LANG: AMERICAN_AMERICA.AL32UTF8
       TNS_ADMIN: ./ci/network/admin
       DATABASE_NAME: XE
@@ -58,16 +58,16 @@ jobs:
           sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
       - name: Download Oracle instant client
         run: |
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2121000/instantclient-basic-linux.x64-21.21.0.0.0dbru.zip
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2121000/instantclient-sqlplus-linux.x64-21.21.0.0.0dbru.zip
-          wget -q https://download.oracle.com/otn_software/linux/instantclient/2121000/instantclient-sdk-linux.x64-21.21.0.0.0dbru.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/2123000/instantclient-basic-linux.x64-21.23.0.0.0dbru.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/2123000/instantclient-sqlplus-linux.x64-21.23.0.0.0dbru.zip
+          wget -q https://download.oracle.com/otn_software/linux/instantclient/2123000/instantclient-sdk-linux.x64-21.23.0.0.0dbru.zip
       - name: Install Oracle instant client
         run: |
           sudo mkdir -p /opt/oracle/
-          sudo unzip -q instantclient-basic-linux.x64-21.21.0.0.0dbru.zip -d /opt/oracle
-          sudo unzip -qo instantclient-sqlplus-linux.x64-21.21.0.0.0dbru.zip -d /opt/oracle
-          sudo unzip -qo instantclient-sdk-linux.x64-21.21.0.0.0dbru.zip -d /opt/oracle
-          echo "/opt/oracle/instantclient_21_21" >> $GITHUB_PATH
+          sudo unzip -q instantclient-basic-linux.x64-21.23.0.0.0dbru.zip -d /opt/oracle
+          sudo unzip -qo instantclient-sqlplus-linux.x64-21.23.0.0.0dbru.zip -d /opt/oracle
+          sudo unzip -qo instantclient-sdk-linux.x64-21.23.0.0.0dbru.zip -d /opt/oracle
+          echo "/opt/oracle/instantclient_21_23" >> $GITHUB_PATH
       - name: Install JDBC Driver
         run: |
           cp "$ORACLE_HOME/ojdbc11.jar" ./lib/ojdbc11.jar


### PR DESCRIPTION
Follow-up to rsim/oracle-enhanced#2621, which moved the 23.x workflows to Oracle's version-less download URLs and left the 11g workflows on an explicit 21.x pin.

- test_11g.yml and test_11g_ojdbc11.yml: Instant Client 21.21.0.0.0dbru to 21.23.0.0.0dbru. These workflows stay on the 21.x line because the version-less URL follows the latest major release (23.x), which cannot connect to Oracle Database 11g. 21.23 is the newest 21.x release on download.oracle.com; 21.24 is not published.
- test_11g.yml: the separately downloaded ojdbc17.jar moves from the 23261 build to 23263 to match the 23.26.3 line.
- .devcontainer/Dockerfile: the arm64 pin moves from 23.26.1.0.0 to 23.26.3.0.0, the newest 23.26.x release (23.26.4 is not published). Oracle does not publish version-less arm64 zips; x86_64 keeps using the version-less URL.

Every new URL returns HTTP 200: basic, sdk and sqlplus for 21.23 x64 and for 23.26.3 arm64, and jdbc/23263/ojdbc17.jar.